### PR TITLE
Remove active API url from default config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
 ## v0.0.12 - In progress
+### Changed
+- Remove actual endpoint from default_config.py: This must be provided during deployment.
 
 ## [v0.0.11](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.11) - 2020/04/16
 ### Added
-- Hit Elasticsearch instance and start configuring facets. 
+- Hit Elasticsearch instance and start configuring facets.
 - Add react, webpack, eslint, and styling dependencies.
 - Make the Elasticsearch endpoint part of the config; Make it a single setting.
 - Make the HuBMAP-Read group ID part of the config.

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -1,6 +1,6 @@
 class DefaultConfig(object):
     ENTITY_API_TIMEOUT = 5
-    ENTITY_API_BASE = 'https://entity-api.test.hubmapconsortium.org'
+    ENTITY_API_BASE = 'should-be-overridden'
 
     GROUP_ID = 'should-be-overridden'
 

--- a/example-app.conf
+++ b/example-app.conf
@@ -13,9 +13,10 @@ GROUP_ID = '5777527e-ec11-11e8-ab41-0af86edb4424'
 # https://github.com/hubmapconsortium/search-api
 ELASTICSEARCH_ENDPOINT = 'https://search-api.dev.hubmapconsortium.org/search'
 
-# default_config defines these:
+# Entity API will still be used for some queries that can't
+# be satisfied by Elasticsearch:
 # ENTITY_API_TIMEOUT = 1
-# ENTITY_API_BASE = 'https://entity-api.test.hubmapconsortium.org'
+ENTITY_API_BASE = 'https://entity-api.dev.hubmapconsortium.org'
 
 # ... or, if the API is not available, uncomment "IS_MOCK";
 # Restart is required for it to take effect.


### PR DESCRIPTION
@yuanzhou : I think the change in default_config.py is what you wanted? Fix #172. Merge if it looks good to you.