### PR TITLE
Mccalluc/get python search working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add react, webpack, eslint, and styling dependencies.
 - Make the Elasticsearch endpoint part of the config; Make it a single setting.
 - Make the HuBMAP-Read group ID a part of the config.
+- Use Elasticsearch to read single records.
 
 ## [v0.0.10](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.10) - 2020/03/06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Added
 - Hit Elasticsearch instance and start configuring facets.
 - Add react, webpack, eslint, and styling dependencies.
-- Make the Elasticsearch endpoint part of the config.
+- Make the Elasticsearch endpoint part of the config; Make it a single setting.
 - Make the HuBMAP-Read group ID a part of the config.
 
 ## [v0.0.10](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.10) - 2020/03/06

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -4,8 +4,6 @@ from datetime import datetime
 
 from flask import abort, current_app
 
-from elasticsearch import Elasticsearch
-from elasticsearch_dsl import Search
 from datauri import DataURI
 import requests
 

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -2,8 +2,9 @@ class DefaultConfig(object):
     ENTITY_API_TIMEOUT = 5
     ENTITY_API_BASE = 'https://entity-api.test.hubmapconsortium.org'
 
-    ELASTICSEARCH_HOST = 'should-be-overridden'
-    ELASTICSEARCH_INDEX = 'should-be-overridden'
+    GROUP_ID = 'should-be-overridden'
+
+    ELASTICSEARCH_ENDPOINT = 'should-be-overridden'
 
     SECRET_KEY = 'should-be-overridden'
     APP_CLIENT_ID = 'should-be-overridden'

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -7,7 +7,6 @@ import pytest
 
 from .main import create_app
 from .config import types
-from .api import client as api_client
 
 
 @pytest.fixture

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -65,28 +65,6 @@ def mock_get(path, **kwargs):
     return MockResponse()
 
 
-class MockSearch():
-    def __init__(self, **kwargs):
-        pass
-
-    def query(self, search, **kwargs):
-        pass
-
-    def execute(self):
-        return [MockResponse()]
-
-
-class MockResponse():
-    def __init__(self):
-        pass
-
-    def to_dict(self):
-        return {
-            'provenance_create_timestamp': '100000',
-            'provenance_modified_timestamp': '100000',
-        }
-
-
 @pytest.mark.parametrize(
     'path',
     ['/', '/help']
@@ -95,7 +73,6 @@ class MockResponse():
 )
 def test_200_html_page(client, path, mocker):
     mocker.patch('requests.get', side_effect=mock_get)
-    mocker.patch.object(api_client, 'Search', MockSearch)
     response = client.get(path)
     assert response.status == '200 OK'
     assert_is_valid_html(response)
@@ -105,8 +82,7 @@ def test_200_html_page(client, path, mocker):
     'path',
     [f'/browse/{t}/fake-uuid.json' for t in types]
 )
-def test_200_json_page(client, path, mocker):
-    mocker.patch.object(api_client, 'Search', MockSearch)
+def test_200_json_page(client, path):
     response = client.get(path)
     assert response.status == '200 OK'
     json.loads(response.data.decode('utf8'))

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -65,6 +65,22 @@ def mock_get(path, **kwargs):
     return MockResponse()
 
 
+def mock_post(path, **kwargs):
+    class MockResponse():
+        def json(self):
+            return {
+                'hits': {
+                    'hits': [
+                        # TODO: Minimal properties.
+                    ]
+                }
+            }
+
+        def raise_for_status(self):
+            pass
+    return MockResponse()
+
+
 @pytest.mark.parametrize(
     'path',
     ['/', '/help']
@@ -73,6 +89,7 @@ def mock_get(path, **kwargs):
 )
 def test_200_html_page(client, path, mocker):
     mocker.patch('requests.get', side_effect=mock_get)
+    mocker.patch('requests.post', side_effect=mock_post)
     response = client.get(path)
     assert response.status == '200 OK'
     assert_is_valid_html(response)
@@ -82,7 +99,8 @@ def test_200_html_page(client, path, mocker):
     'path',
     [f'/browse/{t}/fake-uuid.json' for t in types]
 )
-def test_200_json_page(client, path):
+def test_200_json_page(client, path, mocker):
+    mocker.patch('requests.post', side_effect=mock_post)
     response = client.get(path)
     assert response.status == '200 OK'
     json.loads(response.data.decode('utf8'))

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -71,7 +71,13 @@ def mock_post(path, **kwargs):
             return {
                 'hits': {
                     'hits': [
-                        # TODO: Minimal properties.
+                        {
+                            '_source': {
+                                # Minimal properties.
+                                'provenance_create_timestamp': '100000',
+                                'provenance_modified_timestamp': '100000'
+                            }
+                        }
                     ]
                 }
             }

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -6,4 +6,3 @@ mistune==0.8.4
 jsonschema==3.2.0
 pyyaml==5.2
 python-datauri==0.2.8
-elasticsearch-dsl==7.1.0

--- a/example-app.conf
+++ b/example-app.conf
@@ -9,8 +9,7 @@ APP_CLIENT_SECRET = 'TODO'
 # https://app.globus.org/groups/5777527e-ec11-11e8-ab41-0af86edb4424/about
 GROUP_ID = '5777527e-ec11-11e8-ab41-0af86edb4424'
 
-ELASTICSEARCH_HOST = 'https://TODO.example.com/'
-ELASTICSEARCH_INDEX = 'entities'
+ELASTICSEARCH_ENDPOINT = 'https://search-api.dev.hubmapconsortium.org/search'
 
 # default_config defines these:
 # ENTITY_API_TIMEOUT = 1

--- a/example-app.conf
+++ b/example-app.conf
@@ -9,6 +9,8 @@ APP_CLIENT_SECRET = 'TODO'
 # https://app.globus.org/groups/5777527e-ec11-11e8-ab41-0af86edb4424/about
 GROUP_ID = '5777527e-ec11-11e8-ab41-0af86edb4424'
 
+# More info about the wrapped ES instance here:
+# https://github.com/hubmapconsortium/search-api
 ELASTICSEARCH_ENDPOINT = 'https://search-api.dev.hubmapconsortium.org/search'
 
 # default_config defines these:

--- a/test.sh
+++ b/test.sh
@@ -29,7 +29,8 @@ end quick-start
 start flake8
 # Unit tests require dev dependencies beyond what quick-start provides.
 pip install -r context/requirements-dev.txt > /dev/null
-flake8 || die 'Try "autopep8 --in-place --aggressive -r ."'
+# With the addition
+flake8 || die 'Try "autopep8 --in-place --aggressive -r . --exclude node_modules"'
 end flake8
 
 start pytest


### PR DESCRIPTION
With this, you can click on any item in the entity list and get that item from Elasticsearch.
(I had been using a wrapper library for Elasticsearch in python, but for passing the additional parameters we need, easier to go with requests, since we just have one query.)

Feel free to ask questions about any of this.