### PR TITLE
Moved text on submission instructions from HELP to SUBMISSION document

### DIFF
--- a/context/app/markdown/docs/submission.md
+++ b/context/app/markdown/docs/submission.md
@@ -78,3 +78,31 @@ Data centers provide the following 4 data types (Figure 3)for each data submissi
 
 As an example, here is a link to the CODEX metadata fields, required input and descriptions: 
 **[example assay metadata for CODEX](https://github.com/hubmapconsortium/ingest-validation-tools/blob/master/docs/codex/README.md)**
+
+
+### How to register samples and sample data.
+
+The [*ingest* page](https://ingest.hubmapconsortium.org) in the HuBMAP portal displays buttons to access the *HuBMAP ID* system and the *HuBMAP Data Ingest* system:
+
+![](https://lh6.googleusercontent.com/RZYfyffyjMBI3A3CJeUl4pIj1zAhsVQvEzouYgciB3KlJAQcKz6bZAEOVi-7TC65U7kV5Eh8681DWPM9ioAPq8Ah6Fg46N5nKvU8SX_olfmvvbERbrhMPEcfF4c54D-4g--_kM-P)
+
+- *Register or search for donors and donor samples:*
+Users can register or search for donors, donor organs and tissues through the *HuBMAP ID* system. Sample data may be searched by organization that provided the donor sample, *Sample Type* and/or by keywords.
+- *Register or search for assay data:*
+Users can enter or search for HuBMAP data through the *HuBMAP Data Ingest* system. Data may be filtered by the organization that generated the data and/or by keywords.
+
+### How to download data from the HuBMAP portal.
+
+From the [*ingest* page](https://ingest.hubmapconsortium.org), search for data from *HuBMAP Data Ingest* system. Click the blue Filter button:
+
+![](https://lh3.googleusercontent.com/qxOCLtf_W2Z-zNUgogmYy4IQOrYuHloiYgTNmsUT42J6kSfF32sFM3IxzmkPev2dgGsn8X3DvxuB7kubZ4aBlENm0yVDnOuusFU1VGEGbFzd0cKD7NfK4Irn6qFOMFZ0yrtuGrIk)
+
+Select the **Data** link on the right side of the grid to be directed to the Globus repository. 
+
+![](https://lh4.googleusercontent.com/g5vZzYHUGpvU8tP7bfpZYDSAMduNBZ4kP7Ug_iXbXPQoVZ0lLRSAvvC9A6nrUjmkerV2ogrMGsUjeHzLN0Pjov-gkJPdVfmGng8lq2SfaDzXtCOupLxH8zJc2_0emHJOlXlRjbBj)
+
+The *Download* option will be listed on the right side of the the Globus directory for the selected dataset.
+
+![](https://lh6.googleusercontent.com/o0bTXiYGmELDK6NUGZQSMcNImXGiY3JWkGzT9Nzf5qCsLzRjXSgWKsopaJZWxk-1l18eys3frlzMAZkbh4DxE6dYF10Ldov9UGTDkZZLuT25NKSvjsJd-0Tmsma29MQwK-RRInwg)
+
+


### PR DESCRIPTION
The HELP page will just show the contact info for those seeking help.