### PR TITLE
Fixed React

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Rename Docker Compose config.
 - Remove actual endpoint from default_config.py: This must be provided during deployment.
+- Fix react to show content on details pages.
 
 ## [v0.0.11](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.11) - 2020/04/16
 ### Added

--- a/context/app/static/js/App.jsx
+++ b/context/app/static/js/App.jsx
@@ -12,7 +12,7 @@ export default function App(props) {
 
   const getComponentView = () => {
     // Temp routing solution for showing the correct react component.
-    if (window.location.pathname.indexOf('browse/dataset/') > -1) {
+    if (window.location.pathname.indexOf('browse/') > -1) {
       return (
         <span>
           <NoticeAlert errors={flaskData.flashed_messages} />

--- a/context/app/static/js/components/NoticeAlert.jsx
+++ b/context/app/static/js/components/NoticeAlert.jsx
@@ -7,7 +7,7 @@ import Container from '@material-ui/core/Container';
 export default function NoticeAlert(props) {
   const [open, setOpen] = React.useState(true);
   const generateErrorList = () => props.errors.map((errorObj, ind) => {
-    if (errorObj.issue_url.length) {
+    if (errorObj.issue_url) {
       const base = 'https://github.com/hubmapconsortium/';
       const title = encodeURIComponent('Validation failure');
       let body = encodeURIComponent(`We have this validation error: ${errorObj.traceback}`);

--- a/context/app/static/js/header.jsx
+++ b/context/app/static/js/header.jsx
@@ -33,7 +33,7 @@ export default function Header() {
           </Button>
           <Button>
             <a href="/browse/dataset" className="navLink">
-              Assays
+              Datasets
             </a>
           </Button>
           <Button>


### PR DESCRIPTION
There was a bug in NoticeAlert that was causing a null error so that content would not load in the react version since if the url for the error did not exist it was failing. This push should fix these issues: #177 and #176. I also changed the 'Assays' in the header to say 'Datasets' instead. 