### PR TITLE
Mccalluc/eslint fail fast

### DIFF
--- a/CHANGELOG-eslint-earlier.md
+++ b/CHANGELOG-eslint-earlier.md
@@ -1,0 +1,1 @@
+- Run eslint across all js/jsx before webpack.

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ Low-level unit tests are in python (`pytest -vv`),
 while end-to-end tests use [Cypress](https://docs.cypress.io/guides/overview/why-cypress.html) (`npm run cypress:open`).
 
 ## Linting
-In the `context/` directory, the following command can be run to allow eslint to fix problems:
-
-```sh
-npm run lint-fix
+In the `context/` directory, the following commands can find and fix eslint problems:
+```
+npm run lint
+npm run lint:fix
 ```
 
 ## Buid, tag, and deploy

--- a/context/app/static/js/components/ProvVis/__tests__/ProvData.spec.js
+++ b/context/app/static/js/components/ProvVis/__tests__/ProvData.spec.js
@@ -37,32 +37,19 @@ describe('ProvData methods', () => {
   const prov = new ProvData(fixtures.complex.prov);
 
   it('getParentEntityNames', () => {
-    expect(prov.getParentEntityNames('hubmap:act-4')).toEqual([
-      'hubmap:ent-1',
-      'hubmap:ent-3',
-      'hubmap:ent-4',
-    ]);
+    expect(prov.getParentEntityNames('hubmap:act-4')).toEqual(['hubmap:ent-1', 'hubmap:ent-3', 'hubmap:ent-4']);
   });
 
   it('getChildEntityNames', () => {
-    expect(prov.getChildEntityNames('hubmap:act-2')).toEqual([
-      'hubmap:ent-4',
-      'hubmap:ent-7',
-    ]);
+    expect(prov.getChildEntityNames('hubmap:act-2')).toEqual(['hubmap:ent-4', 'hubmap:ent-7']);
   });
 
   it('getParentActivityNames', () => {
-    expect(prov.getParentActivityNames('hubmap:ent-6')).toEqual([
-      'hubmap:act-4',
-    ]);
+    expect(prov.getParentActivityNames('hubmap:ent-6')).toEqual(['hubmap:act-4']);
   });
 
   it('getChildActivityNames', () => {
-    expect(prov.getChildActivityNames('hubmap:ent-1')).toEqual([
-      'hubmap:act-1',
-      'hubmap:act-2',
-      'hubmap:act-4',
-    ]);
+    expect(prov.getChildActivityNames('hubmap:ent-1')).toEqual(['hubmap:act-1', 'hubmap:act-2', 'hubmap:act-4']);
   });
 });
 

--- a/context/app/static/js/components/ProvVis/__tests__/ProvData.spec.js
+++ b/context/app/static/js/components/ProvVis/__tests__/ProvData.spec.js
@@ -1,6 +1,3 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import expect from 'expect';
-
 import ProvData, { makeCwlInput, makeCwlOutput } from '../ProvData';
 
 import * as fixtures from './fixtures';

--- a/context/app/static/js/components/ProvVis/__tests__/ProvData.spec.js
+++ b/context/app/static/js/components/ProvVis/__tests__/ProvData.spec.js
@@ -1,6 +1,7 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import expect from 'expect';
 
-import ProvData, { makeCwlInput, makeCwlOutput, expand } from '../ProvData';
+import ProvData, { makeCwlInput, makeCwlOutput } from '../ProvData';
 
 import * as fixtures from './fixtures';
 

--- a/context/app/static/js/components/ProvVis/__tests__/ProvVis.spec.js
+++ b/context/app/static/js/components/ProvVis/__tests__/ProvVis.spec.js
@@ -21,10 +21,9 @@ describe('ProvVis', () => {
   });
 
   it('renders React component', () => {
-    render(<ProvVis prov={simple.prov} />, node,
-      () => {
-        // TODO: Just getting empty div.
-        // expect(node.innerHTML).toContain('svg')
-      });
+    render(<ProvVis prov={simple.prov} />, node, () => {
+      // TODO: Just getting empty div.
+      // expect(node.innerHTML).toContain('svg')
+    });
   });
 });

--- a/context/app/static/js/components/ProvVis/__tests__/ProvVis.spec.js
+++ b/context/app/static/js/components/ProvVis/__tests__/ProvVis.spec.js
@@ -1,4 +1,3 @@
-// import expect from 'expect';
 import React from 'react';
 import { render, unmountComponentAtNode } from 'react-dom';
 

--- a/context/app/static/js/components/ProvVis/__tests__/fixtures/index.js
+++ b/context/app/static/js/components/ProvVis/__tests__/fixtures/index.js
@@ -8,7 +8,7 @@ import simpleCwl from './simple-cwl.json';
 import cwlProv from './primary.cwlprov.json';
 
 // This file just builds test fixtures: it has no tests of its own.
-test.skip('skip', () => { });
+test.skip('skip', () => {});
 
 const PROV_NS = 'prov:';
 

--- a/context/app/static/js/components/ProvVis/__tests__/fixtures/index.js
+++ b/context/app/static/js/components/ProvVis/__tests__/fixtures/index.js
@@ -2,7 +2,7 @@ import realProv from './real-prov.json';
 import realCwl from './real-cwl.json';
 import complexProv from './complex-prov.json';
 import complexCwl from './complex-cwl.json';
-import simpleProv from './simple-prov';
+import simpleProv from './simple-prov.json';
 import simpleCwl from './simple-cwl.json';
 
 import cwlProv from './primary.cwlprov.json';

--- a/context/package.json
+++ b/context/package.json
@@ -79,6 +79,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
-    "lint-fix": "eslint -c .eslintrc.yml --ext .js,.jsx --fix app/static/js/"
+    "lint": "eslint -c .eslintrc.yml --ext .js,.jsx app/static/js/",
+    "lint:fix": "eslint -c .eslintrc.yml --ext .js,.jsx --fix app/static/js/"
   }
 }

--- a/dev-start.sh
+++ b/dev-start.sh
@@ -20,6 +20,9 @@ fi
 grep 'TODO' "$APP_CONF" && die "Replace 'TODO' in $APP_CONF."
 
 FLASK_ENV=development FLASK_APP="$CONTEXT/app/main.py" python -m flask run &
-cd $CONTEXT && npm install && npm run dev-server &
+cd $CONTEXT
+npm install
+npm run lint || die 'Try "npm run lint:fix"'
+npm run dev-server &
 
 wait


### PR DESCRIPTION
Fix #861

- Rename `lint-fix` to `lint:fix`, and add a plain `lint`
- Lint all JS code, including tests.
- Fix linting problems in tests.

Questions:
- Linting tests is worthwhile?
- Webpack was already linting, but only after the build was complete, and it wasn't covering tests. Perhaps linting could be turned off in webpack, if we're now doing it externally?
- Is adding `expect` as a peer dependency the right thing to do, since we're getting it from elsewhere? Or is something else better?