### PR TITLE
Tweak results table so more clear the whole thing is the result, not separate links

### DIFF
--- a/CHANGELOG-results-table.md
+++ b/CHANGELOG-results-table.md
@@ -1,0 +1,1 @@
+- Tweak style of results table so it's more clear that the hole row is the result.

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -15,6 +15,7 @@
 
     tbody tr {
         background-color: #FFF;
+        border: 1px solid #cbcbcb;
     }
     tbody tr:hover {
         filter: brightness(96%);

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -8,7 +8,7 @@
 }
 
 .sk-table {
-    width: '100%';
+    width: 100%;
 
     // NOTE: If we want to darken on hover, we need to give an explicit background to all rows.
     // (What looks white is actually "transparent" and brightness() has no effect.

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -6,3 +6,23 @@
 .sk-layout__body {
     margin: 0px;
 }
+
+.sk-table {
+    width: '100%';
+
+    tr:hover {
+        border: 1px solid grey;
+    }
+
+    // Force <a> to fill each cell, so the whole row is clickable.
+    // https://stackoverflow.com/questions/3966027
+    td {
+        overflow: hidden;
+    }
+    td a {
+        display: block;
+        margin: -10em;
+        padding: 10em;
+        color: rgb(0,0,0);
+    }
+}

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -10,7 +10,7 @@
 .sk-table {
     width: '100%';
 
-    tr:hover {
+    tbody tr:hover {
         border: 1px solid grey;
     }
 
@@ -24,5 +24,9 @@
         margin: -10em;
         padding: 10em;
         color: rgb(0,0,0);
+    }
+
+    td:first-child a {
+        color: #3781D1;
     }
 }

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -10,8 +10,14 @@
 .sk-table {
     width: '100%';
 
+    // NOTE: If we want to darken on hover, we need to give an explicit background to all rows.
+    // (What looks white is actually "transparent" and brightness() has no effect.
+
+    tbody tr {
+        background-color: #FFF;
+    }
     tbody tr:hover {
-        border: 1px solid grey;
+        filter: brightness(96%);
     }
 
     // Force <a> to fill each cell, so the whole row is clickable.

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -51,7 +51,7 @@ function makeTableComponent(resultFields, detailsUrlPrefix, idField) {
     const { hits } = props;
     /* eslint-disable no-underscore-dangle */
     return (
-      <table className="sk-table sk-table-striped" style={{ width: '100%' }}>
+      <table className="sk-table sk-table-striped">
         <thead>
           <tr>
             {resultFields.map((field) => (
@@ -64,9 +64,7 @@ function makeTableComponent(resultFields, detailsUrlPrefix, idField) {
             <tr key={hit._id}>
               {resultFields.map((field) => (
                 <td key={field.id}>
-                  <a href={detailsUrlPrefix + hit._source[idField]} style={{ display: 'block' }}>
-                    {getByPath(hit._source, field)}
-                  </a>
+                  <a href={detailsUrlPrefix + hit._source[idField]}>{getByPath(hit._source, field)}</a>
                 </td>
               ))}
             </tr>

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -51,7 +51,7 @@ function makeTableComponent(resultFields, detailsUrlPrefix, idField) {
     const { hits } = props;
     /* eslint-disable no-underscore-dangle */
     return (
-      <table className="sk-table sk-table-striped">
+      <table className="sk-table">
         <thead>
           <tr>
             {resultFields.map((field) => (


### PR DESCRIPTION
Fix #701, and perhaps another one I can't find now: I have this memory that someone was really frustrated that the different "links" all went to the same place.  This is an ad-hoc solution, and may be replaced.

<img width="341" alt="Screen Shot 2020-07-27 at 10 47 42 PM" src="https://user-images.githubusercontent.com/730388/88613373-4c5d3680-d05b-11ea-8c37-8b791e53890e.png">
