### PR TITLE
John conroy/update maintenance page

### DIFF
--- a/.vscode/portal-ui.code-snippets
+++ b/.vscode/portal-ui.code-snippets
@@ -27,5 +27,13 @@
 
 		],
 		"description": "Basic imports needed for a javascript test"
+	},
+	"Import Styled Components": {
+		"prefix": "isc",
+		"body": [
+			"import styled from 'styled-components';",
+
+		],
+		"description": "Import styled-components"
 	}
 }

--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import Providers from './Providers';
 import Routes from './Routes';
 import Footer from './Footer';
-import { Header } from './Header';
+import Header from './Header';
 
 function App(props) {
   const { flaskData } = props;

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 import { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background } from './style';
 
-function Footer() {
+function Footer(props) {
+  const { isMaintenancePage } = props;
   return (
     <Background>
       <FlexContainer maxWidth="lg">
@@ -23,9 +25,11 @@ function Footer() {
               >
                 Project Website
               </LightBlueLink>
-              <LightBlueLink href="/docs" variant="body2">
-                Documentation
-              </LightBlueLink>
+              {!isMaintenancePage && (
+                <LightBlueLink href="/docs" variant="body2">
+                  Documentation
+                </LightBlueLink>
+              )}
               <LightBlueLink variant="body2" href="mailto:help@hubmapconsortium.org">
                 Contact
               </LightBlueLink>
@@ -48,9 +52,11 @@ function Footer() {
               >
                 Data Use Agreement
               </LightBlueLink>
-              <LightBlueLink href="/docs/about#citation" variant="body2">
-                Citing HuBMAP
-              </LightBlueLink>
+              {!isMaintenancePage && (
+                <LightBlueLink href="/docs/about#citation" variant="body2">
+                  Citing HuBMAP
+                </LightBlueLink>
+              )}
             </FlexColumn>
             <FlexColumn>
               <Typography variant="subtitle2">Funding</Typography>
@@ -78,5 +84,13 @@ function Footer() {
     </Background>
   );
 }
+
+Footer.propTypes = {
+  isMaintenancePage: PropTypes.bool,
+};
+
+Footer.defaultProps = {
+  isMaintenancePage: false,
+};
 
 export default Footer;

--- a/context/app/static/js/components/Header/Header/Header.jsx
+++ b/context/app/static/js/components/Header/Header/Header.jsx
@@ -1,62 +1,14 @@
 import React, { useRef } from 'react';
-import Container from '@material-ui/core/Container';
-import Toolbar from '@material-ui/core/Toolbar';
-import Tooltip from '@material-ui/core/Tooltip';
-import { useTheme } from '@material-ui/core/styles';
-import Link from '@material-ui/core/Link';
-import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { StyledAppBar, HubmapLogo, Spacer, HeaderButton } from './style';
-import Menu from '../Menu';
-import PreviewLinks from '../PreviewLinks';
-import Dropdown from '../Dropdown';
-import LoginButton from '../LoginButton';
-import DocumentationLinks from '../DocumentationLinks';
+import HeaderAppBar from '../HeaderAppBar';
+import HeaderContent from '../HeaderContent';
 
 function Header() {
-  const theme = useTheme();
-  const shouldDisplayMenu = !useMediaQuery(theme.breakpoints.up('md'));
   const anchorRef = useRef(null);
 
   return (
-    <StyledAppBar position="sticky" ref={anchorRef} elevation={0}>
-      <Container maxWidth="lg">
-        <Toolbar disableGutters>
-          {shouldDisplayMenu && <Menu anchorRef={anchorRef} />}
-          <a href="/">
-            <HubmapLogo aria-label="HubMAP logo" />
-          </a>
-          {!shouldDisplayMenu && (
-            <>
-              <div>
-                {['Donor', 'Sample', 'Dataset'].map((type) => (
-                  <HeaderButton key={type} href={`/search?entity_type[0]=${type}`} component={Link}>
-                    {`${type}s`}
-                  </HeaderButton>
-                ))}
-                <HeaderButton component={Link} href="/collections">
-                  Collections
-                </HeaderButton>
-              </div>
-              <Spacer />
-              <Dropdown title="Previews" menuListId="preview-options">
-                <PreviewLinks />
-              </Dropdown>
-              <Tooltip title="Explore HuBMAP data using the Common Coordinate Framework">
-                <HeaderButton component={Link} href="/ccf-eui">
-                  CCF
-                </HeaderButton>
-              </Tooltip>
-              <Dropdown title="Documentation" menuListId="documentation-options">
-                <DocumentationLinks />
-              </Dropdown>
-            </>
-          )}
-          {shouldDisplayMenu && <Spacer />}
-          {/* eslint-disable-next-line no-undef */}
-          <LoginButton isAuthenticated={isAuthenticated} />
-        </Toolbar>
-      </Container>
-    </StyledAppBar>
+    <HeaderAppBar anchorRef={anchorRef}>
+      <HeaderContent anchorRef={anchorRef} />
+    </HeaderAppBar>
   );
 }
 

--- a/context/app/static/js/components/Header/HeaderAppBar/HeaderAppBar.jsx
+++ b/context/app/static/js/components/Header/HeaderAppBar/HeaderAppBar.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Container from '@material-ui/core/Container';
+import Toolbar from '@material-ui/core/Toolbar';
+
+import { StyledAppBar } from './style';
+
+function HeaderAppBar(props) {
+  const { children, anchorRef } = props;
+
+  return (
+    <StyledAppBar position="sticky" ref={anchorRef} elevation={0}>
+      <Container maxWidth="lg">
+        <Toolbar disableGutters>{children} </Toolbar>
+      </Container>
+    </StyledAppBar>
+  );
+}
+
+export default HeaderAppBar;

--- a/context/app/static/js/components/Header/HeaderAppBar/index.js
+++ b/context/app/static/js/components/Header/HeaderAppBar/index.js
@@ -1,0 +1,3 @@
+import HeaderAppBar from './HeaderAppBar';
+
+export default HeaderAppBar;

--- a/context/app/static/js/components/Header/HeaderAppBar/style.js
+++ b/context/app/static/js/components/Header/HeaderAppBar/style.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import AppBar from '@material-ui/core/AppBar';
+
+const StyledAppBar = styled(AppBar)`
+  margin-bottom: ${(props) => props.theme.spacing(2)}px;
+`;
+
+export { StyledAppBar };

--- a/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
+++ b/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Tooltip from '@material-ui/core/Tooltip';
+import Link from '@material-ui/core/Link';
+import { useTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+
+import Menu from '../Menu';
+import PreviewLinks from '../PreviewLinks';
+import Dropdown from '../Dropdown';
+import LoginButton from '../LoginButton';
+import DocumentationLinks from '../DocumentationLinks';
+import { HubmapLogo, Spacer, HeaderButton } from './style';
+
+function HeaderContent({ anchorRef }) {
+  const theme = useTheme();
+  const shouldDisplayMenu = !useMediaQuery(theme.breakpoints.up('md'));
+  return (
+    <>
+      {shouldDisplayMenu && <Menu anchorRef={anchorRef} />}
+      <a href="/">
+        <HubmapLogo aria-label="HubMAP logo" />
+      </a>
+      {!shouldDisplayMenu && (
+        <>
+          <div>
+            {['Donor', 'Sample', 'Dataset'].map((type) => (
+              <HeaderButton key={type} href={`/search?entity_type[0]=${type}`} component={Link}>
+                {`${type}s`}
+              </HeaderButton>
+            ))}
+            <HeaderButton component={Link} href="/collections">
+              Collections
+            </HeaderButton>
+          </div>
+          <Spacer />
+          <Dropdown title="Previews" menuListId="preview-options">
+            <PreviewLinks />
+          </Dropdown>
+          <Tooltip title="Explore HuBMAP data using the Common Coordinate Framework">
+            <HeaderButton component={Link} href="/ccf-eui">
+              CCF
+            </HeaderButton>
+          </Tooltip>
+          <Dropdown title="Documentation" menuListId="documentation-options">
+            <DocumentationLinks />
+          </Dropdown>
+        </>
+      )}
+      {shouldDisplayMenu && <Spacer />}
+      {/* eslint-disable-next-line no-undef */}
+      <LoginButton isAuthenticated={isAuthenticated} />
+    </>
+  );
+}
+
+HeaderContent.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  anchorRef: PropTypes.object.isRequired,
+};
+
+export default HeaderContent;

--- a/context/app/static/js/components/Header/HeaderContent/index.js
+++ b/context/app/static/js/components/Header/HeaderContent/index.js
@@ -1,0 +1,3 @@
+import HeaderContent from './HeaderContent';
+
+export default HeaderContent;

--- a/context/app/static/js/components/Header/HeaderContent/style.js
+++ b/context/app/static/js/components/Header/HeaderContent/style.js
@@ -1,19 +1,13 @@
 import styled from 'styled-components';
-import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
-// eslint-disable-next-line import/no-unresolved
-import Logo from 'images/hubmap-logo.svg';
 
-const StyledAppBar = styled(AppBar)`
-  margin-bottom: ${(props) => props.theme.spacing(2)}px;
-`;
+import Logo from 'images/hubmap-logo.svg';
 
 const HubmapLogo = styled(Logo)`
   margin-right: 10px;
   fill: #fff;
   height: 20px;
 `;
-
 const Spacer = styled.div`
   flex-grow: 1;
 `;
@@ -23,4 +17,4 @@ const HeaderButton = styled(Button)`
   color: #ffffff;
 `;
 
-export { StyledAppBar, HubmapLogo, Spacer, HeaderButton };
+export { HubmapLogo, Spacer, HeaderButton };

--- a/context/app/static/js/components/Header/index.js
+++ b/context/app/static/js/components/Header/index.js
@@ -1,3 +1,3 @@
 import Header from './Header';
 
-export { Header };
+export default Header;

--- a/context/app/static/js/index.css
+++ b/context/app/static/js/index.css
@@ -1,5 +1,5 @@
 :root {
-  --header-height: 60px;
+  --header-height: 64px;
 }
 
 html {

--- a/context/app/static/js/maintenance/App.jsx
+++ b/context/app/static/js/maintenance/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 // import ReactGA from 'react-ga';
+import Providers from 'js/components/Providers';
 import MaintenanceHeader from './MaintenanceHeader';
 import MaintenanceError from './MaintenanceError';
 import MaintenanceFooter from './MaintenanceFooter';
@@ -8,11 +9,11 @@ function App() {
   // ReactGA.initialize('UA-133341631-3');
   // ReactGA.pageview('/maintenance');
   return (
-    <>
+    <Providers>
       <MaintenanceHeader />
       <MaintenanceError />
       <MaintenanceFooter />
-    </>
+    </Providers>
   );
 }
 

--- a/context/app/static/js/maintenance/App.jsx
+++ b/context/app/static/js/maintenance/App.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
-// import ReactGA from 'react-ga';
+import ReactGA from 'react-ga';
 import Providers from 'js/components/Providers';
 import Footer from 'js/components/Footer';
 import Error from 'js/pages/Error';
 import MaintenanceHeader from './MaintenanceHeader';
 
 function App() {
-  // ReactGA.initialize('UA-133341631-3');
-  // ReactGA.pageview('/maintenance');
+  ReactGA.initialize('UA-133341631-3');
+  ReactGA.pageview('/maintenance');
   return (
     <Providers>
       <MaintenanceHeader />

--- a/context/app/static/js/maintenance/App.jsx
+++ b/context/app/static/js/maintenance/App.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 // import ReactGA from 'react-ga';
 import Providers from 'js/components/Providers';
+import Footer from 'js/components/Footer';
+import Error from 'js/pages/Error';
 import MaintenanceHeader from './MaintenanceHeader';
-import MaintenanceError from './MaintenanceError';
-import MaintenanceFooter from './MaintenanceFooter';
 
 function App() {
   // ReactGA.initialize('UA-133341631-3');
@@ -11,8 +11,10 @@ function App() {
   return (
     <Providers>
       <MaintenanceHeader />
-      <MaintenanceError />
-      <MaintenanceFooter />
+      <div className="main-content">
+        <Error isMaintenancePage />
+      </div>
+      <Footer isMaintenancePage />
     </Providers>
   );
 }

--- a/context/app/static/js/maintenance/MaintenanceError.jsx
+++ b/context/app/static/js/maintenance/MaintenanceError.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function MaintenanceError() {
-  return <div>Error</div>;
-}
-
-export default MaintenanceError;

--- a/context/app/static/js/maintenance/MaintenanceFooter.jsx
+++ b/context/app/static/js/maintenance/MaintenanceFooter.jsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-function MaintenanceFooter() {
-  return <div>Footer</div>;
-}
-
-export default MaintenanceFooter;

--- a/context/app/static/js/maintenance/MaintenanceHeader.jsx
+++ b/context/app/static/js/maintenance/MaintenanceHeader.jsx
@@ -1,7 +1,13 @@
 import React from 'react';
+import HeaderAppBar from 'js/components/Header/HeaderAppBar';
+import { HubmapLogo } from 'js/components/Header/HeaderContent/style';
 
 function MaintenanceHeader() {
-  return <div>Header</div>;
+  return (
+    <HeaderAppBar>
+      <HubmapLogo />
+    </HeaderAppBar>
+  );
 }
 
 export default MaintenanceHeader;

--- a/context/app/static/js/maintenance/index.css
+++ b/context/app/static/js/maintenance/index.css
@@ -1,0 +1,41 @@
+:root {
+  --header-height: 64px;
+}
+
+html {
+  scroll-padding-top: calc(var(--header-height) + 10px);
+}
+
+body {
+  left: 20px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+li {
+  list-style: none;
+}
+
+.main-content {
+  flex-grow: 1;
+  display: flex;
+}
+
+#react-content {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.container-lg {
+  max-width: 1240px;
+}
+
+a {
+    color: #007bff;
+    text-decoration: none;
+    background-color: transparent;
+}

--- a/context/app/static/js/maintenance/index.html
+++ b/context/app/static/js/maintenance/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <title>Maintenance | HuBMAP</title>
   </head>
   <body>

--- a/context/app/static/js/maintenance/index.html
+++ b/context/app/static/js/maintenance/index.html
@@ -7,6 +7,6 @@
     <title>Maintenance | HuBMAP</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="react-content"></div>
   </body>
 </html>

--- a/context/app/static/js/maintenance/index.jsx
+++ b/context/app/static/js/maintenance/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import './index.css';
 
 import App from './App';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+ReactDOM.render(<App />, document.getElementById('react-content'));

--- a/context/app/static/js/pages/Error/Error.jsx
+++ b/context/app/static/js/pages/Error/Error.jsx
@@ -23,7 +23,7 @@ function Error(props) {
     : `HTTP Error ${errorCode}: ${title}`;
 
   return (
-    <Background>
+    <Background isMaintenancePage={isMaintenancePage}>
       <StyledPaper>
         <StyledTypography variant="h1" $mb={2}>
           {title}

--- a/context/app/static/js/pages/Error/style.js
+++ b/context/app/static/js/pages/Error/style.js
@@ -3,7 +3,8 @@ import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
 const Background = styled.div`
-  background-color: ${(props) => props.theme.palette.error.main};
+  background-color: ${(props) =>
+    props.isMaintenancePage ? props.theme.palette.warning.main : props.theme.palette.error.main};
   width: 100%;
   display: flex;
   justify-content: center;

--- a/context/build-utils/webpack.maintenance.js
+++ b/context/build-utils/webpack.maintenance.js
@@ -78,7 +78,7 @@ const config = {
     ],
   },
   plugins: [
-    new HtmlWebpackPlugin({ template: `${maintenancePath}/index.html` }),
+    new HtmlWebpackPlugin({ template: `${maintenancePath}/index.html`, favicon: './app/static/favicon.ico' }),
     new CleanWebpackPlugin({ cleanStaleWebpackAssets: false }),
   ],
 };


### PR DESCRIPTION
Towards #1035. 

As mentioned in #1067, I'm going to handle the extra margin between the header and error page in the next PR before merging to master. Favicon won't work on maintenance dev-server, but should work in production maintenance mode.

Added another vscode snippet to import styled components.

<img width="1792" alt="Screen Shot 2020-08-19 at 4 26 46 PM" src="https://user-images.githubusercontent.com/62477388/90686545-81fbd680-e239-11ea-8829-85727f593ab4.png">
