### PR TITLE
Update styles to fix please wait bug

### DIFF
--- a/CHANGELOG-vitessce-please-wait.md
+++ b/CHANGELOG-vitessce-please-wait.md
@@ -1,0 +1,1 @@
+- Updated the styles for the .vitessce-container to make the Vitessce Please wait... modal visible

--- a/context/app/static/js/components/Detail/Visualization/style.js
+++ b/context/app/static/js/components/Detail/Visualization/style.js
@@ -59,6 +59,7 @@ const ExpandableDiv = styled.div`
     display: block;
     height: ${(props) => (props.$isExpanded ? `calc(100vh - ${headerFixedHeight}px)` : 'auto')};
     width: 100%;
+    position: static;
   }
 `;
 


### PR DESCRIPTION
This fixes the bug where the Vitessce "Please wait" modal is hidden when the Vitessce component is inline / not full-window.

I have a separate pull request in  Vitessce to change the modal to an animated loading spinner https://github.com/hubmapconsortium/vitessce/pull/651 (but this PR does not necessarily depend on that one)