### PR TITLE
John conroy/dua before globus

### DIFF
--- a/CHANGELOG-auto-open-link-after-dua-agree.md
+++ b/CHANGELOG-auto-open-link-after-dua-agree.md
@@ -1,0 +1,1 @@
+- Automatically open link in new window after agreeing to DUA.

--- a/CHANGELOG-dua-before-globus.md
+++ b/CHANGELOG-dua-before-globus.md
@@ -1,0 +1,1 @@
+- Require user to agree to DUA before accessing Globus files.

--- a/CHANGELOG-dua-typography.md
+++ b/CHANGELOG-dua-typography.md
@@ -1,0 +1,1 @@
+- Update DUA Typography.

--- a/context/app/static/js/components/Detail/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/Detail/FileBrowser/FileBrowser.jsx
@@ -1,48 +1,21 @@
-import React, { useState, useEffect, useContext } from 'react';
+import React, { useState, useEffect } from 'react';
 
-import DetailContext from '../context';
 import { relativeFilePathsToTree } from './utils';
 import FileBrowserNode from '../FileBrowserNode';
 import { ScrollPaper } from './style';
-import FileBrowserDUA from '../FileBrowserDUA';
 
 function FileBrowser(props) {
   const { files } = props;
-
-  const { data_access_level } = useContext(DetailContext);
-  const localStorageKey = `has_agreed_to_${data_access_level}_DUA`;
   const [fileTree, setFileTree] = useState({});
-  const [hasAgreedToDUA, agreeToDUA] = useState(localStorage.getItem(localStorageKey));
-  const [isDialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
     const treePath = relativeFilePathsToTree(files);
     setFileTree(treePath);
   }, [files]);
 
-  function handleDUAAgree() {
-    agreeToDUA(true);
-    localStorage.setItem(localStorageKey, true);
-    setDialogOpen(false);
-  }
-
-  function handleDUAClose() {
-    setDialogOpen(false);
-  }
-
-  function openDUA() {
-    setDialogOpen(true);
-  }
-
   return (
     <ScrollPaper>
-      <FileBrowserNode fileSubTree={fileTree} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} depth={0} />
-      <FileBrowserDUA
-        isOpen={isDialogOpen}
-        handleAgree={handleDUAAgree}
-        handleClose={handleDUAClose}
-        data_access_level={data_access_level}
-      />
+      <FileBrowserNode fileSubTree={fileTree} depth={0} />
     </ScrollPaper>
   );
 }

--- a/context/app/static/js/components/Detail/FileBrowserConditionalLink/FileBrowserConditionalLink.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserConditionalLink/FileBrowserConditionalLink.jsx
@@ -1,26 +1,27 @@
 /* eslint-disable react/jsx-props-no-spreading */
 import React from 'react';
-import { StyledLink } from './style';
+
+import { LightBlueLink } from 'shared-styles/Links';
 
 function ConditionalLink(props) {
-  const { hasAgreedToDUA, openDUA, href, children } = props;
+  const { hasAgreedToDUA, openDUA, href, children, ...rest } = props;
   if (hasAgreedToDUA) {
     return (
-      <StyledLink variant="body1" target="_blank" rel="noopener noreferrer" download underline="none" href={href}>
+      <LightBlueLink target="_blank" rel="noopener noreferrer" underline="none" href={href} {...rest}>
         {children}
-      </StyledLink>
+      </LightBlueLink>
     );
   }
   return (
-    <StyledLink
+    <LightBlueLink
       onClick={() => {
         openDUA();
       }}
-      variant="body1"
       underline="none"
+      {...rest}
     >
       {children}
-    </StyledLink>
+    </LightBlueLink>
   );
 }
 

--- a/context/app/static/js/components/Detail/FileBrowserConditionalLink/index.js
+++ b/context/app/static/js/components/Detail/FileBrowserConditionalLink/index.js
@@ -1,3 +1,0 @@
-import FileBrowserConditionalLink from './FileBrowserConditionalLink';
-
-export default FileBrowserConditionalLink;

--- a/context/app/static/js/components/Detail/FileBrowserConditionalLink/style.js
+++ b/context/app/static/js/components/Detail/FileBrowserConditionalLink/style.js
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-import { LightBlueLink } from 'shared-styles/Links';
-
-const StyledLink = styled(LightBlueLink)`
-  cursor: pointer;
-`;
-
-export { StyledLink };

--- a/context/app/static/js/components/Detail/FileBrowserDUA/FileBrowserDUA.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserDUA/FileBrowserDUA.jsx
@@ -3,13 +3,13 @@ import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
+import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'shared-styles/Links';
 import { getDUAText } from './utils';
-import { ObliqueSpan } from './style';
+import { ObliqueSpan, StyledHeader, StyledDiv } from './style';
 
 function FileBrowserDUA(props) {
   const { isOpen, handleAgree, handleClose, data_access_level } = props;
@@ -26,16 +26,20 @@ function FileBrowserDUA(props) {
       aria-describedby="alert-dialog-description"
     >
       <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          <h1 id="alert-dialog-title">
+        <StyledDiv id="alert-dialog-description">
+          <StyledHeader id="alert-dialog-title" variant="h2" component="h1">
             {'HuBMAP '} <ObliqueSpan>{`${title} Data`}</ObliqueSpan> {' Usage'}
-          </h1>
+          </StyledHeader>
 
-          <h2>Appropriate Use</h2>
-          <p>{appropriateUse}</p>
+          <StyledHeader variant="h4" component="h2">
+            Appropriate Use
+          </StyledHeader>
+          <Typography variant="body1">{appropriateUse}</Typography>
 
-          <h2>Acknowledgement</h2>
-          <p>
+          <StyledHeader variant="h4" component="h2">
+            Acknowledgement
+          </StyledHeader>
+          <Typography variant="body1">
             Investigators using HuBMAP data in publications or presentations are requested to cite The Human Body at
             Cellular Resolution: the NIH Human BioMolecular Atlas Program (doi:
             <LightBlueLink href="https://doi.org/10.1038/s41586-019-1629-x" target="_blank" rel="noopener noreferrer">
@@ -48,17 +52,19 @@ function FileBrowserDUA(props) {
               https://hubmapconsortium.org
             </LightBlueLink>
             .”
-          </p>
+          </Typography>
 
-          <h2>Data Sharing Policy</h2>
-          <p>
+          <StyledHeader variant="h4" component="h2">
+            Data Sharing Policy
+          </StyledHeader>
+          <Typography variant="body1">
             The HuBMAP Data Sharing Policy can be found at{' '}
             <LightBlueLink href="https://hubmapconsortium.org/policies/" target="_blank" rel="noopener noreferrer">
               https://hubmapconsortium.org/policies/
             </LightBlueLink>
             .
-          </p>
-        </DialogContentText>
+          </Typography>
+        </StyledDiv>
         <FormControlLabel
           control={
             <Checkbox

--- a/context/app/static/js/components/Detail/FileBrowserDUA/style.js
+++ b/context/app/static/js/components/Detail/FileBrowserDUA/style.js
@@ -1,7 +1,16 @@
 import styled from 'styled-components';
+import Typography from '@material-ui/core/Typography';
 
 const ObliqueSpan = styled.span`
   font-style: oblique 10deg;
 `;
 
-export { ObliqueSpan };
+const StyledHeader = styled(Typography)`
+  margin: ${(props) => props.theme.spacing(2)}px 0px;
+`;
+
+const StyledDiv = styled.div`
+  margin-bottom: ${(props) => props.theme.spacing(2)}px;
+`;
+
+export { ObliqueSpan, StyledHeader, StyledDiv };

--- a/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
@@ -24,6 +24,8 @@ function FileBrowserFile(props) {
           href={`${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`}
           hasAgreedToDUA={hasAgreedToDUA}
           openDUA={openDUA}
+          variant="body1"
+          download
         >
           {fileObj.file}
         </FileBrowserConditionalLink>

--- a/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
@@ -16,14 +16,16 @@ function FileBrowserFile(props) {
   const token = readCookie('nexus_token');
   const classes = useRoundedSecondaryTooltipStyles();
 
+  const fileUrl = `${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`;
+
   return (
     <StyledDiv>
       <IndentedDiv $depth={depth}>
         <StyledFileIcon color="primary" />
         <FilesConditionalLink
-          href={`${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`}
+          href={fileUrl}
           hasAgreedToDUA={hasAgreedToDUA}
-          openDUA={openDUA}
+          openDUA={() => openDUA(fileUrl)}
           variant="body1"
           download
         >

--- a/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
@@ -4,7 +4,7 @@ import prettyBytes from 'pretty-bytes';
 import { readCookie } from 'helpers/functions';
 
 import { useRoundedSecondaryTooltipStyles } from 'shared-styles/Tooltips';
-import FileBrowserConditionalLink from '../FilesConditionalLink';
+import FilesConditionalLink from '../FilesConditionalLink';
 import { StyledDiv, StyledFileIcon, IndentedDiv, FileSize, StyledInfoIcon } from './style';
 import DetailContext from '../context';
 import FilesContext from '../Files/context';
@@ -20,7 +20,7 @@ function FileBrowserFile(props) {
     <StyledDiv>
       <IndentedDiv $depth={depth}>
         <StyledFileIcon color="primary" />
-        <FileBrowserConditionalLink
+        <FilesConditionalLink
           href={`${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`}
           hasAgreedToDUA={hasAgreedToDUA}
           openDUA={openDUA}
@@ -28,7 +28,7 @@ function FileBrowserFile(props) {
           download
         >
           {fileObj.file}
-        </FileBrowserConditionalLink>
+        </FilesConditionalLink>
         <FileSize variant="body1">{prettyBytes(fileObj.size)}</FileSize>
         <Tooltip title={`${fileObj.description} (Format: ${fileObj.edam_term})`} classes={classes}>
           <StyledInfoIcon color="primary" />

--- a/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
@@ -7,12 +7,15 @@ import { useRoundedSecondaryTooltipStyles } from 'shared-styles/Tooltips';
 import FileBrowserConditionalLink from '../FileBrowserConditionalLink';
 import { StyledDiv, StyledFileIcon, IndentedDiv, FileSize, StyledInfoIcon } from './style';
 import DetailContext from '../context';
+import FilesContext from '../Files/context';
 
 function FileBrowserFile(props) {
-  const { fileObj, depth, hasAgreedToDUA, openDUA } = props;
+  const { fileObj, depth } = props;
+  const { hasAgreedToDUA, openDUA } = useContext(FilesContext);
   const { assetsEndpoint, uuid } = useContext(DetailContext);
   const token = readCookie('nexus_token');
   const classes = useRoundedSecondaryTooltipStyles();
+
   return (
     <StyledDiv>
       <IndentedDiv $depth={depth}>

--- a/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
@@ -4,7 +4,7 @@ import prettyBytes from 'pretty-bytes';
 import { readCookie } from 'helpers/functions';
 
 import { useRoundedSecondaryTooltipStyles } from 'shared-styles/Tooltips';
-import FileBrowserConditionalLink from '../FileBrowserConditionalLink';
+import FileBrowserConditionalLink from '../FilesConditionalLink';
 import { StyledDiv, StyledFileIcon, IndentedDiv, FileSize, StyledInfoIcon } from './style';
 import DetailContext from '../context';
 import FilesContext from '../Files/context';

--- a/context/app/static/js/components/Detail/FileBrowserNode/FileBrowserNode.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserNode/FileBrowserNode.jsx
@@ -5,20 +5,14 @@ import FileBrowserFile from '../FileBrowserFile';
 import { Column } from './style';
 
 function FileBrowserNode(props) {
-  const { fileSubTree, depth, hasAgreedToDUA, openDUA } = props;
+  const { fileSubTree, depth } = props;
   return Object.entries(fileSubTree).map(([k, v]) => {
     // if the object contains array of files, display all files
     if (k === 'files') {
       return (
         <Column key={`${k}-${depth}`}>
           {v.map((file) => (
-            <FileBrowserFile
-              key={file.rel_path}
-              fileObj={file}
-              depth={depth}
-              hasAgreedToDUA={hasAgreedToDUA}
-              openDUA={openDUA}
-            />
+            <FileBrowserFile key={file.rel_path} fileObj={file} depth={depth} />
           ))}
         </Column>
       );
@@ -26,7 +20,7 @@ function FileBrowserNode(props) {
     // if the object contains additional directories, display dir and continue down
     return (
       <FileBrowserDirectory key={`${k}-${depth}`} dirName={k.slice(0, -1)} depth={depth}>
-        <FileBrowserNode fileSubTree={v} depth={depth + 1} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} />
+        <FileBrowserNode fileSubTree={v} depth={depth + 1} />
       </FileBrowserDirectory>
     );
   });

--- a/context/app/static/js/components/Detail/Files/Files.jsx
+++ b/context/app/static/js/components/Detail/Files/Files.jsx
@@ -1,18 +1,50 @@
-import React from 'react';
+import React, { useState, useContext } from 'react';
 
+import DetailContext from '../context';
 import SectionHeader from '../SectionHeader';
 import SectionContainer from '../SectionContainer';
 import GlobusLink from '../GlobusLink';
 import FileBrowser from '../FileBrowser';
+import FileBrowserDUA from '../FileBrowserDUA';
+import FilesContext from './context';
 
 function Files(props) {
   const { files, entityEndpoint, uuid, display_doi } = props;
+
+  const { data_access_level } = useContext(DetailContext);
+
+  const localStorageKey = `has_agreed_to_${data_access_level}_DUA`;
+  const [hasAgreedToDUA, agreeToDUA] = useState(localStorage.getItem(localStorageKey));
+  const [isDialogOpen, setDialogOpen] = useState(false);
+
+  function handleDUAAgree() {
+    agreeToDUA(true);
+    localStorage.setItem(localStorageKey, true);
+    setDialogOpen(false);
+  }
+
+  function handleDUAClose() {
+    setDialogOpen(false);
+  }
+
+  function openDUA() {
+    setDialogOpen(true);
+  }
+
   return (
-    <SectionContainer id="files">
-      <SectionHeader>Files</SectionHeader>
-      {files && <FileBrowser files={files} />}
-      <GlobusLink entityEndpoint={entityEndpoint} uuid={uuid} display_doi={display_doi} />
-    </SectionContainer>
+    <FilesContext.Provider value={{ openDUA, hasAgreedToDUA }}>
+      <SectionContainer id="files">
+        <SectionHeader>Files</SectionHeader>
+        {files && <FileBrowser files={files} />}
+        <GlobusLink entityEndpoint={entityEndpoint} uuid={uuid} display_doi={display_doi} />
+        <FileBrowserDUA
+          isOpen={isDialogOpen}
+          handleAgree={handleDUAAgree}
+          handleClose={handleDUAClose}
+          data_access_level={data_access_level}
+        />
+      </SectionContainer>
+    </FilesContext.Provider>
   );
 }
 

--- a/context/app/static/js/components/Detail/Files/Files.jsx
+++ b/context/app/static/js/components/Detail/Files/Files.jsx
@@ -16,19 +16,22 @@ function Files(props) {
   const localStorageKey = `has_agreed_to_${data_access_level}_DUA`;
   const [hasAgreedToDUA, agreeToDUA] = useState(localStorage.getItem(localStorageKey));
   const [isDialogOpen, setDialogOpen] = useState(false);
+  const [urlClickedBeforeDUA, setUrlClickedBeforeDUA] = useState('');
 
   function handleDUAAgree() {
     agreeToDUA(true);
     localStorage.setItem(localStorageKey, true);
     setDialogOpen(false);
+    window.open(urlClickedBeforeDUA, '_blank');
   }
 
   function handleDUAClose() {
     setDialogOpen(false);
   }
 
-  function openDUA() {
+  function openDUA(linkUrl) {
     setDialogOpen(true);
+    setUrlClickedBeforeDUA(linkUrl);
   }
 
   return (

--- a/context/app/static/js/components/Detail/Files/context.js
+++ b/context/app/static/js/components/Detail/Files/context.js
@@ -1,0 +1,6 @@
+import React from 'react';
+
+// Stores the endpoints, `uuid`, and `display_doi` values.
+const FilesContext = React.createContext({});
+
+export default FilesContext;

--- a/context/app/static/js/components/Detail/FilesConditionalLink/FilesConditionalLink.jsx
+++ b/context/app/static/js/components/Detail/FilesConditionalLink/FilesConditionalLink.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 
 import { LightBlueLink } from 'shared-styles/Links';
+import { AlignedLink } from './style';
 
 function FilesConditionalLink(props) {
   const { hasAgreedToDUA, openDUA, href, children, ...rest } = props;
@@ -13,15 +14,16 @@ function FilesConditionalLink(props) {
     );
   }
   return (
-    <LightBlueLink
+    <AlignedLink
       onClick={() => {
         openDUA();
       }}
+      component="button"
       underline="none"
       {...rest}
     >
       {children}
-    </LightBlueLink>
+    </AlignedLink>
   );
 }
 

--- a/context/app/static/js/components/Detail/FilesConditionalLink/FilesConditionalLink.jsx
+++ b/context/app/static/js/components/Detail/FilesConditionalLink/FilesConditionalLink.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { LightBlueLink } from 'shared-styles/Links';
 
-function ConditionalLink(props) {
+function FilesConditionalLink(props) {
   const { hasAgreedToDUA, openDUA, href, children, ...rest } = props;
   if (hasAgreedToDUA) {
     return (
@@ -25,4 +25,4 @@ function ConditionalLink(props) {
   );
 }
 
-export default ConditionalLink;
+export default FilesConditionalLink;

--- a/context/app/static/js/components/Detail/FilesConditionalLink/index.js
+++ b/context/app/static/js/components/Detail/FilesConditionalLink/index.js
@@ -1,0 +1,3 @@
+import FilesConditionalLink from './FilesConditionalLink';
+
+export default FilesConditionalLink;

--- a/context/app/static/js/components/Detail/FilesConditionalLink/style.js
+++ b/context/app/static/js/components/Detail/FilesConditionalLink/style.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import { LightBlueLink } from 'shared-styles/Links';
+
+const AlignedLink = styled(LightBlueLink)`
+  vertical-align: baseline;
+`;
+
+export { AlignedLink };

--- a/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'shared-styles/Links';
 import FilesContext from '../Files/context';
-import FileBrowserConditionalLink from '../FilesConditionalLink';
+import FilesConditionalLink from '../FilesConditionalLink';
 import { StyledExternalLinkIcon } from './style';
 
 const messages = {
@@ -22,9 +22,9 @@ function GlobusLinkMessage(props) {
     return (
       <Typography variant="body2">
         {`Files are available through the Globus Research Data Management System. Access dataset ${display_doi} on `}
-        <FileBrowserConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} variant="body2">
+        <FilesConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} variant="body2">
           Globus <StyledExternalLinkIcon />
-        </FileBrowserConditionalLink>
+        </FilesConditionalLink>
         .
       </Typography>
     );

--- a/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'shared-styles/Links';
 import FilesContext from '../Files/context';
-import FileBrowserConditionalLink from '../FileBrowserConditionalLink';
+import FileBrowserConditionalLink from '../FilesConditionalLink';
 import { StyledExternalLinkIcon } from './style';
 
 const messages = {

--- a/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'shared-styles/Links';
+import FilesContext from '../Files/context';
+import FileBrowserConditionalLink from '../FileBrowserConditionalLink';
 import { StyledExternalLinkIcon } from './style';
 
 const messages = {
@@ -14,14 +16,15 @@ const messages = {
 
 function GlobusLinkMessage(props) {
   const { statusCode, url, display_doi } = props;
+  const { hasAgreedToDUA, openDUA } = useContext(FilesContext);
 
   if (statusCode === 200) {
     return (
       <Typography variant="body2">
         {`Files are available through the Globus Research Data Management System. Access dataset ${display_doi} on `}
-        <LightBlueLink underline="none" variant="body2" href={url}>
+        <FileBrowserConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} variant="body2">
           Globus <StyledExternalLinkIcon />
-        </LightBlueLink>
+        </FileBrowserConditionalLink>
         .
       </Typography>
     );

--- a/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -22,7 +22,7 @@ function GlobusLinkMessage(props) {
     return (
       <Typography variant="body2">
         {`Files are available through the Globus Research Data Management System. Access dataset ${display_doi} on `}
-        <FilesConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} variant="body2">
+        <FilesConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={() => openDUA(url)} variant="body2">
           Globus <StyledExternalLinkIcon />
         </FilesConditionalLink>
         .


### PR DESCRIPTION
Fixes #915.

I opted to pass DUA variables by context instead of props, context providers which aren't updated shouldn't negatively impact performance and are cleaner than passing props to far away children.

A link without an href isn't keyboard accessible. Reading around many believe using a void or similar href is bad practice. I opted to use a button although the component names are now a little confusing. Any thoughts on the subject?

Example with file browser and globus link: http://localhost:5001/browse/dataset/63a35af025a3662cb368eb3999fe2948