### PR TITLE
John conroy/fix header dropdown z index

### DIFF
--- a/CHANGELOG-fix-header-dropdown-z-index.md
+++ b/CHANGELOG-fix-header-dropdown-z-index.md
@@ -1,0 +1,1 @@
+- Fix main header dropdown menus' z-index to be above the subheader.

--- a/context/app/static/js/components/Header/Dropdown/style.js
+++ b/context/app/static/js/components/Header/Dropdown/style.js
@@ -3,7 +3,7 @@ import Popper from '@material-ui/core/Popper';
 
 const OffsetPopper = styled(Popper)`
   margin-top: 14px;
-  z-index: 5;
+  z-index: 1001;
 `;
 
 export { OffsetPopper };


### PR DESCRIPTION
Fix main header dropdown menus' z-index to be above the subheader.

<img width="1486" alt="Screen Shot 2020-10-07 at 2 56 59 PM" src="https://user-images.githubusercontent.com/62477388/95375661-eb00e180-08ad-11eb-985f-a7a89f1520c2.png">
