### PR TITLE
Elastic search used for detail pages

### DIFF
--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -74,6 +74,8 @@ class ApiClient():
                 'description': 'Mock Entity'
             }
         es_client = Elasticsearch([current_app.config['ELASTICSEARCH_HOST']])
+        # TODO: If we can have the UUID as the Elasticsearch _id,
+        # this can be simplified: https://github.com/hubmapconsortium/search-api/issues/23
         search = Search(using=es_client, index=current_app.config['ELASTICSEARCH_INDEX'])
         search.query('match', uuid=uuid)
         response = search.execute()

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -4,6 +4,8 @@ from datetime import datetime
 
 from flask import abort, current_app
 
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl import Search
 from datauri import DataURI
 import requests
 
@@ -71,12 +73,14 @@ class ApiClient():
                 'display_doi': 'abcd-1234',
                 'description': 'Mock Entity'
             }
-        response = self._request(f'/entities/{uuid}')
-        entity = response['entity_node']
-        # TODO: Move this into object
+        es_client = Elasticsearch([current_app.config['ELASTICSEARCH_HOST']])
+        search = Search(using=es_client, index=current_app.config['ELASTICSEARCH_INDEX'])
+        search.query('match', uuid=uuid)
+        response = search.execute()
+        entity = response[0].to_dict()
         entity['created'] = _format_timestamp(entity['provenance_create_timestamp'])
         entity['modified'] = _format_timestamp(entity['provenance_modified_timestamp'])
-        return response['entity_node']
+        return entity
 
     def get_provenance(self, uuid):
         # TODO: When the API is fixed, only use this when is_mock.

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -2,6 +2,9 @@ class DefaultConfig(object):
     ENTITY_API_TIMEOUT = 5
     ENTITY_API_BASE = 'https://entity-api.test.hubmapconsortium.org'
 
+    ELASTICSEARCH_HOST = 'should-be-overridden'
+    ELASTICSEARCH_INDEX = 'should-be-overridden'
+
     SECRET_KEY = 'should-be-overridden'
     APP_CLIENT_ID = 'should-be-overridden'
     APP_CLIENT_SECRET = 'should-be-overridden'

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -87,5 +87,5 @@ def search():
     return render_template(
         'pages/search.html',
         types=types,
-        elasticsearch_endpoint=current_app.config['ENTITY_API_BASE']
+        elasticsearch_endpoint=current_app.config['ELASTICSEARCH_ENDPOINT']
     )

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -87,5 +87,8 @@ def search():
     return render_template(
         'pages/search.html',
         types=types,
-        elasticsearch_endpoint=current_app.config['ELASTICSEARCH_ENDPOINT']
+        elasticsearch_endpoint=(
+            current_app.config['ELASTICSEARCH_HOST']
+            + current_app.config['ELASTICSEARCH_INDEX']
+        )
     )

--- a/context/app/templates/pages/search.html
+++ b/context/app/templates/pages/search.html
@@ -75,17 +75,6 @@
           {
             type: 'RefinementListFilter',
             props: {
-              // TODO: Only on some records. Should be on all?
-              // https://github.com/hubmapconsortium/search-api/issues/13
-              id: 'phi',
-              title: 'Contains Sequences',
-              field: 'phi.keyword',
-              operator: 'OR'
-            }
-          },
-          {
-            type: 'RefinementListFilter',
-            props: {
               id: 'tmc',
               title: 'TMC',
               field: 'provenance_group_name.keyword',

--- a/context/app/templates/pages/search.html
+++ b/context/app/templates/pages/search.html
@@ -26,9 +26,9 @@
         // Fields to search, and whether they have extra weight:
         prefixQueryFields: ['description'],
         // Prefix for details links:
-        detailsUrlPrefix: '/details/',
+        detailsUrlPrefix: '/browse/dataset/', // TODO: Make this different for different datasets.
         // Search results field which will be appended to detailsUrlPrefix:
-        idField: 'id',
+        idField: 'uuid',
         // Search results fields to display in table:
         resultFields: ['hubmap_identifier', 'display_doi', 'description', 'entitytype'],
         // Default hitsPerPage is 10:

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -7,6 +7,7 @@ import pytest
 
 from .main import create_app
 from .config import types
+from .api import client as api_client
 
 
 @pytest.fixture
@@ -84,12 +85,31 @@ def test_200_html_page(client, path, mocker):
     assert_is_valid_html(response)
 
 
+class MockSearch():
+    def __init__(self, **kwargs):
+        pass
+    def query(self, search, **kwargs):
+        pass
+    def execute(self):
+        return [MockResponse()]
+
+
+class MockResponse():
+    def __init__(self):
+        pass
+    def to_dict(self):
+        return {
+            'provenance_create_timestamp': '100000',
+            'provenance_modified_timestamp': '100000',
+        }
+
+
 @pytest.mark.parametrize(
     'path',
     [f'/browse/{t}/fake-uuid.json' for t in types]
 )
 def test_200_json_page(client, path, mocker):
-    mocker.patch('requests.get', side_effect=mock_get)
+    mocker.patch.object(api_client, 'Search', MockSearch)
     response = client.get(path)
     assert response.status == '200 OK'
     json.loads(response.data.decode('utf8'))

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -53,13 +53,6 @@ def mock_get(path, **kwargs):
                     'agent': '',
                     'prefix': {}
                 }
-            elif path.endswith('fake-uuid'):
-                return {
-                    'entity_node': {
-                        'provenance_create_timestamp': '100000',
-                        'provenance_modified_timestamp': '100000',
-                    }
-                }
             elif '/types/' in path:
                 return {
                     'uuids': []

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -68,8 +68,10 @@ def mock_get(path, **kwargs):
 class MockSearch():
     def __init__(self, **kwargs):
         pass
+
     def query(self, search, **kwargs):
         pass
+
     def execute(self):
         return [MockResponse()]
 
@@ -77,6 +79,7 @@ class MockSearch():
 class MockResponse():
     def __init__(self):
         pass
+
     def to_dict(self):
         return {
             'provenance_create_timestamp': '100000',

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -6,3 +6,4 @@ mistune==0.8.4
 jsonschema==3.2.0
 pyyaml==5.2
 python-datauri==0.2.8
+elasticsearch-dsl==7.1.0

--- a/example-app.conf
+++ b/example-app.conf
@@ -5,7 +5,8 @@ SECRET_KEY = 'abc123!'
 APP_CLIENT_ID = 'TODO'
 APP_CLIENT_SECRET = 'TODO'
 
-ELASTICSEARCH_ENDPOINT = 'https://TODO.example.com/entities/'
+ELASTICSEARCH_HOST = 'https://TODO.example.com/'
+ELASTICSEARCH_INDEX = 'entities'
 
 # default_config defines these:
 # ENTITY_API_TIMEOUT = 1


### PR DESCRIPTION
With this, elastic search is being used for detail pages. It's a little confusing but the faceted search goes straight to ES, while the details page uses a python client. It took me a little white to figure out the mocking... not sure I'm using it the best way. This fixes #138, but #113 is still waiting: ES is not yet in the gateway.