### PR TITLE
Create user-agreement.md

### DIFF
--- a/context/app/markdown/docs/user-agreement.md
+++ b/context/app/markdown/docs/user-agreement.md
@@ -1,0 +1,5 @@
+# HuBMAP User Agreement
+
+By downloading data from the HuBMAP Portal, you affirm you will abide by provisions of the [HuBMAP DUA](https://hubmapconsortium.org/wp-content/uploads/2020/06/DUA_FINAL_2020_02_03_for_Signature.pdf) and [NIH genomic data sharing policy](https://osp.od.nih.gov/scientific-sharing/genomic-data-sharing/) signed by your institutional signatory; including not reidentifying any patient and maintaining confidentiality of HuBMAP participant data.
+
+For questions about the agreement or regardig HuBMAP Policy, please contact [Gloria Pryhuber](mailto:Gloria_Pryhuber@urmc.rochester.edu), HuBMAP policy working group chair.


### PR DESCRIPTION
@computationdoc  7 @schwenk102  - this is a _draft_ page for handling linking to the User Agreement from the Globus InfoLink fields as part of use cases for accessing via protected data group and for consortium access to non-published datasets.

@computationdoc  and I will work on refining with the Policy WG chair prior to release.
