### PR TITLE
Add snackbar to show warning messages emitted from Vitessce

### DIFF
--- a/CHANGELOG-vitessce-warning-snackbar.md
+++ b/CHANGELOG-vitessce-warning-snackbar.md
@@ -1,0 +1,1 @@
+- Added a snackbar to display warning messages from Vitessce

--- a/context/app/static/js/components/Detail/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/Detail/Visualization/Visualization.jsx
@@ -33,8 +33,7 @@ function Visualization(props) {
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isEscSnackbarOpen, setIsEscSnackbarOpen] = useState(false);
-  const [isWarnSnackbarOpen, setIsWarnSnackbarOpen] = useState(false);
-  const [vitessceWarning, setVitessceWarning] = useState();
+  const [vitessceWarnings, setVitessceWarnings] = useState([]);
   const [vitessceTheme, setVitessceTheme] = useState('light');
   const [vitessceSelection, setVitessceSelection] = useState(0);
   const [open, toggle] = useReducer((v) => !v, false);
@@ -50,8 +49,16 @@ function Visualization(props) {
     setIsEscSnackbarOpen(false);
   }
 
-  function setVitessceSelectionAndClearWarnings(i) {
-    setIsWarnSnackbarOpen(false);
+  function removeWarning(warning) {
+    setVitessceWarnings((prev) => prev.filter((w) => w !== warning));
+  }
+
+  function addWarning(warning) {
+    setVitessceWarnings((prev) => (prev.includes(warning) ? prev : [...prev, warning]));
+  }
+
+  function setSelectionAndClearWarnings(i) {
+    setVitessceWarnings([]);
     setVitessceSelection(i);
   }
 
@@ -93,7 +100,7 @@ function Visualization(props) {
                   <ClickAwayListener onClickAway={toggle}>
                     <MenuList id="preview-options">
                       {vitData.map(({ name }, i) => (
-                        <MenuItem onClick={() => setVitessceSelectionAndClearWarnings(i)} key={name}>
+                        <MenuItem onClick={() => setSelectionAndClearWarnings(i)} key={name}>
                           {name}
                         </MenuItem>
                       ))}
@@ -117,25 +124,25 @@ function Visualization(props) {
             onClose={() => setIsEscSnackbarOpen(false)}
             message="Press [esc] to exit full window."
           />
-          <WarnSnackbar
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'right',
-            }}
-            open={isWarnSnackbarOpen}
-          >
-            <Alert severity="warning" variant="filled" onClose={() => setIsWarnSnackbarOpen(false)}>
-              {vitessceWarning}
-            </Alert>
-          </WarnSnackbar>
+          {vitessceWarnings.length > 0 && (
+            <WarnSnackbar
+              anchorOrigin={{
+                vertical: 'bottom',
+                horizontal: 'right',
+              }}
+              open
+              key={vitessceWarnings[0]}
+            >
+              <Alert severity="warning" variant="filled" onClose={() => removeWarning(vitessceWarnings[0])}>
+                {vitessceWarnings[0]}
+              </Alert>
+            </WarnSnackbar>
+          )}
           <Vitessce
             config={vitData[vitessceSelection] || vitData}
             theme={vitessceTheme}
             height={isExpanded ? null : vitessceFixedHeight}
-            onWarn={(warning) => {
-              setVitessceWarning(warning);
-              setIsWarnSnackbarOpen(true);
-            }}
+            onWarn={addWarning}
           />
         </ExpandableDiv>
       </Paper>

--- a/context/app/static/js/components/Detail/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/Detail/Visualization/Visualization.jsx
@@ -21,7 +21,7 @@ import {
   StyledHeaderRight,
   ExpandButton,
   EscSnackbar,
-  WarnSnackbar,
+  ErrorSnackbar,
   ExpandableDiv,
   StyledFooterText,
   SelectionButton,
@@ -33,7 +33,7 @@ function Visualization(props) {
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isEscSnackbarOpen, setIsEscSnackbarOpen] = useState(false);
-  const [vitessceWarnings, setVitessceWarnings] = useState([]);
+  const [vitessceErrors, setVitessceErrors] = useState([]);
   const [vitessceTheme, setVitessceTheme] = useState('light');
   const [vitessceSelection, setVitessceSelection] = useState(0);
   const [open, toggle] = useReducer((v) => !v, false);
@@ -49,16 +49,16 @@ function Visualization(props) {
     setIsEscSnackbarOpen(false);
   }
 
-  function removeWarning(warning) {
-    setVitessceWarnings((prev) => prev.filter((w) => w !== warning));
+  function removeError(message) {
+    setVitessceErrors((prev) => prev.filter((d) => d !== message));
   }
 
-  function addWarning(warning) {
-    setVitessceWarnings((prev) => (prev.includes(warning) ? prev : [...prev, warning]));
+  function addError(message) {
+    setVitessceErrors((prev) => (prev.includes(message) ? prev : [...prev, message]));
   }
 
-  function setSelectionAndClearWarnings(i) {
-    setVitessceWarnings([]);
+  function setSelectionAndClearErrors(i) {
+    setVitessceErrors([]);
     setVitessceSelection(i);
   }
 
@@ -100,7 +100,7 @@ function Visualization(props) {
                   <ClickAwayListener onClickAway={toggle}>
                     <MenuList id="preview-options">
                       {vitData.map(({ name }, i) => (
-                        <MenuItem onClick={() => setSelectionAndClearWarnings(i)} key={name}>
+                        <MenuItem onClick={() => setSelectionAndClearErrors(i)} key={name}>
                           {name}
                         </MenuItem>
                       ))}
@@ -124,25 +124,25 @@ function Visualization(props) {
             onClose={() => setIsEscSnackbarOpen(false)}
             message="Press [esc] to exit full window."
           />
-          {vitessceWarnings.length > 0 && (
-            <WarnSnackbar
+          {vitessceErrors.length > 0 && (
+            <ErrorSnackbar
               anchorOrigin={{
                 vertical: 'bottom',
                 horizontal: 'right',
               }}
               open
-              key={vitessceWarnings[0]}
+              key={vitessceErrors[0]}
             >
-              <Alert severity="warning" variant="filled" onClose={() => removeWarning(vitessceWarnings[0])}>
-                {vitessceWarnings[0]}
+              <Alert severity="error" variant="filled" onClose={() => removeError(vitessceErrors[0])}>
+                {vitessceErrors[0]}
               </Alert>
-            </WarnSnackbar>
+            </ErrorSnackbar>
           )}
           <Vitessce
             config={vitData[vitessceSelection] || vitData}
             theme={vitessceTheme}
             height={isExpanded ? null : vitessceFixedHeight}
-            onWarn={addWarning}
+            onWarn={addError}
           />
         </ExpandableDiv>
       </Paper>

--- a/context/app/static/js/components/Detail/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/Detail/Visualization/Visualization.jsx
@@ -9,6 +9,7 @@ import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUpRounded';
 import Popper from '@material-ui/core/Popper';
 import MenuList from '@material-ui/core/MenuList';
 import MenuItem from '@material-ui/core/MenuItem';
+import Alert from '@material-ui/lab/Alert';
 
 import VisualizationThemeSwitch from '../VisualizationThemeSwitch';
 import {
@@ -19,7 +20,8 @@ import {
   StyledHeaderText,
   StyledHeaderRight,
   ExpandButton,
-  TopSnackbar,
+  EscSnackbar,
+  WarnSnackbar,
   ExpandableDiv,
   StyledFooterText,
   SelectionButton,
@@ -30,7 +32,9 @@ function Visualization(props) {
   const { vitData } = props;
 
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isSnackbarOpen, setIsSnackbarOpen] = useState(false);
+  const [isEscSnackbarOpen, setIsEscSnackbarOpen] = useState(false);
+  const [isWarnSnackbarOpen, setIsWarnSnackbarOpen] = useState(false);
+  const [vitessceWarning, setVitessceWarning] = useState();
   const [vitessceTheme, setVitessceTheme] = useState('light');
   const [vitessceSelection, setVitessceSelection] = useState(0);
   const [open, toggle] = useReducer((v) => !v, false);
@@ -38,12 +42,17 @@ function Visualization(props) {
 
   function handleExpand() {
     setIsExpanded(true);
-    setIsSnackbarOpen(true);
+    setIsEscSnackbarOpen(true);
   }
 
   function handleCollapse() {
     setIsExpanded(false);
-    setIsSnackbarOpen(false);
+    setIsEscSnackbarOpen(false);
+  }
+
+  function setVitessceSelectionAndClearWarnings(i) {
+    setIsWarnSnackbarOpen(false);
+    setVitessceSelection(i);
   }
 
   useEffect(() => {
@@ -57,6 +66,7 @@ function Visualization(props) {
       window.removeEventListener('keydown', onKeydown);
     };
   }, []);
+
   return (
     <StyledSectionContainer id="visualization">
       <StyledHeader>
@@ -83,7 +93,7 @@ function Visualization(props) {
                   <ClickAwayListener onClickAway={toggle}>
                     <MenuList id="preview-options">
                       {vitData.map(({ name }, i) => (
-                        <MenuItem onClick={() => setVitessceSelection(i)} key={name}>
+                        <MenuItem onClick={() => setVitessceSelectionAndClearWarnings(i)} key={name}>
                           {name}
                         </MenuItem>
                       ))}
@@ -97,20 +107,35 @@ function Visualization(props) {
       </StyledHeader>
       <Paper>
         <ExpandableDiv $isExpanded={isExpanded} $theme={vitessceTheme}>
-          <TopSnackbar
+          <EscSnackbar
             anchorOrigin={{
               vertical: 'top',
               horizontal: 'center',
             }}
-            open={isSnackbarOpen}
+            open={isEscSnackbarOpen}
             autoHideDuration={4000}
-            onClose={() => setIsSnackbarOpen(false)}
+            onClose={() => setIsEscSnackbarOpen(false)}
             message="Press [esc] to exit full window."
           />
+          <WarnSnackbar
+            anchorOrigin={{
+              vertical: 'bottom',
+              horizontal: 'right',
+            }}
+            open={isWarnSnackbarOpen}
+          >
+            <Alert severity="warning" variant="filled" onClose={() => setIsWarnSnackbarOpen(false)}>
+              {vitessceWarning}
+            </Alert>
+          </WarnSnackbar>
           <Vitessce
             config={vitData[vitessceSelection] || vitData}
             theme={vitessceTheme}
             height={isExpanded ? null : vitessceFixedHeight}
+            onWarn={(warning) => {
+              setVitessceWarning(warning);
+              setIsWarnSnackbarOpen(true);
+            }}
           />
         </ExpandableDiv>
       </Paper>

--- a/context/app/static/js/components/Detail/Visualization/style.js
+++ b/context/app/static/js/components/Detail/Visualization/style.js
@@ -41,11 +41,15 @@ const SelectionButton = styled(Button)`
   color: white;
 `;
 
-const TopSnackbar = styled(Snackbar)`
+const EscSnackbar = styled(Snackbar)`
   top: ${headerFixedHeight + 10}px;
   & > div {
     background-color: dimgray;
   }
+`;
+
+const WarnSnackbar = styled(Snackbar)`
+  position: absolute;
 `;
 
 const ExpandableDiv = styled.div`
@@ -83,7 +87,8 @@ export {
   StyledHeaderText,
   StyledHeaderRight,
   ExpandButton,
-  TopSnackbar,
+  EscSnackbar,
+  WarnSnackbar,
   ExpandableDiv,
   StyledFooterText,
   SelectionButton,

--- a/context/app/static/js/components/Detail/Visualization/style.js
+++ b/context/app/static/js/components/Detail/Visualization/style.js
@@ -48,7 +48,7 @@ const EscSnackbar = styled(Snackbar)`
   }
 `;
 
-const WarnSnackbar = styled(Snackbar)`
+const ErrorSnackbar = styled(Snackbar)`
   position: absolute;
 `;
 
@@ -88,7 +88,7 @@ export {
   StyledHeaderRight,
   ExpandButton,
   EscSnackbar,
-  WarnSnackbar,
+  ErrorSnackbar,
   ExpandableDiv,
   StyledFooterText,
   SelectionButton,

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ die() { set +v; echo "$*" 1>&2 ; sleep 1; exit 1; }
 
 server_up() {
   TRIES=0
-  MAX_TRIES=150
+  MAX_TRIES=250
   URL=http://localhost:$1
   until curl --silent --fail $URL; do
     [ ${TRIES} -gt ${MAX_TRIES} ] && die "Server not running at $URL"

--- a/test.sh
+++ b/test.sh
@@ -12,7 +12,7 @@ server_up() {
   until curl --silent --fail $URL; do
     [ ${TRIES} -gt ${MAX_TRIES} ] && die "Server not running at $URL"
     printf '.'
-    sleep 1
+    sleep 2
     TRIES=$(($TRIES+1))
   done
   echo "Server starts up, and $URL returns 200."


### PR DESCRIPTION
This pull request adds a close-able `<Snackbar/>` component for displaying warning messages from Vitessce, such as `Error HTTP status fetching cells.` or `Error while validating cells.`  These messages are emitted from the `onWarn` callback on the `<Vitessce/>` component. Right now these warnings only appear in the console.

This PR can be tested by temporarily changing line 411 of vitessce.py https://github.com/hubmapconsortium/portal-ui/blob/971e0ee9e82d674fb9acc6a54d5dd6ed6f0fca9a/context/app/api/vitessce.py#L411

to `base_url = urllib.parse.urljoin(assets_endpoint, f"{self.uuid}/{rel_path}_BAD_URL")`

(I also saw that there is now an ErrorBoundary component. I tried throwing the warning as an error, but it did not seem to trigger that error handler, but maybe I was doing something wrong. Not sure if that would be possible and preferred over this UI.)


![Screen Shot 2020-07-29 at 6 37 41 PM](https://user-images.githubusercontent.com/7525285/88860919-d24bbf80-d1ca-11ea-9a59-57d5483ed649.png)
