### PR TITLE
Mccalluc/style docs

### DIFF
--- a/CHANGELOG-md-css.md
+++ b/CHANGELOG-md-css.md
@@ -1,0 +1,1 @@
+- Add basis CSS for markdown content.

--- a/context/app/static/js/components/Markdown/style.js
+++ b/context/app/static/js/components/Markdown/style.js
@@ -26,8 +26,8 @@ const StyledPaper = styled(Paper)`
     padding-left: 1em;
   }
 
-  ul {
-    list-style: square outside none;
+  li {
+    list-style: square;
   }
 `;
 

--- a/context/app/static/js/components/Markdown/style.js
+++ b/context/app/static/js/components/Markdown/style.js
@@ -1,7 +1,11 @@
 import styled from 'styled-components';
 import Paper from '@material-ui/core/Paper';
 
+// TODO: Copied and pasted the padding.
+// Should find a way to manage it in one place.
 const StyledPaper = styled(Paper)`
+  padding: 30px 40px 30px 40px;
+
   & img {
     max-width: 100%;
   }
@@ -11,13 +15,20 @@ const StyledPaper = styled(Paper)`
     border-collapse: collapse;
   }
   & th,
-  td {
+  & td {
     border: 1px solid grey;
+    padding: 0.25em 0.5em;
   }
 
-  padding: 30px 40px 30px 40px;
+  blockquote {
+    border-left: 4px solid grey;
+    margin-left: 0;
+    padding-left: 1em;
+  }
+
+  ul {
+    list-style: square outside none;
+  }
 `;
-// TODO: Copied and pasted the padding.
-// Should find a way to manage it in one place.
 
 export { StyledPaper };

--- a/context/app/static/js/components/Markdown/style.js
+++ b/context/app/static/js/components/Markdown/style.js
@@ -5,6 +5,16 @@ const StyledPaper = styled(Paper)`
   & img {
     max-width: 100%;
   }
+
+  & table {
+    border-spacing: 0px;
+    border-collapse: collapse;
+  }
+  & th,
+  td {
+    border: 1px solid grey;
+  }
+
   padding: 30px 40px 30px 40px;
 `;
 // TODO: Copied and pasted the padding.


### PR DESCRIPTION
I think material clears a lot of the default styles, at a higher level, so they need to be added back in the markdown scope.

Before:
<img width="150" alt="Screen Shot 2020-07-04 at 3 24 17 PM" src="https://user-images.githubusercontent.com/730388/86519627-7a5bac00-be0a-11ea-9e59-0b13691140d9.png">

After:
<img width="165" alt="Screen Shot 2020-07-04 at 3 21 16 PM" src="https://user-images.githubusercontent.com/730388/86519602-45e7f000-be0a-11ea-99e8-9d98c3334a85.png">
