### PR TITLE
More Single Cell Assays

### DIFF
--- a/CHANGELOG-single_cell_viz.md
+++ b/CHANGELOG-single_cell_viz.md
@@ -1,0 +1,1 @@
+- Add more single cell assay support.

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -81,9 +81,18 @@ IMAGING_ONLY = {
 
 CODEX_CYTOKIT = "codex_cytokit"
 IMAGE_PYRAMID = "image_pyramid"
-SCRNA_SEQ = "salmon_rnaseq_10x"
 
-SCRNASEQ_BASE_PATH = "cluster-marker-genes/output/cluster_marker_genes"
+SCRNA_SEQ_10X = "salmon_rnaseq_10x"
+SCRNA_SEQ_SCI = "salmon_rnaseq_sciseq"
+SCRNA_SEQ_SNARE = "salmon_rnaseq_snareseq"
+
+SCATAC_SEQ_SCI = "sc_atac_seq_sci"
+SCATAC_SEQ_SNARE = "sc_atac_seq_snare"
+SCATAC_SEQ_SN = "sc_atac_seq_sn"
+
+SCRNA_SEQ_BASE_PATH = "cluster-marker-genes/output/cluster_marker_genes"
+SCATAC_SEQ_BASE_PATH = "output"
+
 OFFSETS_PATH = "output_offsets"
 IMAGE_PYRAMID_PATH = "ometiff-pyramids"
 CODEX_TILE_PATH = "output/extract/expressions/ome-tiff"
@@ -97,14 +106,29 @@ IMAGING_PATHS = {
 
 TILE_REGEX = r"R\d+_X\d+_Y\d+"
 
+SCRNA_SEQ_CONFIG = {
+    "base_conf": SCATTERPLOT,
+    "files_conf": [
+        {"rel_path": f"{SCRNA_SEQ_BASE_PATH}.cells.json", "type": "CELLS"},
+        {"rel_path": f"{SCRNA_SEQ_BASE_PATH}.cell-sets.json", "type": "CELL-SETS"},
+    ],
+}
+
+SCATAC_SEQ_CONFIG = {
+    "base_conf": SCATTERPLOT,
+    "files_conf": [
+        {"rel_path": f"{SCATAC_SEQ_BASE_PATH}/umap_coords_clusters.cells.json", "type": "CELLS"},
+        {"rel_path": f"{SCATAC_SEQ_BASE_PATH}/umap_coords_clusters.cell-sets.json", "type": "CELL-SETS"},
+    ],
+}
+
 ASSAY_CONF_LOOKUP = {
-    SCRNA_SEQ: {
-        "base_conf": SCATTERPLOT,
-        "files_conf": [
-            {"rel_path": f"{SCRNASEQ_BASE_PATH}.cells.json", "type": "CELLS"},
-            {"rel_path": f"{SCRNASEQ_BASE_PATH}.cell-sets.json", "type": "CELL-SETS"},
-        ],
-    },
+    SCRNA_SEQ_10X: SCRNA_SEQ_CONFIG,
+    SCRNA_SEQ_SCI: SCRNA_SEQ_CONFIG,
+    SCATAC_SEQ_SCI: SCATAC_SEQ_CONFIG,
+    SCRNA_SEQ_SNARE: SCRNA_SEQ_CONFIG,
+    SCATAC_SEQ_SNARE: SCATAC_SEQ_CONFIG,
+    SCATAC_SEQ_SN: SCATAC_SEQ_CONFIG,
     CODEX_CYTOKIT: {
         "base_conf": TILED_SPRM_IMAGING,
         "view": {"zoom": -1.5, "target": [600, 600, 0]},

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -118,7 +118,10 @@ SCATAC_SEQ_CONFIG = {
     "base_conf": SCATTERPLOT,
     "files_conf": [
         {"rel_path": f"{SCATAC_SEQ_BASE_PATH}/umap_coords_clusters.cells.json", "type": "CELLS"},
-        {"rel_path": f"{SCATAC_SEQ_BASE_PATH}/umap_coords_clusters.cell-sets.json", "type": "CELL-SETS"},
+        {
+            "rel_path": f"{SCATAC_SEQ_BASE_PATH}/umap_coords_clusters.cell-sets.json",
+            "type": "CELL-SETS",
+        },
     ],
 }
 


### PR DESCRIPTION
As per our call earlier today, we only have output data for `SCRNA_SEQ_10X`, `SCRNA_SEQ_SCI`, `SCRNA_SEQ_SNARE`, and `SCATAC_SEQ_SNARE` but I got the rest of the names from Matt so they can be ready when he has run the pipelines (which have identical outputs).

Some examples:
http://localhost:5001/browse/dataset/1cc5eea18dd72ccb0b298d89a6d3d0ce
http://localhost:5001/browse/dataset/3a1ae519d4d92cc0b1bfc78f5360b93e
http://localhost:5001/browse/dataset/70cb9d3f6edbacefdb0917f244e57689
http://localhost:5001/browse/dataset/18c14ef9165c978a14256674158cc181

I know one of these has a not-so-great initial view but I would like to wait to see more data before making any decisions about that.