### PR TITLE
Fix capitalization of globus group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Hit Elasticsearch instance and start configuring facets.
 - Add react, webpack, eslint, and styling dependencies.
 - Make the Elasticsearch endpoint part of the config.
+- Fix capitalization of group.
 
 ## [v0.0.10](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.10) - 2020/03/06
 ### Added

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -37,7 +37,7 @@ def has_hubmap_group(nexus_token):
         params=params)
     response.raise_for_status()
     groups = response.json()
-    return any([group['name'] == 'HuBMAP-read' for group in groups])
+    return any([group['name'] == 'HuBMAP-Read' for group in groups])
 
 
 @blueprint.route('/login')


### PR DESCRIPTION
@shirey : Coming back to this after a month. Looking back at your original note on slack:

> If you can view through the Globus app then you have the correct privileges.  Anyone in the HuBMAP-Read group (just confirmed, you are a member) has read access to everything in the landing zone except the mentioned Stanford data and a few data sets with sequence info.  Not sure of the details of how their API uses the client id- their app internally uses their own client id/secret.

I feel like lower-case "r" in "read" must have worked at some point, but it doesn't now. Please confirm that this capitalization will be correct going forward. (Or if I need to be more flexible, let me know.)