### PR TITLE
Upgrade Vitessce to 0.2.4

### DIFF
--- a/CHANGELOG-upgrade-vitessce-024.md
+++ b/CHANGELOG-upgrade-vitessce-024.md
@@ -1,0 +1,1 @@
+- Upgrade vitessce to 0.2.4, giving us auto-adjusting sliders.

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -3,11 +3,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "@ant-design/css-animation": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@ant-design/css-animation/-/css-animation-1.7.3.tgz",
-      "integrity": "sha512-LrX0OGZtW+W6iLnTAqnTaoIsRelYeuLZWsrmBJFUXDALQphPsN8cE5DCsmoSlL0QYb94BQxINiuS70Ar/8BNgA=="
-    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -1333,9 +1328,9 @@
       }
     },
     "@deck.gl/aggregation-layers": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.2.5.tgz",
-      "integrity": "sha512-4u8C25HY6CVhDlO50cEshj70O22LtHUUHG2PbQDiPEZktqQrUMxICd/NceW4JciQJYqpK2yJw7R3Ggf3Qmf57g==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.2.6.tgz",
+      "integrity": "sha512-IYX5ySEczS7U3tSUDaOVSv0TZ/iFIVs/r7ZBlYdQsA4uVvif9NyM3/zEVBgvQ0hSmmFx4VCRwWjPoNGKKL+c3A==",
       "requires": {
         "@luma.gl/shadertools": "^8.2.0",
         "@math.gl/web-mercator": "^3.2.1",
@@ -1343,9 +1338,9 @@
       }
     },
     "@deck.gl/core": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.2.5.tgz",
-      "integrity": "sha512-KvgPnaQgYYlCEE8J6YBDIHOvqbkShZjhZ5rrjvx54nMCb1picHL1VpXcLyZ+0NHOD4Il/solDEUBZxYUalfTqA==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.2.6.tgz",
+      "integrity": "sha512-mglVrgD382vdl6MNsWGNqw5xUVIhzVNEVjTmEbad8vWU+hs7RnSl0hp09NOr71x2iZNVYkXys8SBtj7qXIHLQg==",
       "requires": {
         "@loaders.gl/core": "^2.2.3",
         "@loaders.gl/images": "^2.2.3",
@@ -1358,17 +1353,17 @@
       }
     },
     "@deck.gl/extensions": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.2.5.tgz",
-      "integrity": "sha512-12OhLaqWhavTijP6o0byzOOBe0xQ09WCQzMFFYhsu7oMzIe5qAwz81MpvbQuFiqLAxAcD1Sz3Z6No0HfpJV8Vg==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.2.6.tgz",
+      "integrity": "sha512-pxOWJ4HA2zIDgC2OXBAugGzopVxP8rCZnomhc03bByv76saowF74xoZaWX8UvxVq3Lu92II54M5TD1qKOrupkg==",
       "requires": {
         "@luma.gl/shadertools": "^8.2.0"
       }
     },
     "@deck.gl/geo-layers": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.2.5.tgz",
-      "integrity": "sha512-NchEG10j5/C1rfNp2wAf9KCV4HUdiueF2gQcKY0NPIIB6HeUcgItnXHqxPg5Fqr7IqUGWr44KPhs8CU1ON1vLg==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.2.6.tgz",
+      "integrity": "sha512-6bB8NYPvIC7S9Y7r/OHDogGKl9LRJzbXTYYPMKJ9ZQ2be19N72rfsNCWwATfNnXct9ff3NW+DpLov1H00dfong==",
       "requires": {
         "@loaders.gl/3d-tiles": "^2.2.3",
         "@loaders.gl/loader-utils": "^2.2.3",
@@ -1383,23 +1378,23 @@
       }
     },
     "@deck.gl/google-maps": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.2.5.tgz",
-      "integrity": "sha512-E9p7leM7ugaFMTCpxs0jkHNjkL6ndc72eVqy1p0ppked9oRbbyLkYFSMfStAly3/q8J/NIl9/dz9FZ+fZ1F5jA=="
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.2.6.tgz",
+      "integrity": "sha512-W+0PP17lzCLehOzo41m2KO7h5inhF+nplAGgodDqcp9sBBASdklxgxkC9btpo5lJvIBuIaeoc+9P211X2Rnf5w=="
     },
     "@deck.gl/json": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.2.5.tgz",
-      "integrity": "sha512-kemiY94KmAPo3/9nEJgzZW/6Fo59d5yJ/IhcpwQkbKMAxAXs2Dqj0AIZqi95xQMjav7dCry+04ox/1exnbZGaw==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.2.6.tgz",
+      "integrity": "sha512-WbJ6J4JDpwksgrcTqSOCXGijoKMm50APeuXQc9t5zgKHXoKQfeftzoCnZFOijFgftNUC7CAw2VXQ6sjpqXZmzA==",
       "requires": {
         "d3-dsv": "^1.0.8",
         "expression-eval": "^2.0.0"
       }
     },
     "@deck.gl/layers": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.2.5.tgz",
-      "integrity": "sha512-Tc9P8TxgJnTMnM/N5iCNijLCLJb7HV/7rR/A4OrGfsaueIH1Wd4aB2oxmQTuqfd1zXHWd9wgrlYUjhlT5B4uEQ==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.2.6.tgz",
+      "integrity": "sha512-thqaHgR/LniSQc7sU+bNtAJ5qQMjICxSXHU3aXu9B+NGykiPSZ7Q2zYwqTqTb3nlTDQKOHnTzZFcqIHQMb0Kzw==",
       "requires": {
         "@loaders.gl/images": "^2.2.3",
         "@mapbox/tiny-sdf": "^1.1.0",
@@ -1408,23 +1403,23 @@
       }
     },
     "@deck.gl/mapbox": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.2.5.tgz",
-      "integrity": "sha512-0fNl+a74piK7UBABFF9bzAI9VDv64GtycD+dBMr1B7hXraWHhGsbgLtW/T3Po3+7qm9g71EkwsW69/wfXQH5Jw=="
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.2.6.tgz",
+      "integrity": "sha512-M/XMW7a/0yFCZ0UDboNFsu5xBx0tCn5a4T5fk2MRPSMv1JLgAMz5K6yOf+ER0fqguxmgblmNo7zfws3nBMuVvA=="
     },
     "@deck.gl/mesh-layers": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.2.5.tgz",
-      "integrity": "sha512-hlaOV5wxzTyYwYnYAK17vvhQ0Cl68thzFJ5TtGV0BXgwYZYcaAAX09AZYF6vcYAMOYOG2WKp1Y3YFg0ZHWRVag==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.2.6.tgz",
+      "integrity": "sha512-8FtEd/1u/HsnDMxk7PqBHfgAVnJ9x+bC/i8v7CEkdd7q4rCg+JdAoWrxfFSf6O3SiheLm8nzHvPWb0sXpzqxXg==",
       "requires": {
         "@luma.gl/experimental": "^8.2.0",
         "@luma.gl/shadertools": "^8.2.0"
       }
     },
     "@deck.gl/react": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.2.5.tgz",
-      "integrity": "sha512-Aczhg9WfydU2vaMyWrnc8ojw0TLLUADrKx2d2YUe5t/hYvHeNUACcKuDM9UgXS1zWH/YL8du7Tv08BhxAiCwUg==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.2.6.tgz",
+      "integrity": "sha512-iJoHGo0NQqs6pyj+x4GeHdrT2QaXQbk/zWeXNnGmq8TJxWkU7qxC5XAoDUI4YAewr/UX+TqLw8A5XjLsIH4BkQ==",
       "requires": {
         "prop-types": "^15.6.0"
       }
@@ -1466,10 +1461,10 @@
         "underscore": "^1.9.1"
       }
     },
-    "@hubmap/vitessce-image-viewer": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@hubmap/vitessce-image-viewer/-/vitessce-image-viewer-0.3.3.tgz",
-      "integrity": "sha512-XxvZro3cai1x3cKPIekytj43jNRj6uQ8WVIqGudJ4WCNFzcKxk9H1CJRC5ZE+XbOy2Mtf7wgISPGDCGXcfNZ8w==",
+    "@hms-dbmi/viv": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.4.2.tgz",
+      "integrity": "sha512-G7ZIsdwo5bXcDKHGOL6RdUSxodxYFESMoBvk3P2ZA1xMFgzuC7BLceW2FJAq5m2YfzapZRvKXcnW+N0AAnwQ7w==",
       "requires": {
         "@deck.gl/core": "^8.2.2",
         "@deck.gl/geo-layers": "^8.2.2",
@@ -6724,7 +6719,7 @@
       "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-element-queries": {
-      "version": "github:marcj/css-element-queries#ee21dfe74f096e8733183296ad34af89a18992ba",
+      "version": "github:marcj/css-element-queries#4eae4654f4683923153d8dd8f5c0d1bc2067b2a8",
       "from": "github:marcj/css-element-queries"
     },
     "css-loader": {
@@ -7275,20 +7270,20 @@
       "dev": true
     },
     "deck.gl": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.2.5.tgz",
-      "integrity": "sha512-4km3I4DfbNcJH47EzgmJqx9fyXpntt0dGkXD8alBy0oJ+PxEK3LCS05QsTvML20seOnfe6xGJYVGxO8gZUU86w==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.2.6.tgz",
+      "integrity": "sha512-emjnU1AxU5DsmOXS70kVhq0HueYft/u0PmFKdEEpSNX5Yi7N1QdsfD9Cd2FMUXqUDdw7THiXtUEG+CMAA7YkHA==",
       "requires": {
-        "@deck.gl/aggregation-layers": "8.2.5",
-        "@deck.gl/core": "8.2.5",
-        "@deck.gl/extensions": "8.2.5",
-        "@deck.gl/geo-layers": "8.2.5",
-        "@deck.gl/google-maps": "8.2.5",
-        "@deck.gl/json": "8.2.5",
-        "@deck.gl/layers": "8.2.5",
-        "@deck.gl/mapbox": "8.2.5",
-        "@deck.gl/mesh-layers": "8.2.5",
-        "@deck.gl/react": "8.2.5"
+        "@deck.gl/aggregation-layers": "8.2.6",
+        "@deck.gl/core": "8.2.6",
+        "@deck.gl/extensions": "8.2.6",
+        "@deck.gl/geo-layers": "8.2.6",
+        "@deck.gl/google-maps": "8.2.6",
+        "@deck.gl/json": "8.2.6",
+        "@deck.gl/layers": "8.2.6",
+        "@deck.gl/mapbox": "8.2.6",
+        "@deck.gl/mesh-layers": "8.2.6",
+        "@deck.gl/react": "8.2.6"
       }
     },
     "decode-uri-component": {
@@ -9746,11 +9741,11 @@
       }
     },
     "glslify": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.0.0.tgz",
-      "integrity": "sha512-yw8jDQIe9FlSH5NiZEqSAsCPj9HI7nhXgXLAgSv2Nm9eBPsFJmyN9+rNwbiozJapcj9xtc/71rMYlN9cxp1B8Q==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.0.tgz",
+      "integrity": "sha512-6NJb9iq+6m4VhYitldiaJs4VB4wPaWNHr+DQ34fTsDVcq+5p9GsKNkJTm91A5IFcpuRQmL5VABEZ0rvB7VEoNQ==",
       "requires": {
-        "bl": "^1.0.0",
+        "bl": "^1.0.1",
         "concat-stream": "^1.5.2",
         "duplexify": "^3.4.5",
         "falafel": "^2.1.0",
@@ -9759,10 +9754,10 @@
         "glsl-token-whitespace-trim": "^1.0.0",
         "glslify-bundle": "^5.0.0",
         "glslify-deps": "^1.2.5",
-        "minimist": "^1.2.0",
+        "minimist": "^1.2.5",
         "resolve": "^1.1.5",
         "stack-trace": "0.0.9",
-        "static-eval": "^2.0.0",
+        "static-eval": "^2.0.5",
         "through2": "^2.0.1",
         "xtend": "^4.0.0"
       }
@@ -9983,9 +9978,9 @@
       "dev": true
     },
     "higlass": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/higlass/-/higlass-1.10.2.tgz",
-      "integrity": "sha512-ZR/OAD4OKwRi43GpACZ22+iBVPD/5szvh2CC26aRDdO3wIgkXmgplWgyyvRhhXz9cbe+cRdIRp7Ew/bMOMc9Jg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/higlass/-/higlass-1.11.2.tgz",
+      "integrity": "sha512-aoD7+AuJmgfdWi5TLnlS2xOvKF/J3U7AN+FkECQ7hXKvAHig6ASABCbUFpdp7eDnIrNQXXGCAzdcLODxy+V+4g==",
       "requires": {
         "ajv": "^6.10.0",
         "box-intersect": "^1.0.1",
@@ -10078,6 +10073,19 @@
             "native-promise-only": "^0.8.1"
           }
         }
+      }
+    },
+    "higlass-register": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/higlass-register/-/higlass-register-0.3.0.tgz",
+      "integrity": "sha512-D4I+ATxFuTn+Q6p8Y9rUa+X3b3cqMqhu9Tya6uHtvgV5cs39Mk7i6Z+7PMA8YuwQd5gLMSxCm2lCyWmxRVBQsQ=="
+    },
+    "higlass-zarr-datafetchers": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/higlass-zarr-datafetchers/-/higlass-zarr-datafetchers-0.2.0.tgz",
+      "integrity": "sha512-jbzBzUI+kglGnMrXRZKEash2BCErmM99dXIj9TKDLIQUi8u1oqe4jmTt2n2qe8ozUWzyjlc0h+GFTDFLZAIdDA==",
+      "requires": {
+        "zarr": "^0.3.0"
       }
     },
     "history": {
@@ -13876,9 +13884,9 @@
       }
     },
     "jsep": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.4.tgz",
-      "integrity": "sha512-ovGD9wE+wvudIIYxZGrRcZCxNyZ3Cl1N7Bzyp7/j4d/tA0BaUwcVM9bu0oZaSrefMiNwv6TwZ9X15gvZosteCQ=="
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-0.3.5.tgz",
+      "integrity": "sha512-AoRLBDc6JNnKjNcmonituEABS5bcfqDhQAWWXNTFrqu6nVXBpBAGfcoTGZMFlIrh9FjmE1CQyX9CTNwZrXMMDA=="
     },
     "jsesc": {
       "version": "2.5.2",
@@ -16743,9 +16751,9 @@
       }
     },
     "prismjs": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.20.0.tgz",
-      "integrity": "sha512-AEDjSrVNkynnw6A+B1DsFkd6AVdTnp+/WoUixFRULlCLZVRZlVQMVWio/16jv7G1FscUxQxOQhWwApgbnxr6kQ==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.21.0.tgz",
+      "integrity": "sha512-uGdSIu1nk3kej2iZsLyDoJ7e9bnPzIgY0naW/HdknGj61zScaprVEVGHrPoXqI+M9sP0NDnTK2jpkvmldpuqDw==",
       "requires": {
         "clipboard": "^2.0.0"
       }
@@ -16907,9 +16915,9 @@
       }
     },
     "pubsub-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.8.0.tgz",
-      "integrity": "sha512-z/61CZMA+jaQpBU0QSWkC4w6lX3tPbOdtl1h2UWac4sn6dkWfx7ND75SsN6U0amczdI66PqfuXXD0Ad7tnbaQg=="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.9.0.tgz",
+      "integrity": "sha512-bBGaOnAdkn3jhZC71mhjNB4mxQAOM99GTh/NoVuf/VXWUuQAZJGWIkEJlkXi0ACdKx3z65u5qilWaE5G4mMQOw=="
     },
     "pump": {
       "version": "3.0.0",
@@ -17131,6 +17139,36 @@
         "raf": "^3.4.0",
         "rc-util": "^4.15.3",
         "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "rc-motion": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.0.2.tgz",
+      "integrity": "sha512-FDmC9ZdzsXerlTZ+YLu+l5erjkMU98s85SFHdQac+pMy6zQ10RuON6Ntv3ZwP0+qY/YlIsK+0uMXIWOJ9LaLIg==",
+      "requires": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "raf": "^3.4.1",
+        "rc-util": "^5.0.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.11.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "rc-util": {
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.0.7.tgz",
+          "integrity": "sha512-nr98b5aMqqvIqxm16nF+zC3K3f81r+HsflT5E9Encr5itRwV7Vo/5GjJMNds/WiFV33rilq7vzb3xeAbCycmwg==",
+          "requires": {
+            "react-is": "^16.12.0",
+            "shallowequal": "^1.1.0"
+          }
+        }
       }
     },
     "rc-slider": {
@@ -19825,9 +19863,9 @@
       "dev": true
     },
     "ts-interface-checker": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.12.tgz",
-      "integrity": "sha512-zfJsb81glBbt4iKclqwWj8ESP2qUq1tccdnYpbUqEy7jj2JFaN09vpgtnPtKmL2jRd/U80rYLo5H4ErxJSAXQQ=="
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "tsconfig-paths": {
       "version": "3.9.0",
@@ -19902,9 +19940,9 @@
       "integrity": "sha1-MdPzIjnk9zHsqd+RVeKyl/AIq2Q="
     },
     "txml": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-3.1.3.tgz",
-      "integrity": "sha512-JOXZxzZtdXqxczL3aYs6ZtJdHKbqrzdb/BOOj9M48kmL095RHmT8Ad+Ax+UVhE3t7XZLaCjaRsUo6qE4RYudIQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/txml/-/txml-3.2.3.tgz",
+      "integrity": "sha512-UQWrwnoeeiJwwiAZ204eXXVgWKwuLHmilWrIw2EhnPfx50DH4FDMIXQMn8X8gZMAXS5uzLU1NEbcsoJxR+0n8A==",
       "requires": {
         "through2": "^3.0.1"
       },
@@ -21028,13 +21066,13 @@
       }
     },
     "vitessce": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-0.2.3.tgz",
-      "integrity": "sha512-zYhC5b7jU5jxUyRi2pz6TzSwHZ/286NLCHGJG1Z/0fVjJsoWMZomr1wtfHUmeYBqN7ShIbBDAqL7obB09HsUQA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-0.2.4.tgz",
+      "integrity": "sha512-8xlGzc7Oyr544PWAfBRGMNqcv14MLBaxt4xz/LcxJFwcTYwlzfbtJwysK70EIKBxY8rxMac+mjdB/jDV6Slw8Q==",
       "requires": {
         "@deck.gl/core": "^8.2.2",
         "@deck.gl/layers": "^8.2.2",
-        "@hubmap/vitessce-image-viewer": "^0.3.3",
+        "@hms-dbmi/viv": "^0.4.2",
         "@loaders.gl/3d-tiles": "^2.2.6",
         "@loaders.gl/core": "^2.2.6",
         "@loaders.gl/images": "^2.2.6",
@@ -21058,7 +21096,9 @@
         "d3-scale-chromatic": "^1.3.3",
         "deck.gl": "^8.2.2",
         "glslify": "^7.0.0",
-        "higlass": "^1.9.5",
+        "higlass": "^1.11.0",
+        "higlass-register": "^0.3.0",
+        "higlass-zarr-datafetchers": "^0.2.0",
         "json2csv": "^4.5.2",
         "lodash": "^4.17.15",
         "math.gl": "^3.1.3",
@@ -21085,9 +21125,9 @@
       },
       "dependencies": {
         "d3-array": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.5.0.tgz",
-          "integrity": "sha512-U+CrYn19GmiKeI9qU1RLV1p5ZodBKXw64k9Z3Id6d11LLuZ4JdyCnMT6W/2b84bvqEMFU15zg/JC3/oRYTanVg=="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.6.0.tgz",
+          "integrity": "sha512-1TgzIGb6hrHKSCGccdL209Ibk41HCeyv5znFEvJfBsBGhD3qpoHt/2W2ECpyLxpG1k7aNJz0BYrmLpVs9hIGNQ=="
         },
         "json2csv": {
           "version": "4.5.4",
@@ -21100,26 +21140,15 @@
           }
         },
         "rc-align": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.1.tgz",
-          "integrity": "sha512-RQ5Fhxl0LW+zsxbY8dxAcpXdaHkHH2jzRSSpvBTS7G9LMK3T+WRcn4ovjg/eqAESM6TdTx0hfqWF2S1pO75jxQ==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
+          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
             "dom-align": "^1.7.0",
             "rc-util": "^5.0.1",
             "resize-observer-polyfill": "^1.5.1"
-          }
-        },
-        "rc-animate": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-3.1.0.tgz",
-          "integrity": "sha512-8FsM+3B1H+0AyTyGggY6JyVldHTs1CyYT8CfTmG/nGHHXlecvSLeICJhcKgRLjUiQlctNnRtB1rwz79cvBVmrw==",
-          "requires": {
-            "@ant-design/css-animation": "^1.7.2",
-            "classnames": "^2.2.6",
-            "raf": "^3.4.0",
-            "rc-util": "^5.0.1"
           }
         },
         "rc-tooltip": {
@@ -21131,22 +21160,22 @@
           }
         },
         "rc-trigger": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.3.5.tgz",
-          "integrity": "sha512-OKIrgGVHnpQ16H/nuOjANrnufHx/tw4cvCuiWSM+XflahUlcqJu6UtlQzNTZ2BoNinC/9Eopx5I38jVD+xLvew==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.0.tgz",
+          "integrity": "sha512-09562wc5I1JUbCdWohcFYJeLTpjKjEqH+0lY7plDtyI9yFXRngrvmqsrSJyT6Nat+C35ymD7fhwCCPq3cfUI4g==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "^2.2.6",
             "raf": "^3.4.1",
             "rc-align": "^4.0.0",
-            "rc-animate": "^3.0.0",
+            "rc-motion": "^1.0.0",
             "rc-util": "^5.0.1"
           }
         },
         "rc-util": {
-          "version": "5.0.6",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.0.6.tgz",
-          "integrity": "sha512-uLGxF9WjbpJSjd6iDnIjl8ZeMUglpcuh1DwO26aaXh++yAmlB6eIAJMUwwJCuqJvo4quCvsDPg1VkqHILc4U0A==",
+          "version": "5.0.7",
+          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.0.7.tgz",
+          "integrity": "sha512-nr98b5aMqqvIqxm16nF+zC3K3f81r+HsflT5E9Encr5itRwV7Vo/5GjJMNds/WiFV33rilq7vzb3xeAbCycmwg==",
           "requires": {
             "react-is": "^16.12.0",
             "shallowequal": "^1.1.0"

--- a/context/package.json
+++ b/context/package.json
@@ -24,7 +24,7 @@
     "typeface-inter": "^3.12.0",
     "vega": "^5.13.0",
     "vega-lite": "^4.13.1",
-    "vitessce": "^0.2.3",
+    "vitessce": "^0.2.4",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There should be no changes except that when you open any `[Image Pyramid]` or `CODEX` datatype, the sliders should be set to make the image appear brighter than they were previously in the portal - this will be especially noticeable for CODEX and Autofluorescence datasets.