### PR TITLE
Update ccf-eui base href

### DIFF
--- a/CHANGELOG-ccf-version.md
+++ b/CHANGELOG-ccf-version.md
@@ -1,0 +1,1 @@
+- CCF is now explicitly versioned, instead of just pulling latest.

--- a/context/app/templates/pages/ccf-eui.html
+++ b/context/app/templates/pages/ccf-eui.html
@@ -16,7 +16,7 @@
   </script>
   <meta charset="utf-8">
   <title>HuBMAP CCF Exploration User Interface (CCF-EUI)</title>
-  <base href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@portal-version/">
+  <base href="https://cdn.jsdelivr.net/gh/hubmapconsortium/ccf-ui@1/">
   <script>
     window.dbOptions = {
       hubmapDataService: 'search-api',


### PR DESCRIPTION
We have changed our method of delivering CCF EUI releases to use a tagged versioning system. This PR just updates the base href it needs to point to.