### PR TITLE
John conroy/update footer

### DIFF
--- a/CHANGELOG-update-footer.md
+++ b/CHANGELOG-update-footer.md
@@ -1,0 +1,1 @@
+- Update footer per 07/29/2020 design.

--- a/context/app/static/js/components/Collections/Collections/style.js
+++ b/context/app/static/js/components/Collections/Collections/style.js
@@ -1,10 +1,10 @@
 import styled from 'styled-components';
 import Paper from '@material-ui/core/Paper';
 
-// 88px = header height + header margin, 60px = footer height
+// 88px = header height + header margin
 const PageWrapper = styled.div`
   @media (min-width: ${(props) => props.theme.breakpoints.values.md}px) {
-    height: calc(100vh - 88px - 60px);
+    height: calc(100vh - 88px);
     display: flex;
     flex-direction: column;
   }

--- a/context/app/static/js/components/Detail/DetailLayout/style.js
+++ b/context/app/static/js/components/Detail/DetailLayout/style.js
@@ -8,6 +8,7 @@ const FlexRow = styled.div`
   flex-grow: 1;
   display: flex;
   justify-content: center;
+  margin-bottom: ${(props) => props.theme.spacing(5)}px;
 `;
 
 export { Content, FlexRow };

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -1,23 +1,79 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
-import Hyperlink from '@material-ui/core/Link';
-import { Flex } from './style';
+
+import { LightBlueLink } from 'shared-styles/Links';
+import { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background } from './style';
 
 function Footer() {
   return (
-    <Flex maxWidth="lg">
-      <Typography variant="body2" color="secondary">
-        {'Copyright © '}
-        <Hyperlink color="inherit" href="https://hubmapconsortium.org" target="_blank" rel="noopener noreferrer">
-          Human BioMolecular Atlas Program (HuBMAP)
-        </Hyperlink>{' '}
-        {new Date().getFullYear()}
-        {'. All rights reserved. '}
-      </Typography>
-      <Typography variant="body2" color="secondary">
-        Supported by the NIH Common Fund.
-      </Typography>
-    </Flex>
+    <Background>
+      <FlexContainer maxWidth="lg">
+        <LogoWrapper>
+          <HubmapLogo />
+        </LogoWrapper>
+        <div>
+          <Flex>
+            <FlexColumn $mr={1}>
+              <Typography variant="subtitle2">About</Typography>
+              <LightBlueLink
+                href="https://hubmapconsortium.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="body2"
+              >
+                Project Website
+              </LightBlueLink>
+              <LightBlueLink href="/docs" variant="body2">
+                Documentation
+              </LightBlueLink>
+              <LightBlueLink variant="body2" href="mailto:help@hubmapconsortium.org">
+                Contact
+              </LightBlueLink>
+            </FlexColumn>
+            <FlexColumn $mr={1}>
+              <Typography variant="subtitle2">Policies</Typography>
+              <LightBlueLink
+                href="https://hubmapconsortium.org/policies/"
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="body2"
+              >
+                Overview
+              </LightBlueLink>
+              <LightBlueLink
+                href="https://hubmapconsortium.org/wp-content/uploads/2020/06/DUA_FINAL_2020_02_03_for_Signature.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="body2"
+              >
+                Data Use Agreement
+              </LightBlueLink>
+              <LightBlueLink variant="body2">Citing HuBMAP</LightBlueLink>
+            </FlexColumn>
+            <FlexColumn>
+              <Typography variant="subtitle2">Funding</Typography>
+              <LightBlueLink
+                href="https://commonfund.nih.gov/hubmap"
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="body2"
+              >
+                NIH Common Fund
+              </LightBlueLink>
+            </FlexColumn>
+          </Flex>
+          <Typography variant="body1" color="secondary">
+            {'Copyright '}
+            <LightBlueLink href="https://hubmapconsortium.org" target="_blank" rel="noopener noreferrer">
+              NIH Human BioMolecular Atlas Program (HuBMAP)
+            </LightBlueLink>{' '}
+            {new Date().getFullYear()}
+            {'. All rights reserved. '}
+          </Typography>
+        </div>
+        <div />
+      </FlexContainer>
+    </Background>
   );
 }
 

--- a/context/app/static/js/components/Footer/style.js
+++ b/context/app/static/js/components/Footer/style.js
@@ -1,12 +1,42 @@
 import styled from 'styled-components';
 import Container from '@material-ui/core/Container';
+import Logo from 'images/hubmap-logo.svg';
 
-const Flex = styled(Container)`
-  height: 60px;
+const FlexContainer = styled(Container)`
+  margin-top: ${(props) => props.theme.spacing(4)}px;
+  margin-bottom: ${(props) => props.theme.spacing(2)}px;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  align-items: center;
+  align-items: top;
 `;
 
-export { Flex };
+const Flex = styled.div`
+  display: flex;
+  margin-bottom: ${(props) => props.theme.spacing(4)}px;
+  flex-wrap: wrap;
+`;
+
+const FlexColumn = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-right: ${(props) => (props.$mr ? props.theme.spacing(10) : '0')}px;
+`;
+
+const HubmapLogo = styled(Logo)`
+  height: 29px;
+  fill: ${(props) => props.theme.palette.primary.main};
+`;
+
+// To account for the line height of the other text
+const LogoWrapper = styled.div`
+  margin-top: 5px;
+`;
+
+const Background = styled.div`
+  background-color: #fff;
+  width: 100%;
+`;
+
+
+export { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background };

--- a/context/app/static/js/components/Footer/style.js
+++ b/context/app/static/js/components/Footer/style.js
@@ -38,5 +38,4 @@ const Background = styled.div`
   width: 100%;
 `;
 
-
 export { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background };

--- a/context/app/static/js/index.css
+++ b/context/app/static/js/index.css
@@ -1,5 +1,4 @@
 :root {
-  --foot-height: 60px;
   --header-height: 60px;
 }
 
@@ -33,12 +32,6 @@ li {
 
 .container-lg {
   max-width: 1240px;
-}
-
-.footer {
-  height: var(--foot-height);
-  width: 100%;
-  line-height: var(--foot-height); /* Vertically center the text there */
 }
 
 a {

--- a/context/app/static/js/shared-styles/Links/index.js
+++ b/context/app/static/js/shared-styles/Links/index.js
@@ -1,7 +1,11 @@
+import React from 'react';
 import styled from 'styled-components';
 import Link from '@material-ui/core/Link';
 
-const LightBlueLink = styled(Link)`
+// eslint-disable-next-line react/jsx-props-no-spreading
+const LinkWithoutUnderline = (props) => <Link {...props} underline="none" />;
+
+const LightBlueLink = styled(LinkWithoutUnderline)`
   color: ${(props) => props.theme.palette.info.main};
 `;
 

--- a/context/app/static/js/theme.jsx
+++ b/context/app/static/js/theme.jsx
@@ -70,7 +70,7 @@ const theme = createMuiTheme({
     },
     subtitle2: {
       fontWeight: 500,
-      fontiSize: '0.875rem',
+      fontSize: '0.875rem',
     },
     body1: {
       fontWeight: 300,


### PR DESCRIPTION
Fix #936. Fix #919. 

- Footer is now below the fold for collections page.
- No link exists for 'Citing HuBMAP' in footer.

<img width="1792" alt="Screen Shot 2020-07-30 at 4 09 29 PM" src="https://user-images.githubusercontent.com/62477388/88973605-55c9e700-d285-11ea-9f9e-52167a639429.png">
