### PR TITLE
John conroy/sample tissue tests

### DIFF
--- a/context/CHANGELOG-sample-tissue-tests.md
+++ b/context/CHANGELOG-sample-tissue-tests.md
@@ -1,0 +1,1 @@
+- Add tests for sample tissue component.

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
@@ -1,0 +1,34 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import { render, screen } from 'test-utils/functions';
+import SampleTissue from './SampleTissue';
+
+test('text displays properly when all props provided', () => {
+  render(
+    <SampleTissue
+      mapped_organ="Fake Organ"
+      mapped_specimen_type="Fake Specimen Type"
+      tissueLocation="Fake Tissue Location"
+    />,
+  );
+
+  expect(screen.getByText('Tissue')).toBeInTheDocument();
+
+  const labelsToTest = ['Organ Type', 'Specimen Type', 'Tissue Location'];
+  labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+
+  const valuesToTest = ['Fake Organ', 'Fake Specimen Type', 'Fake Tissue Location'];
+  valuesToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+});
+
+test('text displays properly when tissue location is not provided', () => {
+  render(<SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" />);
+
+  expect(screen.getByText('Tissue')).toBeInTheDocument();
+
+  const labelsToTest = ['Organ Type', 'Specimen Type', 'Tissue Location'];
+  labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+
+  const valuesToTest = ['Fake Organ', 'Fake Specimen Type', 'Tissue Location not defined'];
+  valuesToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+});


### PR DESCRIPTION
Add tests for sample tissue component.

- There's some refactoring that could be done between `SampleTissue` and `DonorMetadata`, but I don't think it's a pressing issue. 
- Do we want to continue to include `Tissue Location` even though it's still not present in the data?

