### PR TITLE
Redirect to the right type, if we are on the wrong one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v0.0.14 - In progress
+### Added
+- Redirect to the correct entity type, if we've landed on the wrong one.
 
 ## [v0.0.13](https://github.com/hubmapconsortium/portal-ui/tree/v0.0.13) - 2020/05/03
 ### Added

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,5 +1,6 @@
 from flask import (Blueprint, render_template, abort, current_app,
-                   session, flash, request, get_flashed_messages)
+                   session, flash, request, get_flashed_messages,
+                   redirect, url_for)
 
 from yaml import safe_load as load_yaml
 
@@ -39,6 +40,10 @@ def details(type, uuid):
     client = _get_client()
 
     entity = client.get_entity(uuid)
+    actual_type = entity['entity_type'].lower()
+    if type != actual_type:
+        return redirect(url_for('routes.details', type=actual_type, uuid=uuid))
+
     # TODO: These schemas don't need to be reloaded per request.
     with open(current_app.root_path + f'/schemas/{type}.schema.yaml') as type_schema_file:
         type_schema = load_yaml(type_schema_file)

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -47,18 +47,10 @@ def assert_is_valid_html(response):
 def mock_get(path, **kwargs):
     class MockResponse():
         def json(self):
-            if path.endswith('/provenance'):
-                return {
-                    'agent': '',
-                    'prefix': {}
-                }
-            elif '/types/' in path:
-                return {
-                    'entity_type': 'Donor'
-                }
-            else:
-                raise Exception('No mock for:', path)
-
+            return {
+                'agent': '',
+                'prefix': {}
+            }
         def raise_for_status(self):
             pass
     return MockResponse()

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -44,7 +44,7 @@ def assert_is_valid_html(response):
         raise Exception(f'{e.msg}\n{numbered}')
 
 
-def mock_get(path, **kwargs):
+def mock_prov_get(path, **kwargs):
     class MockResponse():
         def json(self):
             return {
@@ -84,7 +84,7 @@ def mock_search_donor_post(path, **kwargs):
     ['/', '/help', '/browse/donor/fake-uuid']
 )
 def test_200_html_page(client, path, mocker):
-    mocker.patch('requests.get', side_effect=mock_get)
+    mocker.patch('requests.get', side_effect=mock_prov_get)
     mocker.patch('requests.post', side_effect=mock_search_donor_post)
     response = client.get(path)
     assert response.status == '200 OK'

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -51,6 +51,7 @@ def mock_prov_get(path, **kwargs):
                 'agent': '',
                 'prefix': {}
             }
+
         def raise_for_status(self):
             pass
     return MockResponse()


### PR DESCRIPTION
Fix #92. @ilan-gold, besides the code, does this seem like the right thing to do?
- Not a replacement for pointing people to the right url from search (#184 / #178), but seems like good thing in its own right.
- Just above the added lines, there's still a 404 if the entity type is unrecognized... Should I get rid of that? 
- Default is 302... but we could send a 301... But permanent redirects can be very annoying, if you ever get them wrong.