### PR TITLE
John conroy/fix preview fullscreen

### DIFF
--- a/CHANGELOG-fix-preview-fullscreen.md
+++ b/CHANGELOG-fix-preview-fullscreen.md
@@ -1,0 +1,1 @@
+- Do not offset for entity header when visualization is fullscreen on preview pages.

--- a/context/app/static/js/components/Detail/visualization/Visualization/style.js
+++ b/context/app/static/js/components/Detail/visualization/Visualization/style.js
@@ -9,7 +9,12 @@ import SectionHeader from 'js/components/Detail/SectionHeader';
 import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 import { entityHeaderHeight } from 'js/components/Detail/entityHeader/EntityHeader';
 
-const totalHeightOffset = headerHeight + entityHeaderHeight;
+let totalHeightOffset = headerHeight;
+
+if (!window.location.pathname.startsWith('/preview')) {
+  totalHeightOffset += entityHeaderHeight;
+}
+
 const vitessceFixedHeight = 600;
 
 const StyledHeader = styled.div`

--- a/context/app/static/js/components/Detail/visualization/Visualization/style.js
+++ b/context/app/static/js/components/Detail/visualization/Visualization/style.js
@@ -9,11 +9,9 @@ import SectionHeader from 'js/components/Detail/SectionHeader';
 import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 import { entityHeaderHeight } from 'js/components/Detail/entityHeader/EntityHeader';
 
-let totalHeightOffset = headerHeight;
-
-if (!window.location.pathname.startsWith('/preview')) {
-  totalHeightOffset += entityHeaderHeight;
-}
+const totalHeightOffset = window.location.pathname.startsWith('/preview')
+  ? headerHeight
+  : headerHeight + entityHeaderHeight;
 
 const vitessceFixedHeight = 600;
 


### PR DESCRIPTION
Fix #1288. I could handle this with a prop instead of `window.location.pathname` if we think that is cleaner?