### PR TITLE
Portal prod.stage zhou

### DIFF
--- a/CHANGELOG-redeploy.md
+++ b/CHANGELOG-redeploy.md
@@ -1,0 +1,1 @@
+- Update redeploy.sh to handle to stage environment.

--- a/compose/hubmap.stage.yml
+++ b/compose/hubmap.stage.yml
@@ -1,0 +1,26 @@
+version: "3.7"
+
+services:
+
+  portal-ui-prod:
+    hostname: portal-ui-prod
+    container_name: portal-ui-prod
+    image: hubmap/portal-ui:latest
+
+    # Mount the app config in container to keep it outside the image.
+    volumes:
+      - "../context/instance/portal-prod.stage-app.conf:/app/instance/app.conf"
+
+    # Avoid accidentally creating zombie processes
+    init: true
+
+    # Specifying a restart policy to avoid downtime
+    restart: always
+
+    networks:
+      - gateway_hubmap
+
+networks:
+  # This is the network created by gateway to enable communicaton between multiple docker-compose projects
+  gateway_hubmap:
+    external: true

--- a/compose/hubmap.stage.yml
+++ b/compose/hubmap.stage.yml
@@ -9,7 +9,7 @@ services:
 
     # Mount the app config in container to keep it outside the image.
     volumes:
-      - "../context/instance/portal-prod.stage-app.conf:/app/instance/app.conf"
+      - "../context/instance/app.stage.conf:/app/instance/app.conf"
 
     # Avoid accidentally creating zombie processes
     init: true

--- a/compose/hubmap.stage.yml
+++ b/compose/hubmap.stage.yml
@@ -9,7 +9,7 @@ services:
 
     # Mount the app config in container to keep it outside the image.
     volumes:
-      - "../context/instance/app.stage.conf:/app/instance/app.conf"
+      - "../context/instance/app.prod.conf:/app/instance/app.conf"
 
     # Avoid accidentally creating zombie processes
     init: true

--- a/compose/hubmap.stage.yml
+++ b/compose/hubmap.stage.yml
@@ -2,6 +2,24 @@ version: "3.7"
 
 services:
 
+  portal-ui:
+    hostname: portal-ui
+    container_name: portal-ui
+    image: hubmap/portal-ui:latest
+
+    # Mount the app config in container to keep it outside the image.
+    volumes:
+      - "../context/instance/app.conf:/app/instance/app.conf"
+
+    # Avoid accidentally creating zombie processes
+    init: true
+
+    # Specifying a restart policy to avoid downtime
+    restart: always
+
+    networks:
+      - gateway_hubmap
+
   portal-ui-prod:
     hostname: portal-ui-prod
     container_name: portal-ui-prod

--- a/redeploy.sh
+++ b/redeploy.sh
@@ -21,7 +21,7 @@ echo 'stopping...'
 
 # Also stop and remove the portal-ui-pord container on STAGE only
 if [ "$2" = "stage" ]; then
-    docker-compose -f hubmap.yml -f portal-prod.stage.yml down
+    docker-compose -f hubmap.yml -f hubmap.stage.yml down
 else
     docker-compose -f hubmap.yml down
 fi
@@ -36,7 +36,7 @@ echo 'starting...'
 
 # Also start the portal-ui-pord container on STAGE only
 if [ "$2" = "stage" ]; then
-    docker-compose -f hubmap.yml -f portal-prod.stage.yml up -d
+    docker-compose -f hubmap.yml -f hubmap.stage.yml up -d
 else
     docker-compose -f hubmap.yml up -d
 fi

--- a/redeploy.sh
+++ b/redeploy.sh
@@ -3,7 +3,7 @@ set -o errexit
 
 die() { set +v; echo "$*" 1>&2 ; exit 1; }
 
-[ "$#" -eq 2 ] || die "usage: $0 USERNAME [ dev | test ]"
+[ "$#" -eq 2 ] || die "usage: $0 USERNAME [ dev | test | stage]"
 USER="$1"
 TARGET="$2"
 
@@ -18,7 +18,14 @@ cd /home/centos/hubmap/portal-ui/compose
 echo 'portal running?' `docker ps | grep portal-ui`
 
 echo 'stopping...'
-docker-compose -f hubmap.yml down
+
+# Also stop and remove the portal-ui-pord container on STAGE only
+if [ "$2" = "stage" ]; then
+    docker-compose -f hubmap.yml -f portal-prod.stage.yml down
+else
+    docker-compose -f hubmap.yml down
+fi
+
 echo 'portal running?' `docker ps | grep portal-ui`
 
 echo 'removing old "latest"...'
@@ -26,7 +33,14 @@ echo 'removing old "latest"...'
 docker rmi hubmap/portal-ui:latest
 
 echo 'starting...'
-docker-compose -f hubmap.yml up -d
+
+# Also start the portal-ui-pord container on STAGE only
+if [ "$2" = "stage" ]; then
+    docker-compose -f hubmap.yml -f portal-prod.stage.yml up -d
+else
+    docker-compose -f hubmap.yml up -d
+fi
+
 echo 'portal running?' `docker ps | grep portal-ui`
 
 # TODO: Move VERSION into context, and cat it.
@@ -35,3 +49,8 @@ docker exec -it portal-ui cat package.json
 EOF
 
 echo "Visit --> http://portal.$TARGET.hubmapconsortium.org/"
+
+if [ "$2" = "stage" ]; then
+    echo "Visit --> http://portal-prod.$TARGET.hubmapconsortium.org/"
+fi
+

--- a/redeploy.sh
+++ b/redeploy.sh
@@ -21,7 +21,7 @@ echo 'stopping...'
 
 # Also stop and remove the portal-ui-pord container on STAGE only
 if [ "$2" = "stage" ]; then
-    docker-compose -f hubmap.yml -f hubmap.stage.yml down
+    docker-compose -f hubmap.stage.yml down
 else
     docker-compose -f hubmap.yml down
 fi
@@ -36,7 +36,7 @@ echo 'starting...'
 
 # Also start the portal-ui-pord container on STAGE only
 if [ "$2" = "stage" ]; then
-    docker-compose -f hubmap.yml -f hubmap.stage.yml up -d
+    docker-compose -f hubmap.stage.yml up -d
 else
     docker-compose -f hubmap.yml up -d
 fi
@@ -51,6 +51,6 @@ EOF
 echo "Visit --> http://portal.$TARGET.hubmapconsortium.org/"
 
 if [ "$2" = "stage" ]; then
-    echo "Visit --> http://portal-prod.$TARGET.hubmapconsortium.org/"
+    echo "Visit --> http://portal-prod.stage.hubmapconsortium.org/"
 fi
 


### PR DESCRIPTION
This is to replace PR #1344 (causes strange 502 error, probably due to orphan container) by handling the `portal-ui-prod` container in the same project.

- changes only apply to STAGE redeployment
- there are two docker compose yaml files now: `hubmap.yml` (only one `portal-ui` container for DEV/TEST/PROD) and `hubmap.stage.yml` (one `portal-ui` and one `portal-ui-prod` containers for STAGE only)
- the `portal-ui-prod` container will require `context/instance/app.prod.conf` to make calls against the PROD API services

@mccalluc you may need to tweak the `test.sh`. Feel free to tweak the `redeploy.sh` too.

I've tested the redeploy script with a modified script without the ssh section on STAGE and it works well. Please give it a try by running this script from your local.