### PR TITLE
Fix ShowcaseDropdown bugs

### DIFF
--- a/CHANGELOG-showcase-dropdown-z-index.md
+++ b/CHANGELOG-showcase-dropdown-z-index.md
@@ -1,0 +1,2 @@
+- Added a z-index of `5` to the `ShowcaseDropdown` styles to allow it to be rendered above the `Visualization` component.
+- Changed the `ShowcaseDropdown` arrow icon behavior (point down when closed, point up when open).

--- a/context/app/static/js/components/Header/ShowcaseDropdown/ShowcaseDropdown.jsx
+++ b/context/app/static/js/components/Header/ShowcaseDropdown/ShowcaseDropdown.jsx
@@ -17,7 +17,7 @@ function ShowcaseDropdown() {
     <>
       <Button ref={anchorRef} onClick={toggle} style={{ color: 'white' }}>
         Showcases
-        {open ? <ArrowDropDownIcon /> : <ArrowDropUpIcon />}
+        {open ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
       </Button>
       <OffsetPopper open={open} anchorEl={anchorRef.current} placement="bottom-start">
         <Paper>

--- a/context/app/static/js/components/Header/ShowcaseDropdown/style.js
+++ b/context/app/static/js/components/Header/ShowcaseDropdown/style.js
@@ -3,6 +3,7 @@ import Popper from '@material-ui/core/Popper';
 
 const OffsetPopper = styled(Popper)`
   margin-top: 14px;
+  z-index: 5;
 `;
 
 export { OffsetPopper };


### PR DESCRIPTION
Fixes #593 by adding a z-index of `5` to the ShowcaseDropdown popper component. Changes the direction of the arrow icon.