### PR TITLE
John conroy/fix header elevation

### DIFF
--- a/CHANGELOG-fix-header-elevation.md
+++ b/CHANGELOG-fix-header-elevation.md
@@ -1,0 +1,1 @@
+- Fix bug where header elevation was incorrect on entity detail pages when subheader was not displaying.

--- a/context/app/static/js/components/Header/Header/Header.jsx
+++ b/context/app/static/js/components/Header/Header/Header.jsx
@@ -1,13 +1,19 @@
 import React, { useRef } from 'react';
 
 import EntityHeader from 'js/components/Detail/entityHeader/EntityHeader';
+import useEntityStore from 'js/stores/useEntityStore';
 import HeaderAppBar from '../HeaderAppBar';
 import HeaderContent from '../HeaderContent';
 
+const entityStoreSelector = (state) => state.summaryInView;
+
 function Header() {
   const anchorRef = useRef(null);
+  const summaryInView = useEntityStore(entityStoreSelector);
   const displayEntityHeader =
-    window.location.pathname.startsWith('/browse') && !window.location.pathname.startsWith('/browse/collection');
+    !summaryInView &&
+    window.location.pathname.startsWith('/browse') &&
+    !window.location.pathname.startsWith('/browse/collection');
 
   return (
     <>


### PR DESCRIPTION
Fix bug where header elevation was incorrect on entity detail pages when subheader was not displaying.

> Ah, I see what happens. John Conroy on pages that support the subheader the header no longer has a dropshadow after the subheader appears and then disappears.

Filed #1266 which I will look into tomorrow.