### PR TITLE
Mccalluc/npm ci

### DIFF
--- a/CHANGELOG-dockerfile.md
+++ b/CHANGELOG-dockerfile.md
@@ -1,0 +1,1 @@
+- Tweaks to make docker build a little faster.

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,14 +1,14 @@
 FROM node:12.16.3-alpine as builder
 WORKDIR /work
-RUN apk add --no-cache python git
+RUN apk add --no-cache python
 
 # COPY only what is needed so layers can be cached.
 COPY package.json .
 COPY package-lock.json .
 
-RUN npm install
+RUN npm ci
 
-# TODO: Copy only the JS for the npm build.
+# Most of our changes are in the JS, so don't worry about blowing away cache.
 COPY . .
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:12.16.3-alpine as builder
 WORKDIR /work
-RUN apk add --no-cache python
+RUN apk add --no-cache python git
 
 # COPY only what is needed so layers can be cached.
 COPY package.json .


### PR DESCRIPTION
Prompted by your note about the vitessce build being slow... I didn't find any easy answers, but in on Travis or in docker, `npm ci` may be good.  