### PR TITLE
John conroy/search sidebar vendor prefixes

### DIFF
--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -32,6 +32,9 @@ $secondary-gray: #636363;
 
 .sk-layout__filters {
   height: fit-content;
+  height:-webkit-fit-content;
+  height:-ms-fit-content;
+  height:-moz-fit-content;
   background-color: white;
 }
 


### PR DESCRIPTION
Since search styles aren't in styled-components we don't get vendor prefixes for free. Fixes the sidebar height in Firefox.