### PR TITLE
Mccalluc/search pagination

### DIFF
--- a/CHANGELOG-pagination.md
+++ b/CHANGELOG-pagination.md
@@ -1,0 +1,1 @@
+- Fix pagination by updating searchkit.

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -4370,9 +4370,9 @@
       "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
     },
     "@types/history": {
-      "version": "4.7.5",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
-      "integrity": "sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw=="
+      "version": "4.7.6",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.6.tgz",
+      "integrity": "sha512-GRTZLeLJ8ia00ZH8mxMO8t0aC9M1N9bN461Z2eaRurJo6Fpa+utgCwLzI4jQHcrdzuzp5WPN9jRwpsCQ1VhJ5w=="
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.2",
@@ -4416,9 +4416,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.150",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.150.tgz",
-      "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w=="
+      "version": "4.14.156",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.156.tgz",
+      "integrity": "sha512-l2AgHXcKUwx2DsvP19wtRPqZ4NkONjmorOdq4sMcxIjqdIuuV/ULo2ftuv4NUpevwfW7Ju/UKLqo0ZXuEt/8lQ=="
     },
     "@types/minimatch": {
       "version": "3.0.3",
@@ -17500,9 +17500,9 @@
       }
     },
     "searchkit": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/searchkit/-/searchkit-2.4.1.tgz",
-      "integrity": "sha512-K/oDM5SXCT7oVfciBoZgsy3UcQ3KmZ1XH8b7nVzQ/LRRj3eyx7Qd2hj4UEgoiVAdZe47iF1fqT4nxjalSkSfcQ==",
+      "version": "2.4.1-alpha.4",
+      "resolved": "https://registry.npmjs.org/searchkit/-/searchkit-2.4.1-alpha.4.tgz",
+      "integrity": "sha512-TcVWqZ+1rFKg4mY2Fl1PeA2n0WTr1QpnUq+V2Mkkv0v4l7l1KaDpF5+kO1gVRDWjG5q8dPRSj0/w9LVBM83FGA==",
       "requires": {
         "@types/history": "^4.6.0",
         "@types/lodash": "^4.14.77",

--- a/context/package.json
+++ b/context/package.json
@@ -11,7 +11,7 @@
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-twitter-embed": "^3.0.3",
-    "searchkit": "^2.4.1",
+    "searchkit": "^2.4.1-alpha.4",
     "styled-components": "^5.1.0",
     "typeface-inter": "^3.12.0",
     "vitessce": "^0.1.5",


### PR DESCRIPTION
ES responses changed slightly between versions: It used to return 
```
hits: {
  ...
  total: 42
}
```
... but now `total` is an object. [This SK issue](https://github.com/searchkit/searchkit/issues/732) describes the issue, and points to the PRs that fix it.

NPM won't grab the alpha version with the fix by default, so we need to pin the version.

Fix #267. 