### PR TITLE
Search for items with or without metadata

### DIFF
--- a/CHANGELOG-w-wo-metadata.md
+++ b/CHANGELOG-w-wo-metadata.md
@@ -1,0 +1,1 @@
+- Add a docs page with links to constrained searches with and without metadata.

--- a/context/app/markdown/docs/dev-tools.md
+++ b/context/app/markdown/docs/dev-tools.md
@@ -1,0 +1,11 @@
+# Dev Tools
+
+- Donor: 
+    - [has metadata](/search?has_metadata=true&entity_type[0]=Donor)
+    - [no metadata](/search?no_metadata=true&entity_type[0]=Donor)
+- Sample: 
+    - [has metadata](/search?has_metadata=true&entity_type[0]=Sample)
+    - [no metadata](/search?no_metadata=true&entity_type[0]=Sample)
+- Dataset: 
+    - [has metadata](/search?has_metadata=true&entity_type[0]=Dataset)
+    - [no metadata](/search?no_metadata=true&entity_type[0]=Dataset)

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -1,22 +1,27 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
+import { ExistsQuery, BoolMustNot } from 'searchkit';
 import SearchWrapper from './SearchWrapper';
 import { readCookie } from '../../helpers/functions';
 import './Search.scss';
-
 import { donorConfig, sampleConfig, datasetConfig } from './config';
 // eslint-disable-next-line import/named
-import { filter } from './utils';
+import { filter, checkboxFilter } from './utils';
 import AncestorNote from './AncestorNote';
 import LookupEntity from '../../helpers/LookupEntity';
 
-const baseFilters = [filter('ancestor_ids', 'Ancestor ID'), filter('entity_type', 'Entity Type')];
+const hiddenFilters = [
+  filter('ancestor_ids', 'Ancestor ID'),
+  filter('entity_type', 'Entity Type'),
+  checkboxFilter('has_metadata', 'Has metadata?', ExistsQuery('metadata')),
+  checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata'))),
+];
 
 const filtersByType = {
-  '': baseFilters,
-  donor: donorConfig.filters.concat(baseFilters),
-  sample: sampleConfig.filters.concat(baseFilters),
-  dataset: datasetConfig.filters.concat(baseFilters),
+  '': hiddenFilters,
+  donor: donorConfig.filters.concat(hiddenFilters),
+  sample: sampleConfig.filters.concat(hiddenFilters),
+  dataset: datasetConfig.filters.concat(hiddenFilters),
 };
 
 const resultFieldsByType = {
@@ -68,7 +73,7 @@ const searchProps = {
       defaultOption: false,
     },
   ],
-  hiddenFilterIds: ['entity_type', 'ancestor_ids'],
+  hiddenFilterIds: hiddenFilters.map((hiddenFilter) => hiddenFilter.props.id),
   queryFields: ['everything'],
   isLoggedIn: Boolean(nexus_token),
 };

--- a/context/app/static/js/components/Search/utils.js
+++ b/context/app/static/js/components/Search/utils.js
@@ -39,3 +39,16 @@ export function rangeFilter(id, name, min, max) {
     },
   };
 }
+
+// eslint-disable-next-line no-shadow
+export function checkboxFilter(id, name, filter) {
+  return {
+    type: 'CheckboxFilter',
+    props: {
+      id,
+      title: name,
+      label: 'True',
+      filter,
+    },
+  };
+}


### PR DESCRIPTION
Revive ideas from #645, and add a docs page that helps you find items with or without metadata. (Possible to make a custom report like the one in slack, but that would be more work.)

Fix #757, I think.