### PR TITLE
Less space at top of search page. Fix #265

### DIFF
--- a/CHANGELOG-search-css.md
+++ b/CHANGELOG-search-css.md
@@ -1,0 +1,1 @@
+- Get rid of excess space at top of search page.

--- a/context/app/static/js/components/Search/Search.css
+++ b/context/app/static/js/components/Search/Search.css
@@ -1,4 +1,9 @@
-a {color: #007bff;
+a {
+   color: #007bff;
    text-decoration: none;
    background-color: transparent;
+}
+
+.sk-layout__body {
+   margin: 0px;
 }


### PR DESCRIPTION
I'm not sure why I had trouble seeing where the margin was coming from the first time I looked at it. Easy fix.