### PR TITLE
Tweak table height

### DIFF
--- a/CHANGELOG-table-height.md
+++ b/CHANGELOG-table-height.md
@@ -1,0 +1,1 @@
+- Change table-height to land in the middle of a row.

--- a/context/app/static/js/components/Detail/CollectionCreatorsTable/CollectionCreatorsTable.jsx
+++ b/context/app/static/js/components/Detail/CollectionCreatorsTable/CollectionCreatorsTable.jsx
@@ -26,7 +26,7 @@ function CollectionCreatorsTable(props) {
     <SectionContainer id="datasets-table">
       <SectionHeader>Creators</SectionHeader>
       <Paper>
-        <StyledTableContainer $maxHeight={312}>
+        <StyledTableContainer>
           <Table stickyHeader>
             <TableHead>
               <TableRow>

--- a/context/app/static/js/components/Detail/CollectionDatasetsTable/CollectionDatasetsTable.jsx
+++ b/context/app/static/js/components/Detail/CollectionDatasetsTable/CollectionDatasetsTable.jsx
@@ -47,7 +47,7 @@ function CollectionDatasetsTable(props) {
         {tableRows.length} Datasets
       </Typography>
       <Paper>
-        <StyledTableContainer $maxHeight={312}>
+        <StyledTableContainer>
           <Table stickyHeader>
             <TableHead>
               <TableRow>

--- a/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
@@ -55,7 +55,8 @@ function MetadataTable(props) {
         </SecondaryBackgroundTooltip>
       </Flex>
       <Paper>
-        <StyledTableContainer $maxHeight={364}>
+        <StyledTableContainer $maxHeight={340}>
+          {/* Height lands in the middle of a row, to show that div can scroll. */}
           <Table stickyHeader>
             <TableHead>
               <TableRow>

--- a/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
@@ -55,8 +55,7 @@ function MetadataTable(props) {
         </SecondaryBackgroundTooltip>
       </Flex>
       <Paper>
-        <StyledTableContainer $maxHeight={340}>
-          {/* Height lands in the middle of a row, to show that div can scroll. */}
+        <StyledTableContainer>
           <Table stickyHeader>
             <TableHead>
               <TableRow>

--- a/context/app/static/js/shared-styles/Table/index.js
+++ b/context/app/static/js/shared-styles/Table/index.js
@@ -3,7 +3,7 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableCell from '@material-ui/core/TableCell';
 
 const StyledTableContainer = styled(TableContainer)`
-  max-height: ${(props) => props.$maxHeight}px;
+  max-height: 340px; // Height lands in the middle of a row, to show that div can scroll.
 
   th {
     background-color: #ffffff;


### PR DESCRIPTION
Fix #1263. @tsliaw - We had tabled this, but I still find myself wondering where the rest of the metadata is. I believe that a half-obscured row is a clear way to suggest that it can be scrolled. Need Nils' approval before merging, but what's your first impression?
<img width="214" alt="Screen Shot 2020-11-10 at 1 39 52 PM" src="https://user-images.githubusercontent.com/730388/98718322-4cf4b100-235c-11eb-98b4-1e3a27757b37.png">
