### PR TITLE
Mccalluc/fix http tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Better documentation for IS_MOCK config option.
 - Post-merge Travis runs were failing; fixed now.
 - Fix docker.sh by being tighter about routing for markdown pages.
+- app.conf is no longer read during tests.
 
 ## [v0.0.6](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.6) - 2019-12-18
 ### Added

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -1,3 +1,7 @@
 class DefaultConfig(object):
     ENTITY_API_TIMEOUT = 5
     ENTITY_API_BASE = 'https://entity-api.test.hubmapconsortium.org'
+
+    SECRET_KEY = 'should-be-overridden'
+    APP_CLIENT_ID = 'should-be-overridden'
+    APP_CLIENT_SECRET = 'should-be-overridden'

--- a/context/app/main.py
+++ b/context/app/main.py
@@ -23,10 +23,14 @@ def gateway_timeout(e):
     return render_template('errors/504.html', types={}), 504
 
 
-def create_app():
+def create_app(testing=False):
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_object(default_config.DefaultConfig)
-    app.config.from_pyfile('app.conf')
+    if testing:
+        app.config['TESTING'] = True
+    else:
+        # We should not load the gitignored app.conf during tests.
+        app.config.from_pyfile('app.conf')
 
     app.register_blueprint(routes_main.blueprint)
     app.register_blueprint(routes_auth.blueprint)

--- a/context/app/test_routes_errors.py
+++ b/context/app/test_routes_errors.py
@@ -27,12 +27,12 @@ def mock_get_400(path, **kwargs):
     return MockResponse()
 
 # TODO: https://github.com/hubmapconsortium/portal-ui/issues/102
-# def test_400_html_page(client, mocker):
-#     mocker.patch('requests.get', side_effect=mock_get_400)
-#     response = client.get('/browse/donor')
-#     assert response.status == '400 BAD REQUEST'
-#     assert_is_valid_html(response)
-#     assert '400: Bad Request' in response.data.decode('utf8')
+def test_400_html_page(client, mocker):
+    mocker.patch('requests.get', side_effect=mock_get_400)
+    response = client.get('/browse/donor')
+    assert response.status == '400 BAD REQUEST'
+    assert_is_valid_html(response)
+    assert '400: Bad Request' in response.data.decode('utf8')
 
 
 @pytest.fixture
@@ -44,11 +44,11 @@ def client_not_logged_in():
         yield client
 
 # TODO: https://github.com/hubmapconsortium/portal-ui/issues/102
-# def test_403_html_page(client_not_logged_in):
-#     response = client_not_logged_in.get('/browse/donor')
-#     assert response.status == '403 FORBIDDEN'
-#     assert_is_valid_html(response)
-#     assert '403: Access Denied' in response.data.decode('utf8')
+def test_403_html_page(client_not_logged_in):
+    response = client_not_logged_in.get('/browse/donor')
+    assert response.status == '403 FORBIDDEN'
+    assert_is_valid_html(response)
+    assert '403: Access Denied' in response.data.decode('utf8')
 
 
 @pytest.mark.parametrize('path', [
@@ -67,9 +67,9 @@ def mock_timeout_get(path, **kwargs):
     raise requests.exceptions.ConnectTimeout()
 
 # TODO: https://github.com/hubmapconsortium/portal-ui/issues/102
-# def test_504_html_page(client, mocker):
-#     mocker.patch('requests.get', side_effect=mock_timeout_get)
-#     response = client.get('/browse/donor')
-#     assert response.status == '504 GATEWAY TIMEOUT'
-#     assert_is_valid_html(response)
-#     assert '504: Gateway Timeout' in response.data.decode('utf8')
+def test_504_html_page(client, mocker):
+    mocker.patch('requests.get', side_effect=mock_timeout_get)
+    response = client.get('/browse/donor')
+    assert response.status == '504 GATEWAY TIMEOUT'
+    assert_is_valid_html(response)
+    assert '504: Gateway Timeout' in response.data.decode('utf8')

--- a/context/app/test_routes_errors.py
+++ b/context/app/test_routes_errors.py
@@ -6,19 +6,12 @@ from .config import types
 from .test_routes_main import assert_is_valid_html
 
 
-def test_not_mock():
-    '''With IS_MOCK enabled in instance/app.conf,
-    HTTP requests are not actually made,
-    so patches to requests.get have no effect.
-    To fix this: Comment out the IS_MOCK line
-    in instance/app.conf.'''
-    assert 'IS_MOCK' not in create_app().config
-
-
 @pytest.fixture
 def client():
-    app = create_app()
-    app.config['TESTING'] = True
+    app = create_app(testing=True)
+    # gitignored instance/app.conf should not be read during tests:
+    # We should just get the default config.
+    assert 'IS_MOCK' not in app.config
     with app.test_client() as client:
         with client.session_transaction() as session:
             session['nexus_token'] = '{}'
@@ -46,8 +39,7 @@ def test_400_html_page(client, mocker):
 
 @pytest.fixture
 def client_not_logged_in():
-    app = create_app()
-    app.config['TESTING'] = True
+    app = create_app(testing=True)
     with app.test_client() as client:
         # No nexus_token!
         yield client

--- a/context/app/test_routes_errors.py
+++ b/context/app/test_routes_errors.py
@@ -6,6 +6,15 @@ from .config import types
 from .test_routes_main import assert_is_valid_html
 
 
+def test_not_mock():
+    '''With IS_MOCK enabled in instance/app.conf,
+    HTTP requests are not actually made,
+    so patches to requests.get have no effect.
+    To fix this: Comment out the IS_MOCK line
+    in instance/app.conf.'''
+    assert 'IS_MOCK' not in create_app().config
+
+
 @pytest.fixture
 def client():
     app = create_app()
@@ -26,7 +35,7 @@ def mock_get_400(path, **kwargs):
             raise requests.exceptions.HTTPError(response=self)
     return MockResponse()
 
-# TODO: https://github.com/hubmapconsortium/portal-ui/issues/102
+
 def test_400_html_page(client, mocker):
     mocker.patch('requests.get', side_effect=mock_get_400)
     response = client.get('/browse/donor')
@@ -43,7 +52,7 @@ def client_not_logged_in():
         # No nexus_token!
         yield client
 
-# TODO: https://github.com/hubmapconsortium/portal-ui/issues/102
+
 def test_403_html_page(client_not_logged_in):
     response = client_not_logged_in.get('/browse/donor')
     assert response.status == '403 FORBIDDEN'
@@ -66,7 +75,7 @@ def test_404_html_page(client, path):
 def mock_timeout_get(path, **kwargs):
     raise requests.exceptions.ConnectTimeout()
 
-# TODO: https://github.com/hubmapconsortium/portal-ui/issues/102
+
 def test_504_html_page(client, mocker):
     mocker.patch('requests.get', side_effect=mock_timeout_get)
     response = client.get('/browse/donor')

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -11,8 +11,7 @@ from .config import types
 
 @pytest.fixture
 def client():
-    app = create_app()
-    app.config['TESTING'] = True
+    app = create_app(testing=True)
     with app.test_client() as client:
         with client.session_transaction() as session:
             session['nexus_token'] = '{}'


### PR DESCRIPTION
Tests were failing locally because my local app.conf was being read, and it had `IS_MOCK` turned on. Now in tests, we'll need to remember `create_app(testing=True)`. This fixes my local tests, and I think is a better way to ensure that tests are run the same way in all environments going forward.

@ilan-gold : I'll go ahead and merge when tests pass, but does this make sense to you?

Fix #102.