### PR TITLE
Facet schema violation errors

### DIFF
--- a/CHANGELOG-dev-search-validation-errors.md
+++ b/CHANGELOG-dev-search-validation-errors.md
@@ -1,0 +1,2 @@
+- Facet the validation errors, to understand what part of the schema is being violated,
+  and what part of the documents are in violation.

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -43,6 +43,10 @@ function DevSearch() {
         listFilter('metadata.metadata.assay_category', 'assay_category'),
         listFilter('metadata.metadata.assay_type', 'assay_type'),
       ],
+      'Validation Errors': [
+        listFilter('mapper_metadata.validation_errors.absolute_path', 'Document Path'),
+        listFilter('mapper_metadata.validation_errors.absolute_schema_path', 'Schema Path'),
+      ],
       Booleans: [
         checkboxFilter('has_metadata', 'Has metadata?', ExistsQuery('metadata.metadata')),
         checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata.metadata'))),


### PR DESCRIPTION
Under /dev-search, we can now see where validation errors are coming from:
<img width="200" alt="Screen Shot 2020-10-27 at 11 05 47 AM" src="https://user-images.githubusercontent.com/730388/97321558-64ed1080-1845-11eb-8282-481c339beedb.png">

I recognize that we're not on the same page about some aspects of the architecture, but I think we do agree that there should be clean, usable, reliable APIs, and one part of that is documenting the API responses. One step on that path is moving the current entity-api responses closer to the schema... or the schema closer to the api. These facets show what part of the documents are in violation, and what part of the schema they are violating. I hope this will be useful.