### PR TITLE
Docker compose fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.0.6 - in progress
+### Changed
+- Fixed Docker Compose.
+
 ## [v0.0.5](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.5) - 2019-12-16
 ### Added
 - Format details page headers.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ update `app.conf` with the Globus client ID and client secret,
 run `quick-start.sh` again,
 and visit [localhost:5000](http://localhost:5000).
 
-## Tag and release
+## Tag, release, and deployment
 To tag a new version for github and [dockerhub](https://hub.docker.com/repository/docker/hubmap/portal-ui),
-increment `VERSION` and run:
+checkout a release branch, increment `VERSION` and run:
 ```sh
 ./push.sh
 ```
+
+If this should be deployed publicly, make `@yuanzhou` a reviewer on the PR,
+so he knows a new version is available.
+
 
 ## Related projects and dependencies
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -2,22 +2,22 @@
 
 We first need to [install Docker Compose](https://docs.docker.com/compose/install/).
 
-To start up the container with Dicker Compose:
+To start up the container with Dicker Compose, in the current directory of `compose/`:
 
 ````
-docker-compose -f compose/base.yml -f compose/dev.yml up
+docker-compose -f base.yml -f dev.yml up
 ````
 
 Then you will see the logs of the containers in stdout. Once it's ready, you'll be able to access the portal at  http://localhost:8686/. If you want to run the container in background:
 
 ````
-docker-compose -f compose/base.yml -f compose/dev.yml up -d
+docker-compose -f base.yml -f dev.yml up -d
 ````
 
 To safely stop the active container:
 
 ````
-docker-compose -f compose/base.yml -f compose/dev.yml stop
+docker-compose -f base.yml -f dev.yml stop
 ````
 
-The `test.yml` is used for deploying this portal-ui on the testing server.
+The `test.yml` is used for deploying this portal-ui on the testing server. And it works with the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git).

--- a/compose/README.md
+++ b/compose/README.md
@@ -1,6 +1,12 @@
 # Docker Compose
 
+This directory is used for deploying the portal-ui with docker-compose. The `dev.yml` can be used to spin up the contianer quickly by pulling the image from DockerHub. And the `test.yml` is used for deploying this portal-ui on the testing server. 
+
 We first need to [install Docker Compose](https://docs.docker.com/compose/install/).
+
+## Local dev
+
+You'll first need to create the Flask configuration file based off `example-app.conf` found in the project root directory and place it at `portal-ui/context/instance/` (this directory needs to be created if not existing).
 
 To start up the container with Dicker Compose, in the current directory of `compose/`:
 
@@ -8,7 +14,7 @@ To start up the container with Dicker Compose, in the current directory of `comp
 docker-compose -f base.yml -f dev.yml up
 ````
 
-Then you will see the logs of the containers in stdout. Once it's ready, you'll be able to access the portal at  http://localhost:8686/. If you want to run the container in background:
+Then you will see the logs of the containers in stdout. Once it's ready, you'll be able to access the portal at  http://localhost:5000/. If you want to run the container in background:
 
 ````
 docker-compose -f base.yml -f dev.yml up -d
@@ -20,4 +26,8 @@ To safely stop the active container:
 docker-compose -f base.yml -f dev.yml stop
 ````
 
-The `test.yml` is used for deploying this portal-ui on the testing server. And it works with the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git).
+## Deployment on huBMAP testing server
+
+For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name. All the requests to the `https://portal.test.hubmapconsortium.org/` will be send to the Gateway's nginx, then get proxied to the `portal-ui` container where another nginx listens on the port 80 of this container. 
+
+Starting and stopping the container on testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.

--- a/compose/README.md
+++ b/compose/README.md
@@ -32,4 +32,7 @@ docker-compose -f base.yml -f dev.yml stop
 
 For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name. All the requests to `https://portal.test.hubmapconsortium.org/` will be send to the Gateway's nginx, then proxied to the `portal-ui` container where another nginx listens on port 80.
 
+Uncomment one of the `SERVER_NAME` lines in app.conf: With an explicit `SERVER_NAME`,
+it will not work on localhost, but it is required for deployments.
+
 Starting and stopping the container in the testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.

--- a/compose/README.md
+++ b/compose/README.md
@@ -1,20 +1,22 @@
 # Docker Compose
 
-This directory is used for deploying the portal-ui with docker-compose. The `dev.yml` can be used to spin up the contianer quickly by pulling the image from DockerHub. And the `test.yml` is used for deploying this portal-ui on the testing server. 
+This directory is used for deploying the portal-ui with docker-compose. The `dev.yml` can be used to spin up the container quickly by pulling the image from DockerHub, and the `test.yml` is used for deploying this portal-ui on the testing server.
 
 We first need to [install Docker Compose](https://docs.docker.com/compose/install/).
 
 ## Local dev
 
-You'll first need to create the Flask configuration file based off `example-app.conf` found in the project root directory and place it at `portal-ui/context/instance/` (this directory needs to be created if not existing).
+You'll need a configuration file in place at `context/instance/app.conf`:
+Globus access requires a secret key, so this is not checked in:
+Instead ask another developer to share theirs.
 
-To start up the container with Dicker Compose, in the current directory of `compose/`:
+To start up the container with Docker Compose, `cd compose` and then:
 
 ````
 docker-compose -f base.yml -f dev.yml up
 ````
 
-Then you will see the logs of the containers in stdout. Once it's ready, you'll be able to access the portal at  http://localhost:5000/. If you want to run the container in background:
+You will see the logs of the containers in stdout. Once it's ready, you'll be able to access the portal at  http://localhost:5000/. If you want to run the container in background:
 
 ````
 docker-compose -f base.yml -f dev.yml up -d
@@ -26,8 +28,8 @@ To safely stop the active container:
 docker-compose -f base.yml -f dev.yml stop
 ````
 
-## Deployment on huBMAP testing server
+## Deployment on HuBMAP testing server
 
-For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name. All the requests to the `https://portal.test.hubmapconsortium.org/` will be send to the Gateway's nginx, then get proxied to the `portal-ui` container where another nginx listens on the port 80 of this container. 
+For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name. All the requests to `https://portal.test.hubmapconsortium.org/` will be send to the Gateway's nginx, then proxied to the `portal-ui` container where another nginx listens on port 80.
 
-Starting and stopping the container on testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.
+Starting and stopping the container in the testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -8,4 +8,4 @@ services:
     container_name: portal-ui
     volumes:
       # Mount the app config to container in order to keep it outside of the image
-      - "./context/instance/app.conf:/app/instance/app.conf"
+      - "../context/instance/app.conf:/app/instance/app.conf"

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -3,8 +3,9 @@ version: "3.7"
 services:
 
   portal-ui:
+    # Map post 5000 on host machine to 80 on container
     ports:
-      - "8686:80"
+      - "5000:80"
     networks:
       - hubmap
 

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -60,7 +60,7 @@ def login():
         nexus_token=nexus_token,
         is_authenticated=True
     )
-    return redirect(url_for('routes.index'))
+    return redirect(url_for('routes.index'), _external=True)
 
 
 @blueprint.route('/logout')

--- a/example-app.conf
+++ b/example-app.conf
@@ -6,3 +6,7 @@ APP_CLIENT_ID = 'TODO'
 APP_CLIENT_SECRET = 'TODO'
 
 ENTITY_API_BASE = 'https://entity-api.test.hubmapconsortium.org'
+
+# For real deployments, uncomment the appropriate line:
+# SERVER_NAME = 'portal.test.hubmapconsortium.org'
+# SERVER_NAME = 'portal.hubmapconsortium.org'


### PR DESCRIPTION
@mccalluc I finally got a chance to checkout the modifications you made based on PR #77 and thanks for incorporating the deployment changes. I like the idea of pulling from DockerHub image for testing deployment with docker-compose. This way, you'll have control to make all the code changes and push the updated image (with a release version/tag) to DockerHub. Then I'll just pull the updated docker-compose files for deployment on testing server.

My PR includes:

- fix to the volume mount path for `app.conf`. Since you moved the docker-compose yaml files to its own directory 'compose/', the path to `app.conf` needs to be updated as well.
- due to the error with globus settings, I couldn't use either port 5001 or 8686 for local dev compose settings, so I changed to port 5000, which is in the whitelist. Tested the local dev deployment on my machine and it works well.
- updated instructions

I also deployed again on the testing server, still having the Globus mismatch URL which uses `portal-ui/login` as the redirect URL. Can you change the flask code and make the backend URL configurable in `app.conf`? Without changes, it works fine on local dev, but testing has different infrastructure.   