### PR TITLE
Remove rel from ccf-ui a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Use cookie for search.
 - Add react header and footer
 - Tweak to accommodate new ES document structure.
+- Remove rel from ccf-ui link
 
 ## [v0.0.11](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.11) - 2020/04/16
 ### Added

--- a/context/app/static/js/Header.jsx
+++ b/context/app/static/js/Header.jsx
@@ -25,7 +25,11 @@ export default function Header() {
           {['Donor', 'Sample', 'Dataset'].map((type) => <Button key={type}><a href={`search?entity_type[0]=${type}`} className="navLink">{`${type}s`}</a></Button>) }
           <Tooltip title="Explore HuBMAP data using the Common Coordinate Framework">
             <Button>
-              <a href="https://hubmapconsortium.github.io/ccf-ui/home" target="_blank" rel="noopener noreferrer" className="navLink">
+              <a
+                href="https://hubmapconsortium.github.io/ccf-ui/home"
+                target="_blank" // eslint-disable-line react/jsx-no-target-blank
+                className="navLink"
+              >
                 CCF-UI
               </a>
             </Button>


### PR DESCRIPTION
Safe to remove `rel="noopener noreferrer"` from ccf-ui link as suggested by @mccalluc 