### PR TITLE
Remove bad link. Fix #830

### DIFF
--- a/CHANGELOG-help-404.md
+++ b/CHANGELOG-help-404.md
@@ -1,0 +1,1 @@
+- In the narrow layout, the header linked to "/help", which is not valid. Help is still available from "/docs".

--- a/context/app/static/js/components/Header/Menu/Menu.jsx
+++ b/context/app/static/js/components/Header/Menu/Menu.jsx
@@ -43,7 +43,6 @@ function Menu(props) {
             <DropdownLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
               CCF
             </DropdownLink>
-            <DropdownLink href="/help">Help</DropdownLink>
           </MenuList>
         </WidePaper>
       </WidePopper>


### PR DESCRIPTION
Remove bad link. If this could have been done with just CSS, that might have been good, but not something to worry about now.