### PR TITLE
Removed submission info from HELP page

### DIFF
--- a/context/app/markdown/docs/help.md
+++ b/context/app/markdown/docs/help.md
@@ -1,37 +1,5 @@
 # Help
 
-**How to** register samples and sample data.
-
-The [*ingest* page](https://ingest.hubmapconsortium.org) in the HuBMAP portal displays buttons to access the *HuBMAP ID* system and the *HuBMAP Data Ingest* system:
-
-![](https://lh6.googleusercontent.com/RZYfyffyjMBI3A3CJeUl4pIj1zAhsVQvEzouYgciB3KlJAQcKz6bZAEOVi-7TC65U7kV5Eh8681DWPM9ioAPq8Ah6Fg46N5nKvU8SX_olfmvvbERbrhMPEcfF4c54D-4g--_kM-P)
-
-- *Register or search for donors and donor samples:*
-Users can register or search for donors, donor organs and tissues through the *HuBMAP ID* system. Sample data may be searched by organization that provided the donor sample, *Sample Type* and/or by keywords.
-- *Register or search for assay data:*
-Users can enter or search for HuBMAP data through the *HuBMAP Data Ingest* system. Data may be filtered by the organization that generated the data and/or by keywords.
-
-**How to** [Submit a Dataset to HuBMAP](/docs/submission).
-This document covers the following topics:
-
-- *Required components and general structure of a data submission directory*
-- *Preparing an assay metadata.tsv for data submission*
-
-
-**How to** download data from the HuBMAP portal.
-
-From the [*ingest* page](https://ingest.hubmapconsortium.org), search for data from *HuBMAP Data Ingest* system. Click the blue Filter button:
-
-![](https://lh3.googleusercontent.com/qxOCLtf_W2Z-zNUgogmYy4IQOrYuHloiYgTNmsUT42J6kSfF32sFM3IxzmkPev2dgGsn8X3DvxuB7kubZ4aBlENm0yVDnOuusFU1VGEGbFzd0cKD7NfK4Irn6qFOMFZ0yrtuGrIk)
-
-Select the **Data** link on the right side of the grid to be directed to the Globus repository. 
-
-![](https://lh4.googleusercontent.com/g5vZzYHUGpvU8tP7bfpZYDSAMduNBZ4kP7Ug_iXbXPQoVZ0lLRSAvvC9A6nrUjmkerV2ogrMGsUjeHzLN0Pjov-gkJPdVfmGng8lq2SfaDzXtCOupLxH8zJc2_0emHJOlXlRjbBj)
-
-The *Download* option will be listed on the right side of the the Globus directory for the selected dataset.
-
-![](https://lh6.googleusercontent.com/o0bTXiYGmELDK6NUGZQSMcNImXGiY3JWkGzT9Nzf5qCsLzRjXSgWKsopaJZWxk-1l18eys3frlzMAZkbh4DxE6dYF10Ldov9UGTDkZZLuT25NKSvjsJd-0Tmsma29MQwK-RRInwg)
-
-**How to** get technical support, feature requests, bug reports. 
+## How to get technical support, submit feature requests or bug reports. 
 Go to:
 help@hubmapconsortium.org


### PR DESCRIPTION
Submission info has been moved to the SUBMISSION page. HELP will just show the help contact info.