### PR TITLE
Mccalluc/columns sort

### DIFF
--- a/CHANGELOG-sort-cols.md
+++ b/CHANGELOG-sort-cols.md
@@ -1,0 +1,1 @@
+- Sort columns by clicking headers.

--- a/context/app/static/js/components/Search/DevSearch.jsx
+++ b/context/app/static/js/components/Search/DevSearch.jsx
@@ -7,7 +7,6 @@ import SearchWrapper from './SearchWrapper';
 import './Search.scss';
 // eslint-disable-next-line import/named
 import { field, filter, checkboxFilter } from './utils';
-import { lastModifiedSort, sizeSort } from './config';
 
 const nexus_token = readCookie('nexus_token');
 const httpHeaders = nexus_token
@@ -44,7 +43,6 @@ const searchProps = {
     checkboxFilter('has_files', 'Has files?', ExistsQuery('files')),
     checkboxFilter('no_files', 'No files?', BoolMustNot(ExistsQuery('files'))),
   ],
-  sortOptions: lastModifiedSort.concat(sizeSort),
   queryFields: ['everything'],
   isLoggedIn: Boolean(nexus_token),
 };

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -56,9 +56,14 @@ const searchProps = {
   filters: filtersByType[type],
   sortOptions: resultFields
     .map((field) => {
+      const base = {
+        defaultOption: false,
+        label: field.name,
+        field: `${field.id}.keyword`,
+      };
       return [
-        { defaultOption: false, label: `${field.name} down`, field: `${field.id}.keyword`, order: 'desc' },
-        { defaultOption: false, label: `${field.name} up`, field: `${field.id}.keyword`, order: 'asc' },
+        { ...base, order: 'desc' },
+        { ...base, order: 'asc' },
       ];
     })
     .flat(),

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -62,7 +62,7 @@ const searchProps = {
         field: `${field.id}.keyword`,
       };
       return [
-        { ...base, order: 'desc' },
+        { ...base, order: 'desc', defaultOption: field.id === 'mapped_last_modified_timestamp' },
         { ...base, order: 'asc' },
       ];
     })

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -35,6 +35,7 @@ const httpHeaders = nexus_token
       Authorization: `Bearer ${nexus_token}`,
     }
   : {};
+const resultFields = resultFieldsByType[type];
 const searchProps = {
   // The default behavior is to add a "_search" path.
   // We don't want that.
@@ -46,14 +47,21 @@ const searchProps = {
   // Search results field which will be appended to detailsUrlPrefix:
   idField: 'uuid',
   // Search results fields to display in table:
-  resultFields: resultFieldsByType[type],
+  resultFields,
   // Default hitsPerPage is 10:
   hitsPerPage: 20,
   // Sidebar facet configuration;
   // "type" should be one of the filters described here:
   // http://docs.searchkit.co/stable/components/navigation/
   filters: filtersByType[type],
-  sortOptions: lastModifiedSort,
+  sortOptions: resultFields
+    .map((field) => {
+      return [
+        { defaultOption: false, label: `${field.name} down`, field: `${field.id}.keyword`, order: 'desc' },
+        { defaultOption: false, label: `${field.name} up`, field: `${field.id}.keyword`, order: 'asc' },
+      ];
+    })
+    .flat(),
   hiddenFilterIds: hiddenFilters.map((hiddenFilter) => hiddenFilter.props.id),
   queryFields: ['everything'],
   isLoggedIn: Boolean(nexus_token),

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -4,7 +4,7 @@ import { readCookie } from 'helpers/functions';
 import LookupEntity from 'helpers/LookupEntity';
 import SearchWrapper from './SearchWrapper';
 import './Search.scss';
-import { donorConfig, sampleConfig, datasetConfig, lastModifiedSort } from './config';
+import { donorConfig, sampleConfig, datasetConfig } from './config';
 // eslint-disable-next-line import/named
 import { filter } from './utils';
 import AncestorNote from './AncestorNote';
@@ -54,19 +54,6 @@ const searchProps = {
   // "type" should be one of the filters described here:
   // http://docs.searchkit.co/stable/components/navigation/
   filters: filtersByType[type],
-  sortOptions: resultFields
-    .map((field) => {
-      const base = {
-        defaultOption: false,
-        label: field.name,
-        field: `${field.id}.keyword`,
-      };
-      return [
-        { ...base, order: 'desc', defaultOption: field.id === 'mapped_last_modified_timestamp' },
-        { ...base, order: 'asc' },
-      ];
-    })
-    .flat(),
   hiddenFilterIds: hiddenFilters.map((hiddenFilter) => hiddenFilter.props.id),
   queryFields: ['everything'],
   isLoggedIn: Boolean(nexus_token),

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -10,6 +10,10 @@
 .sk-table {
     width: 100%;
 
+    th {
+        cursor: pointer;
+    }
+
     // NOTE: If we want to darken on hover, we need to give an explicit background to all rows.
     // (What looks white is actually "transparent" and brightness() has no effect.
 
@@ -28,8 +32,8 @@
     }
     td a {
         display: block;
-        margin: -10em;
-        padding: 10em;
+        margin: -100%;
+        padding: 100%;
         color: rgb(0,0,0);
     }
 

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -12,6 +12,7 @@
 
     th {
         cursor: pointer;
+        white-space: nowrap;
     }
 
     // NOTE: If we want to darken on hover, we need to give an explicit background to all rows.

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -46,13 +46,18 @@ function getByPath(nested, field) {
   return current;
 }
 
-function makeTheadComponent(resultFields) {
-  return function ResultsThead(props) {
+function makeTheadComponent() {
+  return function ResultsTheadTd(props) {
+    const { items } = props;
+    const pairs = [];
+    for (let i = 0; i < items.length; i += 2) {
+      pairs.push(items.slice(i, i + 2));
+    }
     return (
       <thead>
         <tr>
-          {resultFields.map((field) => (
-            <th key={field.id}>{field.name}</th>
+          {pairs.map((pair) => (
+            <td>{JSON.stringify(pair)}</td>
           ))}
         </tr>
       </thead>
@@ -161,7 +166,6 @@ function SearchWrapper(props) {
                 }}
               />
               <MaskedSelectedFilters hiddenFilterIds={hiddenFilterIds} />
-              <SortingSelector options={sortOptions} />
             </ActionBarRow>
           </ActionBar>
           {debug && (
@@ -174,7 +178,7 @@ function SearchWrapper(props) {
           )}
 
           <table className="sk-table">
-            {makeTheadComponent(resultFields)()}
+            <SortingSelector options={sortOptions} listComponent={makeTheadComponent()} />
             <Hits
               mod="sk-hits-list"
               hitsPerPage={hitsPerPage}

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -21,10 +21,6 @@ import {
 import * as filterTypes from 'searchkit'; // eslint-disable-line import/no-duplicates
 // There is more in the name space, but we only need the filterTypes.
 
-function DebugItem(props) {
-  return <pre>{JSON.stringify(props, false, 2)}</pre>;
-}
-
 function getByPath(nested, field) {
   const path = field.id;
   let current = nested;
@@ -47,7 +43,7 @@ function getByPath(nested, field) {
 }
 
 function makeTheadComponent() {
-  return function ResultsTheadTd(props) {
+  return function ResultsThead(props) {
     const { items, toggleItem, selectedItems } = props;
     if (selectedItems.length > 1) {
       console.warn('Expected only a single sort, not:', selectedItems);
@@ -147,7 +143,6 @@ function SearchWrapper(props) {
     idField,
     resultFields,
     hitsPerPage,
-    debug,
     httpHeaders,
     sortOptions,
     hiddenFilterIds,
@@ -188,15 +183,6 @@ function SearchWrapper(props) {
               <MaskedSelectedFilters hiddenFilterIds={hiddenFilterIds} />
             </ActionBarRow>
           </ActionBar>
-          {debug && (
-            <Hits
-              mod="sk-hits-list"
-              hitsPerPage={hitsPerPage}
-              itemComponent={DebugItem}
-              sourceFilter={resultFieldIds}
-            />
-          )}
-
           <table className="sk-table">
             <SortingSelector options={sortOptions} listComponent={makeTheadComponent()} />
             <Hits
@@ -205,18 +191,12 @@ function SearchWrapper(props) {
               listComponent={makeTbodyComponent(resultFields, detailsUrlPrefix, idField)}
               sourceFilter={resultFieldIds}
             />
-            <tbody>
-              <tr>
-                <td>
-                  <NoHits
-                    translations={{
-                      'NoHits.NoResultsFound': `No results found. ${isLoggedIn ? '' : 'Login to view more results.'}`,
-                    }}
-                  />
-                </td>
-              </tr>
-            </tbody>
           </table>
+          <NoHits
+            translations={{
+              'NoHits.NoResultsFound': `No results found. ${isLoggedIn ? '' : 'Login to view more results.'}`,
+            }}
+          />
           <Pagination showNumbers />
         </LayoutResults>
       </LayoutBody>
@@ -272,7 +252,6 @@ SearchWrapper.propTypes = {
     }),
   ).isRequired,
   hitsPerPage: PropTypes.number.isRequired,
-  debug: PropTypes.bool,
   httpHeaders: PropTypes.objectOf(PropTypes.string),
   sortOptions: PropTypes.arrayOf(
     PropTypes.exact({
@@ -289,7 +268,6 @@ SearchWrapper.propTypes = {
 };
 
 SearchWrapper.defaultProps = {
-  debug: false,
   sortOptions: [
     {
       label: 'Relevance',

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -46,31 +46,36 @@ function getByPath(nested, field) {
   return current;
 }
 
-function makeTableComponent(resultFields, detailsUrlPrefix, idField) {
-  return function ResultsTable(props) {
+function makeTheadComponent(resultFields) {
+  return function ResultsThead(props) {
+    return (
+      <thead>
+        <tr>
+          {resultFields.map((field) => (
+            <th key={field.id}>{field.name}</th>
+          ))}
+        </tr>
+      </thead>
+    );
+  };
+}
+
+function makeTbodyComponent(resultFields, detailsUrlPrefix, idField) {
+  return function ResultsTbody(props) {
     const { hits } = props;
     /* eslint-disable no-underscore-dangle */
     return (
-      <table className="sk-table">
-        <thead>
-          <tr>
+      <tbody>
+        {hits.map((hit) => (
+          <tr key={hit._id}>
             {resultFields.map((field) => (
-              <th key={field.id}>{field.name}</th>
+              <td key={field.id}>
+                <a href={detailsUrlPrefix + hit._source[idField]}>{getByPath(hit._source, field)}</a>
+              </td>
             ))}
           </tr>
-        </thead>
-        <tbody>
-          {hits.map((hit) => (
-            <tr key={hit._id}>
-              {resultFields.map((field) => (
-                <td key={field.id}>
-                  <a href={detailsUrlPrefix + hit._source[idField]}>{getByPath(hit._source, field)}</a>
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+        ))}
+      </tbody>
     );
     /* eslint-enable no-underscore-dangle */
   };
@@ -168,17 +173,26 @@ function SearchWrapper(props) {
             />
           )}
 
-          <Hits
-            mod="sk-hits-list"
-            hitsPerPage={hitsPerPage}
-            listComponent={makeTableComponent(resultFields, detailsUrlPrefix, idField)}
-            sourceFilter={resultFieldIds}
-          />
-          <NoHits
-            translations={{
-              'NoHits.NoResultsFound': `No results found. ${isLoggedIn ? '' : 'Login to view more results.'}`,
-            }}
-          />
+          <table className="sk-table">
+            {makeTheadComponent(resultFields)()}
+            <Hits
+              mod="sk-hits-list"
+              hitsPerPage={hitsPerPage}
+              listComponent={makeTbodyComponent(resultFields, detailsUrlPrefix, idField)}
+              sourceFilter={resultFieldIds}
+            />
+            <tbody>
+              <tr>
+                <td>
+                  <NoHits
+                    translations={{
+                      'NoHits.NoResultsFound': `No results found. ${isLoggedIn ? '' : 'Login to view more results.'}`,
+                    }}
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
           <Pagination showNumbers />
         </LayoutResults>
       </LayoutBody>

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -63,9 +63,14 @@ function makeTheadComponent() {
           {pairs.map((pair) => {
             const match = pair.filter((item) => item.key === selectedItem);
             const order = match.length ? match[0].order : undefined;
-            const orderIcon = order ? { asc: '^', desc: 'v' }[order] : undefined;
+            const orderIcon = order ? { asc: '▲', desc: '▼' }[order] : undefined;
             return (
-              <th key={pair[0].key}>
+              <th
+                key={pair[0].key}
+                onClick={() => {
+                  setItems([pair[0].key]);
+                }}
+              >
                 {pair[0].label}&nbsp;{orderIcon}
               </th>
             );

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -22,6 +22,7 @@ import * as filterTypes from 'searchkit'; // eslint-disable-line import/no-dupli
 // There is more in the name space, but we only need the filterTypes.
 
 import { resultFieldsToSortOptions } from './utils';
+import { ArrowUpOn, ArrowDownOn, ArrowDownOff } from './style';
 
 function getByPath(nested, field) {
   const path = field.id;
@@ -65,7 +66,7 @@ function makeTheadComponent() {
           {pairs.map((pair) => {
             const match = pair.filter((item) => item.key === selectedItem);
             const order = match.length ? match[0].order : undefined;
-            const orderIcon = order ? { asc: '▲', desc: '▼' }[order] : undefined;
+            const orderIcon = order ? { asc: <ArrowUpOn />, desc: <ArrowDownOn /> }[order] : <ArrowDownOff />;
             return (
               <th
                 key={pair[0].key}

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -77,6 +77,7 @@ function SortingThead(props) {
           const order = getOrder(pair, selectedItems);
           return (
             <th
+              role="button"
               key={pair[0].key}
               onClick={() => {
                 toggleItem(pair[order && order === pair[0].order ? 1 : 0].key);

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -50,12 +50,16 @@ function makeTheadComponent() {
   return function ResultsTheadTd(props) {
     const { items, toggleItem, selectedItems } = props;
     if (selectedItems.length > 1) {
-      console.warn(`Expected only a single selected sort, not ${JSON.stringify(selectedItems)}`);
+      console.warn('Expected only a single sort, not:', selectedItems);
     }
     const selectedItem = selectedItems.length ? selectedItems[0] : undefined;
     const pairs = [];
     for (let i = 0; i < items.length; i += 2) {
-      pairs.push(items.slice(i, i + 2));
+      const pair = items.slice(i, i + 2);
+      pairs.push(pair);
+      if (pair[0].label !== pair[1].label || pair[0].field !== pair[1].field) {
+        console.warn('Expected pair.label and .field to match', pair);
+      }
     }
     return (
       <thead>

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -45,43 +45,50 @@ function getByPath(nested, field) {
   return current;
 }
 
-function makeTheadComponent() {
-  return function ResultsThead(props) {
-    const { items, toggleItem, selectedItems } = props;
-    if (selectedItems.length > 1) {
-      console.warn('Expected only a single sort, not:', selectedItems);
+function getOrder(orderPair, selectedItems) {
+  if (selectedItems.length > 1) {
+    console.warn('Expected only a single sort, not:', selectedItems);
+  }
+  const selectedItem = selectedItems.length ? selectedItems[0] : undefined;
+  const match = orderPair.filter((item) => item.key === selectedItem);
+  return match.length ? match[0].order : undefined;
+}
+
+function getOrderIcon(order) {
+  if (order === 'asc') return <ArrowUpOn />;
+  if (order === 'desc') return <ArrowDownOn />;
+  return <ArrowDownOff />;
+}
+
+function SortingThead(props) {
+  const { items, toggleItem, selectedItems } = props;
+  const pairs = [];
+  for (let i = 0; i < items.length; i += 2) {
+    const pair = items.slice(i, i + 2);
+    pairs.push(pair);
+    if (pair[0].label !== pair[1].label || pair[0].field !== pair[1].field) {
+      console.warn('Expected pair.label and .field to match', pair);
     }
-    const selectedItem = selectedItems.length ? selectedItems[0] : undefined;
-    const pairs = [];
-    for (let i = 0; i < items.length; i += 2) {
-      const pair = items.slice(i, i + 2);
-      pairs.push(pair);
-      if (pair[0].label !== pair[1].label || pair[0].field !== pair[1].field) {
-        console.warn('Expected pair.label and .field to match', pair);
-      }
-    }
-    return (
-      <thead>
-        <tr>
-          {pairs.map((pair) => {
-            const match = pair.filter((item) => item.key === selectedItem);
-            const order = match.length ? match[0].order : undefined;
-            const orderIcon = order ? { asc: <ArrowUpOn />, desc: <ArrowDownOn /> }[order] : <ArrowDownOff />;
-            return (
-              <th
-                key={pair[0].key}
-                onClick={() => {
-                  toggleItem(pair[order && order === pair[0].order ? 1 : 0].key);
-                }}
-              >
-                {pair[0].label}&nbsp;{orderIcon}
-              </th>
-            );
-          })}
-        </tr>
-      </thead>
-    );
-  };
+  }
+  return (
+    <thead>
+      <tr>
+        {pairs.map((pair) => {
+          const order = getOrder(pair, selectedItems);
+          return (
+            <th
+              key={pair[0].key}
+              onClick={() => {
+                toggleItem(pair[order && order === pair[0].order ? 1 : 0].key);
+              }}
+            >
+              {pair[0].label} {getOrderIcon(order)}
+            </th>
+          );
+        })}
+      </tr>
+    </thead>
+  );
 }
 
 function makeTbodyComponent(resultFields, detailsUrlPrefix, idField) {
@@ -187,7 +194,7 @@ function SearchWrapper(props) {
             </ActionBarRow>
           </ActionBar>
           <table className="sk-table">
-            <SortingSelector options={sortOptions} listComponent={makeTheadComponent()} />
+            <SortingSelector options={sortOptions} listComponent={SortingThead} />
             <Hits
               mod="sk-hits-list"
               hitsPerPage={hitsPerPage}

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -48,7 +48,7 @@ function getByPath(nested, field) {
 
 function makeTheadComponent() {
   return function ResultsTheadTd(props) {
-    const { items, setItems, selectedItems } = props;
+    const { items, toggleItem, selectedItems } = props;
     if (selectedItems.length > 1) {
       console.warn(`Expected only a single selected sort, not ${JSON.stringify(selectedItems)}`);
     }
@@ -68,7 +68,7 @@ function makeTheadComponent() {
               <th
                 key={pair[0].key}
                 onClick={() => {
-                  setItems([pair[0].key]);
+                  toggleItem(pair[order && order === pair[0].order ? 1 : 0].key);
                 }}
               >
                 {pair[0].label}&nbsp;{orderIcon}

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -48,7 +48,11 @@ function getByPath(nested, field) {
 
 function makeTheadComponent() {
   return function ResultsTheadTd(props) {
-    const { items, setItems } = props;
+    const { items, setItems, selectedItems } = props;
+    if (selectedItems.length > 1) {
+      console.warn(`Expected only a single selected sort, not ${JSON.stringify(selectedItems)}`);
+    }
+    const selectedItem = selectedItems.length ? selectedItems[0] : undefined;
     const pairs = [];
     for (let i = 0; i < items.length; i += 2) {
       pairs.push(items.slice(i, i + 2));
@@ -56,9 +60,16 @@ function makeTheadComponent() {
     return (
       <thead>
         <tr>
-          {pairs.map((pair) => (
-            <th key={pair[0].key}>{pair[0].label}</th>
-          ))}
+          {pairs.map((pair) => {
+            const match = pair.filter((item) => item.key === selectedItem);
+            const order = match.length ? match[0].order : undefined;
+            const orderIcon = order ? { asc: '^', desc: 'v' }[order] : undefined;
+            return (
+              <th key={pair[0].key}>
+                {pair[0].label}&nbsp;{orderIcon}
+              </th>
+            );
+          })}
         </tr>
       </thead>
     );

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -21,6 +21,8 @@ import {
 import * as filterTypes from 'searchkit'; // eslint-disable-line import/no-duplicates
 // There is more in the name space, but we only need the filterTypes.
 
+import { resultFieldsToSortOptions } from './utils';
+
 function getByPath(nested, field) {
   const path = field.id;
   let current = nested;
@@ -144,12 +146,12 @@ function SearchWrapper(props) {
     resultFields,
     hitsPerPage,
     httpHeaders,
-    sortOptions,
     hiddenFilterIds,
     searchUrlPath,
     queryFields,
     isLoggedIn,
   } = props;
+  const sortOptions = resultFieldsToSortOptions(resultFields);
   const resultFieldIds = resultFields.map((field) => field.id).concat(idField);
   const searchkit = new SearchkitManager(apiUrl, { httpHeaders, searchUrlPath });
 

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -48,7 +48,7 @@ function getByPath(nested, field) {
 
 function makeTheadComponent() {
   return function ResultsTheadTd(props) {
-    const { items } = props;
+    const { items, setItems } = props;
     const pairs = [];
     for (let i = 0; i < items.length; i += 2) {
       pairs.push(items.slice(i, i + 2));
@@ -57,7 +57,7 @@ function makeTheadComponent() {
       <thead>
         <tr>
           {pairs.map((pair) => (
-            <td>{JSON.stringify(pair)}</td>
+            <th key={pair[0].key}>{pair[0].label}</th>
           ))}
         </tr>
       </thead>

--- a/context/app/static/js/components/Search/config.js
+++ b/context/app/static/js/components/Search/config.js
@@ -65,33 +65,3 @@ export const datasetConfig = {
     field('mapped_last_modified_timestamp', 'Last Modified'),
   ],
 };
-
-export const lastModifiedSort = [
-  {
-    label: 'Newest',
-    field: 'last_modified_timestamp',
-    order: 'desc',
-    defaultOption: true,
-  },
-  {
-    label: 'Oldest',
-    field: 'last_modified_timestamp',
-    order: 'asc',
-    defaultOption: false,
-  },
-];
-
-export const sizeSort = [
-  {
-    label: 'Largest',
-    field: 'mapper_metadata.size',
-    order: 'desc',
-    defaultOption: false,
-  },
-  {
-    label: 'Smallest',
-    field: 'mapper_metadata.size',
-    order: 'asc',
-    defaultOption: false,
-  },
-];

--- a/context/app/static/js/components/Search/style.js
+++ b/context/app/static/js/components/Search/style.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import ArrowUpward from '@material-ui/icons/ArrowUpwardRounded';
+import ArrowDownward from '@material-ui/icons/ArrowDownwardRounded';
+
+const ArrowUpOn = styled(ArrowUpward)`
+  vertical-align: middle;
+`;
+
+const ArrowDownOn = styled(ArrowDownward)`
+  vertical-align: middle;
+`;
+
+const ArrowUpOff = styled(ArrowUpward)`
+  vertical-align: middle;
+  opacity: 12%;
+`;
+
+const ArrowDownOff = styled(ArrowDownward)`
+  vertical-align: middle;
+  opacity: 12%;
+`;
+
+export { ArrowUpOn, ArrowDownOn, ArrowUpOff, ArrowDownOff };

--- a/context/app/static/js/components/Search/utils.js
+++ b/context/app/static/js/components/Search/utils.js
@@ -52,3 +52,19 @@ export function checkboxFilter(id, name, filter) {
     },
   };
 }
+
+export function resultFieldsToSortOptions(fields) {
+  return fields
+    .map((f) => {
+      const base = {
+        defaultOption: false,
+        label: f.name,
+        field: `${f.id}.keyword`,
+      };
+      return [
+        { ...base, order: 'desc', defaultOption: f.id === 'mapped_last_modified_timestamp' },
+        { ...base, order: 'asc' },
+      ];
+    })
+    .flat();
+}

--- a/context/app/static/js/components/Search/utils.js
+++ b/context/app/static/js/components/Search/utils.js
@@ -56,10 +56,18 @@ export function checkboxFilter(id, name, filter) {
 export function resultFieldsToSortOptions(fields) {
   return fields
     .map((f) => {
+      // We are using default mappings in Elasticsearch.
+      // As a consequence, if we want to sort a text field,
+      // we need to use the ".keyword" mapping.
+      // No such suffix is necessary (or allowed) for numeric fields.
+      // https://www.elastic.co/blog/strings-are-dead-long-live-strings
+      //
+      // So: If there are more numeric fields, remember to update the regex!
+      const isNumeric = f.id.match(/\.(age|bmi|size)$/);
       const base = {
         defaultOption: false,
         label: f.name,
-        field: `${f.id}.keyword`,
+        field: `${f.id}${isNumeric ? '' : '.keyword'}`,
       };
       return [
         { ...base, order: 'desc', defaultOption: f.id === 'mapped_last_modified_timestamp' },


### PR DESCRIPTION
Fix #753 - Click any column header to sort.
- Sort options are generated based on the columns in the table.
- The table header has been removed, and replaced by the sort selector ... except instead of generating a pulldown menu, it generates the `<th>`s.
- One UI consequence is that when there are no results, the table header is still shown... I'm ok with this.
- Feel free to say the code is just a rat's nest: Should it be split into more files? Should the nested functions be pulled out?
- Would you prefer some kind of icon to the unicode triangles?
