### PR TITLE
Add docs from PK

### DIFF
--- a/CHANGELOG-pk-md.md
+++ b/CHANGELOG-pk-md.md
@@ -1,0 +1,1 @@
+- Add Markdown from Peter Kant.

--- a/context/app/markdown/about.md
+++ b/context/app/markdown/about.md
@@ -1,0 +1,27 @@
+# HuBMAP Consortium
+The HuBMAP Consortium is developing the tools to create an open, global atlas of the human body at the cellular level. These tools and maps will be openly available, to accelerate understanding of the relationships between cell and tissue organization and function and human health.
+
+
+
+
+### Consortium Data access policies & procedures
+[Policies](https://hubmapconsortium.org/policies/)
+
+### Consortium Data Use Agreement (DUA)
+[DUA](https://hubmapconsortium.org/wp-content/uploads/2019/08/DUA_040719_final.pdf)
+
+### Protected data & access via dbGaP
+[Access dbGaP](https://dbgap.ncbi.nlm.nih.gov/aa/wga.cgi?page=login) for HuBMAP protected data & bring study ID
+
+### Funding
+[Common Fund of the National Institutes of Health](https://commonfund.nih.gov/HuBMAP)
+[Funded Research](https://commonfund.nih.gov/HuBMAP/fundedresearch)
+ 
+### Contact
+General - help@hubmapconsortium.org
+Consortium Leadership - Executive Committee Co-Chairs [Jonathan Silverstein](mailto:j.c.s@pitt.edu) & [Mike Snyder](mailto:mpsnyder@stanford.edu) 
+NIH Leadership - [Richard Conroy](mailto:richard.conroy@nih.gov)
+<!--stackedit_data:
+eyJoaXN0b3J5IjpbMTYyNDEzMzc3NSwxMTQxOTAzNjQzLC0yMD
+gwMzE0MTc1XX0=
+-->


### PR DESCRIPTION
- This would be at `/about` ... Ok, or do you want something different?
- Should there be a link to this somewhere? Suggest speccing that in a separate issue, but could also be part of this PR: Your call.