### PR TITLE
Use _id field

### DIFF
--- a/CHANGELOG-use-es-id.md
+++ b/CHANGELOG-use-es-id.md
@@ -1,0 +1,1 @@
+- Use the Elasticsearch `_id` field, whose uniqueness is assured.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -100,13 +100,7 @@ class ApiClient():
                 'description': 'Mock Entity'
             }
 
-        query = {
-            'query': {
-                'match': {
-                    'uuid': uuid
-                }
-            }
-        }
+        query = {'query': {'ids': {'values': [uuid]}}}
         response_json = self._post_check_errors(
             current_app.config['ELASTICSEARCH_ENDPOINT'],
             json=query)


### PR DESCRIPTION
This follows-up on the work they did for https://github.com/hubmapconsortium/search-api/issues/23. There should be an even simpler [get interface](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-get.html), but it seems they haven't white-listed it:
```
curl 'https://search-api.test.hubmapconsortium.org/search/_doc/2397fa14a6608ed31bfc57426d962c26'  -H 'Authorization: Bearer ...'
<html>
<head><title>401 Authorization Required</title></head>
<body>
<center><h1>401 Authorization Required</h1></center>
<hr><center>nginx/1.19.0</center>
```

I have been frustrated by the wrapper they've put on ES, but I think we need to pick our battles... but if you think this will cause more confusion in the long run, opening an issue isn't unreasonable.