### PR TITLE
Mccalluc/log doc validation errors

### DIFF
--- a/CHANGELOG-details-log-validation.md
+++ b/CHANGELOG-details-log-validation.md
@@ -1,0 +1,1 @@
+- Log validation errors, if we see them.

--- a/context/app/static/js/index.jsx
+++ b/context/app/static/js/index.jsx
@@ -3,6 +3,12 @@ import ReactDOM from 'react-dom';
 
 import App from './components/App';
 
+// eslint-disable-next-line no-undef
+const { validation_errors } = flaskData.entity.mapper_metadata;
+if (validation_errors && validation_errors.length) {
+  console.warn('Schema validation errors', validation_errors);
+}
+
 ReactDOM.render(
   // eslint-disable-next-line no-undef
   <App flaskData={flaskData} />,

--- a/context/app/static/js/index.jsx
+++ b/context/app/static/js/index.jsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import App from './components/App';
 
 // eslint-disable-next-line no-undef
-const { validation_errors } = flaskData.entity.mapper_metadata;
+const validation_errors = flaskData.entity?.mapper_metadata?.validation_errors;
 if (validation_errors && validation_errors.length) {
   console.warn('Schema validation errors', validation_errors);
 }


### PR DESCRIPTION
The next time we get a reindex, following https://github.com/hubmapconsortium/search-api/pull/188, there will be information about schema validation errors. To me, just logging this at the earliest possible point seems like the least obtrusive way of making this information available. (I'll make another PR adding another boolean facet to dev-search: Until I've seen them work, they'll remain drafts.)