### PR TITLE
John conroy/auto open link after dua agree

### DIFF
--- a/CHANGELOG-auto-open-link-after-dua-agree.md
+++ b/CHANGELOG-auto-open-link-after-dua-agree.md
@@ -1,0 +1,1 @@
+- Automatically open link in new window after agreeing to DUA.

--- a/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/Detail/FileBrowserFile/FileBrowserFile.jsx
@@ -16,14 +16,16 @@ function FileBrowserFile(props) {
   const token = readCookie('nexus_token');
   const classes = useRoundedSecondaryTooltipStyles();
 
+  const fileUrl = `${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`;
+
   return (
     <StyledDiv>
       <IndentedDiv $depth={depth}>
         <StyledFileIcon color="primary" />
         <FilesConditionalLink
-          href={`${assetsEndpoint}/${uuid}/${fileObj.rel_path}?token=${token}`}
+          href={fileUrl}
           hasAgreedToDUA={hasAgreedToDUA}
-          openDUA={openDUA}
+          openDUA={() => openDUA(fileUrl)}
           variant="body1"
           download
         >

--- a/context/app/static/js/components/Detail/Files/Files.jsx
+++ b/context/app/static/js/components/Detail/Files/Files.jsx
@@ -16,19 +16,22 @@ function Files(props) {
   const localStorageKey = `has_agreed_to_${data_access_level}_DUA`;
   const [hasAgreedToDUA, agreeToDUA] = useState(localStorage.getItem(localStorageKey));
   const [isDialogOpen, setDialogOpen] = useState(false);
+  const [urlClickedBeforeDUA, setUrlClickedBeforeDUA] = useState('');
 
   function handleDUAAgree() {
     agreeToDUA(true);
     localStorage.setItem(localStorageKey, true);
     setDialogOpen(false);
+    window.open(urlClickedBeforeDUA, '_blank');
   }
 
   function handleDUAClose() {
     setDialogOpen(false);
   }
 
-  function openDUA() {
+  function openDUA(url) {
     setDialogOpen(true);
+    setUrlClickedBeforeDUA(url);
   }
 
   return (

--- a/context/app/static/js/components/Detail/Files/Files.jsx
+++ b/context/app/static/js/components/Detail/Files/Files.jsx
@@ -29,9 +29,9 @@ function Files(props) {
     setDialogOpen(false);
   }
 
-  function openDUA(url) {
+  function openDUA(linkUrl) {
     setDialogOpen(true);
-    setUrlClickedBeforeDUA(url);
+    setUrlClickedBeforeDUA(linkUrl);
   }
 
   return (

--- a/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/Detail/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -22,7 +22,7 @@ function GlobusLinkMessage(props) {
     return (
       <Typography variant="body2">
         {`Files are available through the Globus Research Data Management System. Access dataset ${display_doi} on `}
-        <FilesConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={openDUA} variant="body2">
+        <FilesConditionalLink href={url} hasAgreedToDUA={hasAgreedToDUA} openDUA={() => openDUA(url)} variant="body2">
           Globus <StyledExternalLinkIcon />
         </FilesConditionalLink>
         .


### PR DESCRIPTION
Fix #916 .

Automatically opens the link in a new window/tab (controlled by browser) after the user agrees to the DUA. Could be blocked by pop-up blockers. I couldn't find a better alternative or new practice.