### PR TITLE
John conroy/alert no prov

### DIFF
--- a/CHANGELOG-alert-no-prov.md
+++ b/CHANGELOG-alert-no-prov.md
@@ -1,0 +1,1 @@
+- Display alert in provenance section when provenance data is unavailable.

--- a/context/app/static/js/components/Detail/Dataset/Dataset.jsx
+++ b/context/app/static/js/components/Detail/Dataset/Dataset.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'shared-styles/Links';
-import ProvTabs from '../ProvTabs';
+import ProvSection from '../ProvSection';
 import Summary from '../Summary';
 import Attribution from '../Attribution';
 import Protocol from '../Protocol';
@@ -100,7 +100,7 @@ function DatasetDetail(props) {
           created_by_user_displayname={created_by_user_displayname}
           created_by_user_email={created_by_user_email}
         />
-        <ProvTabs uuid={uuid} assayMetadata={assayMetadata} entityEndpoint={entityEndpoint} />
+        <ProvSection uuid={uuid} assayMetadata={assayMetadata} entityEndpoint={entityEndpoint} />
         {shouldDisplaySection.protocols && (
           <Protocol protocol_url={protocol_url} portal_uploaded_protocol_files={portal_uploaded_protocol_files} />
         )}

--- a/context/app/static/js/components/Detail/Donor/Donor.jsx
+++ b/context/app/static/js/components/Detail/Donor/Donor.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import ProvTabs from '../ProvTabs';
+import ProvSection from '../ProvSection';
 import Summary from '../Summary';
 import Attribution from '../Attribution';
 import Protocol from '../Protocol';
@@ -47,7 +47,7 @@ function DonorDetail(props) {
           created_by_user_displayname={created_by_user_displayname}
           created_by_user_email={created_by_user_email}
         />
-        <ProvTabs uuid={uuid} assayMetadata={assayMetadata} entityEndpoint={entityEndpoint} />
+        <ProvSection uuid={uuid} assayMetadata={assayMetadata} entityEndpoint={entityEndpoint} />
         {shouldDisplaySection.protocols && (
           <Protocol protocol_url={protocol_url} portal_uploaded_protocol_files={portal_uploaded_protocol_files} />
         )}

--- a/context/app/static/js/components/Detail/ProvSection/ProvSection.jsx
+++ b/context/app/static/js/components/Detail/ProvSection/ProvSection.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Alert from '@material-ui/lab/Alert';
 
-import { readCookie } from 'helpers/functions';
+import useProvData from 'hooks/useProvData';
 import ProvTabs from '../ProvTabs';
 import SectionHeader from '../SectionHeader';
 import SectionContainer from '../SectionContainer';
@@ -11,33 +11,7 @@ function ProvSection(props) {
   const { uuid, assayMetadata, entityEndpoint } = props;
   const { entity_type } = assayMetadata;
 
-  const [provData, setProvData] = React.useState(null);
-  const [isLoading, setIsLoading] = React.useState(true);
-
-  React.useEffect(() => {
-    async function getAndSetProvData() {
-      const nexus_token = readCookie('nexus_token');
-      const requestInit = nexus_token
-        ? {
-            headers: {
-              Authorization: `Bearer ${nexus_token}`,
-            },
-          }
-        : {};
-
-      const response = await fetch(`${entityEndpoint}/entities/${uuid}/provenance`, requestInit);
-
-      if (!response.ok) {
-        console.error('Prov API failed', response);
-        setIsLoading(false);
-        return;
-      }
-      const responseProvData = await response.json();
-      setProvData(responseProvData);
-      setIsLoading(false);
-    }
-    getAndSetProvData();
-  }, [entityEndpoint, uuid]);
+  const { provData, isLoading } = useProvData(uuid, entityEndpoint);
 
   if (isLoading) {
     return (

--- a/context/app/static/js/components/Detail/ProvSection/ProvSection.jsx
+++ b/context/app/static/js/components/Detail/ProvSection/ProvSection.jsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Alert from '@material-ui/lab/Alert';
+
+import { readCookie } from 'helpers/functions';
+import ProvTabs from '../ProvTabs';
+import SectionHeader from '../SectionHeader';
+import SectionContainer from '../SectionContainer';
+
+function ProvSection(props) {
+  const { uuid, assayMetadata, entityEndpoint } = props;
+  const { entity_type } = assayMetadata;
+
+  const [provData, setProvData] = React.useState(null);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    async function getAndSetProvData() {
+      const nexus_token = readCookie('nexus_token');
+      const requestInit = nexus_token
+        ? {
+            headers: {
+              Authorization: `Bearer ${nexus_token}`,
+            },
+          }
+        : {};
+
+      const response = await fetch(`${entityEndpoint}/entities/${uuid}/provenance`, requestInit);
+
+      if (!response.ok) {
+        console.error('Prov API failed', response);
+        setIsLoading(false);
+        return;
+      }
+      const responseProvData = await response.json();
+      setProvData(responseProvData);
+      setIsLoading(false);
+    }
+    getAndSetProvData();
+  }, [entityEndpoint, uuid]);
+
+  if (isLoading) {
+    return (
+      <SectionContainer id="provenance">
+        <SectionHeader>Provenance</SectionHeader>
+      </SectionContainer>
+    );
+  }
+
+  return (
+    <SectionContainer id="provenance">
+      <SectionHeader>Provenance</SectionHeader>
+      {provData ? (
+        <ProvTabs uuid={uuid} assayMetadata={assayMetadata} provData={provData} />
+      ) : (
+        <Alert variant="filled" severity="warning">
+          {`We were unable to retrieve provenance information for this ${entity_type.toLowerCase()}.`}
+        </Alert>
+      )}
+    </SectionContainer>
+  );
+}
+
+ProvSection.propTypes = {
+  uuid: PropTypes.string.isRequired,
+  // eslint-disable-next-line react/forbid-prop-types
+  assayMetadata: PropTypes.object.isRequired,
+  entityEndpoint: PropTypes.string.isRequired,
+};
+
+export default ProvSection;

--- a/context/app/static/js/components/Detail/ProvSection/index.js
+++ b/context/app/static/js/components/Detail/ProvSection/index.js
@@ -1,0 +1,3 @@
+import ProvSection from './ProvSection';
+
+export default ProvSection;

--- a/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Paper from '@material-ui/core/Paper';
+
 import { StyledTab, StyledTabs, StyledTabPanel } from './style';
 import ProvGraph from '../ProvGraph';
 import ProvTable from '../ProvTable';
 import ProvAnalysisDetails from '../ProvAnalysisDetails';
-import SectionHeader from '../SectionHeader';
-import SectionContainer from '../SectionContainer';
-import { readCookie } from '../../../helpers/functions';
 
 function ProvTabs(props) {
-  const { uuid, assayMetadata, entityEndpoint } = props;
+  const { uuid, assayMetadata, provData } = props;
   const { metadata, entity_type, ancestors } = assayMetadata;
 
   const [open, setOpen] = React.useState(0);
@@ -20,69 +18,40 @@ function ProvTabs(props) {
 
   const shouldDisplayDag = entity_type === 'Dataset' && metadata && 'dag_provenance_list' in metadata;
 
-  const [provData, setProvData] = React.useState(null);
-  React.useEffect(() => {
-    async function getAndSetProvData() {
-      const nexus_token = readCookie('nexus_token');
-      const requestInit = nexus_token
-        ? {
-            headers: {
-              Authorization: `Bearer ${nexus_token}`,
-            },
-          }
-        : {};
-      const response = await fetch(`${entityEndpoint}/entities/${uuid}/provenance`, requestInit);
-      if (!response.ok) {
-        console.error('Prov API failed', response);
-        return;
-      }
-      const responseProvData = await response.json();
-      setProvData(responseProvData);
-    }
-    getAndSetProvData();
-  }, [entityEndpoint, uuid]);
-
   return (
-    <SectionContainer id="provenance">
-      <SectionHeader>Provenance</SectionHeader>
-      <Paper>
-        <StyledTabs
-          variant="standard"
-          value={open}
-          onChange={handleChange}
-          aria-label="Detail View Tabs"
-          TabIndicatorProps={{ style: { backgroundColor: '#9CB965' } }}
-        >
-          <StyledTab label="Table" id="tab-0" aria-controls="tabpanel-0" />
-          <StyledTab label="Graph" id="tab-1" aria-controls="tabpanel-1" />
-          {shouldDisplayDag && <StyledTab label="Analysis Details" id="tab-2" aria-controls="tabpanel-2" />}
-        </StyledTabs>
-        {provData && (
-          <>
-            <StyledTabPanel value={open} index={0} pad={1}>
-              <ProvTable
-                provData={provData}
-                uuid={uuid}
-                entity_type={entity_type}
-                typesToSplit={['Donor', 'Sample', 'Dataset']}
-                ancestors={ancestors}
-                assayMetadata={assayMetadata}
-              />
-            </StyledTabPanel>
-            <StyledTabPanel value={open} index={1}>
-              <span id="prov-vis-react">
-                <ProvGraph provData={provData} />
-              </span>
-            </StyledTabPanel>
-            <StyledTabPanel value={open} index={2} pad={1}>
-              {shouldDisplayDag && (
-                <ProvAnalysisDetails dagListData={metadata.dag_provenance_list} dagData={metadata.dag_provenance} />
-              )}
-            </StyledTabPanel>
-          </>
+    <Paper>
+      <StyledTabs
+        variant="standard"
+        value={open}
+        onChange={handleChange}
+        aria-label="Detail View Tabs"
+        TabIndicatorProps={{ style: { backgroundColor: '#9CB965' } }}
+      >
+        <StyledTab label="Table" id="tab-0" aria-controls="tabpanel-0" />
+        <StyledTab label="Graph" id="tab-1" aria-controls="tabpanel-1" />
+        {shouldDisplayDag && <StyledTab label="Analysis Details" id="tab-2" aria-controls="tabpanel-2" />}
+      </StyledTabs>
+      <StyledTabPanel value={open} index={0} pad={1}>
+        <ProvTable
+          provData={provData}
+          uuid={uuid}
+          entity_type={entity_type}
+          typesToSplit={['Donor', 'Sample', 'Dataset']}
+          ancestors={ancestors}
+          assayMetadata={assayMetadata}
+        />
+      </StyledTabPanel>
+      <StyledTabPanel value={open} index={1}>
+        <span id="prov-vis-react">
+          <ProvGraph provData={provData} />
+        </span>
+      </StyledTabPanel>
+      <StyledTabPanel value={open} index={2} pad={1}>
+        {shouldDisplayDag && (
+          <ProvAnalysisDetails dagListData={metadata.dag_provenance_list} dagData={metadata.dag_provenance} />
         )}
-      </Paper>
-    </SectionContainer>
+      </StyledTabPanel>
+    </Paper>
   );
 }
 
@@ -90,7 +59,7 @@ ProvTabs.propTypes = {
   uuid: PropTypes.string.isRequired,
   // eslint-disable-next-line react/forbid-prop-types
   assayMetadata: PropTypes.object.isRequired,
-  entityEndpoint: PropTypes.string.isRequired,
+  provData: PropTypes.objectOf(PropTypes.object).isRequired,
 };
 
 export default ProvTabs;

--- a/context/app/static/js/components/Detail/Sample/Sample.jsx
+++ b/context/app/static/js/components/Detail/Sample/Sample.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
-import ProvTabs from '../ProvTabs';
+import ProvSection from '../ProvSection';
 import Summary from '../Summary';
 import Attribution from '../Attribution';
 import Protocol from '../Protocol';
@@ -60,7 +60,7 @@ function SampleDetail(props) {
           created_by_user_displayname={created_by_user_displayname}
           created_by_user_email={created_by_user_email}
         />
-        <ProvTabs uuid={uuid} assayMetadata={assayMetadata} entityEndpoint={entityEndpoint} />
+        <ProvSection uuid={uuid} assayMetadata={assayMetadata} entityEndpoint={entityEndpoint} />
         {shouldDisplaySection.protocols && (
           <Protocol protocol_url={protocol_url} portal_uploaded_protocol_files={portal_uploaded_protocol_files} />
         )}

--- a/context/app/static/js/hooks/useProvData.js
+++ b/context/app/static/js/hooks/useProvData.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { readCookie } from 'helpers/functions';
+
+function useProvData(uuid, entityEndpoint) {
+  const [provData, setProvData] = React.useState(undefined);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    async function getAndSetProvData() {
+      const nexus_token = readCookie('nexus_token');
+      const requestInit = nexus_token
+        ? {
+            headers: {
+              Authorization: `Bearer ${nexus_token}`,
+            },
+          }
+        : {};
+
+      const response = await fetch(`${entityEndpoint}/entities/${uuid}/provenance`, requestInit);
+
+      if (!response.ok) {
+        console.error('Prov API failed', response);
+        setIsLoading(false);
+        return;
+      }
+      const responseProvData = await response.json();
+      setProvData(responseProvData);
+      setIsLoading(false);
+    }
+    getAndSetProvData();
+  }, [entityEndpoint, uuid]);
+
+  return { provData, isLoading };
+}
+
+export default useProvData;


### PR DESCRIPTION
Fixes #838.

- Used a guard clause instead of adding a short-circuit inside `ProvSection` jsx.
- Added `useProvData` hook which keeps state for both `provData` and `isLoading`. Is this an improvement to you? If so, we could probably create another hook, something like `useAsyncData`, to extract common code for hooks used to fetch data.
- I chose not to display a progress loader while data is loading, but could if you think it makes sense.

<img width="1109" alt="Screen Shot 2020-07-21 at 10 09 04 AM" src="https://user-images.githubusercontent.com/62477388/88072880-91590880-cb43-11ea-8e83-a70be9bc64c0.png">
