### PR TITLE
Mccalluc/consistent table styling

### DIFF
--- a/CHANGELOG-material-search.md
+++ b/CHANGELOG-material-search.md
@@ -1,0 +1,1 @@
+- Use Material UI styling for the search table.

--- a/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
@@ -5,6 +5,7 @@ import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
 import IconButton from '@material-ui/core/IconButton';
 import metadataFieldDescriptions from 'metadata-field-descriptions';
 import { tableToDelimitedString, createDownloadUrl } from 'helpers/functions';

--- a/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
@@ -5,7 +5,6 @@ import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
 import IconButton from '@material-ui/core/IconButton';
 import metadataFieldDescriptions from 'metadata-field-descriptions';
 import { tableToDelimitedString, createDownloadUrl } from 'helpers/functions';

--- a/context/app/static/js/components/Search/DevSearch.jsx
+++ b/context/app/static/js/components/Search/DevSearch.jsx
@@ -4,7 +4,6 @@ import { ExistsQuery, BoolMustNot } from 'searchkit';
 
 import { readCookie } from 'helpers/functions';
 import SearchWrapper from './SearchWrapper';
-import './Search.scss';
 // eslint-disable-next-line import/named
 import { field, filter, checkboxFilter } from './utils';
 

--- a/context/app/static/js/components/Search/DevSearch.jsx
+++ b/context/app/static/js/components/Search/DevSearch.jsx
@@ -38,8 +38,8 @@ const searchProps = {
   filters: [
     filter('entity_type', 'Entity Type'),
     filter('mapper_metadata.version', 'Mapper Version'),
-    checkboxFilter('has_metadata', 'Has metadata?', ExistsQuery('metadata')),
-    checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata'))),
+    checkboxFilter('has_metadata', 'Has metadata?', ExistsQuery('metadata.metadata')),
+    checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata.metadata'))),
     checkboxFilter('has_files', 'Has files?', ExistsQuery('files')),
     checkboxFilter('no_files', 'No files?', BoolMustNot(ExistsQuery('files'))),
   ],

--- a/context/app/static/js/components/Search/Search.jsx
+++ b/context/app/static/js/components/Search/Search.jsx
@@ -3,7 +3,6 @@ import Typography from '@material-ui/core/Typography';
 import { readCookie } from 'helpers/functions';
 import LookupEntity from 'helpers/LookupEntity';
 import SearchWrapper from './SearchWrapper';
-import './Search.scss';
 import { donorConfig, sampleConfig, datasetConfig } from './config';
 // eslint-disable-next-line import/named
 import { filter } from './utils';

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -10,17 +10,6 @@
 .sk-table {
     width: 100%;
 
-    // NOTE: If we want to darken on hover, we need to give an explicit background to all rows.
-    // (What looks white is actually "transparent" and brightness() has no effect.
-
-    tbody tr {
-        background-color: #FFF;
-        border: 1px solid #cbcbcb;
-    }
-    tbody tr:hover {
-        filter: brightness(96%);
-    }
-
     // Force <a> to fill each cell, so the whole row is clickable.
     // https://stackoverflow.com/questions/3966027
     td {

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -10,11 +10,6 @@
 .sk-table {
     width: 100%;
 
-    th {
-        cursor: pointer;
-        white-space: nowrap;
-    }
-
     // NOTE: If we want to darken on hover, we need to give an explicit background to all rows.
     // (What looks white is actually "transparent" and brightness() has no effect.
 

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -1,28 +1,6 @@
-// For example: This makes the "View all" links red.
-// $sk-action-text-color: red;
-
 @import "~searchkit/theming/theme.scss";
 
 .sk-layout__body {
+    // Without this, there's too much space at the top.
     margin: 0px;
-}
-
-.sk-table {
-    width: 100%;
-
-    // Force <a> to fill each cell, so the whole row is clickable.
-    // https://stackoverflow.com/questions/3966027
-    td {
-        overflow: hidden;
-    }
-    td a {
-        display: block;
-        margin: -100%;
-        padding: 100%;
-        color: rgb(0,0,0);
-    }
-
-    td:first-child a {
-        color: #3781D1;
-    }
 }

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -6,7 +6,6 @@ import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
-import { StyledTableContainer, HeaderCell } from 'shared-styles/Table';
 
 import {
   SearchkitManager,
@@ -29,7 +28,7 @@ import * as filterTypes from 'searchkit'; // eslint-disable-line import/no-dupli
 // There is more in the name space, but we only need the filterTypes.
 
 import { resultFieldsToSortOptions } from './utils';
-import { ArrowUpOn, ArrowDownOn, ArrowDownOff } from './style';
+import { ArrowUpOn, ArrowDownOn, ArrowDownOff, StyledHeaderCell } from './style';
 
 function getByPath(nested, field) {
   const path = field.id;
@@ -83,7 +82,7 @@ function SortingTableHead(props) {
         {pairs.map((pair) => {
           const order = getOrder(pair, selectedItems);
           return (
-            <HeaderCell
+            <StyledHeaderCell
               role="button"
               key={pair[0].key}
               onClick={() => {
@@ -91,7 +90,7 @@ function SortingTableHead(props) {
               }}
             >
               {pair[0].label} {getOrderIcon(order)}
-            </HeaderCell>
+            </StyledHeaderCell>
           );
         })}
       </TableRow>

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
 
 import {
   SearchkitManager,
@@ -77,7 +78,7 @@ function SortingTableHead(props) {
   }
   return (
     <TableHead>
-      <StyledTableRow>
+      <TableRow>
         {pairs.map((pair) => {
           const order = getOrder(pair, selectedItems);
           return (
@@ -92,7 +93,7 @@ function SortingTableHead(props) {
             </StyledHeaderCell>
           );
         })}
-      </StyledTableRow>
+      </TableRow>
     </TableHead>
   );
 }

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+import { StyledTableContainer, HeaderCell } from 'shared-styles/Table';
+
 import {
   SearchkitManager,
   SearchkitProvider,
@@ -60,7 +67,7 @@ function getOrderIcon(order) {
   return <ArrowDownOff />;
 }
 
-function SortingThead(props) {
+function SortingTableHead(props) {
   const { items, toggleItem, selectedItems } = props;
   const pairs = [];
   for (let i = 0; i < items.length; i += 2) {
@@ -71,12 +78,12 @@ function SortingThead(props) {
     }
   }
   return (
-    <thead>
-      <tr>
+    <TableHead>
+      <TableRow>
         {pairs.map((pair) => {
           const order = getOrder(pair, selectedItems);
           return (
-            <th
+            <HeaderCell
               role="button"
               key={pair[0].key}
               onClick={() => {
@@ -84,30 +91,30 @@ function SortingThead(props) {
               }}
             >
               {pair[0].label} {getOrderIcon(order)}
-            </th>
+            </HeaderCell>
           );
         })}
-      </tr>
-    </thead>
+      </TableRow>
+    </TableHead>
   );
 }
 
-function makeTbodyComponent(resultFields, detailsUrlPrefix, idField) {
-  return function ResultsTbody(props) {
+function makeTableBodyComponent(resultFields, detailsUrlPrefix, idField) {
+  return function ResultsTableBody(props) {
     const { hits } = props;
     /* eslint-disable no-underscore-dangle */
     return (
-      <tbody>
+      <TableBody>
         {hits.map((hit) => (
-          <tr key={hit._id}>
+          <TableRow key={hit._id}>
             {resultFields.map((field) => (
-              <td key={field.id}>
+              <TableCell key={field.id}>
                 <a href={detailsUrlPrefix + hit._source[idField]}>{getByPath(hit._source, field)}</a>
-              </td>
+              </TableCell>
             ))}
-          </tr>
+          </TableRow>
         ))}
-      </tbody>
+      </TableBody>
     );
     /* eslint-enable no-underscore-dangle */
   };
@@ -194,15 +201,14 @@ function SearchWrapper(props) {
               <MaskedSelectedFilters hiddenFilterIds={hiddenFilterIds} />
             </ActionBarRow>
           </ActionBar>
-          <table className="sk-table">
-            <SortingSelector options={sortOptions} listComponent={SortingThead} />
+          <Table>
+            <SortingSelector options={sortOptions} listComponent={SortingTableHead} />
             <Hits
-              mod="sk-hits-list"
               hitsPerPage={hitsPerPage}
-              listComponent={makeTbodyComponent(resultFields, detailsUrlPrefix, idField)}
+              listComponent={makeTableBodyComponent(resultFields, detailsUrlPrefix, idField)}
               sourceFilter={resultFieldIds}
             />
-          </table>
+          </Table>
           <NoHits
             translations={{
               'NoHits.NoResultsFound': `No results found. ${isLoggedIn ? '' : 'Login to view more results.'}`,

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -27,6 +27,7 @@ import * as filterTypes from 'searchkit'; // eslint-disable-line import/no-dupli
 
 import { resultFieldsToSortOptions } from './utils';
 import { ArrowUpOn, ArrowDownOn, ArrowDownOff, StyledHeaderCell, StyledTableRow, StyledTableCell } from './style';
+import './Search.scss';
 
 function getByPath(nested, field) {
   const path = field.id;

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -28,7 +28,7 @@ import * as filterTypes from 'searchkit'; // eslint-disable-line import/no-dupli
 // There is more in the name space, but we only need the filterTypes.
 
 import { resultFieldsToSortOptions } from './utils';
-import { ArrowUpOn, ArrowDownOn, ArrowDownOff, StyledHeaderCell } from './style';
+import { ArrowUpOn, ArrowDownOn, ArrowDownOff, StyledHeaderCell, StyledTableRow } from './style';
 
 function getByPath(nested, field) {
   const path = field.id;
@@ -105,13 +105,13 @@ function makeTableBodyComponent(resultFields, detailsUrlPrefix, idField) {
     return (
       <TableBody>
         {hits.map((hit) => (
-          <TableRow key={hit._id}>
+          <StyledTableRow key={hit._id}>
             {resultFields.map((field) => (
               <TableCell key={field.id}>
                 <a href={detailsUrlPrefix + hit._source[idField]}>{getByPath(hit._source, field)}</a>
               </TableCell>
             ))}
-          </TableRow>
+          </StyledTableRow>
         ))}
       </TableBody>
     );

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
 import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
 
 import {
   SearchkitManager,
@@ -28,7 +26,7 @@ import * as filterTypes from 'searchkit'; // eslint-disable-line import/no-dupli
 // There is more in the name space, but we only need the filterTypes.
 
 import { resultFieldsToSortOptions } from './utils';
-import { ArrowUpOn, ArrowDownOn, ArrowDownOff, StyledHeaderCell, StyledTableRow } from './style';
+import { ArrowUpOn, ArrowDownOn, ArrowDownOff, StyledHeaderCell, StyledTableRow, StyledTableCell } from './style';
 
 function getByPath(nested, field) {
   const path = field.id;
@@ -78,7 +76,7 @@ function SortingTableHead(props) {
   }
   return (
     <TableHead>
-      <TableRow>
+      <StyledTableRow>
         {pairs.map((pair) => {
           const order = getOrder(pair, selectedItems);
           return (
@@ -93,7 +91,7 @@ function SortingTableHead(props) {
             </StyledHeaderCell>
           );
         })}
-      </TableRow>
+      </StyledTableRow>
     </TableHead>
   );
 }
@@ -107,9 +105,9 @@ function makeTableBodyComponent(resultFields, detailsUrlPrefix, idField) {
         {hits.map((hit) => (
           <StyledTableRow key={hit._id}>
             {resultFields.map((field) => (
-              <TableCell key={field.id}>
+              <StyledTableCell key={field.id}>
                 <a href={detailsUrlPrefix + hit._source[idField]}>{getByPath(hit._source, field)}</a>
-              </TableCell>
+              </StyledTableCell>
             ))}
           </StyledTableRow>
         ))}

--- a/context/app/static/js/components/Search/style.js
+++ b/context/app/static/js/components/Search/style.js
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import ArrowUpward from '@material-ui/icons/ArrowUpwardRounded';
 import ArrowDownward from '@material-ui/icons/ArrowDownwardRounded';
+import TableRow from '@material-ui/core/TableRow';
+
 import { HeaderCell } from 'shared-styles/Table';
 
 const ArrowUpOn = styled(ArrowUpward)`
@@ -26,4 +28,14 @@ const StyledHeaderCell = styled(HeaderCell)`
   white-space: nowrap;
 `;
 
-export { ArrowUpOn, ArrowDownOn, ArrowUpOff, ArrowDownOff, StyledHeaderCell };
+const StyledTableRow = styled(TableRow)`
+  // NOTE: If we want to darken on hover, we need to give an explicit background to all rows.
+  // What looks white is actually transparent and brightness() has no effect.
+  background-color: #fff;
+
+  :hover {
+    filter: brightness(96%);
+  }
+`;
+
+export { ArrowUpOn, ArrowDownOn, ArrowUpOff, ArrowDownOff, StyledHeaderCell, StyledTableRow };

--- a/context/app/static/js/components/Search/style.js
+++ b/context/app/static/js/components/Search/style.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import ArrowUpward from '@material-ui/icons/ArrowUpwardRounded';
 import ArrowDownward from '@material-ui/icons/ArrowDownwardRounded';
 import TableRow from '@material-ui/core/TableRow';
+import TableCell from '@material-ui/core/TableCell';
 
 import { HeaderCell } from 'shared-styles/Table';
 
@@ -38,4 +39,22 @@ const StyledTableRow = styled(TableRow)`
   }
 `;
 
-export { ArrowUpOn, ArrowDownOn, ArrowUpOff, ArrowDownOff, StyledHeaderCell, StyledTableRow };
+const StyledTableCell = styled(TableCell)`
+  // Force <a> to fill each cell, so the whole row is clickable.
+  // https://stackoverflow.com/questions/3966027
+
+  overflow: hidden;
+
+  & a {
+    display: block;
+    margin: -100%;
+    padding: 100%;
+    color: rgb(0, 0, 0);
+  }
+
+  &:first-child a {
+    color: #3781d1;
+  }
+`;
+
+export { ArrowUpOn, ArrowDownOn, ArrowUpOff, ArrowDownOff, StyledHeaderCell, StyledTableRow, StyledTableCell };

--- a/context/app/static/js/components/Search/style.js
+++ b/context/app/static/js/components/Search/style.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import ArrowUpward from '@material-ui/icons/ArrowUpwardRounded';
 import ArrowDownward from '@material-ui/icons/ArrowDownwardRounded';
+import { HeaderCell } from 'shared-styles/Table';
 
 const ArrowUpOn = styled(ArrowUpward)`
   vertical-align: middle;
@@ -20,4 +21,9 @@ const ArrowDownOff = styled(ArrowDownward)`
   opacity: 12%;
 `;
 
-export { ArrowUpOn, ArrowDownOn, ArrowUpOff, ArrowDownOff };
+const StyledHeaderCell = styled(HeaderCell)`
+  cursor: pointer;
+  white-space: nowrap;
+`;
+
+export { ArrowUpOn, ArrowDownOn, ArrowUpOff, ArrowDownOff, StyledHeaderCell };


### PR DESCRIPTION
Fix #928. Conversion to Material UI was pretty straight-forward.

Tweak to dev-search: The metadata table actually comes from `metadata.metadata`.

Somewhat contingent on #953, should anything different be done with the space above the column headers right now? Or is this fine for now?

<img width="608" alt="Screen Shot 2020-07-31 at 3 07 25 PM" src="https://user-images.githubusercontent.com/730388/89068700-ca615c00-d33f-11ea-98db-b74dd1136025.png">
