### PR TITLE
Mccalluc/search for existence

### DIFF
--- a/context/app/static/js/components/Search/config.js
+++ b/context/app/static/js/components/Search/config.js
@@ -1,4 +1,4 @@
-import { TermQuery } from 'searchkit'; // eslint-disable-line import/no-duplicates
+import { ExistsQuery } from 'searchkit';
 
 // eslint-disable-next-line import/named
 import { filter, rangeFilter, checkboxFilter, field } from './utils';
@@ -41,12 +41,12 @@ export const sampleConfig = {
 
 export const datasetConfig = {
   filters: [
-    checkboxFilter('is_stanford', 'Is Stanford?', TermQuery('donor.group_name.keyword', 'Stanford TMC')),
     filter('created_by_user_displayname', 'Creator'),
     filter('data_types', 'Data types'),
     filter('donor.group_name', 'Group'),
     filter('source_sample.mapped_specimen_type', 'Specimen Type'),
     filter('mapped_status', 'Status'),
+    checkboxFilter('has_files', 'Has files?', ExistsQuery('files')),
   ],
   fields: [
     field('display_doi', 'ID'),

--- a/context/app/static/js/components/Search/config.js
+++ b/context/app/static/js/components/Search/config.js
@@ -1,5 +1,7 @@
+import { TermQuery } from 'searchkit'; // eslint-disable-line import/no-duplicates
+
 // eslint-disable-next-line import/named
-import { filter, rangeFilter, field } from './utils';
+import { filter, rangeFilter, checkboxFilter, field } from './utils';
 
 export const donorConfig = {
   filters: [
@@ -39,6 +41,7 @@ export const sampleConfig = {
 
 export const datasetConfig = {
   filters: [
+    checkboxFilter('is_stanford', 'Is Stanford?', TermQuery('donor.group_name.keyword', 'Stanford TMC')),
     filter('created_by_user_displayname', 'Creator'),
     filter('data_types', 'Data types'),
     filter('donor.group_name', 'Group'),

--- a/context/app/static/js/components/Search/utils.js
+++ b/context/app/static/js/components/Search/utils.js
@@ -39,3 +39,16 @@ export function rangeFilter(id, name, min, max) {
     },
   };
 }
+
+// eslint-disable-next-line no-shadow
+export function checkboxFilter(id, name, filter) {
+  return {
+    type: 'CheckboxFilter',
+    props: {
+      id,
+      title: name,
+      label: name,
+      filter,
+    },
+  };
+}

--- a/context/app/static/js/components/Search/utils.js
+++ b/context/app/static/js/components/Search/utils.js
@@ -47,7 +47,7 @@ export function checkboxFilter(id, name, filter) {
     props: {
       id,
       title: name,
-      label: name,
+      label: 'True',
       filter,
     },
   };


### PR DESCRIPTION
I have often found it hard to find examples of documents which possessed a particular attribute I wanted to exercise: Right now, I want to find datasets that have files so I can work on the modal... but I'd imagine that outside users also might be interested in this filter, so they could find data they could immediately download.

<img width="214" alt="Screen Shot 2020-07-06 at 2 47 18 PM" src="https://user-images.githubusercontent.com/730388/86628337-c38d3680-bf97-11ea-9fa9-1e6898b13b1d.png">

- Ok to expose this, or does it need to be a development-mode only feature?
- If it will be exposed, is this text ok, or does it need to change?
- If we add additional ones, they will also have their own bold heading... Is that ok, or do we need to find some way to group them?