### PR TITLE
fix compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.0.8 - In progress
 ### Changed
-- Get the Docker Compose to better emulate the production environment.
+- Get Globus login redirect working with Docker Compose reverse proxy.
 
 ## [v0.0.7](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.7) - 2020-01-08
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v0.0.8 - In progress
+### Changed
+- Get the Docker Compose to better emulate the production environment.
 
 ## [v0.0.7](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.7) - 2020-01-08
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To build and run:
 ```
 You will need globus keys to login to the demo. The base image is based on [this template](https://github.com/tiangolo/uwsgi-nginx-flask-docker#quick-start-for-bigger-projects-structured-as-a-python-package).
 
-Docker compose configurations for testing and production environments
+Docker compose configurations for local dev and test environments
 are also [checked in](compose/).
 
 ## Development

--- a/compose/README.md
+++ b/compose/README.md
@@ -1,6 +1,8 @@
 # Docker Compose
 
-This directory is used for deploying the portal-ui with docker-compose. The `dev.yml` can be used to spin up the container quickly by pulling the image from DockerHub, and the `test.yml` is used for deploying this portal-ui on the testing server.
+This directory is used for deploying the portal-ui with docker-compose.
+The `dev.yml` can be used to spin up the container quickly by pulling the image from DockerHub,
+and the `test.yml` is used for deploying this portal-ui on the testing server.
 
 We first need to [install Docker Compose](https://docs.docker.com/compose/install/).
 
@@ -18,7 +20,9 @@ To start up the container with Docker Compose, `cd compose` and then:
 docker-compose -f base.yml -f dev.yml up
 ````
 
-You will see the logs of the containers in stdout. Once it's ready, you'll be able to access the portal at  http://localhost:5000/. If you want to run the container in background:
+You will see the logs of the containers in stdout.
+Once it's ready, you'll be able to access the portal at  http://localhost:5000/.
+If you want to run the container in background:
 
 ````
 docker-compose -f base.yml -f dev.yml up -d
@@ -32,10 +36,12 @@ docker-compose -f base.yml -f dev.yml stop
 
 ### HuBMAP testing server deployment
 
-For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name. All the requests to `https://portal.test.hubmapconsortium.org/` will be sent to the Gateway's nginx, then proxied to the `portal-ui` container where another nginx listens on port 80.
+For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name.
+All the requests to `https://portal.test.hubmapconsortium.org/` will be sent to the Gateway's nginx,
+then proxied to the `portal-ui` container where another nginx listens on port 80.
 
-Uncomment one of the `SERVER_NAME` lines in app.conf: With an explicit `SERVER_NAME`,
-it will not work on localhost, but it is required for deployments.
+Uncomment one of the `SERVER_NAME` lines in app.conf:
+With an explicit `SERVER_NAME`, it will not work on localhost, but it is required for deployments.
 
 Starting and stopping the container in the testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.
 

--- a/compose/README.md
+++ b/compose/README.md
@@ -42,9 +42,6 @@ For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium
 All the requests to `https://portal.test.hubmapconsortium.org/` will be sent to the Gateway's nginx,
 then proxied to the `portal-ui` container where another nginx listens on port 80.
 
-Uncomment one of the `SERVER_NAME` lines in app.conf:
-With an explicit `SERVER_NAME`, it will not work on localhost, but it is required for deployments.
-
 Starting and stopping the container in the testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.
 
 ### HuBMAP production server deployment

--- a/compose/README.md
+++ b/compose/README.md
@@ -10,6 +10,8 @@ We first need to [install Docker Compose](https://docs.docker.com/compose/instal
 
 ### Local dev deployment
 
+First, confirm that nothing is already running on http://localhost:5000/.
+
 You'll need a configuration file in place at `context/instance/app.conf`:
 Globus access requires a secret key, so this is not checked in:
 Instead ask another developer to share theirs.
@@ -21,7 +23,7 @@ docker-compose -f base.yml -f dev.yml up
 ````
 
 You will see the logs of the containers in stdout.
-Once it's ready, you'll be able to access the portal at  http://localhost:5000/.
+Once it's ready, you'll be able to access the portal at http://localhost:5000/.
 If you want to run the container in background:
 
 ````

--- a/compose/README.md
+++ b/compose/README.md
@@ -4,7 +4,9 @@ This directory is used for deploying the portal-ui with docker-compose. The `dev
 
 We first need to [install Docker Compose](https://docs.docker.com/compose/install/).
 
-## Local dev
+## Deployments
+
+### Local dev deployment
 
 You'll need a configuration file in place at `context/instance/app.conf`:
 Globus access requires a secret key, so this is not checked in:
@@ -28,11 +30,15 @@ To safely stop the active container:
 docker-compose -f base.yml -f dev.yml stop
 ````
 
-## Deployment on HuBMAP testing server
+### HuBMAP testing server deployment
 
-For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name. All the requests to `https://portal.test.hubmapconsortium.org/` will be send to the Gateway's nginx, then proxied to the `portal-ui` container where another nginx listens on port 80.
+For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name. All the requests to `https://portal.test.hubmapconsortium.org/` will be sent to the Gateway's nginx, then proxied to the `portal-ui` container where another nginx listens on port 80.
 
 Uncomment one of the `SERVER_NAME` lines in app.conf: With an explicit `SERVER_NAME`,
 it will not work on localhost, but it is required for deployments.
 
 Starting and stopping the container in the testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.
+
+### HuBMAP production server deployment
+
+*TODO*

--- a/compose/README.md
+++ b/compose/README.md
@@ -4,17 +4,23 @@ This directory is used for deploying the portal-ui with docker-compose.
 The `dev.yml` can be used to spin up the container quickly by pulling the image from DockerHub,
 and the `test.yml` is used for deploying this portal-ui on the testing server.
 
-We first need to [install Docker Compose](https://docs.docker.com/compose/install/).
+You'll need [Docker Compose](https://docs.docker.com/compose/install/) installed.
 
 ## Deployments
 
 ### Local dev deployment
 
-First, confirm that nothing is already running on http://localhost:5000/.
+The local dev deployment mimics the test and prod deployments
+by including a nginx reverse proxy container,
+separate from the nginx already included in the portal-ui container.
+This nginx container stands in for the gateway provided
+in test and prod environments.
 
 You'll need a configuration file in place at `context/instance/app.conf`:
 Globus access requires a secret key, so this is not checked in:
 Instead ask another developer to share theirs.
+
+Then, confirm that nothing is already running on http://localhost:5000/.
 
 To start up the container with Docker Compose, `cd compose` and then:
 
@@ -40,7 +46,7 @@ docker-compose -f base.yml -f dev.yml stop
 
 For testing deployment, the [HuBMAP Gateway](https://github.com/hubmapconsortium/gateway.git) handles the SSL certificates and domain name.
 All the requests to `https://portal.test.hubmapconsortium.org/` will be sent to the Gateway's nginx,
-then proxied to the `portal-ui` container where another nginx listens on port 80.
+then proxied to the `portal-ui` container.
 
 Starting and stopping the container in the testing environment is similar to the local dev, just replace `dev.yml` with `test.yml`.
 

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -3,8 +3,6 @@ version: "3.7"
 services:
 
   portal-ui:
-    build: ../context
-    # image: hubmap/portal-ui:v0.0.7
     hostname: portal-ui
     container_name: portal-ui
     volumes:

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -3,7 +3,8 @@ version: "3.7"
 services:
 
   portal-ui:
-    image: hubmap/portal-ui:v0.0.7
+    build: ../context
+    # image: hubmap/portal-ui:v0.0.7
     hostname: portal-ui
     container_name: portal-ui
     volumes:

--- a/compose/base.yml
+++ b/compose/base.yml
@@ -7,5 +7,5 @@ services:
     hostname: portal-ui
     container_name: portal-ui
     volumes:
-      # Mount the app config to container in order to keep it outside of the image
+      # Mount the app config in container to keep it outside the image.
       - "../context/instance/app.conf:/app/instance/app.conf"

--- a/compose/dev-volumes/nginx/nginx.conf
+++ b/compose/dev-volumes/nginx/nginx.conf
@@ -1,38 +1,11 @@
-location / {
-    proxy_pass http://portal-ui;
+events {
+    worker_connections  1024;
 }
 
-# Default config:
-#
-# user  nginx;
-# worker_processes  1;
-#
-# error_log  /var/log/nginx/error.log warn;
-# pid        /var/run/nginx.pid;
-#
-#
-# events {
-#     worker_connections  1024;
-# }
-#
-#
-# http {
-#     include       /etc/nginx/mime.types;
-#     default_type  application/octet-stream;
-#
-#     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-#                       '$status $body_bytes_sent "$http_referer" '
-#                       '"$http_user_agent" "$http_x_forwarded_for"';
-#
-#     access_log  /var/log/nginx/access.log  main;
-#
-#     sendfile        on;
-#     #tcp_nopush     on;
-#
-#     keepalive_timeout  65;
-#
-#     #gzip  on;
-#
-#     include /etc/nginx/conf.d/*.conf;
-# }
-#
+http {
+    server {
+        location / {
+            proxy_pass http://portal-ui;
+        }
+    }
+}

--- a/compose/dev-volumes/nginx/nginx.conf
+++ b/compose/dev-volumes/nginx/nginx.conf
@@ -1,0 +1,38 @@
+location / {
+    proxy_pass http://portal-ui;
+}
+
+# Default config:
+#
+# user  nginx;
+# worker_processes  1;
+#
+# error_log  /var/log/nginx/error.log warn;
+# pid        /var/run/nginx.pid;
+#
+#
+# events {
+#     worker_connections  1024;
+# }
+#
+#
+# http {
+#     include       /etc/nginx/mime.types;
+#     default_type  application/octet-stream;
+#
+#     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+#                       '$status $body_bytes_sent "$http_referer" '
+#                       '"$http_user_agent" "$http_x_forwarded_for"';
+#
+#     access_log  /var/log/nginx/access.log  main;
+#
+#     sendfile        on;
+#     #tcp_nopush     on;
+#
+#     keepalive_timeout  65;
+#
+#     #gzip  on;
+#
+#     include /etc/nginx/conf.d/*.conf;
+# }
+#

--- a/compose/dev-volumes/nginx/nginx.conf
+++ b/compose/dev-volumes/nginx/nginx.conf
@@ -6,13 +6,11 @@ http {
     server {
         location / {
             proxy_pass        http://portal-ui;
-            proxy_set_header  Host "localhost:5000";
+            proxy_set_header  Host $http_host;
 
             # If proxy_set_header is missing,
             # the redirect url passed to Globus will use "portal-ui" instead.
-
-            # If the nginx port mapping changes,
-            # the port here will need to change, too.
+            # (Plain "$host" does not include port.)
         }
     }
 }

--- a/compose/dev-volumes/nginx/nginx.conf
+++ b/compose/dev-volumes/nginx/nginx.conf
@@ -5,7 +5,14 @@ events {
 http {
     server {
         location / {
-            proxy_pass http://portal-ui;
+            proxy_pass        http://portal-ui;
+            proxy_set_header  Host "localhost:5000";
+
+            # If proxy_set_header is missing,
+            # the redirect url passed to Globus will use "portal-ui" instead.
+
+            # If the nginx port mapping changes,
+            # the port here will need to change, too.
         }
     }
 }

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -3,21 +3,23 @@ version: "3.7"
 services:
 
   portal-ui:
-    # ports:
-    #   - "5000:80"
+    ports:
+      - "80:80"
     networks:
       - hubmap
 
   nginx:
     # In test and prod, the nginx reverse proxy is provided by the gateway.
     ports:
-      # Map post 5000 on host machine to 80 on container
+      # Map port 5000 on host machine to 80 on container
       - "5000:80"
     networks:
       - hubmap
     image: nginx:1.17.6
     hostname: nginx
     container_name: nginx
+    volumes:
+      - "./dev-volumes/nginx/nginx.conf:/etc/nginx/nginx.conf"
 
 networks:
   hubmap:

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
 
   portal-ui:
+    build: ../context
     ports:
       - "80:80"
     networks:

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -3,11 +3,21 @@ version: "3.7"
 services:
 
   portal-ui:
-    # Map post 5000 on host machine to 80 on container
+    # ports:
+    #   - "5000:80"
+    networks:
+      - hubmap
+
+  nginx:
+    # In test and prod, the nginx reverse proxy is provided by the gateway.
     ports:
+      # Map post 5000 on host machine to 80 on container
       - "5000:80"
     networks:
       - hubmap
+    image: nginx:1.17.6
+    hostname: nginx
+    container_name: nginx
 
 networks:
   hubmap:

--- a/compose/test.yml
+++ b/compose/test.yml
@@ -3,6 +3,7 @@ version: "3.7"
 services:
 
   portal-ui:
+    image: hubmap/portal-ui:v0.0.7
     # Avoid accidentally creating zombie processes
     init: true
     # Specifying a restart policy to avoid downtime

--- a/example-app.conf
+++ b/example-app.conf
@@ -12,7 +12,3 @@ APP_CLIENT_SECRET = 'TODO'
 # ... or, if the API is not available, uncomment "IS_MOCK";
 # Restart is required for it to take effect.
 # IS_MOCK = True
-
-# For real deployments, uncomment the appropriate line:
-# SERVER_NAME = 'portal.test.hubmapconsortium.org'
-# SERVER_NAME = 'portal.hubmapconsortium.org'

--- a/push.sh
+++ b/push.sh
@@ -9,7 +9,7 @@ VERSION_IN_CHANGELOG="$VERSION - In progress"
 grep "$VERSION_IN_CHANGELOG" CHANGELOG.md || die "Missing from CHANGELOG.md: '$VERSION_IN_CHANGELOG'"
 
 IMAGE_NAME=hubmap/portal-ui:$VERSION
-grep "$IMAGE_NAME" compose/base.yml || die "Update compose/base.yml: $IMAGE_NAME"
+grep "$IMAGE_NAME" compose/test.yml || die "Update compose/test.yml: $IMAGE_NAME"
 
 git tag $VERSION
 git push origin --tags


### PR DESCRIPTION
Fix #89

The important part is `proxy_set_header  Host $http_host;` in the nginx config: No changes required in the flask code.

I've also changed dev to build from source rather than relying on image. Conceivably, you could do this for test, too, but I think the docker images make things more predictable.

I'll go ahead and merge, but will ping you and Bill on Slack: It'd be really nice to have this up on your infrastructure by Friday morning.