### PR TITLE
Mccalluc/search page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Hide entity_type facet.
 - Different search configs for different types.
 - Link to derived Samples and Datasets.
+- Title on search page.
 ### Changed
 - Use the code that had been in portal-search directly.
 - Fix VisTabs panel overflow.

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from flask import (Blueprint, render_template, abort, current_app,
-                   session, flash, get_flashed_messages,
+                   session, flash, get_flashed_messages, request,
                    redirect, url_for)
 
 from yaml import safe_load as load_yaml
@@ -99,11 +99,12 @@ def details_ext(type, uuid, ext):
 @blueprint.route('/search')
 def search():
     core_props = {'endpoints': {'esEndpoint': current_app.config['ELASTICSEARCH_ENDPOINT']}}
+    entity_type = request.args.get('entity_type[0]')
     if 'nexus_token' not in session:
         abort(403)
     return render_template(
         'pages/base_react.html',
-        title='Search!',
+        title=f'{entity_type}s' if entity_type else 'Search',
         types=types,
         flask_data=core_props
     )

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -103,6 +103,7 @@ def search():
         abort(403)
     return render_template(
         'pages/base_react.html',
+        title='Search!',
         types=types,
         flask_data=core_props
     )

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -98,13 +98,17 @@ def details_ext(type, uuid, ext):
 
 @blueprint.route('/search')
 def search():
-    core_props = {'endpoints': {'esEndpoint': current_app.config['ELASTICSEARCH_ENDPOINT']}}
     entity_type = request.args.get('entity_type[0]')
+    title = f'{entity_type}s' if entity_type else 'Search'
+    core_props = {
+        'endpoints': {'esEndpoint': current_app.config['ELASTICSEARCH_ENDPOINT']},
+        'title': title
+    }
     if 'nexus_token' not in session:
         abort(403)
     return render_template(
         'pages/base_react.html',
-        title=f'{entity_type}s' if entity_type else 'Search',
+        title=title,
         types=types,
         flask_data=core_props
     )

--- a/context/app/static/js/App.jsx
+++ b/context/app/static/js/App.jsx
@@ -25,6 +25,7 @@ function App(props) {
 
 App.propTypes = {
   flaskData: PropTypes.exact({
+    title: PropTypes.string,
     entity: PropTypes.object,
     flashed_messages: PropTypes.array,
     provenance: PropTypes.object,

--- a/context/app/static/js/Routes.jsx
+++ b/context/app/static/js/Routes.jsx
@@ -42,6 +42,7 @@ function Routes(props) {
 
 Routes.propTypes = {
   flaskData: PropTypes.exact({
+    title: PropTypes.string,
     entity: PropTypes.object,
     flashed_messages: PropTypes.array,
     provenance: PropTypes.object,

--- a/context/app/static/js/Routes.jsx
+++ b/context/app/static/js/Routes.jsx
@@ -9,7 +9,7 @@ import Search from './components/Search/Search';
 function Routes(props) {
   const { flaskData } = props;
   const {
-    flashed_messages, entity, provenance, vitessce_conf, endpoints,
+    flashed_messages, entity, provenance, vitessce_conf, endpoints, title,
   } = flaskData;
   const urlPath = window.location.pathname;
 
@@ -35,7 +35,7 @@ function Routes(props) {
 
   if (urlPath.startsWith('/search')) {
     return (
-      <Search esEndpoint={endpoints.esEndpoint} />
+      <Search esEndpoint={endpoints.esEndpoint} title={title} />
     );
   }
 }

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -122,8 +122,7 @@ const resultFieldsByType = {
   sample: ['description', 'status', 'entity_type'],
   dataset: ['description', 'status', 'entity_type'],
 };
-const typeUC = (new URL(document.location).searchParams.get('entity_type[0]') || '');
-const type = typeUC.toLowerCase();
+const type = (new URL(document.location).searchParams.get('entity_type[0]') || '').toLowerCase();
 
 const searchProps = {
   // The default behavior is to add a "_search" path.
@@ -149,12 +148,12 @@ const searchProps = {
 };
 
 function Search(props) {
-  const { esEndpoint } = props;
+  const { title, esEndpoint } = props;
   const allProps = Object.assign(searchProps, { apiUrl: esEndpoint });
   /* eslint-disable react/jsx-props-no-spreading */
   return (
     <Container maxWidth="lg">
-      <Typography component="h1" variant="h1">{typeUC}s</Typography>
+      <Typography component="h1" variant="h1">{title}</Typography>
       <PortalSearch {...allProps} />
     </Container>
   );

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Container from '@material-ui/core/Container';
+import Typography from '@material-ui/core/Typography';
 import PortalSearch from '../PortalSearch/PortalSearch';
 import { readCookie } from '../../helpers/functions';
 import 'searchkit/theming/theme.scss';
@@ -121,7 +122,8 @@ const resultFieldsByType = {
   sample: ['description', 'status', 'entity_type'],
   dataset: ['description', 'status', 'entity_type'],
 };
-const type = (new URL(document.location).searchParams.get('entity_type[0]') || '').toLowerCase();
+const typeUC = (new URL(document.location).searchParams.get('entity_type[0]') || '');
+const type = typeUC.toLowerCase();
 
 const searchProps = {
   // The default behavior is to add a "_search" path.
@@ -152,6 +154,7 @@ function Search(props) {
   /* eslint-disable react/jsx-props-no-spreading */
   return (
     <Container maxWidth="lg">
+      <Typography component="h1" variant="h1">{typeUC}s</Typography>
       <PortalSearch {...allProps} />
     </Container>
   );

--- a/context/app/templates/pages/base_react.html
+++ b/context/app/templates/pages/base_react.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     {% block extra_stylesheets %}{% endblock %}
 
-    <title>{% block title_text %}{% endblock %} | HuBMAP</title>
+    <title>{% block title_text %}{{ title }}{% endblock %} | HuBMAP</title>
     <script>
       const isAuthenticated = {{ 'true' if is_authenticated else 'false' }};
     </script>


### PR DESCRIPTION
Generate title on the python side (where it is used for the `<title>`) and pass through to client side. If the facet is missing, defaults to "Search" but if it's been munged to some strange value, does not fail gracefully.... will look into that, but not sure if necessary for PR -- feel free to block.

Fix #266, towards #270