### PR TITLE
Update aria and focus for TilesSortDropdown

### DIFF
--- a/context/app/static/js/components/Search/TilesSortDropdown/TilesSortDropdown.jsx
+++ b/context/app/static/js/components/Search/TilesSortDropdown/TilesSortDropdown.jsx
@@ -48,18 +48,22 @@ function TilesSortDropdown(props) {
         variant="contained"
         color="primary"
         $searchView={searchView}
+        aria-haspopup="true"
       >
         {selectedItemLabel} {isOpen ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
       </SelectionButton>
       <Popper open={isOpen} anchorEl={anchorRef.current} placement="bottom-start" style={{ zIndex: 50 }}>
         <Paper>
           <ClickAwayListener onClickAway={() => setIsOpen(false)}>
-            <MenuList id="preview-options">
+            <MenuList id="preview-options" role="listbox">
               {pairs.map((pair) => (
                 <StyledDropdownSelectItem
                   onClick={() => selectSortItem(pair)}
                   key={pair[0].field}
                   isSelected={pair[0].label === selectedItemLabel}
+                  autoFocus={pair[0].label === selectedItemLabel}
+                  selected={pair[0].label === selectedItemLabel}
+                  aria-selected={pair[0].label === selectedItemLabel}
                 >
                   {pair[0].label}
                 </StyledDropdownSelectItem>

--- a/context/app/static/js/shared-styles/dropdowns/index.js
+++ b/context/app/static/js/shared-styles/dropdowns/index.js
@@ -19,11 +19,11 @@ const StyledSpan = styled.span`
 `;
 
 function DropdownSelectItem(props) {
-  const { children, isSelected, className, ...rest } = props;
+  const { children, selected, className, ...rest } = props;
   return (
-    <FlexMenuItem className={className} {...rest}>
-      {isSelected && <CheckIcon color="primary" />}
-      <StyledSpan isSelected={isSelected}>{children}</StyledSpan>
+    <FlexMenuItem className={className} selected={selected} {...rest} role="option">
+      {selected && <CheckIcon color="primary" />}
+      <StyledSpan isSelected={selected}>{children}</StyledSpan>
     </FlexMenuItem>
   );
 }


### PR DESCRIPTION
The dropdown now autofocuses on the selected item when open and can be traversed by keydown/up. Aria attributes taken from [w3](https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html).