### PR TITLE
John conroy/remove collections from nav

### DIFF
--- a/CHANGELOG-remove-collections-from-nav.md
+++ b/CHANGELOG-remove-collections-from-nav.md
@@ -1,0 +1,1 @@
+- Remove collections from navigation menus.

--- a/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
+++ b/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
@@ -29,9 +29,6 @@ function HeaderContent({ anchorRef }) {
                 {`${type}s`}
               </HeaderButton>
             ))}
-            <HeaderButton component={Link} href="/collections">
-              Collections
-            </HeaderButton>
           </div>
           <Spacer />
           <Dropdown title="Previews" menuListId="preview-options">

--- a/context/app/static/js/components/Header/Menu/Menu.jsx
+++ b/context/app/static/js/components/Header/Menu/Menu.jsx
@@ -29,7 +29,6 @@ function Menu(props) {
             {['Donor', 'Sample', 'Dataset'].map((type) => (
               <DropdownLink key={type} href={`/search?entity_type[0]=${type}`}>{`${type}s`}</DropdownLink>
             ))}
-            <DropdownLink href="/collections">Collections</DropdownLink>
             <DropdownMenuItem onClick={togglePreview}>
               Previews
               {openPreview ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}


### PR DESCRIPTION
Removes collections from navigation, but keeps it as an available route.

<img width="1588" alt="Screen Shot 2020-08-28 at 2 47 22 PM" src="https://user-images.githubusercontent.com/62477388/91604927-92990480-e93d-11ea-80b7-b08f8ac6daa8.png">

<img width="690" alt="Screen Shot 2020-08-28 at 2 47 47 PM" src="https://user-images.githubusercontent.com/62477388/91604934-96c52200-e93d-11ea-9a80-4578b99e7a42.png">
