### PR TITLE
John conroy/standardize icon buttons

### DIFF
--- a/CHANGELOG-standardize-icon-buttons.md
+++ b/CHANGELOG-standardize-icon-buttons.md
@@ -1,0 +1,1 @@
+- Standardize icon button sizes.

--- a/context/app/static/js/components/Detail/SummaryData/SummaryData.jsx
+++ b/context/app/static/js/components/Detail/SummaryData/SummaryData.jsx
@@ -6,7 +6,8 @@ import 'intersection-observer';
 
 import useEntityStore from 'js/stores/useEntityStore';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
-import { Flex, FlexRight, FlexEnd, JsonButton, StyledFileIcon, StyledTypography } from './style';
+import { FileIcon } from 'js/shared-styles/icons';
+import { Flex, FlexRight, FlexEnd, JsonButton, StyledTypography } from './style';
 import SummaryItem from '../SummaryItem';
 import StatusIcon from '../StatusIcon';
 
@@ -49,7 +50,7 @@ function SummaryData(props) {
           <FlexEnd>
             <SecondaryBackgroundTooltip title="View JSON">
               <JsonButton href={`/browse/${entity_type.toLowerCase()}/${uuid}.json`} target="_blank" component="a">
-                <StyledFileIcon color="primary" />
+                <FileIcon color="primary" />
               </JsonButton>
             </SecondaryBackgroundTooltip>
           </FlexEnd>

--- a/context/app/static/js/components/Detail/SummaryData/style.js
+++ b/context/app/static/js/components/Detail/SummaryData/style.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
 
-import { FileIcon } from 'js/shared-styles/icons';
 import Typography from '@material-ui/core/Typography';
 
 const Flex = styled.div`
@@ -23,12 +22,8 @@ const JsonButton = styled(WhiteBackgroundIconButton)`
   margin-left: auto;
 `;
 
-const StyledFileIcon = styled(FileIcon)`
-  font-size: 1.2rem;
-`;
-
 const StyledTypography = styled(Typography)`
   margin-bottom: ${(props) => props.theme.spacing(0.5)}px;
 `;
 
-export { Flex, FlexRight, FlexEnd, JsonButton, StyledFileIcon, StyledTypography };
+export { Flex, FlexRight, FlexEnd, JsonButton, StyledTypography };

--- a/context/app/static/js/components/Detail/entityHeader/EntityHeader/EntityHeader.jsx
+++ b/context/app/static/js/components/Detail/entityHeader/EntityHeader/EntityHeader.jsx
@@ -15,7 +15,7 @@ const visualizationSelector = (state) => ({
   vizIsFullscreen: state.vizIsFullscreen,
 });
 
-const entityHeaderHeight = 35;
+const entityHeaderHeight = 40;
 
 function Header() {
   const {

--- a/context/app/static/js/components/Detail/entityHeader/EntityHeader/EntityHeader.jsx
+++ b/context/app/static/js/components/Detail/entityHeader/EntityHeader/EntityHeader.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTransition, animated } from 'react-spring';
 
 import { useEntityStore, useVisualizationStore } from 'js/stores';
+import { iconButtonHeight } from 'js/shared-styles/buttons';
 import { StyledPaper } from './style';
 import EntityHeaderContent from '../EntityHeaderContent';
 import { extractHeaderMetadata } from './utils';
@@ -15,7 +16,7 @@ const visualizationSelector = (state) => ({
   vizIsFullscreen: state.vizIsFullscreen,
 });
 
-const entityHeaderHeight = 40;
+const entityHeaderHeight = iconButtonHeight;
 
 function Header() {
   const {

--- a/context/app/static/js/components/Detail/entityHeader/EntityHeader/style.js
+++ b/context/app/static/js/components/Detail/entityHeader/EntityHeader/style.js
@@ -4,6 +4,7 @@ import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 
 const StyledPaper = styled(Paper)`
   position: fixed;
+  height: 40px;
   width: 100%;
   top: ${headerHeight}px;
   z-index: 1000;

--- a/context/app/static/js/components/Detail/entityHeader/EntityHeader/style.js
+++ b/context/app/static/js/components/Detail/entityHeader/EntityHeader/style.js
@@ -3,7 +3,6 @@ import Paper from '@material-ui/core/Paper';
 import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 
 const StyledPaper = styled(Paper)`
-  height: 35px;
   position: fixed;
   width: 100%;
   top: ${headerHeight}px;

--- a/context/app/static/js/components/Detail/entityHeader/EntityHeader/style.js
+++ b/context/app/static/js/components/Detail/entityHeader/EntityHeader/style.js
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 import Paper from '@material-ui/core/Paper';
+
 import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
+import { iconButtonHeight } from 'js/shared-styles/buttons';
 
 const StyledPaper = styled(Paper)`
   position: fixed;
-  height: 40px;
+  height: ${iconButtonHeight}px;
   width: 100%;
   top: ${headerHeight}px;
   z-index: 1000;

--- a/context/app/static/js/components/Detail/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
+++ b/context/app/static/js/components/Detail/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
@@ -4,14 +4,7 @@ import { useTransition, animated } from 'react-spring';
 
 import VizualizationThemeSwitch from 'js/components/Detail/visualization/VisualizationThemeSwitch';
 import VisualizationCollapseButton from 'js/components/Detail/visualization/VisualizationCollapseButton';
-import {
-  StyledDatasetIcon,
-  StyledSampleIcon,
-  StyledDonorIcon,
-  FlexContainer,
-  FullscreenToggleButton,
-  RightDiv,
-} from './style';
+import { StyledDatasetIcon, StyledSampleIcon, StyledDonorIcon, FlexContainer, RightDiv } from './style';
 import EntityHeaderItem from '../EntityHeaderItem';
 
 const iconMap = {
@@ -40,7 +33,7 @@ function EntityHeaderContent({ display_doi, entity_type, data, shouldDisplayHead
           ))}
           {vizIsFullscreen && (
             <RightDiv>
-              <VizualizationThemeSwitch toggleButtonComponent={FullscreenToggleButton} />
+              <VizualizationThemeSwitch />
               <VisualizationCollapseButton />
             </RightDiv>
           )}

--- a/context/app/static/js/components/Detail/visualization/Visualization/style.js
+++ b/context/app/static/js/components/Detail/visualization/Visualization/style.js
@@ -13,7 +13,8 @@ const totalHeightOffset = headerHeight + entityHeaderHeight;
 const vitessceFixedHeight = 600;
 
 const StyledHeader = styled.div`
-  margin-bottom: ${(props) => props.theme.spacing(2)}px;
+  margin-bottom: ${(props) => props.theme.spacing(1)}px;
+  display: flex;
 `;
 
 const StyledHeaderText = styled(SectionHeader)`
@@ -22,7 +23,7 @@ const StyledHeaderText = styled(SectionHeader)`
 `;
 
 const StyledHeaderRight = styled.div`
-  float: right;
+  margin-left: auto;
   display: flex;
 `;
 

--- a/context/app/static/js/components/Detail/visualization/VisualizationCollapseButton/VisualizationCollapseButton.jsx
+++ b/context/app/static/js/components/Detail/visualization/VisualizationCollapseButton/VisualizationCollapseButton.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import FullscreenExitRoundedIcon from '@material-ui/icons/FullscreenExitRounded';
+
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import useVisualizationStore from 'js/stores/useVisualizationStore';
-
-import { CollapseButton } from './style';
+import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
 
 const visualizationStoreSelector = (state) => ({
   collapseViz: state.collapseViz,
@@ -13,9 +13,9 @@ function VisualizationCollapseButton() {
   const { collapseViz } = useVisualizationStore(visualizationStoreSelector);
   return (
     <SecondaryBackgroundTooltip title="Exit Fullscreen">
-      <CollapseButton onClick={() => collapseViz()}>
+      <WhiteBackgroundIconButton onClick={() => collapseViz()}>
         <FullscreenExitRoundedIcon color="primary" />
-      </CollapseButton>
+      </WhiteBackgroundIconButton>
     </SecondaryBackgroundTooltip>
   );
 }

--- a/context/app/static/js/components/Detail/visualization/VisualizationCollapseButton/style.js
+++ b/context/app/static/js/components/Detail/visualization/VisualizationCollapseButton/style.js
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
-
-const CollapseButton = styled(WhiteBackgroundIconButton)`
-  height: 35px;
-`;
-
-export { CollapseButton };

--- a/context/app/static/js/components/Detail/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.jsx
+++ b/context/app/static/js/components/Detail/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.jsx
@@ -13,7 +13,7 @@ const visualizationStoreSelector = (state) => ({
   setVizTheme: state.setVizTheme,
 });
 
-function VisualizationThemeSwitch({ toggleButtonComponent }) {
+function VisualizationThemeSwitch() {
   const { vizTheme, setVizTheme } = useVisualizationStore(visualizationStoreSelector);
 
   return (
@@ -21,7 +21,6 @@ function VisualizationThemeSwitch({ toggleButtonComponent }) {
       <TooltipToggleButton
         tooltipComponent={SecondaryBackgroundTooltip}
         tooltipTitle="Switch to Light Theme"
-        buttonComponent={toggleButtonComponent}
         disableRipple
         value="light"
         aria-label="Visualization light theme button"
@@ -31,7 +30,6 @@ function VisualizationThemeSwitch({ toggleButtonComponent }) {
       <TooltipToggleButton
         tooltipComponent={SecondaryBackgroundTooltip}
         tooltipTitle="Switch to Dark Theme"
-        buttonComponent={toggleButtonComponent}
         disableRipple
         value="dark"
         aria-label="Visualization dark theme button"

--- a/context/app/static/js/shared-styles/buttons/index.js
+++ b/context/app/static/js/shared-styles/buttons/index.js
@@ -3,10 +3,12 @@ import styled, { css } from 'styled-components';
 import IconButton from '@material-ui/core/IconButton';
 import ToggleButton from '@material-ui/lab/ToggleButton';
 
+const iconButtonHeight = 40;
+
 const WhiteBackgroundButtonCSS = css`
   background-color: #fff;
-  height: 40px;
-  width: 40px;
+  height: ${iconButtonHeight}px;
+  width: ${iconButtonHeight}px;
   border-radius: 4px;
   padding: 0px;
 `;
@@ -39,4 +41,4 @@ function TooltipToggleButton(props) {
 
 export default TooltipToggleButton;
 
-export { WhiteBackgroundButtonCSS, WhiteBackgroundIconButton, TooltipToggleButton };
+export { WhiteBackgroundButtonCSS, WhiteBackgroundIconButton, TooltipToggleButton, iconButtonHeight };

--- a/context/app/static/js/shared-styles/buttons/index.js
+++ b/context/app/static/js/shared-styles/buttons/index.js
@@ -5,27 +5,34 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 
 const WhiteBackgroundButtonCSS = css`
   background-color: #fff;
-  padding: 10px;
+  height: 40px;
+  width: 40px;
   border-radius: 4px;
+  padding: 0px;
 `;
 
 const WhiteBackgroundIconButton = styled(IconButton)`
   ${WhiteBackgroundButtonCSS}
+  svg {
+    font-size: 1.25rem;
+  }
 `;
 
 const WhiteBackgroundToggleButton = styled(ToggleButton)`
   ${WhiteBackgroundButtonCSS}
   border: 0px;
+  svg {
+    font-size: 1.25rem;
+  }
 `;
 
 function TooltipToggleButton(props) {
   const { children, tooltipComponent, tooltipTitle, buttonComponent, ...rest } = props;
   const Tooltip = tooltipComponent;
 
-  const Button = buttonComponent || WhiteBackgroundToggleButton;
   return (
     <Tooltip title={tooltipTitle}>
-      <Button {...rest}>{children}</Button>
+      <WhiteBackgroundToggleButton {...rest}>{children}</WhiteBackgroundToggleButton>
     </Tooltip>
   );
 }


### PR DESCRIPTION
Fix bug regarding visualization collapse button placement in safari. All icon buttons now have a uniform height, width and svg icon size.

<img width="1792" alt="Screen Shot 2020-10-07 at 1 32 52 PM" src="https://user-images.githubusercontent.com/62477388/95373664-4c738100-08ab-11eb-9378-85c3d8c6e45b.png">

<img width="1792" alt="Screen Shot 2020-10-07 at 2 40 33 PM" src="https://user-images.githubusercontent.com/62477388/95373690-539a8f00-08ab-11eb-9520-063f875e72db.png">
