### PR TITLE
No more currently selected filters at top

### DIFF
--- a/CHANGELOG-no-selected-filters-at-top.md
+++ b/CHANGELOG-no-selected-filters-at-top.md
@@ -1,0 +1,1 @@
+- Don't show the currently selected filters across the top.

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -9,7 +9,6 @@ import {
   SortingSelector,
   ActionBar,
   ActionBarRow,
-  SelectedFilters,
   NoHits,
   HitsStats,
   Hits,
@@ -113,39 +112,6 @@ function makeTbodyComponent(resultFields, detailsUrlPrefix, idField) {
   };
 }
 
-function MaskedSelectedFilters(props) {
-  const { hiddenFilterIds } = props;
-  const SelectedFilter = (filterProps) => {
-    const isHidden = hiddenFilterIds.indexOf(filterProps.filterId) !== -1;
-
-    const style = isHidden ? { display: 'None' } : {};
-
-    // Copy and paste from
-    // http://docs.searchkit.co/v0.8.3/docs/components/navigation/selected-filters.html
-    // plus typo corrections and wrapping div.
-    /* eslint-disable jsx-a11y/click-events-have-key-events */
-    /* eslint-disable jsx-a11y/no-static-element-interactions */
-    return (
-      <div
-        style={style}
-        className={filterProps.bemBlocks
-          .option()
-          .mix(filterProps.bemBlocks.container('item'))
-          .mix(`selected-filter--${filterProps.filterId}`)}
-      >
-        <div className={filterProps.bemBlocks.option('name')}>
-          {`${filterProps.labelKey}: ${filterProps.labelValue}`}
-        </div>
-        <div className={filterProps.bemBlocks.option('remove-action')} onClick={filterProps.removeFilter}>
-          x
-        </div>
-      </div>
-    );
-    /* eslint-enable */
-  };
-  return <SelectedFilters itemComponent={SelectedFilter} />;
-}
-
 function SearchWrapper(props) {
   const {
     apiUrl,
@@ -191,7 +157,6 @@ function SearchWrapper(props) {
                   'hitstats.results_found': '{hitCount} results found',
                 }}
               />
-              <MaskedSelectedFilters hiddenFilterIds={hiddenFilterIds} />
             </ActionBarRow>
           </ActionBar>
           <table className="sk-table">


### PR DESCRIPTION
Fix #951 
<img width="985" alt="Screen Shot 2020-07-31 at 1 15 14 PM" src="https://user-images.githubusercontent.com/730388/89060257-b7935b00-d330-11ea-99a5-344825f272d1.png">

@tsliaw : I won't block, but I am really uncomfortable with this. It's going to be so easy for the user to loose track of what filters are applied. If there is some replacement that you and Nils are envisaging, I would like to get that in now rather than leaving it in this state.
