### PR TITLE
Replace gender with sex

### DIFF
--- a/CHANGELOG-sex-instead-of-gender.md
+++ b/CHANGELOG-sex-instead-of-gender.md
@@ -1,0 +1,1 @@
+- Replace "gender" with "sex" in the donor facets.

--- a/context/app/static/js/components/Detail/DonorMetadata/DonorMetadata.jsx
+++ b/context/app/static/js/components/Detail/DonorMetadata/DonorMetadata.jsx
@@ -17,14 +17,14 @@ function MetadataItem(props) {
 
 function DonorMetadata(props) {
   const { metadata } = props;
-  const { gender, age, bmi, race } = metadata;
+  const { sex, age, bmi, race } = metadata;
   return (
     <SectionContainer id="metadata">
       <SectionHeader variant="h3" component="h2">
         Metadata
       </SectionHeader>
       <FlexPaper>
-        <MetadataItem label="Gender Finding" value={gender} />
+        <MetadataItem label="Sex" value={sex} />
         <MetadataItem label="Current Chronological Age" ml={1} value={age} />
         <MetadataItem label="Body Mass Index" ml={1} value={bmi} />
         <MetadataItem label="Racial Group" ml={1} value={race} />
@@ -35,7 +35,7 @@ function DonorMetadata(props) {
 
 DonorMetadata.propTypes = {
   metadata: PropTypes.shape({
-    gender: PropTypes.string,
+    sex: PropTypes.string,
     age: PropTypes.number,
     bmi: PropTypes.number,
     race: PropTypes.string,

--- a/context/app/static/js/components/Detail/DonorMetadata/DonorMetadata.spec.js
+++ b/context/app/static/js/components/Detail/DonorMetadata/DonorMetadata.spec.js
@@ -4,15 +4,15 @@ import { render, screen } from 'test-utils/functions';
 import DonorMetadata from './DonorMetadata';
 
 test('text displays properly when metadata prop contains data', () => {
-  const metadata = { gender: 'Test Gender', age: 30, bmi: 25, race: 'Test Race' };
+  const metadata = { sex: 'Test Sex', age: 30, bmi: 25, race: 'Test Race' };
   render(<DonorMetadata metadata={metadata} />);
 
   expect(screen.getByText('Metadata')).toBeInTheDocument();
 
-  const labelsToTest = ['Gender Finding', 'Current Chronological Age', 'Body Mass Index', 'Racial Group'];
+  const labelsToTest = ['Sex', 'Current Chronological Age', 'Body Mass Index', 'Racial Group'];
   labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 
-  const valuesToTest = ['Test Gender', '30', '25', 'Test Race'];
+  const valuesToTest = ['Test Sex', '30', '25', 'Test Race'];
   valuesToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 });
 
@@ -22,11 +22,11 @@ test('text displays properly when metadata prop is empty', () => {
 
   expect(screen.getByText('Metadata')).toBeInTheDocument();
 
-  const labelsToTest = ['Gender Finding', 'Current Chronological Age', 'Body Mass Index', 'Racial Group'];
+  const labelsToTest = ['Sex', 'Current Chronological Age', 'Body Mass Index', 'Racial Group'];
   labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 
   const valuesToTest = [
-    'Gender Finding not defined',
+    'Sex not defined',
     'Current Chronological Age not defined',
     'Body Mass Index not defined',
     'Racial Group not defined',

--- a/context/app/static/js/components/Search/config.js
+++ b/context/app/static/js/components/Search/config.js
@@ -6,7 +6,7 @@ function makeDonorMetadataFilters(isDonor) {
   const pathPrefix = isDonor ? '' : 'donor.';
   const labelPrefix = isDonor ? '' : 'Donor ';
   return [
-    filter(`${pathPrefix}mapped_metadata.gender`, `${labelPrefix}Gender`),
+    filter(`${pathPrefix}mapped_metadata.sex`, `${labelPrefix}Sex`),
     rangeFilter(`${pathPrefix}mapped_metadata.age`, `${labelPrefix}Age`, 0, 100),
     filter(`${pathPrefix}mapped_metadata.race`, `${labelPrefix}Race`),
     rangeFilter(`${pathPrefix}mapped_metadata.bmi`, `${labelPrefix}BMI`, 0, 50),
@@ -23,17 +23,14 @@ export const donorConfig = {
     field('group_name', 'Group'),
     field('mapped_metadata.age', 'Age'),
     field('mapped_metadata.bmi', 'BMI'),
-    field('mapped_metadata.gender', 'Gender'),
+    field('mapped_metadata.sex', 'Sex'),
     field('mapped_metadata.race', 'Race'),
     field('mapped_last_modified_timestamp', 'Last Modified'),
   ],
 };
 
 export const sampleConfig = {
-  filters: [
-    filter('origin_sample.mapped_organ', 'Organ'),
-    filter('mapped_specimen_type', 'Specimen Type'),
-  ]
+  filters: [filter('origin_sample.mapped_organ', 'Organ'), filter('mapped_specimen_type', 'Specimen Type')]
     .concat(makeDonorMetadataFilters(false))
     .concat([filter('donor.group_name', 'Group'), filter('created_by_user_displayname', 'Creator')]),
   fields: [

--- a/context/app/static/js/components/entity-tile/EntityTileTopText/EntityTileTopText.jsx
+++ b/context/app/static/js/components/entity-tile/EntityTileTopText/EntityTileTopText.jsx
@@ -24,7 +24,7 @@ function EntityTileTopText(props) {
       {entity_type === 'Donor' && 'mapped_metadata' in entityData && (
         <>
           <Flex>
-            <Typography variant="body2">{entityData.mapped_metadata.gender}</Typography>
+            <Typography variant="body2">{entityData.mapped_metadata.sex}</Typography>
             <StyledDivider flexItem orientation="vertical" $invertColors={invertColors} />
             <Typography variant="body2">{entityData.mapped_metadata.age} years</Typography>
           </Flex>


### PR DESCRIPTION
This complements the indexing changes in search-api: https://github.com/hubmapconsortium/search-api/pull/144

- @john-conroy : Code review... just a search and replace, so hopefully I didn't find a way to mess this up.
- @ngehlenborg : When should this be merged? I think it's ok as long as the production environment has `sex`... but if the other environments have not caught up, the facet will not be available there. I think that's ok, but wanted to confirm.

(Separately from this, we want a tabular display of Donor metadata, but I don't think that more involved change should be crammed into this PR.)