### PR TITLE
Fix Data Types For Vitesse Sequencing Viz

### DIFF
--- a/CHANGELOG-fix-seq-vitessce-views.md
+++ b/CHANGELOG-fix-seq-vitessce-views.md
@@ -1,0 +1,1 @@
+- Fix seq vitessce views.

--- a/context/app/api/test_vitessce.py
+++ b/context/app/api/test_vitessce.py
@@ -1,4 +1,7 @@
-from .vitessce import Vitessce, _group_by_file_name
+import requests
+from yaml import safe_load as load_yaml
+
+from .vitessce import Vitessce, _group_by_file_name, SC_DATA_TYPES
 
 TEST_ENTITY_CODEX = {
     "data_types": ["codex_cytokit"],
@@ -31,6 +34,9 @@ TEST_UUID = "uuid"
 TEST_PATH_TIFF = "path/to/example.ome.tiff"
 
 MOCK_URL = "https://example.com"
+
+SEARCH_SCHEMA_ASSAYS = 'https://raw.githubusercontent.com/hubmapconsortium/search-api'\
+    '/master/src/search-schema/data/definitions/enums/assay_types.yaml'
 
 
 def test_build_image_schema():
@@ -89,3 +95,9 @@ def test_group_by_file_name():
     grouped = _group_by_file_name(data)
     # Grouped by file name.
     assert [['jazz/bar.js'], ['foo/bar.sh', 'zap/bar.sh'], ['jazz/not_bar.js']] == grouped
+
+
+def test_data_types():
+    res_search_assay_types = requests.get(SEARCH_SCHEMA_ASSAYS).text
+    search_assay_types = load_yaml(res_search_assay_types)
+    assert(all([assay in search_assay_types for assay in SC_DATA_TYPES]))

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -103,10 +103,11 @@ IMAGE_PYRAMID = "image_pyramid"
 SCRNA_SEQ_10X = "salmon_rnaseq_10x"
 SCRNA_SEQ_SCI = "salmon_rnaseq_sciseq"
 SCRNA_SEQ_SNARE = "salmon_rnaseq_snareseq"
+SCRNA_SEQ_SN = "salmon_sn_rnaseq_10x"
 
 SCATAC_SEQ_SCI = "sc_atac_seq_sci"
 SCATAC_SEQ_SNARE = "sc_atac_seq_snare"
-SCATAC_SEQ_SN = "sc_atac_seq_sn"
+SCATAC_SEQ_SN = "sn_atac_seq"
 
 SCRNA_SEQ_BASE_PATH = "cluster-marker-genes/output/cluster_marker_genes"
 SCATAC_SEQ_BASE_PATH = "output"
@@ -162,6 +163,7 @@ SCATAC_SEQ_CONFIG = {
 
 ASSAY_CONF_LOOKUP = {
     SCRNA_SEQ_10X: SCRNA_SEQ_CONFIG,
+    SCRNA_SEQ_SN: SCRNA_SEQ_CONFIG,
     SCRNA_SEQ_SCI: SCRNA_SEQ_CONFIG,
     SCATAC_SEQ_SCI: SCATAC_SEQ_CONFIG,
     SCRNA_SEQ_SNARE: SCRNA_SEQ_CONFIG,

--- a/context/app/api/vitessce.py
+++ b/context/app/api/vitessce.py
@@ -109,6 +109,11 @@ SCATAC_SEQ_SCI = "sc_atac_seq_sci"
 SCATAC_SEQ_SNARE = "sc_atac_seq_snare"
 SCATAC_SEQ_SN = "sn_atac_seq"
 
+SC_DATA_TYPES = [
+    SCRNA_SEQ_10X, SCRNA_SEQ_SCI, SCRNA_SEQ_SNARE, SCRNA_SEQ_SN,
+    SCATAC_SEQ_SCI, SCATAC_SEQ_SNARE, SCATAC_SEQ_SN
+]
+
 SCRNA_SEQ_BASE_PATH = "cluster-marker-genes/output/cluster_marker_genes"
 SCATAC_SEQ_BASE_PATH = "output"
 


### PR DESCRIPTION
On PROD, http://localhost:5001/browse/dataset/eec6f3356dc3078c957baaa740849fcc is a new data type, "salmon_sn_rnaseq_10x" and Joel has informed me that the "sc_atac_seq_sn" should be "sn_atac_seq" to match https://github.com/hubmapconsortium/search-api/blob/master/src/search-schema/data/definitions/enums/assay_types.yaml