### PR TITLE
John conroy/search id link

### DIFF
--- a/CHANGELOG-search-id-link.md
+++ b/CHANGELOG-search-id-link.md
@@ -1,0 +1,1 @@
+- Link to detail page in each row's HuBMAP ID cell not the entire row in search table.

--- a/context/app/static/js/components/Search/ResultsTable.jsx
+++ b/context/app/static/js/components/Search/ResultsTable.jsx
@@ -5,6 +5,7 @@ import Table from '@material-ui/core/Table';
 
 import { SortingSelector, Hits } from 'searchkit'; // eslint-disable-line import/no-duplicates
 
+import { LightBlueLink } from 'js/shared-styles/Links';
 import { StyledTableBody, StyledTableRow, StyledTableCell } from './style';
 
 import SortingTableHead from './SortingTableHead';
@@ -38,20 +39,23 @@ function makeTableBodyComponent(resultFields, detailsUrlPrefix, idField) {
       <>
         {hits.map((hit) => (
           <StyledTableBody key={hit._id}>
-            <StyledTableRow
-              className={'highlight' in hit && 'before-highlight'}
-              onClick={() => window.location.assign(detailsUrlPrefix + hit._source[idField])}
-              role="row link"
-            >
+            <StyledTableRow className={'highlight' in hit && 'before-highlight'}>
               {resultFields.map((field) => (
-                <StyledTableCell key={field.id}>{getByPath(hit._source, field)}</StyledTableCell>
+                <StyledTableCell key={field.id}>
+                  {field.id === 'display_doi' ? (
+                    <LightBlueLink href={detailsUrlPrefix + hit._source[idField]}>
+                      {getByPath(hit._source, field)}
+                    </LightBlueLink>
+                  ) : (
+                    getByPath(hit._source, field)
+                  )}
+                </StyledTableCell>
               ))}
             </StyledTableRow>
             {'highlight' in hit && (
               <StyledTableRow className="highlight">
                 <StyledTableCell colSpan={resultFields.length}>
-                  <a
-                    href={detailsUrlPrefix + hit._source[idField]}
+                  <p
                     dangerouslySetInnerHTML={{
                       __html: hit.highlight.everything.join(' ... '),
                     }}

--- a/context/app/static/js/components/Search/styleForTable.js
+++ b/context/app/static/js/components/Search/styleForTable.js
@@ -62,6 +62,7 @@ const StyledTableRow = styled(TableRow)`
     padding-right: ${sidePadding};
     & p {
       color: rgba(0, 0, 0, 0.54);
+      margin: 0px;
     }
   }
 `;

--- a/context/app/static/js/components/Search/styleForTable.js
+++ b/context/app/static/js/components/Search/styleForTable.js
@@ -50,13 +50,7 @@ const interPadding = `${16 * 0.6}px`;
 const sidePadding = '64px';
 
 const StyledTableRow = styled(TableRow)`
-  cursor: pointer;
   border: 0;
-
-  // So just one entry in the row looks like a link.
-  td:first-child {
-    color: ${(props) => props.theme.palette.link.main};
-  }
 
   &.before-highlight td {
     padding-bottom: 0px;
@@ -66,7 +60,7 @@ const StyledTableRow = styled(TableRow)`
     padding-top: ${interPadding};
     padding-left: ${sidePadding};
     padding-right: ${sidePadding};
-    & a {
+    & p {
       color: rgba(0, 0, 0, 0.54);
     }
   }


### PR DESCRIPTION
Link to detail page in each row's HuBMAP ID cell not the entire row in search table. The row and highlight should look the same, but will no longer link to the detail page.

<img width="1000" alt="Screen Shot 2020-09-25 at 4 09 13 PM" src="https://user-images.githubusercontent.com/62477388/94311569-7f338600-ff49-11ea-9337-d4c35a2edc19.png">

<img width="995" alt="Screen Shot 2020-09-25 at 4 08 59 PM" src="https://user-images.githubusercontent.com/62477388/94311583-85296700-ff49-11ea-86b5-4b259d88457c.png">

