### PR TITLE
John conroy/disable prov table for snare

### DIFF
--- a/CHANGELOG-disable-prov-table-for-snare.md
+++ b/CHANGELOG-disable-prov-table-for-snare.md
@@ -1,0 +1,1 @@
+- Update ProvTabs to disable table for snare_lab and TMT-LC-MS data types.

--- a/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
@@ -6,7 +6,7 @@ import { StyledTab, StyledTabs, StyledTabPanel } from './style';
 import ProvGraph from '../ProvGraph';
 import ProvTable from '../ProvTable';
 import ProvAnalysisDetails from '../ProvAnalysisDetails';
-import { checkDataTypesForValues } from './utils';
+import { hasDataTypes } from './utils';
 
 function ProvTabs(props) {
   const { uuid, assayMetadata, provData } = props;
@@ -17,11 +17,7 @@ function ProvTabs(props) {
     setOpen(newValue);
   };
 
-  const shouldDisplayTable = !checkDataTypesForValues(data_types, [
-    'sc_rna_seq_snare_lab',
-    'sc_atac_seq_snare_lab',
-    'TMT-LC-MS',
-  ]);
+  const shouldDisplayTable = !hasDataTypes(data_types, ['sc_rna_seq_snare_lab', 'sc_atac_seq_snare_lab', 'TMT-LC-MS']);
   const shouldDisplayDag = entity_type === 'Dataset' && metadata && 'dag_provenance_list' in metadata;
 
   const graphIndex = shouldDisplayTable ? 1 : 0;
@@ -36,10 +32,10 @@ function ProvTabs(props) {
         aria-label="Detail View Tabs"
         TabIndicatorProps={{ style: { backgroundColor: '#9CB965' } }}
       >
-        {shouldDisplayTable && <StyledTab label="Table" id="tab-table" aria-controls="tabpanel-0" />}
-        <StyledTab label="Graph" id="tab-graph" aria-controls={`tabpanel-${graphIndex}`} />
+        {shouldDisplayTable && <StyledTab label="Table" id="tab-table" aria-controls="tabpanel-table" />}
+        <StyledTab label="Graph" id="tab-graph" aria-controls="tabpanel-graph" />
         {shouldDisplayDag && (
-          <StyledTab label="Analysis Details" id="tab-analysis-details" aria-controls={`tabpanel-${dagIndex}`} />
+          <StyledTab label="Analysis Details" id="tab-analysis-details" aria-controls="tabpanel-analysis-details" />
         )}
       </StyledTabs>
       {shouldDisplayTable && (

--- a/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
@@ -6,17 +6,26 @@ import { StyledTab, StyledTabs, StyledTabPanel } from './style';
 import ProvGraph from '../ProvGraph';
 import ProvTable from '../ProvTable';
 import ProvAnalysisDetails from '../ProvAnalysisDetails';
+import { checkDataTypesForValues, getTabIndex } from './utils';
 
 function ProvTabs(props) {
   const { uuid, assayMetadata, provData } = props;
-  const { metadata, entity_type, ancestors } = assayMetadata;
+  const { metadata, entity_type, ancestors, data_types } = assayMetadata;
 
   const [open, setOpen] = React.useState(0);
   const handleChange = (event, newValue) => {
     setOpen(newValue);
   };
 
+  const shouldDisplayTable = !(
+    entity_type === 'Dataset' &&
+    data_types &&
+    checkDataTypesForValues(data_types, ['snare_lab', 'TMT-LC-MS'])
+  );
   const shouldDisplayDag = entity_type === 'Dataset' && metadata && 'dag_provenance_list' in metadata;
+
+  const graphIndex = getTabIndex(1, shouldDisplayTable);
+  const dagIndex = graphIndex + 1;
 
   return (
     <Paper>
@@ -27,30 +36,34 @@ function ProvTabs(props) {
         aria-label="Detail View Tabs"
         TabIndicatorProps={{ style: { backgroundColor: '#9CB965' } }}
       >
-        <StyledTab label="Table" id="tab-0" aria-controls="tabpanel-0" />
-        <StyledTab label="Graph" id="tab-1" aria-controls="tabpanel-1" />
-        {shouldDisplayDag && <StyledTab label="Analysis Details" id="tab-2" aria-controls="tabpanel-2" />}
+        {shouldDisplayTable && <StyledTab label="Table" id="tab-0" aria-controls="tabpanel-0" />}
+        <StyledTab label="Graph" id={`tab-${graphIndex}`} aria-controls={`tabpanel-${graphIndex}`} />
+        {shouldDisplayDag && (
+          <StyledTab label="Analysis Details" id={`tab-${dagIndex}`} aria-controls={`tabpanel-${dagIndex}`} />
+        )}
       </StyledTabs>
-      <StyledTabPanel value={open} index={0} pad={1}>
-        <ProvTable
-          provData={provData}
-          uuid={uuid}
-          entity_type={entity_type}
-          typesToSplit={['Donor', 'Sample', 'Dataset']}
-          ancestors={ancestors}
-          assayMetadata={assayMetadata}
-        />
-      </StyledTabPanel>
-      <StyledTabPanel value={open} index={1}>
+      {shouldDisplayTable && (
+        <StyledTabPanel value={open} index={0} pad={1}>
+          <ProvTable
+            provData={provData}
+            uuid={uuid}
+            entity_type={entity_type}
+            typesToSplit={['Donor', 'Sample', 'Dataset']}
+            ancestors={ancestors}
+            assayMetadata={assayMetadata}
+          />
+        </StyledTabPanel>
+      )}
+      <StyledTabPanel value={open} index={graphIndex}>
         <span id="prov-vis-react">
           <ProvGraph provData={provData} />
         </span>
       </StyledTabPanel>
-      <StyledTabPanel value={open} index={2} pad={1}>
-        {shouldDisplayDag && (
+      {shouldDisplayDag && (
+        <StyledTabPanel value={open} index={dagIndex} pad={1}>
           <ProvAnalysisDetails dagListData={metadata.dag_provenance_list} dagData={metadata.dag_provenance} />
-        )}
-      </StyledTabPanel>
+        </StyledTabPanel>
+      )}
     </Paper>
   );
 }

--- a/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
@@ -36,10 +36,10 @@ function ProvTabs(props) {
         aria-label="Detail View Tabs"
         TabIndicatorProps={{ style: { backgroundColor: '#9CB965' } }}
       >
-        {shouldDisplayTable && <StyledTab label="Table" id="tab-0" aria-controls="tabpanel-0" />}
-        <StyledTab label="Graph" id={`tab-${graphIndex}`} aria-controls={`tabpanel-${graphIndex}`} />
+        {shouldDisplayTable && <StyledTab label="Table" id="tab-table" aria-controls="tabpanel-0" />}
+        <StyledTab label="Graph" id="tab-graph" aria-controls={`tabpanel-${graphIndex}`} />
         {shouldDisplayDag && (
-          <StyledTab label="Analysis Details" id={`tab-${dagIndex}`} aria-controls={`tabpanel-${dagIndex}`} />
+          <StyledTab label="Analysis Details" id="tab-analysis-details" aria-controls={`tabpanel-${dagIndex}`} />
         )}
       </StyledTabs>
       {shouldDisplayTable && (

--- a/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
@@ -6,7 +6,7 @@ import { StyledTab, StyledTabs, StyledTabPanel } from './style';
 import ProvGraph from '../ProvGraph';
 import ProvTable from '../ProvTable';
 import ProvAnalysisDetails from '../ProvAnalysisDetails';
-import { checkDataTypesForValues, getTabIndex } from './utils';
+import { checkDataTypesForValues } from './utils';
 
 function ProvTabs(props) {
   const { uuid, assayMetadata, provData } = props;
@@ -20,11 +20,11 @@ function ProvTabs(props) {
   const shouldDisplayTable = !(
     entity_type === 'Dataset' &&
     data_types &&
-    checkDataTypesForValues(data_types, ['snare_lab', 'TMT-LC-MS'])
+    checkDataTypesForValues(data_types, ['sc_rna_seq_snare_lab', 'sc_atac_seq_snare_lab', 'TMT-LC-MS'])
   );
   const shouldDisplayDag = entity_type === 'Dataset' && metadata && 'dag_provenance_list' in metadata;
 
-  const graphIndex = getTabIndex(1, shouldDisplayTable);
+  const graphIndex = shouldDisplayTable ? 1 : 0;
   const dagIndex = graphIndex + 1;
 
   return (

--- a/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/ProvTabs/ProvTabs.jsx
@@ -17,11 +17,11 @@ function ProvTabs(props) {
     setOpen(newValue);
   };
 
-  const shouldDisplayTable = !(
-    entity_type === 'Dataset' &&
-    data_types &&
-    checkDataTypesForValues(data_types, ['sc_rna_seq_snare_lab', 'sc_atac_seq_snare_lab', 'TMT-LC-MS'])
-  );
+  const shouldDisplayTable = !checkDataTypesForValues(data_types, [
+    'sc_rna_seq_snare_lab',
+    'sc_atac_seq_snare_lab',
+    'TMT-LC-MS',
+  ]);
   const shouldDisplayDag = entity_type === 'Dataset' && metadata && 'dag_provenance_list' in metadata;
 
   const graphIndex = shouldDisplayTable ? 1 : 0;

--- a/context/app/static/js/components/Detail/ProvTabs/utils.js
+++ b/context/app/static/js/components/Detail/ProvTabs/utils.js
@@ -1,3 +1,7 @@
 export function checkDataTypesForValues(dataTypes, valuesToCheck) {
+  if (!dataTypes) {
+    return false;
+  }
+
   return dataTypes.some((type) => valuesToCheck.some((value) => type === value));
 }

--- a/context/app/static/js/components/Detail/ProvTabs/utils.js
+++ b/context/app/static/js/components/Detail/ProvTabs/utils.js
@@ -1,0 +1,11 @@
+export function checkDataTypesForValues(dataTypes, valuesToCheck) {
+  return (
+    dataTypes.filter(
+      (type) => valuesToCheck.filter((value) => type.toLowerCase().includes(value.toLowerCase())).length > 0,
+    ).length > 0
+  );
+}
+
+export function getTabIndex(defaultIndex, shouldDisplayTable) {
+  return shouldDisplayTable ? defaultIndex : defaultIndex - 1;
+}

--- a/context/app/static/js/components/Detail/ProvTabs/utils.js
+++ b/context/app/static/js/components/Detail/ProvTabs/utils.js
@@ -1,7 +1,7 @@
-export function checkDataTypesForValues(dataTypes, valuesToCheck) {
+export function hasDataTypes(dataTypes, typesToCheck) {
   if (!dataTypes) {
     return false;
   }
 
-  return dataTypes.some((type) => valuesToCheck.some((value) => type === value));
+  return dataTypes.some((type) => typesToCheck.some((value) => type === value));
 }

--- a/context/app/static/js/components/Detail/ProvTabs/utils.js
+++ b/context/app/static/js/components/Detail/ProvTabs/utils.js
@@ -1,11 +1,3 @@
 export function checkDataTypesForValues(dataTypes, valuesToCheck) {
-  return (
-    dataTypes.filter(
-      (type) => valuesToCheck.filter((value) => type.toLowerCase().includes(value.toLowerCase())).length > 0,
-    ).length > 0
-  );
-}
-
-export function getTabIndex(defaultIndex, shouldDisplayTable) {
-  return shouldDisplayTable ? defaultIndex : defaultIndex - 1;
+  return dataTypes.some((type) => valuesToCheck.some((value) => type === value));
 }

--- a/context/app/static/js/components/Detail/ProvTabs/utils.spec.js
+++ b/context/app/static/js/components/Detail/ProvTabs/utils.spec.js
@@ -1,16 +1,16 @@
-import { checkDataTypesForValues } from './utils';
+import { hasDataTypes } from './utils';
 
 test('returns false when neither values to check are in data types array', () => {
   const dataTypes = ['fake', 'fake2'];
-  expect(checkDataTypesForValues(dataTypes, ['fake_snare_lab', 'fake3'])).toBe(false);
+  expect(hasDataTypes(dataTypes, ['fake_snare_lab', 'fake3'])).toBe(false);
 });
 
 test('returns true when one of the values to check is in data types array', () => {
   const dataTypes = ['fake', 'fake_snare_lab'];
-  expect(checkDataTypesForValues(dataTypes, ['fake_snare_lab'])).toBe(true);
+  expect(hasDataTypes(dataTypes, ['fake_snare_lab'])).toBe(true);
 });
 
 test('returns true when both of the values to check is in data types array', () => {
   const dataTypes = ['fake', 'fake_snare_lab'];
-  expect(checkDataTypesForValues(dataTypes, ['fake_snare_lab', 'fake'])).toBe(true);
+  expect(hasDataTypes(dataTypes, ['fake_snare_lab', 'fake'])).toBe(true);
 });

--- a/context/app/static/js/components/Detail/ProvTabs/utils.spec.js
+++ b/context/app/static/js/components/Detail/ProvTabs/utils.spec.js
@@ -1,0 +1,29 @@
+import { checkDataTypesForValues, getTabIndex } from './utils';
+
+test('returns false when neither values to check are in data types array', () => {
+  const dataTypes = ['fake', 'fake2'];
+  expect(checkDataTypesForValues(dataTypes, ['snare_lab', 'fake3'])).toBe(false);
+});
+
+test('returns true when one of the values to check is in data types array', () => {
+  const dataTypes = ['fake', 'fake_snare_lab'];
+  expect(checkDataTypesForValues(dataTypes, ['snare_lab'])).toBe(true);
+});
+
+test('returns true when both of the values to check is in data types array', () => {
+  const dataTypes = ['fake', 'fake_snare_lab'];
+  expect(checkDataTypesForValues(dataTypes, ['snare_lab', 'fake'])).toBe(true);
+});
+
+test('returns true when one of the values to check is in data types array and cases do not match', () => {
+  const dataTypes = ['fake', 'fake_snare_LAB'];
+  expect(checkDataTypesForValues(dataTypes, ['SNARE_lab'])).toBe(true);
+});
+
+test('returns default index when shouldDisplayTable is true', () => {
+  expect(getTabIndex(1, true)).toBe(1);
+});
+
+test('returns default index less 1 when shouldDisplayTable is false', () => {
+  expect(getTabIndex(1, false)).toBe(0);
+});

--- a/context/app/static/js/components/Detail/ProvTabs/utils.spec.js
+++ b/context/app/static/js/components/Detail/ProvTabs/utils.spec.js
@@ -1,29 +1,16 @@
-import { checkDataTypesForValues, getTabIndex } from './utils';
+import { checkDataTypesForValues } from './utils';
 
 test('returns false when neither values to check are in data types array', () => {
   const dataTypes = ['fake', 'fake2'];
-  expect(checkDataTypesForValues(dataTypes, ['snare_lab', 'fake3'])).toBe(false);
+  expect(checkDataTypesForValues(dataTypes, ['fake_snare_lab', 'fake3'])).toBe(false);
 });
 
 test('returns true when one of the values to check is in data types array', () => {
   const dataTypes = ['fake', 'fake_snare_lab'];
-  expect(checkDataTypesForValues(dataTypes, ['snare_lab'])).toBe(true);
+  expect(checkDataTypesForValues(dataTypes, ['fake_snare_lab'])).toBe(true);
 });
 
 test('returns true when both of the values to check is in data types array', () => {
   const dataTypes = ['fake', 'fake_snare_lab'];
-  expect(checkDataTypesForValues(dataTypes, ['snare_lab', 'fake'])).toBe(true);
-});
-
-test('returns true when one of the values to check is in data types array and cases do not match', () => {
-  const dataTypes = ['fake', 'fake_snare_LAB'];
-  expect(checkDataTypesForValues(dataTypes, ['SNARE_lab'])).toBe(true);
-});
-
-test('returns default index when shouldDisplayTable is true', () => {
-  expect(getTabIndex(1, true)).toBe(1);
-});
-
-test('returns default index less 1 when shouldDisplayTable is false', () => {
-  expect(getTabIndex(1, false)).toBe(0);
+  expect(checkDataTypesForValues(dataTypes, ['fake_snare_lab', 'fake'])).toBe(true);
 });


### PR DESCRIPTION
Disables the provenance table for datasets which include `snare_lab` or `TMT-LC-MS` in its `data_types` array. It's working as expected for the `TMT-LC-MS` dataset in test, but there isn't a `snare_lab` example to check.