### PR TITLE
Mccalluc/globus link

### DIFF
--- a/CHANGELOG-globus.md
+++ b/CHANGELOG-globus.md
@@ -1,0 +1,1 @@
+- Link to globus file browser.

--- a/context/app/static/js/components/Detail/Dataset/Dataset.jsx
+++ b/context/app/static/js/components/Detail/Dataset/Dataset.jsx
@@ -87,7 +87,9 @@ function DatasetDetail(props) {
         <Protocol protocol_url={protocol_url} portal_uploaded_protocol_files={portal_uploaded_protocol_files} />
       )}
       {shouldDisplaySection.metadataTable && <MetadataTable metadata={metadata.metadata} display_doi={display_doi} />}
-      {shouldDisplaySection.files && <FileTable files={files} assetsEndpoint={assetsEndpoint} uuid={uuid} />}
+      {shouldDisplaySection.files && (
+        <FileTable files={files} assetsEndpoint={assetsEndpoint} entityEndpoint={entityEndpoint} uuid={uuid} />
+      )}
     </DetailLayout>
   );
 }

--- a/context/app/static/js/components/Detail/Dataset/Dataset.jsx
+++ b/context/app/static/js/components/Detail/Dataset/Dataset.jsx
@@ -60,7 +60,6 @@ function DatasetDetail(props) {
     visualization: 'name' in vitData,
     protocols: Boolean(portal_uploaded_protocol_files || protocol_url),
     metadataTable: metadata && 'metadata' in metadata,
-    files: files && files.length > 0,
   };
 
   return (
@@ -87,9 +86,7 @@ function DatasetDetail(props) {
         <Protocol protocol_url={protocol_url} portal_uploaded_protocol_files={portal_uploaded_protocol_files} />
       )}
       {shouldDisplaySection.metadataTable && <MetadataTable metadata={metadata.metadata} display_doi={display_doi} />}
-      {shouldDisplaySection.files && (
-        <FileTable files={files} assetsEndpoint={assetsEndpoint} entityEndpoint={entityEndpoint} uuid={uuid} />
-      )}
+      <FileTable files={files} assetsEndpoint={assetsEndpoint} entityEndpoint={entityEndpoint} uuid={uuid} />
     </DetailLayout>
   );
 }

--- a/context/app/static/js/components/Detail/FileTable/FileTable.jsx
+++ b/context/app/static/js/components/Detail/FileTable/FileTable.jsx
@@ -52,36 +52,38 @@ function FileTable(props) {
       </SectionHeader>
       <Paper>
         <GlobusLink entityEndpoint={entityEndpoint} uuid={uuid} />
-        <StyledTableContainer>
-          <Table stickyHeader>
-            <TableHead>
-              <TableRow>
-                {columns.map((column) => (
-                  <TableCell key={column.id}>{column.label}</TableCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.map((row) => (
-                <TableRow key={row.rel_path}>
-                  <TableCell>
-                    <StyledLink
-                      href={`${assetsEndpoint}/${uuid}/${row.rel_path}?token=${token}`}
-                      variant="body1"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      download
-                    >
-                      {row.rel_path}
-                    </StyledLink>
-                  </TableCell>
-                  <TableCell>{row.size}</TableCell>
-                  <TableCell>{row.type}</TableCell>
+        {Boolean(rows.length) && (
+          <StyledTableContainer>
+            <Table stickyHeader>
+              <TableHead>
+                <TableRow>
+                  {columns.map((column) => (
+                    <TableCell key={column.id}>{column.label}</TableCell>
+                  ))}
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </StyledTableContainer>
+              </TableHead>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.rel_path}>
+                    <TableCell>
+                      <StyledLink
+                        href={`${assetsEndpoint}/${uuid}/${row.rel_path}?token=${token}`}
+                        variant="body1"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        download
+                      >
+                        {row.rel_path}
+                      </StyledLink>
+                    </TableCell>
+                    <TableCell>{row.size}</TableCell>
+                    <TableCell>{row.type}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </StyledTableContainer>
+        )}
       </Paper>
     </SectionContainer>
   );
@@ -94,9 +96,13 @@ FileTable.propTypes = {
       size: PropTypes.number,
       type: PropTypes.string,
     }),
-  ).isRequired,
+  ),
   assetsEndpoint: PropTypes.string.isRequired,
   uuid: PropTypes.string.isRequired,
+};
+
+FileTable.defaultProps = {
+  files: [],
 };
 
 export default FileTable;

--- a/context/app/static/js/components/Detail/FileTable/FileTable.jsx
+++ b/context/app/static/js/components/Detail/FileTable/FileTable.jsx
@@ -23,7 +23,7 @@ function GlobusLink(props) {
   const [globusUrlText, setGlobusUrlText] = React.useState({ url: null, text: 'Please wait...' });
   React.useEffect(() => {
     async function getAndSetGlobusUrlText() {
-      const response = await fetch(`${entityEndpoint}/entities/dataset/${uuid}`, {
+      const response = await fetch(`${entityEndpoint}/entities/dataset/globus-url/${uuid}`, {
         headers: {
           Authorization: `Bearer ${readCookie('nexus_token')}`,
         },

--- a/context/app/static/js/components/Detail/FileTable/FileTable.jsx
+++ b/context/app/static/js/components/Detail/FileTable/FileTable.jsx
@@ -43,6 +43,11 @@ function GlobusLink(props) {
   return globusUrlText.url ? <Link href={globusUrlText.url}>View in Globus File Browser</Link> : globusUrlText.text;
 }
 
+GlobusLink.propTypes = {
+  entityEndpoint: PropTypes.string.isRequired,
+  uuid: PropTypes.string.isRequired,
+};
+
 function FileTable(props) {
   const { files: rows, assetsEndpoint, uuid, entityEndpoint } = props;
   const token = readCookie('nexus_token');

--- a/context/app/static/js/components/Detail/FileTable/FileTable.jsx
+++ b/context/app/static/js/components/Detail/FileTable/FileTable.jsx
@@ -6,6 +6,7 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
+import { Link } from '@material-ui/core';
 import { StyledTableContainer, StyledLink } from './style';
 import SectionHeader from '../SectionHeader';
 import SectionContainer from '../SectionContainer';
@@ -17,8 +18,32 @@ const columns = [
   { id: 'type', label: 'Type' },
 ];
 
+function GlobusLink(props) {
+  const { uuid, entityEndpoint } = props;
+  const [globusUrl, setGlobusUrl] = React.useState(null);
+  React.useEffect(() => {
+    async function getAndSetGlobusUrl() {
+      const response = await fetch(`${entityEndpoint}/entities/dataset/${uuid}`, {
+        headers: {
+          Authorization: `Bearer ${readCookie('nexus_token')}`,
+        },
+      });
+      if (!response.ok) {
+        console.error('Entities API failed', response);
+        return;
+      }
+      // TODO: I have never gotten a non-401 response, so I'm not sure this works.
+      const responseGlobusUrl = await response.json();
+      setGlobusUrl(responseGlobusUrl);
+    }
+    getAndSetGlobusUrl();
+  }, [entityEndpoint, uuid]);
+
+  return globusUrl && <Link href={globusUrl}>View in Globus File Browser</Link>;
+}
+
 function FileTable(props) {
-  const { files: rows, assetsEndpoint, uuid } = props;
+  const { files: rows, assetsEndpoint, uuid, entityEndpoint } = props;
   const token = readCookie('nexus_token');
   return (
     <SectionContainer id="files">
@@ -26,6 +51,7 @@ function FileTable(props) {
         Files
       </SectionHeader>
       <Paper>
+        <GlobusLink entityEndpoint={entityEndpoint} uuid={uuid} />
         <StyledTableContainer>
           <Table stickyHeader>
             <TableHead>

--- a/context/app/static/js/components/Detail/FileTable/FileTable.jsx
+++ b/context/app/static/js/components/Detail/FileTable/FileTable.jsx
@@ -26,8 +26,8 @@ function FileTable(props) {
       <SectionHeader variant="h3" component="h2">
         Files
       </SectionHeader>
+      <GlobusLink entityEndpoint={entityEndpoint} uuid={uuid} />
       <Paper>
-        <GlobusLink entityEndpoint={entityEndpoint} uuid={uuid} />
         {Boolean(rows.length) && (
           <StyledTableContainer>
             <Table stickyHeader>

--- a/context/app/static/js/components/Detail/FileTable/FileTable.jsx
+++ b/context/app/static/js/components/Detail/FileTable/FileTable.jsx
@@ -6,10 +6,10 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import { Link } from '@material-ui/core';
 import { StyledTableContainer, StyledLink } from './style';
 import SectionHeader from '../SectionHeader';
 import SectionContainer from '../SectionContainer';
+import GlobusLink from '../GlobusLink';
 import { readCookie } from '../../../helpers/functions';
 
 const columns = [
@@ -17,36 +17,6 @@ const columns = [
   { id: 'size', label: 'File Size' },
   { id: 'type', label: 'Type' },
 ];
-
-function GlobusLink(props) {
-  const { uuid, entityEndpoint } = props;
-  const [globusUrlText, setGlobusUrlText] = React.useState({ url: null, text: 'Please wait...' });
-  React.useEffect(() => {
-    async function getAndSetGlobusUrlText() {
-      const response = await fetch(`${entityEndpoint}/entities/dataset/globus-url/${uuid}`, {
-        headers: {
-          Authorization: `Bearer ${readCookie('nexus_token')}`,
-        },
-      });
-      if (!response.ok) {
-        console.error('Entities API failed', response);
-        setGlobusUrlText({ url: null, text: `Globus File Browser: ${response.status}: ${response.statusText}` });
-        return;
-      }
-      // TODO: I have never gotten a non-401 response, so I'm not sure this works.
-      const responseGlobusUrl = await response.text();
-      setGlobusUrlText({ url: responseGlobusUrl, text: 'View in Globus File Browser' });
-    }
-    getAndSetGlobusUrlText();
-  }, [entityEndpoint, uuid]);
-
-  return globusUrlText.url ? <Link href={globusUrlText.url}>View in Globus File Browser</Link> : globusUrlText.text;
-}
-
-GlobusLink.propTypes = {
-  entityEndpoint: PropTypes.string.isRequired,
-  uuid: PropTypes.string.isRequired,
-};
 
 function FileTable(props) {
   const { files: rows, assetsEndpoint, uuid, entityEndpoint } = props;

--- a/context/app/static/js/components/Detail/FileTable/FileTable.jsx
+++ b/context/app/static/js/components/Detail/FileTable/FileTable.jsx
@@ -20,9 +20,9 @@ const columns = [
 
 function GlobusLink(props) {
   const { uuid, entityEndpoint } = props;
-  const [globusUrl, setGlobusUrl] = React.useState(null);
+  const [globusUrlText, setGlobusUrlText] = React.useState({ url: null, text: 'Please wait...' });
   React.useEffect(() => {
-    async function getAndSetGlobusUrl() {
+    async function getAndSetGlobusUrlText() {
       const response = await fetch(`${entityEndpoint}/entities/dataset/${uuid}`, {
         headers: {
           Authorization: `Bearer ${readCookie('nexus_token')}`,
@@ -30,16 +30,17 @@ function GlobusLink(props) {
       });
       if (!response.ok) {
         console.error('Entities API failed', response);
+        setGlobusUrlText({ url: null, text: `Globus File Browser: ${response.status}: ${response.statusText}` });
         return;
       }
       // TODO: I have never gotten a non-401 response, so I'm not sure this works.
-      const responseGlobusUrl = await response.json();
-      setGlobusUrl(responseGlobusUrl);
+      const responseGlobusUrl = await response.text();
+      setGlobusUrlText({ url: responseGlobusUrl, text: 'View in Globus File Browser' });
     }
-    getAndSetGlobusUrl();
+    getAndSetGlobusUrlText();
   }, [entityEndpoint, uuid]);
 
-  return globusUrl && <Link href={globusUrl}>View in Globus File Browser</Link>;
+  return globusUrlText.url ? <Link href={globusUrlText.url}>View in Globus File Browser</Link> : globusUrlText.text;
 }
 
 function FileTable(props) {

--- a/context/app/static/js/components/Detail/GlobusLink/GlobusLink.jsx
+++ b/context/app/static/js/components/Detail/GlobusLink/GlobusLink.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from '@material-ui/core';
+import { readCookie } from '../../../helpers/functions';
+
+function GlobusLink(props) {
+  const { uuid, entityEndpoint } = props;
+  const [globusUrlText, setGlobusUrlText] = React.useState({ url: null, text: 'Please wait...' });
+  React.useEffect(() => {
+    async function getAndSetGlobusUrlText() {
+      const response = await fetch(`${entityEndpoint}/entities/dataset/globus-url/${uuid}`, {
+        headers: {
+          Authorization: `Bearer ${readCookie('nexus_token')}`,
+        },
+      });
+      if (!response.ok) {
+        console.error('Entities API failed', response);
+        setGlobusUrlText({ url: null, text: `Globus File Browser: ${response.status}: ${response.statusText}` });
+        return;
+      }
+      // TODO: I have never gotten a non-401 response, so I'm not sure this works.
+      const responseGlobusUrl = await response.text();
+      setGlobusUrlText({ url: responseGlobusUrl, text: 'View in Globus File Browser' });
+    }
+    getAndSetGlobusUrlText();
+  }, [entityEndpoint, uuid]);
+
+  return globusUrlText.url ? <Link href={globusUrlText.url}>View in Globus File Browser</Link> : globusUrlText.text;
+}
+
+GlobusLink.propTypes = {
+  entityEndpoint: PropTypes.string.isRequired,
+  uuid: PropTypes.string.isRequired,
+};
+
+export default GlobusLink;

--- a/context/app/static/js/components/Detail/GlobusLink/GlobusLink.jsx
+++ b/context/app/static/js/components/Detail/GlobusLink/GlobusLink.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from '@material-ui/core';
 import { readCookie } from '../../../helpers/functions';
+import { StyledButton } from './style';
 
 function GlobusLink(props) {
   const { uuid, entityEndpoint } = props;
@@ -25,7 +26,13 @@ function GlobusLink(props) {
     getAndSetGlobusUrlText();
   }, [entityEndpoint, uuid]);
 
-  return globusUrlText.url ? <Link href={globusUrlText.url}>View in Globus File Browser</Link> : globusUrlText.text;
+  return globusUrlText.url ? (
+    <StyledButton>
+      <Link href={globusUrlText.url}>View in Globus File Browser</Link>
+    </StyledButton>
+  ) : (
+    globusUrlText.text
+  );
 }
 
 GlobusLink.propTypes = {

--- a/context/app/static/js/components/Detail/GlobusLink/index.js
+++ b/context/app/static/js/components/Detail/GlobusLink/index.js
@@ -1,0 +1,3 @@
+import GlobusLink from './GlobusLink';
+
+export default GlobusLink;

--- a/context/app/static/js/components/Detail/GlobusLink/style.js
+++ b/context/app/static/js/components/Detail/GlobusLink/style.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import Button from '@material-ui/core/Button';
+
+const StyledButton = styled(Button)`
+  background-color: #ffffff;
+  border: 1px solid black;
+`;
+
+export { StyledButton };


### PR DESCRIPTION
@tsliaw : It looks like this right now:
<img width="243" alt="Screen Shot 2020-06-24 at 5 01 12 PM" src="https://user-images.githubusercontent.com/730388/85628069-8347c300-b63d-11ea-827f-e86e123bad30.png">
If you can give some design direction, in whatever way is easiest for you.

@john-conroy : Code review. Would you like the component split off by itself, or it is small enough to live in the same file?

Both : Access denied will be a fairly common response when globus has genetic sequence data... but maybe showing the raw status code isn't the best choice?

Making this a draft for now, until I can actually get a 200 response. In contact with Bill.