### PR TITLE
Fix #456: Node OOM during build

### DIFF
--- a/CHANGELOG-oom.md
+++ b/CHANGELOG-oom.md
@@ -1,0 +1,1 @@
+- Fix JS OOM error during build.

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,10 +1,17 @@
 FROM node:12.16.3-alpine as builder
 WORKDIR /work
 RUN apk add --no-cache python git
-COPY . .
+
+# COPY only what is needed so layers can be cached.
+COPY package.json .
+COPY package-lock.json .
+
 RUN npm install
 # TODO: Get rid of prepublish... wget the prov-vis schema shouldn't be necessary. See PR #232.
 RUN npm run prepublish
+
+COPY . .
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 
 FROM tiangolo/uwsgi-nginx-flask:python3.7


### PR DESCRIPTION
- The first hits in google involve CLI options either to Node or NPM: These did not work for me, and I'm not sure why.
- I'm also not sure why we didn't get travis errors before this, which is disconcerting.