### PR TITLE
Mccalluc/no more pr after release

### DIFF
--- a/CHANGELOG-no-pr-after-release.md
+++ b/CHANGELOG-no-pr-after-release.md
@@ -1,0 +1,1 @@
+- For a release, just do everything on master. Requiring manual PR doesn't really help us.

--- a/push.sh
+++ b/push.sh
@@ -9,8 +9,6 @@ git pull
 
 perl -i -pne 's/(\d+)$/$1+1/e' context/app/markdown/VERSION.md
 VERSION=`cat VERSION`
-BRANCH="release-$VERSION"
-git checkout -b "$BRANCH"
 git add .
 git commit -m 'Version bump'
 
@@ -53,6 +51,4 @@ git submodule foreach '
 git add .
 git commit -m 'Update submodules' || echo 'Nothing to commit; Continue to git push...'
 
-git push --set-upstream origin $BRANCH
-
-echo "Open a new PR on github with $BRANCH."
+git push origin


### PR DESCRIPTION
Fix #990. This would prevent the problem we had in 47 and 48 from recurring:
> Chuck neglected to merge the PR for v0.0.47, though the docker image and tag were made successfully. He then misdiagnosed the problem, and incremented the version number.
>
> So: Changes below include work from v0.0.47, and there is no v0.0.48. Sorry!