### PR TITLE
Image Pyramids

### DIFF
--- a/CHANGELOG-vitessce-imaging-generic.md
+++ b/CHANGELOG-vitessce-imaging-generic.md
@@ -1,0 +1,1 @@
+- Add a generic image viewing vitessce configuration.

--- a/context/app/api/test_vitessce.py
+++ b/context/app/api/test_vitessce.py
@@ -37,7 +37,7 @@ def test_build_image_schema():
     vitessce = Vitessce(
         entity=TEST_ENTITY_CODEX, nexus_token=TEST_NEXUS_TOKEN, is_mock=True
     )
-    schema = vitessce._build_image_schema(rel_path=TEST_PATH_TIFF)
+    schema = vitessce._build_image_schema(image_rel_path=TEST_PATH_TIFF)
     assert schema["name"] == "example.ome.tiff"
     assert (
         schema["url"]
@@ -46,7 +46,7 @@ def test_build_image_schema():
     assert schema["type"] == "ome-tiff"
     assert (
         schema["metadata"]["omeTiffOffsetsUrl"]
-        == f"https://example.com/uuid/output_offsets/example.offsets.json?token={TEST_NEXUS_TOKEN}"
+        == f"https://example.com/uuid/path/to/example.offsets.json?token={TEST_NEXUS_TOKEN}"
     )
 
 

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -7,13 +7,6 @@ import copy
 
 from flask import current_app
 
-# Hardcoded CODEX offsets and tile path.
-CODEX_OFFSETS_PATH = "output_offsets"
-CODEX_TILE_PATH = "output/extract/expressions/ome-tiff"
-CODDEX_SPRM_PATH = "output_json"
-
-SCRNASEQ_BASE_PATH = "cluster-marker-genes/output/cluster_marker_genes"
-
 SCATTERPLOT = {
     "layers": [],
     "name": "NAME",
@@ -34,7 +27,7 @@ SCATTERPLOT = {
     ],
 }
 
-IMAGING = {
+TILED_SPRM_IMAGING = {
     "name": "NAME",
     "layers": [],
     "staticLayout": [
@@ -54,17 +47,50 @@ IMAGING = {
     ],
 }
 
+IMAGING_ONLY = {
+    "name": "NAME",
+    "layers": [],
+    "staticLayout": [
+        {"component": "layerController", "x": 0, "y": 0, "w": 3, "h": 4},
+        {"component": "description", "x": 0, "y": 4, "w": 3, "h": 2},
+        {
+            "component": "spatial",
+            "props": {"view": {}},
+            "x": 3,
+            "y": 0,
+            "w": 9,
+            "h": 6,
+        },
+    ],
+}
+
+
+CODEX_CYTOKIT = "codex_cytokit"
+IMAGE_PYRAMID = "image_pyramid"
+SCRNA_SEQ = "salmon_rnaseq_10x"
+
+SCRNASEQ_BASE_PATH = "cluster-marker-genes/output/cluster_marker_genes"
+OFFSETS_PATH = "output_offsets"
+IMAGE_PYRAMID_PATH = "ometiff-pyramids"
+CODEX_TILE_PATH = "output/extract/expressions/ome-tiff"
+CODDEX_SPRM_PATH = "output_json"
+
+# Hardcoded CODEX offsets and tile path.
+IMAGING_PATHS = {
+    CODEX_CYTOKIT: {"offsets": OFFSETS_PATH, "image": CODEX_TILE_PATH,},
+    IMAGE_PYRAMID: {"offsets": OFFSETS_PATH, "image": IMAGE_PYRAMID_PATH,},
+}
 
 ASSAY_CONF_LOOKUP = {
-    "salmon_rnaseq_10x": {
+    SCRNA_SEQ: {
         "base_conf": SCATTERPLOT,
         "files_conf": [
             {"rel_path": f"{SCRNASEQ_BASE_PATH}.cells.json", "type": "CELLS"},
             {"rel_path": f"{SCRNASEQ_BASE_PATH}.cell-sets.json", "type": "CELL-SETS"},
         ],
     },
-    "codex_cytokit": {
-        "base_conf": IMAGING,
+    CODEX_CYTOKIT: {
+        "base_conf": TILED_SPRM_IMAGING,
         "view": {"zoom": -1.5, "target": [600, 600, 0]},
         "files_conf": [
             {
@@ -89,24 +115,30 @@ ASSAY_CONF_LOOKUP = {
             },
         ],
     },
+    IMAGE_PYRAMID: {
+        "base_conf": IMAGING_ONLY,
+        # We can actually fetch height/width using a COG tiff library, but for now this will do.
+        "view": {"zoom": -6.5, "target": [1000, 1000, 0]},
+        "files_conf": [
+            {"rel_path": IMAGE_PYRAMID_PATH + r"/.*.ome.tif(f?)", "type": "RASTER",},
+        ],
+    },
 }
 
-CODEX_ASSAY = "codex_cytokit"
-
-IMAGE_ASSAYS = [CODEX_ASSAY]
-TILED_ASSAYS = [CODEX_ASSAY]
+IMAGE_ASSAYS = [CODEX_CYTOKIT, IMAGE_PYRAMID]
+TILED_ASSAYS = [CODEX_CYTOKIT]
 
 TILE_REGEX = r"R\d+_X\d+_Y\d+"
 
 MOCK_URL = "https://example.com"
 
 
-def _get_tiles(files):
+def _get_matching_files(files, regex):
     return list(
         set(
             [
                 match[0]
-                for match in set(re.search(TILE_REGEX, file) for file in files)
+                for match in set(re.search(regex, file) for file in files)
                 if match
             ]
         )
@@ -168,7 +200,7 @@ class Vitessce:
         file_paths_found = [file["rel_path"] for file in self.entity["files"]]
         conf = ASSAY_CONF_LOOKUP[self.assay_type]["base_conf"]
         # Codex and other tiled assays needs to be built up based on their input tiles.
-        if self.assay_type not in TILED_ASSAYS:
+        if self.assay_type not in IMAGE_ASSAYS:
             # We need to check that the files we expect actually exist.
             # This is due to the volatility of the datasets.
             if not set(file_paths_expected).issubset(set(file_paths_found)):
@@ -184,8 +216,8 @@ class Vitessce:
             conf = self._replace_view(conf)
             self.conf = conf
             return conf
-        else:
-            found_tiles = _get_tiles(file_paths_found)
+        elif self.assay_type in TILED_ASSAYS:
+            found_tiles = _get_matching_files(file_paths_found, TILE_REGEX)
             confs = []
             for tile in sorted(found_tiles):
                 new_conf = copy.deepcopy(conf)
@@ -196,6 +228,14 @@ class Vitessce:
                 confs += [new_conf]
             self.conf = confs
             return confs
+        elif self.assay_type in IMAGE_ASSAYS:
+            found_images = _get_matching_files(file_paths_found, files[0]["rel_path"])
+            layer = self._build_multi_file_image_layer_conf(found_images)
+            conf["layers"] = [layer]
+            conf["name"] = self.uuid
+            conf = self._replace_view(conf)
+            self.conf = conf
+            return conf
 
     def _build_layer_conf(self, file, tile=""):
         """Build each layer in the layers section.
@@ -205,7 +245,7 @@ class Vitessce:
         {
           'type': 'CELLS',
           'url': 'https://assets.dev.hubmapconsortium.org/uuid/cells.json',
-          'name': 'cells
+          'name': 'cells'
         }
         """
 
@@ -214,12 +254,29 @@ class Vitessce:
             "url": self._build_assets_url(file["rel_path"].replace("#TILE#", tile))
             if file["type"] != "RASTER"
             else self._build_image_layer_datauri(
-                file["rel_path"].replace("#TILE#", tile)
+                [file["rel_path"].replace("#TILE#", tile)]
             ),
             "name": file["type"].lower(),
         }
 
-    def _build_image_layer_datauri(self, rel_path):
+    def _build_multi_file_image_layer_conf(self, files):
+        """Build each layer in the layers section.
+
+        returns e.g
+
+        {
+          'type': 'RASTER',
+          'url': DataURI({})
+          'name': 'rasters'
+        }
+        """
+        return {
+            "type": "RASTER",
+            "url": self._build_image_layer_datauri([file for file in files]),
+            "name": "raster",
+        }
+
+    def _build_image_layer_datauri(self, rel_paths):
         """
         Specifically for the RASTERS schema, we need to build a DataURI of the schema because
         it contains a URL for a file whose location is unknown until pipelines have been run.
@@ -247,13 +304,15 @@ class Vitessce:
         """
 
         image_layer = {}
-        image_layer["images"] = [self._build_image_schema(rel_path)]
+        image_layer["images"] = [
+            self._build_image_schema(rel_path) for rel_path in rel_paths
+        ]
         image_layer["schemaVersion"] = "0.0.2"
         return DataURI.make(
             "text/plain", charset="us-ascii", base64=True, data=json.dumps(image_layer)
         )
 
-    def _build_image_schema(self, rel_path):
+    def _build_image_schema(self, image_rel_path):
         """
         Builds the 'images' sections of the RASTER schema.
 
@@ -268,12 +327,15 @@ class Vitessce:
         """
 
         schema = {}
-        schema["name"] = Path(rel_path).name
+        schema["name"] = Path(image_rel_path).name
         schema["type"] = "ome-tiff"
-        schema["url"] = self._build_assets_url(rel_path)
+        schema["url"] = self._build_assets_url(image_rel_path)
         schema["metadata"] = {}
-        offsets_path = Path(CODEX_OFFSETS_PATH) / Path(
-            Path(rel_path).name.replace("ome.tiff", "offsets.json")
+        imaging_paths = IMAGING_PATHS[self.assay_type]
+        offsets_path = (
+            image_rel_path.replace(imaging_paths["image"], imaging_paths["offsets"])
+            .replace("ome.tiff", "offsets.json")
+            .replace("ome.tif", "offsets.json")
         )
         schema["metadata"]["omeTiffOffsetsUrl"] = self._build_assets_url(
             str(offsets_path)

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -122,7 +122,10 @@ ASSAY_CONF_LOOKUP = {
         # We can actually fetch height/width using a COG tiff library, but for now this will do.
         "view": {"zoom": -6.5, "target": [1000, 1000, 0]},
         "files_conf": [
-            {"rel_path": re.escape(IMAGE_PYRAMID_PATH) + r"/.*\.ome\.tiff?$", "type": "RASTER" },
+            {
+                "rel_path": re.escape(IMAGE_PYRAMID_PATH) + r"/.*\.ome\.tiff?$",
+                "type": "RASTER",
+            },
         ],
     },
 }
@@ -333,8 +336,10 @@ class Vitessce:
         schema["metadata"] = {}
         imaging_paths = IMAGING_PATHS[self.assay_type]
         offsets_path = re.sub(
-            r'ome\.tiff?$', 'offsets.json',
-            image_rel_path.replace(imaging_paths["image"], imaging_paths["offsets"]))
+            r"ome\.tiff?$",
+            "offsets.json",
+            image_rel_path.replace(imaging_paths["image"], imaging_paths["offsets"]),
+        )
         schema["metadata"]["omeTiffOffsetsUrl"] = self._build_assets_url(
             str(offsets_path)
         )

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -112,7 +112,7 @@ ASSAY_CONF_LOOKUP = {
                 "type": "GENES",
             },
             {
-                "rel_path": CODDEX_SPRM_PATH + "/" + TILE_REGEX + ".clusters.json",
+                "rel_path": f"{CODDEX_SPRM_PATH}/{TILE_REGEX}.clusters.json",
                 "type": "CLUSTERS",
             },
         ],
@@ -122,7 +122,7 @@ ASSAY_CONF_LOOKUP = {
         # We can actually fetch height/width using a COG tiff library, but for now this will do.
         "view": {"zoom": -6.5, "target": [1000, 1000, 0]},
         "files_conf": [
-            {"rel_path": IMAGE_PYRAMID_PATH + r"/.*.ome.tif(f?)", "type": "RASTER", },
+            {"rel_path": re.escape(IMAGE_PYRAMID_PATH) + r"/.*\.ome\.tiff?$", "type": "RASTER" },
         ],
     },
 }
@@ -266,7 +266,7 @@ class Vitessce:
 
         {
           'type': 'RASTER',
-          'url': DataURI({})
+          'url': 'data:base-64-encoded-string'
           'name': 'rasters'
         }
         """
@@ -332,11 +332,9 @@ class Vitessce:
         schema["url"] = self._build_assets_url(image_rel_path)
         schema["metadata"] = {}
         imaging_paths = IMAGING_PATHS[self.assay_type]
-        offsets_path = (
-            image_rel_path.replace(imaging_paths["image"], imaging_paths["offsets"])
-            .replace("ome.tiff", "offsets.json")
-            .replace("ome.tif", "offsets.json")
-        )
+        offsets_path = re.sub(
+            r'ome\.tiff?$', 'offsets.json',
+            image_rel_path.replace(imaging_paths["image"], imaging_paths["offsets"]))
         schema["metadata"]["omeTiffOffsetsUrl"] = self._build_assets_url(
             str(offsets_path)
         )

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -77,8 +77,8 @@ CODDEX_SPRM_PATH = "output_json"
 
 # Hardcoded CODEX offsets and tile path.
 IMAGING_PATHS = {
-    CODEX_CYTOKIT: {"offsets": OFFSETS_PATH, "image": CODEX_TILE_PATH,},
-    IMAGE_PYRAMID: {"offsets": OFFSETS_PATH, "image": IMAGE_PYRAMID_PATH,},
+    CODEX_CYTOKIT: {"offsets": OFFSETS_PATH, "image": CODEX_TILE_PATH, },
+    IMAGE_PYRAMID: {"offsets": OFFSETS_PATH, "image": IMAGE_PYRAMID_PATH, },
 }
 
 TILE_REGEX = r"R\d+_X\d+_Y\d+"
@@ -122,7 +122,7 @@ ASSAY_CONF_LOOKUP = {
         # We can actually fetch height/width using a COG tiff library, but for now this will do.
         "view": {"zoom": -6.5, "target": [1000, 1000, 0]},
         "files_conf": [
-            {"rel_path": IMAGE_PYRAMID_PATH + r"/.*.ome.tif(f?)", "type": "RASTER",},
+            {"rel_path": IMAGE_PYRAMID_PATH + r"/.*.ome.tif(f?)", "type": "RASTER", },
         ],
     },
 }

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -81,6 +81,8 @@ IMAGING_PATHS = {
     IMAGE_PYRAMID: {"offsets": OFFSETS_PATH, "image": IMAGE_PYRAMID_PATH,},
 }
 
+TILE_REGEX = r"R\d+_X\d+_Y\d+"
+
 ASSAY_CONF_LOOKUP = {
     SCRNA_SEQ: {
         "base_conf": SCATTERPLOT,
@@ -94,23 +96,23 @@ ASSAY_CONF_LOOKUP = {
         "view": {"zoom": -1.5, "target": [600, 600, 0]},
         "files_conf": [
             {
-                "rel_path": str(Path(CODEX_TILE_PATH) / "#TILE#.ome.tiff"),
+                "rel_path": CODEX_TILE_PATH + "/" + TILE_REGEX + ".ome.tiff",
                 "type": "RASTER",
             },
             {
-                "rel_path": str(Path(CODDEX_SPRM_PATH) / "#TILE#.cells.json"),
+                "rel_path": CODDEX_SPRM_PATH + "/" + TILE_REGEX + ".cells.json",
                 "type": "CELLS",
             },
             {
-                "rel_path": str(Path(CODDEX_SPRM_PATH) / "#TILE#.cell-sets.json"),
+                "rel_path": CODDEX_SPRM_PATH + "/" + TILE_REGEX + ".cell-sets.json",
                 "type": "CELL-SETS",
             },
             {
-                "rel_path": str(Path(CODDEX_SPRM_PATH) / "#TILE#.genes.json"),
+                "rel_path": CODDEX_SPRM_PATH + "/" + TILE_REGEX + ".genes.json",
                 "type": "GENES",
             },
             {
-                "rel_path": str(Path(CODDEX_SPRM_PATH) / "#TILE#.clusters.json"),
+                "rel_path": CODDEX_SPRM_PATH + "/" + TILE_REGEX + ".clusters.json",
                 "type": "CLUSTERS",
             },
         ],
@@ -128,12 +130,10 @@ ASSAY_CONF_LOOKUP = {
 IMAGE_ASSAYS = [CODEX_CYTOKIT, IMAGE_PYRAMID]
 TILED_ASSAYS = [CODEX_CYTOKIT]
 
-TILE_REGEX = r"R\d+_X\d+_Y\d+"
-
 MOCK_URL = "https://example.com"
 
 
-def _get_matching_files(files, regex):
+def _get_matches(files, regex):
     return list(
         set(
             [
@@ -217,7 +217,7 @@ class Vitessce:
             self.conf = conf
             return conf
         elif self.assay_type in TILED_ASSAYS:
-            found_tiles = _get_matching_files(file_paths_found, TILE_REGEX)
+            found_tiles = _get_matches(file_paths_found, TILE_REGEX)
             confs = []
             for tile in sorted(found_tiles):
                 new_conf = copy.deepcopy(conf)
@@ -229,7 +229,7 @@ class Vitessce:
             self.conf = confs
             return confs
         elif self.assay_type in IMAGE_ASSAYS:
-            found_images = _get_matching_files(file_paths_found, files[0]["rel_path"])
+            found_images = _get_matches(file_paths_found, files[0]["rel_path"])
             layer = self._build_multi_file_image_layer_conf(found_images)
             conf["layers"] = [layer]
             conf["name"] = self.uuid
@@ -251,10 +251,10 @@ class Vitessce:
 
         return {
             "type": file["type"],
-            "url": self._build_assets_url(file["rel_path"].replace("#TILE#", tile))
+            "url": self._build_assets_url(file["rel_path"].replace(TILE_REGEX, tile))
             if file["type"] != "RASTER"
             else self._build_image_layer_datauri(
-                [file["rel_path"].replace("#TILE#", tile)]
+                [file["rel_path"].replace(TILE_REGEX, tile)]
             ),
             "name": file["type"].lower(),
         }


### PR DESCRIPTION
This should give us a generic view configuration for image pyramids that will allow users (especially Ivan) to spot check runs immediately.  This also cleans up the CODEX stuff a bit to match more what we have now for pyramids.

Here are some uuids to check that the view config works:

AF: ec27c2b6b5f177c0ca6387120d8736b0 (should work)
CODEX: 53f19f543429a03af5a6c0e333f593de (getting a 403 and not sure why, but the configuration looks right)
PAS: 2ce183e38a31ff1d836675d3b75654b0 (part of the image is cutoff, a known bug, and the colors are wrong which is because we don't have rgb handling yet in vitessce)