### PR TITLE
John conroy/fix sample ccf link

### DIFF
--- a/CHANGELOG-fix-sample-ccf-link.md
+++ b/CHANGELOG-fix-sample-ccf-link.md
@@ -1,0 +1,1 @@
+- Remove host from sample tissue ccf link.

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -32,7 +32,7 @@ function SampleTissue(props) {
         <MetadataItem label="Tissue Location" ml={1}>
           <>
             The spatial coordinates of this sample have been registered and it can be found in the{' '}
-            <LightBlueLink href="https://portal.hubmapconsortium.org/ccf-eui" target="_blank" rel="noopener noreferrer">
+            <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
               Common Coordinate Framework Exploration User Interface
             </LightBlueLink>
             .

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
@@ -18,7 +18,7 @@ test('text displays properly when all props provided', () => {
       exact: false,
     }),
   ).toBeInTheDocument();
-  expect(screen.getByRole('link')).toHaveAttribute('href', 'https://portal.hubmapconsortium.org/ccf-eui');
+  expect(screen.getByRole('link')).toHaveAttribute('href', '/ccf-eui');
 });
 
 test('displays label not defined when values are undefined', () => {


### PR DESCRIPTION
Fix #1159. We can remove `target="_blank" rel="noopener noreferrer"`, right?