### PR TITLE
John conroy/disable prov table snare rna

### DIFF
--- a/CHANGELOG-disable-prov-table-snare-rna.md
+++ b/CHANGELOG-disable-prov-table-snare-rna.md
@@ -1,0 +1,1 @@
+- Disable provenance table for salmon_rnaseq_snareseq data types.

--- a/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
@@ -17,7 +17,12 @@ function ProvTabs(props) {
     setOpen(newValue);
   };
 
-  const shouldDisplayTable = !hasDataTypes(data_types, ['sc_rna_seq_snare_lab', 'sc_atac_seq_snare_lab', 'TMT-LC-MS']);
+  const shouldDisplayTable = !hasDataTypes(data_types, [
+    'sc_rna_seq_snare_lab',
+    'sc_atac_seq_snare_lab',
+    'TMT-LC-MS',
+    'salmon_rnaseq_snareseq',
+  ]);
   const shouldDisplayDag = entity_type === 'Dataset' && metadata && 'dag_provenance_list' in metadata;
 
   const graphIndex = shouldDisplayTable ? 1 : 0;


### PR DESCRIPTION
Fix #1294. This was the value in the `data_types` array for the example provided in the issue. Would we want to be more broad and disable the table for any data types which include the words `snare` and `rna` or similar?