### PR TITLE
John conroy/dua typography

### DIFF
--- a/CHANGELOG-auto-open-link-after-dua-agree.md
+++ b/CHANGELOG-auto-open-link-after-dua-agree.md
@@ -1,0 +1,1 @@
+- Automatically open link in new window after agreeing to DUA.

--- a/CHANGELOG-dua-typography.md
+++ b/CHANGELOG-dua-typography.md
@@ -1,0 +1,1 @@
+- Update DUA Typography.

--- a/context/app/static/js/components/Detail/FileBrowserDUA/FileBrowserDUA.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserDUA/FileBrowserDUA.jsx
@@ -3,13 +3,13 @@ import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
+import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'shared-styles/Links';
 import { getDUAText } from './utils';
-import { ObliqueSpan } from './style';
+import { ObliqueSpan, StyledHeader, StyledDiv } from './style';
 
 function FileBrowserDUA(props) {
   const { isOpen, handleAgree, handleClose, data_access_level } = props;
@@ -26,16 +26,20 @@ function FileBrowserDUA(props) {
       aria-describedby="alert-dialog-description"
     >
       <DialogContent>
-        <DialogContentText id="alert-dialog-description">
-          <h1 id="alert-dialog-title">
+        <StyledDiv id="alert-dialog-description">
+          <StyledHeader id="alert-dialog-title" variant="h2" component="h1">
             {'HuBMAP '} <ObliqueSpan>{`${title} Data`}</ObliqueSpan> {' Usage'}
-          </h1>
+          </StyledHeader>
 
-          <h2>Appropriate Use</h2>
-          <p>{appropriateUse}</p>
+          <StyledHeader variant="h5" component="h2">
+            Appropriate Use
+          </StyledHeader>
+          <Typography variant="body1">{appropriateUse}</Typography>
 
-          <h2>Acknowledgement</h2>
-          <p>
+          <StyledHeader variant="h5" component="h2">
+            Acknowledgement
+          </StyledHeader>
+          <Typography variant="body1">
             Investigators using HuBMAP data in publications or presentations are requested to cite The Human Body at
             Cellular Resolution: the NIH Human BioMolecular Atlas Program (doi:
             <LightBlueLink href="https://doi.org/10.1038/s41586-019-1629-x" target="_blank" rel="noopener noreferrer">
@@ -48,17 +52,19 @@ function FileBrowserDUA(props) {
               https://hubmapconsortium.org
             </LightBlueLink>
             .”
-          </p>
+          </Typography>
 
-          <h2>Data Sharing Policy</h2>
-          <p>
+          <StyledHeader variant="h5" component="h2">
+            Data Sharing Policy
+          </StyledHeader>
+          <Typography variant="body1">
             The HuBMAP Data Sharing Policy can be found at{' '}
             <LightBlueLink href="https://hubmapconsortium.org/policies/" target="_blank" rel="noopener noreferrer">
               https://hubmapconsortium.org/policies/
             </LightBlueLink>
             .
-          </p>
-        </DialogContentText>
+          </Typography>
+        </StyledDiv>
         <FormControlLabel
           control={
             <Checkbox

--- a/context/app/static/js/components/Detail/FileBrowserDUA/FileBrowserDUA.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserDUA/FileBrowserDUA.jsx
@@ -31,12 +31,12 @@ function FileBrowserDUA(props) {
             {'HuBMAP '} <ObliqueSpan>{`${title} Data`}</ObliqueSpan> {' Usage'}
           </StyledHeader>
 
-          <StyledHeader variant="h5" component="h2">
+          <StyledHeader variant="h4" component="h2">
             Appropriate Use
           </StyledHeader>
           <Typography variant="body1">{appropriateUse}</Typography>
 
-          <StyledHeader variant="h5" component="h2">
+          <StyledHeader variant="h4" component="h2">
             Acknowledgement
           </StyledHeader>
           <Typography variant="body1">
@@ -54,7 +54,7 @@ function FileBrowserDUA(props) {
             .”
           </Typography>
 
-          <StyledHeader variant="h5" component="h2">
+          <StyledHeader variant="h4" component="h2">
             Data Sharing Policy
           </StyledHeader>
           <Typography variant="body1">

--- a/context/app/static/js/components/Detail/FileBrowserDUA/style.js
+++ b/context/app/static/js/components/Detail/FileBrowserDUA/style.js
@@ -1,7 +1,16 @@
 import styled from 'styled-components';
+import Typography from '@material-ui/core/Typography';
 
 const ObliqueSpan = styled.span`
   font-style: oblique 10deg;
 `;
 
-export { ObliqueSpan };
+const StyledHeader = styled(Typography)`
+  margin: ${(props) => props.theme.spacing(2)}px 0px;
+`;
+
+const StyledDiv = styled.div`
+  margin-bottom: ${(props) => props.theme.spacing(2)}px;
+`;
+
+export { ObliqueSpan, StyledHeader, StyledDiv };

--- a/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
@@ -16,14 +16,16 @@ function FileBrowserFile(props) {
   const token = readCookie('nexus_token');
   const classes = useRoundedSecondaryTooltipStyles();
 
+  const fileUrl = `${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`;
+
   return (
     <StyledDiv>
       <IndentedDiv $depth={depth}>
         <StyledFileIcon color="primary" />
         <FilesConditionalLink
-          href={`${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`}
+          href={fileUrl}
           hasAgreedToDUA={hasAgreedToDUA}
-          openDUA={openDUA}
+          openDUA={() => openDUA(fileUrl)}
           variant="body1"
           download
         >

--- a/context/app/static/js/components/Detail/Files/Files.jsx
+++ b/context/app/static/js/components/Detail/Files/Files.jsx
@@ -16,19 +16,22 @@ function Files(props) {
   const localStorageKey = `has_agreed_to_${data_access_level}_DUA`;
   const [hasAgreedToDUA, agreeToDUA] = useState(localStorage.getItem(localStorageKey));
   const [isDialogOpen, setDialogOpen] = useState(false);
+  const [urlClickedBeforeDUA, setUrlClickedBeforeDUA] = useState('');
 
   function handleDUAAgree() {
     agreeToDUA(true);
     localStorage.setItem(localStorageKey, true);
     setDialogOpen(false);
+    window.open(urlClickedBeforeDUA, '_blank');
   }
 
   function handleDUAClose() {
     setDialogOpen(false);
   }
 
-  function openDUA() {
+  function openDUA(linkUrl) {
     setDialogOpen(true);
+    setUrlClickedBeforeDUA(linkUrl);
   }
 
   return (

--- a/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -22,7 +22,7 @@ function GlobusLinkMessage(props) {
     return (
       <Typography variant="body2">
         {`Files are available through the Globus Research Data Management System. Access dataset ${display_doi} on `}
-        <FilesConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} variant="body2">
+        <FilesConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={() => openDUA(url)} variant="body2">
           Globus <StyledExternalLinkIcon />
         </FilesConditionalLink>
         .


### PR DESCRIPTION
`DialogContentText` is just a paragraph element with some default styles so we were getting a number of DOM nesting errors because we were placing headers inside of a paragraph.  Switched to using typography components to get font styles from the theme. I also opted to use our main text color instead of the secondary gray from our palette because the new font weights heightened the contrast issues discussed in #914 .

<img width="627" alt="Screen Shot 2020-07-28 at 9 52 35 AM" src="https://user-images.githubusercontent.com/62477388/88675236-bb1cad00-d0b8-11ea-89a8-be61a29d3c9a.png">
