### PR TITLE
Webpack alias to tidy-up long relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Triage issue template.
 
+### Changed
+
+- Use webpack aliasing to shorten relative path.
+
 ## v0.0.19 - 2020-05-18
 
 ### Added

--- a/context/app/static/js/components/Search/utils.js
+++ b/context/app/static/js/components/Search/utils.js
@@ -1,5 +1,5 @@
 import fromEntries from 'fromentries';
-import searchDefinitions from '../../../../../search-schema/data/definitions.yaml';
+import searchDefinitions from 'search-schema-definitions';
 
 export const organTranslations = fromEntries(
   Object.entries(

--- a/context/webpack.config.js
+++ b/context/webpack.config.js
@@ -9,6 +9,9 @@ const config = {
   },
   resolve: {
     extensions: ['.js', '.jsx', '.css', '.woff', '.woff2', '.svg', '.yaml', '.yml'],
+    alias: {
+      'search-schema-definitions$': resolve('./search-schema/data/definitions.yaml'),
+    }
   },
   module: {
     rules: [


### PR DESCRIPTION
That definitions.yaml is really the only thing in that repo that we'll need to reference, so just alias directly to it. Not clear that there's an established naming convention for aliases.