### PR TITLE
Mccalluc/md style no anchors

### DIFF
--- a/CHANGELOG-data-type-links.md
+++ b/CHANGELOG-data-type-links.md
@@ -1,0 +1,1 @@
+- Still waiting for the index that would map abbreviations to full names, but this makes sure the link targets are rendered, and datasets with multiple types can link to each.

--- a/context/app/static/js/components/Detail/Dataset/Dataset.jsx
+++ b/context/app/static/js/components/Detail/Dataset/Dataset.jsx
@@ -32,9 +32,10 @@ function SummaryData(props) {
     <>
       {data_types && data_types.length > 0 && (
         <AssaySpecificItem>
-          {data_types_array.map((data_type) => (
-            <a href={`/docs/assays#${data_type}`}>{data_type}</a>
-          ))}
+          {data_types_array.map((data_type, i) => [
+            i > 0 && ' / ',
+            <a href={`/docs/assays#${data_type}`}>{data_type}</a>,
+          ])}
         </AssaySpecificItem>
       )}
       <Typography variant="body1">{origin_sample.mapped_organ}</Typography>

--- a/context/app/static/js/components/Detail/Dataset/Dataset.jsx
+++ b/context/app/static/js/components/Detail/Dataset/Dataset.jsx
@@ -26,12 +26,15 @@ function AssaySpecificItem(props) {
 
 function SummaryData(props) {
   const { data_types, origin_sample } = props;
-  const data_types_string = data_types.constructor.name === 'Array' ? data_types.join(' / ') : data_types;
+  // TODO: ES should consistenty return array. Waiting for reindex.
+  const data_types_array = data_types.constructor.name === 'Array' ? data_types : [data_types];
   return (
     <>
       {data_types && data_types.length > 0 && (
         <AssaySpecificItem>
-          <a href={`/docs/assays#${data_types_string}`}>{data_types_string}</a>
+          {data_types_array.map((data_type) => (
+            <a href={`/docs/assays#${data_type}`}>{data_type}</a>
+          ))}
         </AssaySpecificItem>
       )}
       <Typography variant="body1">{origin_sample.mapped_organ}</Typography>

--- a/context/app/static/js/components/Markdown/Markdown.jsx
+++ b/context/app/static/js/components/Markdown/Markdown.jsx
@@ -9,7 +9,7 @@ function Markdown(props) {
 
   return (
     <StyledPaper>
-      <ReactMarkdown source={markdown} />
+      <ReactMarkdown source={markdown} escapeHtml={false} />
     </StyledPaper>
   );
 }

--- a/context/app/static/js/components/Markdown/Markdown.jsx
+++ b/context/app/static/js/components/Markdown/Markdown.jsx
@@ -8,6 +8,7 @@ function Markdown(props) {
   const { markdown } = props;
 
   return (
+    // Turn off escapeHtml so that <a name="assay"> comes through.
     <StyledPaper>
       <ReactMarkdown source={markdown} escapeHtml={false} />
     </StyledPaper>


### PR DESCRIPTION
Still waiting for the index that would map abbreviations to full names, but this makes sure the link targets are rendered, and datasets with multiple types can link to each.