### PR TITLE
Create placeholder for FAQ and link from documentation overview

### DIFF
--- a/context/app/markdown/docs.md
+++ b/context/app/markdown/docs.md
@@ -6,6 +6,7 @@
    * [Contact](mailto:help@hubmapconsortium.org)
 
 - [2020 Summer Release](/docs/release-summer-2020)
+- [Frequently Asked Questions](/docs/faq)
 
 ---
 - [Data States](/docs/data-states)

--- a/context/app/markdown/docs/faq.md
+++ b/context/app/markdown/docs/faq.md
@@ -1,0 +1,13 @@
+# Frequently Asked Questions
+
+_Placeholder while FAQ is being written._
+
+## General Questions
+
+### What is HuBMAP and what are its goals?
+
+We are developing the tools to create an open, global atlas of the human body at the cellular level. These tools and maps will be openly available, to accelerate understanding of the relationships between cell and tissue organization and function and human health.
+
+It takes trillions of cells to build a human adult, and how those cells interact, connect, and arrange into tissues has a direct effect on our health. HuBMAP (the Human BioMolecular Atlas Program) will create the next generation of molecular analysis technologies and computational tools, enabling the generation of foundational 3D tissue maps and construction of an atlas of the function and relationships among cells in the human body. These maps and atlas can lead us to a better understanding of how the relationships among our cells affects our health.
+
+## Experimental Design & Data Analysis Questions


### PR DESCRIPTION
The actual FAQ is written by a cross-consortium team and will be delivered by the end of July 2020.