### PR TITLE
John conroy/qa files

### DIFF
--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -38,7 +38,7 @@ function FileBrowser(props) {
           clickable
           onClick={toggleDisplayOnlyQaQc}
           color={displayOnlyQaQc ? 'primary' : undefined}
-          icon={displayOnlyQaQc ? <DoneIcon /> : null}
+          icon={displayOnlyQaQc && <DoneIcon />}
           component="button"
           disabled={Object.keys(fileTrees.qa).length === 0}
         />

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -4,14 +4,12 @@ import Chip from '@material-ui/core/Chip';
 import DoneIcon from '@material-ui/icons/Done';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
-import TableContainer from '@material-ui/core/TableContainer';
 import TableRow from '@material-ui/core/TableRow';
-import TableHead from '@material-ui/core/TableHead';
 
 import useFilesStore from 'js/stores/useFilesStore';
 import { relativeFilePathsToTree } from './utils';
 import FileBrowserNode from '../FileBrowserNode';
-import { ChipWrapper, ScrollTableBody } from './style';
+import { ChipWrapper, ScrollTableBody, StyledTableContainer, HiddenTableHead } from './style';
 
 const filesStoreSelector = (state) => ({
   displayOnlyQaQc: state.displayOnlyQaQc,
@@ -31,7 +29,7 @@ function FileBrowser(props) {
   }, [files]);
 
   return (
-    <TableContainer component={Paper} style={{ maxHeight: '600px' }}>
+    <StyledTableContainer component={Paper}>
       <ChipWrapper>
         <Chip
           label="Show QA Files Only"
@@ -44,18 +42,18 @@ function FileBrowser(props) {
         />
       </ChipWrapper>
       <Table data-testid="file-browser">
-        <TableHead style={{ display: 'none' }}>
+        <HiddenTableHead>
           <TableRow>
             <td>File</td>
             <td>Is QA</td>
             <td>Size</td>
           </TableRow>
-        </TableHead>
+        </HiddenTableHead>
         <ScrollTableBody>
           <FileBrowserNode fileSubTree={displayOnlyQaQc ? qaFileTree : fileTree} depth={0} />
         </ScrollTableBody>
       </Table>
-    </TableContainer>
+    </StyledTableContainer>
   );
 }
 

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -45,8 +45,8 @@ function FileBrowser(props) {
       <Table data-testid="file-browser">
         <HiddenTableHead>
           <TableRow>
-            <td>File</td>
-            <td>Is QA</td>
+            <td>Name</td>
+            <td>Type</td>
             <td>Size</td>
           </TableRow>
         </HiddenTableHead>

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -34,6 +34,7 @@ function FileBrowser(props) {
         onClick={toggleDisplayOnlyQaQc}
         icon={<DoneIcon />}
         component="button"
+        disabled={Object.keys(qaFileTree).length === 0}
       />
       <ScrollPaper data-testid="file-browser">
         <FileBrowserNode fileSubTree={displayOnlyQaQc ? qaFileTree : fileTree} depth={0} />

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -2,11 +2,16 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Chip from '@material-ui/core/Chip';
 import DoneIcon from '@material-ui/icons/Done';
+import Paper from '@material-ui/core/Paper';
+import Table from '@material-ui/core/Table';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableRow from '@material-ui/core/TableRow';
+import TableHead from '@material-ui/core/TableHead';
 
 import useFilesStore from 'js/stores/useFilesStore';
 import { relativeFilePathsToTree } from './utils';
 import FileBrowserNode from '../FileBrowserNode';
-import { ScrollPaper } from './style';
+import { ChipWrapper, ScrollTableBody } from './style';
 
 const filesStoreSelector = (state) => ({
   displayOnlyQaQc: state.displayOnlyQaQc,
@@ -26,20 +31,31 @@ function FileBrowser(props) {
   }, [files]);
 
   return (
-    <>
-      <Chip
-        label="Show QA Files Only"
-        clickable
-        color="primary"
-        onClick={toggleDisplayOnlyQaQc}
-        icon={<DoneIcon />}
-        component="button"
-        disabled={Object.keys(qaFileTree).length === 0}
-      />
-      <ScrollPaper data-testid="file-browser">
-        <FileBrowserNode fileSubTree={displayOnlyQaQc ? qaFileTree : fileTree} depth={0} />
-      </ScrollPaper>
-    </>
+    <TableContainer component={Paper} style={{ maxHeight: '600px' }}>
+      <ChipWrapper>
+        <Chip
+          label="Show QA Files Only"
+          clickable
+          color="primary"
+          onClick={toggleDisplayOnlyQaQc}
+          icon={<DoneIcon />}
+          component="button"
+          disabled={Object.keys(qaFileTree).length === 0}
+        />
+      </ChipWrapper>
+      <Table data-testid="file-browser">
+        <TableHead style={{ display: 'none' }}>
+          <TableRow>
+            <td>File</td>
+            <td>Is QA</td>
+            <td>Size</td>
+          </TableRow>
+        </TableHead>
+        <ScrollTableBody>
+          <FileBrowserNode fileSubTree={displayOnlyQaQc ? qaFileTree : fileTree} depth={0} />
+        </ScrollTableBody>
+      </Table>
+    </TableContainer>
   );
 }
 

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -60,12 +60,13 @@ function FileBrowser(props) {
 
 FileBrowser.propTypes = {
   files: PropTypes.arrayOf(
-    PropTypes.exact({
+    PropTypes.shape({
       rel_path: PropTypes.string,
       edam_term: PropTypes.string,
       description: PropTypes.string,
       size: PropTypes.number,
       type: PropTypes.string,
+      is_qa_qc: PropTypes.bool,
     }),
   ).isRequired,
 };

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -62,11 +62,11 @@ function FileBrowser(props) {
 FileBrowser.propTypes = {
   files: PropTypes.arrayOf(
     PropTypes.shape({
-      rel_path: PropTypes.string,
-      edam_term: PropTypes.string,
-      description: PropTypes.string,
-      size: PropTypes.number,
-      type: PropTypes.string,
+      rel_path: PropTypes.string.isRequired,
+      edam_term: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+      size: PropTypes.number.isRequired,
+      type: PropTypes.string.isRequired,
       is_qa_qc: PropTypes.bool,
     }),
   ).isRequired,

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Chip from '@material-ui/core/Chip';
 import DoneIcon from '@material-ui/icons/Done';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableRow from '@material-ui/core/TableRow';
+import Chip from '@material-ui/core/Chip';
 
 import useFilesStore from 'js/stores/useFilesStore';
 import { relativeFilePathsToTree } from './utils';
@@ -34,11 +34,12 @@ function FileBrowser(props) {
         <Chip
           label="Show QA Files Only"
           clickable
-          color="primary"
           onClick={toggleDisplayOnlyQaQc}
-          icon={<DoneIcon />}
+          color={displayOnlyQaQc ? 'primary' : ''}
+          icon={displayOnlyQaQc ? <DoneIcon /> : null}
           component="button"
           disabled={Object.keys(qaFileTree).length === 0}
+          displayOnlyQaQc={displayOnlyQaQc}
         />
       </ChipWrapper>
       <Table data-testid="file-browser">

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import Chip from '@material-ui/core/Chip';
+import DoneIcon from '@material-ui/icons/Done';
 
 import { relativeFilePathsToTree } from './utils';
 import FileBrowserNode from '../FileBrowserNode';
@@ -8,16 +10,28 @@ import { ScrollPaper } from './style';
 function FileBrowser(props) {
   const { files } = props;
   const [fileTree, setFileTree] = useState({});
+  const [qaFileTree, setQaFileTree] = useState({});
+  const [displayOnlyQaFiles, setDisplayOnlyQaFiles] = useState(false);
 
   useEffect(() => {
-    const treePath = relativeFilePathsToTree(files);
-    setFileTree(treePath);
+    setFileTree(relativeFilePathsToTree(files));
+    setQaFileTree(relativeFilePathsToTree(files.filter((file) => file?.is_qa_qc)));
   }, [files]);
 
   return (
-    <ScrollPaper data-testid="file-browser">
-      <FileBrowserNode fileSubTree={fileTree} depth={0} />
-    </ScrollPaper>
+    <>
+      <Chip
+        label="Show QA Files Only"
+        clickable
+        color="primary"
+        onClick={() => setDisplayOnlyQaFiles((prevState) => !prevState)}
+        icon={<DoneIcon />}
+        component="button"
+      />
+      <ScrollPaper data-testid="file-browser">
+        <FileBrowserNode fileSubTree={displayOnlyQaFiles ? qaFileTree : fileTree} depth={0} />
+      </ScrollPaper>
+    </>
   );
 }
 

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -36,7 +36,7 @@ function FileBrowser(props) {
           label="Show QA Files Only"
           clickable
           onClick={toggleDisplayOnlyQaQc}
-          color={displayOnlyQaQc ? 'primary' : ''}
+          color={displayOnlyQaQc ? 'primary' : undefined}
           icon={displayOnlyQaQc ? <DoneIcon /> : null}
           component="button"
           disabled={Object.keys(fileTrees.qa).length === 0}

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -3,15 +3,22 @@ import PropTypes from 'prop-types';
 import Chip from '@material-ui/core/Chip';
 import DoneIcon from '@material-ui/icons/Done';
 
+import useFilesStore from 'js/stores/useFilesStore';
 import { relativeFilePathsToTree } from './utils';
 import FileBrowserNode from '../FileBrowserNode';
 import { ScrollPaper } from './style';
+
+const filesStoreSelector = (state) => ({
+  displayOnlyQaQc: state.displayOnlyQaQc,
+  toggleDisplayOnlyQaQc: state.toggleDisplayOnlyQaQc,
+});
 
 function FileBrowser(props) {
   const { files } = props;
   const [fileTree, setFileTree] = useState({});
   const [qaFileTree, setQaFileTree] = useState({});
-  const [displayOnlyQaFiles, setDisplayOnlyQaFiles] = useState(false);
+
+  const { displayOnlyQaQc, toggleDisplayOnlyQaQc } = useFilesStore(filesStoreSelector);
 
   useEffect(() => {
     setFileTree(relativeFilePathsToTree(files));
@@ -24,12 +31,12 @@ function FileBrowser(props) {
         label="Show QA Files Only"
         clickable
         color="primary"
-        onClick={() => setDisplayOnlyQaFiles((prevState) => !prevState)}
+        onClick={toggleDisplayOnlyQaQc}
         icon={<DoneIcon />}
         component="button"
       />
       <ScrollPaper data-testid="file-browser">
-        <FileBrowserNode fileSubTree={displayOnlyQaFiles ? qaFileTree : fileTree} depth={0} />
+        <FileBrowserNode fileSubTree={displayOnlyQaQc ? qaFileTree : fileTree} depth={0} />
       </ScrollPaper>
     </>
   );

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -4,12 +4,13 @@ import DoneIcon from '@material-ui/icons/Done';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableRow from '@material-ui/core/TableRow';
+import TableBody from '@material-ui/core/TableBody';
 import Chip from '@material-ui/core/Chip';
 
 import useFilesStore from 'js/stores/useFilesStore';
 import { relativeFilePathsToTree } from './utils';
 import FileBrowserNode from '../FileBrowserNode';
-import { ChipWrapper, ScrollTableBody, StyledTableContainer, HiddenTableHead } from './style';
+import { ChipWrapper, StyledTableContainer, HiddenTableHead } from './style';
 
 const filesStoreSelector = (state) => ({
   displayOnlyQaQc: state.displayOnlyQaQc,
@@ -50,9 +51,9 @@ function FileBrowser(props) {
             <td>Size</td>
           </TableRow>
         </HiddenTableHead>
-        <ScrollTableBody>
+        <TableBody>
           <FileBrowserNode fileSubTree={displayOnlyQaQc ? fileTrees.qa : fileTrees.all} depth={0} />
-        </ScrollTableBody>
+        </TableBody>
       </Table>
     </StyledTableContainer>
   );

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -40,7 +40,6 @@ function FileBrowser(props) {
           icon={displayOnlyQaQc ? <DoneIcon /> : null}
           component="button"
           disabled={Object.keys(fileTrees.qa).length === 0}
-          displayOnlyQaQc={displayOnlyQaQc}
         />
       </ChipWrapper>
       <Table data-testid="file-browser">

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import DoneIcon from '@material-ui/icons/Done';
 import Paper from '@material-ui/core/Paper';
@@ -18,15 +18,16 @@ const filesStoreSelector = (state) => ({
 
 function FileBrowser(props) {
   const { files } = props;
-  const [fileTree, setFileTree] = useState({});
-  const [qaFileTree, setQaFileTree] = useState({});
 
   const { displayOnlyQaQc, toggleDisplayOnlyQaQc } = useFilesStore(filesStoreSelector);
 
-  useEffect(() => {
-    setFileTree(relativeFilePathsToTree(files));
-    setQaFileTree(relativeFilePathsToTree(files.filter((file) => file?.is_qa_qc)));
-  }, [files]);
+  const fileTrees = useMemo(
+    () => ({
+      all: relativeFilePathsToTree(files),
+      qa: relativeFilePathsToTree(files.filter((file) => file?.is_qa_qc)),
+    }),
+    [files],
+  );
 
   return (
     <StyledTableContainer component={Paper}>
@@ -38,7 +39,7 @@ function FileBrowser(props) {
           color={displayOnlyQaQc ? 'primary' : ''}
           icon={displayOnlyQaQc ? <DoneIcon /> : null}
           component="button"
-          disabled={Object.keys(qaFileTree).length === 0}
+          disabled={Object.keys(fileTrees.qa).length === 0}
           displayOnlyQaQc={displayOnlyQaQc}
         />
       </ChipWrapper>
@@ -51,7 +52,7 @@ function FileBrowser(props) {
           </TableRow>
         </HiddenTableHead>
         <ScrollTableBody>
-          <FileBrowserNode fileSubTree={displayOnlyQaQc ? qaFileTree : fileTree} depth={0} />
+          <FileBrowserNode fileSubTree={displayOnlyQaQc ? fileTrees.qa : fileTrees.all} depth={0} />
         </ScrollTableBody>
       </Table>
     </StyledTableContainer>

--- a/context/app/static/js/components/files/FileBrowser/FileBrowser.spec.js
+++ b/context/app/static/js/components/files/FileBrowser/FileBrowser.spec.js
@@ -21,6 +21,9 @@ const FilesProviders = ({ children }) => {
   );
 };
 
+const expectArrayOfStringsToExist = (arr) => arr.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+const expectArrayOfStringsToNotExist = (arr) => arr.forEach((text) => expect(screen.queryByText(text)).toBeNull());
+
 test('displays files and directories', () => {
   const sharedEntries = {
     edam_term: 'faketerm',
@@ -59,13 +62,75 @@ test('displays files and directories', () => {
   );
 
   const textInDocumentBeforeOpenDirectory = ['path1', 'path3', 'fake5.txt'];
-  textInDocumentBeforeOpenDirectory.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+  expectArrayOfStringsToExist(textInDocumentBeforeOpenDirectory);
 
   const textNotInDocumentBeforeOpenDirectory = ['path2', 'fake1.txt', 'fake2.txt', 'fake3.txt', 'fake4.txt'];
-  textNotInDocumentBeforeOpenDirectory.forEach((text) => expect(screen.queryByText(text)).toBeNull());
+  expectArrayOfStringsToNotExist(textNotInDocumentBeforeOpenDirectory);
 
   userEvent.click(screen.getByRole('button', { name: 'path1' }));
 
   const textInDocumentAfterOpenDirectory = [...textInDocumentBeforeOpenDirectory, 'fake3.txt', 'path2'];
-  textInDocumentAfterOpenDirectory.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+  expectArrayOfStringsToExist(textInDocumentAfterOpenDirectory);
+});
+
+test('Displays correct files before and after display only QA files chip is clicked', () => {
+  const sharedEntries = {
+    edam_term: 'faketerm',
+    description: 'fakedescription',
+    size: 1000,
+    type: 'faketype',
+  };
+
+  const testFiles = [
+    {
+      rel_path: 'path1/path2/fake1.txt',
+      ...sharedEntries,
+      is_qa_qc: true,
+    },
+    {
+      rel_path: 'path1/path2/fake2.txt',
+      ...sharedEntries,
+    },
+    {
+      rel_path: 'path1/fake3.txt',
+      ...sharedEntries,
+      is_qa_qc: true,
+    },
+    {
+      rel_path: 'path3/fake4.txt',
+      ...sharedEntries,
+    },
+    {
+      rel_path: 'fake5.txt',
+      ...sharedEntries,
+    },
+  ];
+
+  render(
+    <FilesProviders>
+      <FileBrowser files={testFiles} />
+    </FilesProviders>,
+  );
+
+  // intial
+  const textInDocumentBeforeQAFilesOnly = ['path1', 'path3', 'fake5.txt'];
+  expectArrayOfStringsToExist(textInDocumentBeforeQAFilesOnly);
+
+  const textNotInDocumentBeforeQAFilesOnly = ['path2', 'fake1.txt', 'fake2.txt', 'fake3.txt', 'fake4.txt'];
+  expectArrayOfStringsToNotExist(textNotInDocumentBeforeQAFilesOnly);
+
+  userEvent.click(screen.getByRole('button', { name: 'Show QA Files Only' }));
+
+  // after QA files chip clicked
+  const textInDocumentAfterQAFilesOnly = ['path1', 'path2', 'fake1.txt', 'fake3.txt'];
+  expectArrayOfStringsToExist(textInDocumentAfterQAFilesOnly);
+
+  const textNotInDocumentAfterQAFilesOnly = ['path3', 'fake4.txt', 'fake2.txt', 'fake5.txt'];
+  expectArrayOfStringsToNotExist(textNotInDocumentAfterQAFilesOnly);
+
+  userEvent.click(screen.getByRole('button', { name: 'Show QA Files Only' }));
+
+  // returns to all dirs closed
+  expectArrayOfStringsToExist(textInDocumentBeforeQAFilesOnly);
+  expectArrayOfStringsToNotExist(textNotInDocumentBeforeQAFilesOnly);
 });

--- a/context/app/static/js/components/files/FileBrowser/style.js
+++ b/context/app/static/js/components/files/FileBrowser/style.js
@@ -5,7 +5,7 @@ import TableHead from '@material-ui/core/TableHead';
 
 const ChipWrapper = styled.div`
   border-bottom: 1px solid ${(props) => props.theme.palette.divider};
-  padding: 12px 15px 12px 15px;
+  padding: 12px 15px;
   position: sticky;
   top: 0;
   background-color: #fff;

--- a/context/app/static/js/components/files/FileBrowser/style.js
+++ b/context/app/static/js/components/files/FileBrowser/style.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import TableBody from '@material-ui/core/TableBody';
+import TableContainer from '@material-ui/core/TableContainer';
+import TableHead from '@material-ui/core/TableHead';
 
 const ChipWrapper = styled.div`
   border-bottom: 1px solid ${(props) => props.theme.palette.divider};
@@ -14,4 +16,12 @@ const ScrollTableBody = styled(TableBody)`
   max-height: 600px;
 `;
 
-export { ScrollTableBody, ChipWrapper };
+const StyledTableContainer = styled(TableContainer)`
+  max-height: 600px;
+`;
+
+const HiddenTableHead = styled(TableHead)`
+  display: none;
+`;
+
+export { ScrollTableBody, ChipWrapper, StyledTableContainer, HiddenTableHead };

--- a/context/app/static/js/components/files/FileBrowser/style.js
+++ b/context/app/static/js/components/files/FileBrowser/style.js
@@ -1,9 +1,17 @@
 import styled from 'styled-components';
-import Paper from '@material-ui/core/Paper';
+import TableBody from '@material-ui/core/TableBody';
 
-const ScrollPaper = styled(Paper)`
-  max-height: 600px;
-  overflow-y: auto;
+const ChipWrapper = styled.div`
+  border-bottom: 1px solid ${(props) => props.theme.palette.divider};
+  padding: 12px 15px 12px 15px;
+  position: sticky;
+  top: 0;
+  background-color: #fff;
 `;
 
-export { ScrollPaper };
+const ScrollTableBody = styled(TableBody)`
+  overflow-y: auto;
+  max-height: 600px;
+`;
+
+export { ScrollTableBody, ChipWrapper };

--- a/context/app/static/js/components/files/FileBrowser/style.js
+++ b/context/app/static/js/components/files/FileBrowser/style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import TableBody from '@material-ui/core/TableBody';
 import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 
@@ -11,17 +10,13 @@ const ChipWrapper = styled.div`
   background-color: #fff;
 `;
 
-const ScrollTableBody = styled(TableBody)`
-  overflow-y: auto;
-  max-height: 600px;
-`;
-
 const StyledTableContainer = styled(TableContainer)`
   max-height: 600px;
+  overflow-y: auto;
 `;
 
 const HiddenTableHead = styled(TableHead)`
   display: none;
 `;
 
-export { ScrollTableBody, ChipWrapper, StyledTableContainer, HiddenTableHead };
+export { ChipWrapper, StyledTableContainer, HiddenTableHead };

--- a/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
+++ b/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import useFilesStore from 'js/stores/useFilesStore';
-import { Directory, StyledFolderIcon, StyledFolderOpenIcon } from './style';
+import { StyledTableRow, Directory, StyledFolderIcon, StyledFolderOpenIcon } from './style';
 
 const filesStoreSelector = (state) => state.displayOnlyQaQc;
 
@@ -27,19 +27,24 @@ function FileBrowserDirectory(props) {
   }, [displayOnlyQaQc]);
 
   return (
-    <div>
-      <Directory
-        $depth={depth}
+    <>
+      <StyledTableRow
         onClick={() => setIsExpanded(!isExpanded)}
         onKeyDown={onKeyDownHandler}
         role="button"
         tabIndex="0"
       >
-        {isExpanded ? <StyledFolderOpenIcon color="primary" /> : <StyledFolderIcon color="primary" />}
-        {dirName}
-      </Directory>
+        <td>
+          <Directory $depth={depth}>
+            {isExpanded ? <StyledFolderOpenIcon color="primary" /> : <StyledFolderIcon color="primary" />}
+            {dirName}
+          </Directory>
+        </td>
+        <td />
+        <td />
+      </StyledTableRow>
       {isExpanded && children}
-    </div>
+    </>
   );
 }
 

--- a/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
+++ b/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
@@ -1,7 +1,10 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
+import useFilesStore from 'js/stores/useFilesStore';
 import { Directory, StyledFolderIcon, StyledFolderOpenIcon } from './style';
+
+const filesStoreSelector = (state) => state.displayOnlyQaQc;
 
 function FileBrowserDirectory(props) {
   const { dirName, children, depth } = props;
@@ -12,6 +15,16 @@ function FileBrowserDirectory(props) {
       setIsExpanded(!isExpanded);
     }
   };
+
+  const displayOnlyQaQc = useFilesStore(filesStoreSelector);
+
+  useEffect(() => {
+    if (displayOnlyQaQc === true) {
+      setIsExpanded(true);
+      return;
+    }
+    setIsExpanded(false);
+  }, [displayOnlyQaQc]);
 
   return (
     <div>

--- a/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
+++ b/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
@@ -21,11 +21,7 @@ function FileBrowserDirectory(props) {
   const displayOnlyQaQc = useFilesStore(filesStoreSelector);
 
   useEffect(() => {
-    if (displayOnlyQaQc === true) {
-      setIsExpanded(true);
-      return;
-    }
-    setIsExpanded(false);
+    setIsExpanded(displayOnlyQaQc);
   }, [displayOnlyQaQc]);
 
   return (

--- a/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
+++ b/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import ArrowRightRoundedIcon from '@material-ui/icons/ArrowRightRounded';
+import ArrowDropDownRoundedIcon from '@material-ui/icons/ArrowDropDownRounded';
 
 import useFilesStore from 'js/stores/useFilesStore';
 import { StyledTableRow, Directory, StyledFolderIcon, StyledFolderOpenIcon } from './style';
@@ -36,7 +38,17 @@ function FileBrowserDirectory(props) {
       >
         <td>
           <Directory $depth={depth}>
-            {isExpanded ? <StyledFolderOpenIcon color="primary" /> : <StyledFolderIcon color="primary" />}
+            {isExpanded ? (
+              <>
+                <ArrowDropDownRoundedIcon color="secondary" />
+                <StyledFolderOpenIcon color="primary" />
+              </>
+            ) : (
+              <>
+                <ArrowRightRoundedIcon color="secondary" />
+                <StyledFolderIcon color="primary" />
+              </>
+            )}
             {dirName}
           </Directory>
         </td>

--- a/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.spec.js
+++ b/context/app/static/js/components/files/FileBrowserDirectory/FileBrowserDirectory.spec.js
@@ -51,7 +51,7 @@ test('has correct left padding', () => {
   // depth * indentation multiplier * 8px spacing unit + base padding
   const expectedPadding = depth * 1.5 * 8 + 40;
 
-  expect(screen.getByRole('button')).toHaveStyle(`padding-left: ${expectedPadding}px`);
+  expect(screen.getByText('fakedir')).toHaveStyle(`padding-left: ${expectedPadding}px`);
 });
 
 test('is keyboard focusable', () => {

--- a/context/app/static/js/components/files/FileBrowserDirectory/style.js
+++ b/context/app/static/js/components/files/FileBrowserDirectory/style.js
@@ -1,18 +1,21 @@
 import styled from 'styled-components';
 import FolderIcon from '@material-ui/icons/FolderRounded';
 import FolderOpenIcon from '@material-ui/icons/FolderOpenRounded';
+import TableRow from '@material-ui/core/TableRow';
 
-const Directory = styled.div`
-  padding: 10px 0px 10px ${(props) => props.theme.spacing(props.$depth * 1.5) + 40}px;
+const StyledTableRow = styled(TableRow)`
   border-bottom: 1px solid ${(props) => props.theme.palette.divider};
-  font-size: ${(props) => props.theme.typography.body1.fontSize};
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-
   &:hover {
     background-color: rgb(0, 0, 0, 0.08);
   }
+  cursor: pointer;
+`;
+
+const Directory = styled.div`
+  padding: 10px 0px 10px ${(props) => props.theme.spacing(props.$depth * 1.5) + 40}px;
+  font-size: ${(props) => props.theme.typography.body1.fontSize};
+  display: flex;
+  align-items: center;
 `;
 
 const StyledFolderIcon = styled(FolderIcon)`
@@ -23,4 +26,4 @@ const StyledFolderOpenIcon = styled(FolderOpenIcon)`
   margin-right: ${(props) => props.theme.spacing(1)}px;
 `;
 
-export { Directory, StyledFolderOpenIcon, StyledFolderIcon };
+export { StyledTableRow, Directory, StyledFolderOpenIcon, StyledFolderIcon };

--- a/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.jsx
@@ -7,7 +7,7 @@ import { getTokenParam } from 'js/helpers/functions';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import DetailContext from 'js/components//Detail/context';
 import FilesConditionalLink from '../FilesConditionalLink';
-import { StyledDiv, StyledFileIcon, IndentedDiv, FileSize, StyledInfoIcon } from './style';
+import { StyledRow, StyledFileIcon, IndentedDiv, FileSize, StyledInfoIcon, QaChip } from './style';
 import FilesContext from '../Files/context';
 
 function FileBrowserFile(props) {
@@ -21,24 +21,29 @@ function FileBrowserFile(props) {
   const fileUrl = `${assetsEndpoint}/${uuid}/${fileObj.rel_path}${tokenParam}`;
 
   return (
-    <StyledDiv>
-      <IndentedDiv $depth={depth} data-testid="file-indented-div">
-        <StyledFileIcon color="primary" />
-        <FilesConditionalLink
-          href={fileUrl}
-          hasAgreedToDUA={hasAgreedToDUA}
-          openDUA={() => openDUA(fileUrl)}
-          variant="body1"
-          download
-        >
-          {fileObj.file}
-        </FilesConditionalLink>
+    <StyledRow>
+      <td>
+        <IndentedDiv $depth={depth} data-testid="file-indented-div">
+          <StyledFileIcon color="primary" />
+          <FilesConditionalLink
+            href={fileUrl}
+            hasAgreedToDUA={hasAgreedToDUA}
+            openDUA={() => openDUA(fileUrl)}
+            variant="body1"
+            download
+          >
+            {fileObj.file}
+          </FilesConditionalLink>
+          <SecondaryBackgroundTooltip title={`${fileObj.description} (Format: ${fileObj.edam_term})`}>
+            <StyledInfoIcon color="primary" />
+          </SecondaryBackgroundTooltip>
+        </IndentedDiv>
+      </td>
+      <td>{fileObj?.is_qa_qc ? <QaChip label="QA" variant="outlined" /> : null}</td>
+      <td>
         <FileSize variant="body1">{prettyBytes(fileObj.size)}</FileSize>
-        <SecondaryBackgroundTooltip title={`${fileObj.description} (Format: ${fileObj.edam_term})`}>
-          <StyledInfoIcon color="primary" />
-        </SecondaryBackgroundTooltip>
-      </IndentedDiv>
-    </StyledDiv>
+      </td>
+    </StyledRow>
   );
 }
 

--- a/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.jsx
@@ -54,6 +54,7 @@ FileBrowserFile.propTypes = {
     size: PropTypes.number,
     description: PropTypes.string,
     edam_term: PropTypes.string,
+    is_qa_qc: PropTypes.bool,
   }).isRequired,
   depth: PropTypes.number.isRequired,
 };

--- a/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.jsx
@@ -49,11 +49,11 @@ function FileBrowserFile(props) {
 
 FileBrowserFile.propTypes = {
   fileObj: PropTypes.shape({
-    rel_path: PropTypes.string,
-    file: PropTypes.string,
-    size: PropTypes.number,
-    description: PropTypes.string,
-    edam_term: PropTypes.string,
+    rel_path: PropTypes.string.isRequired,
+    file: PropTypes.string.isRequired,
+    size: PropTypes.number.isRequired,
+    description: PropTypes.string.isRequired,
+    edam_term: PropTypes.string.isRequired,
     is_qa_qc: PropTypes.bool,
   }).isRequired,
   depth: PropTypes.number.isRequired,

--- a/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.spec.js
+++ b/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.spec.js
@@ -60,8 +60,8 @@ test('has correct left margin', () => {
     </FilesProviders>,
   );
 
-  // depth * indentation multiplier * 8px spacing unit
-  const expectedMargin = depth * 1.5 * 8;
+  // depth * indentation multiplier * 8px spacing unit + width of dir arrow icon
+  const expectedMargin = depth * 1.5 * 8 + 24;
 
   expect(screen.getByTestId('file-indented-div')).toHaveStyle(`margin-left: ${expectedMargin}px`);
 });

--- a/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.spec.js
+++ b/context/app/static/js/components/files/FileBrowserFile/FileBrowserFile.spec.js
@@ -65,3 +65,65 @@ test('has correct left margin', () => {
 
   expect(screen.getByTestId('file-indented-div')).toHaveStyle(`margin-left: ${expectedMargin}px`);
 });
+
+test('displays QA chip when is_qa_qc is true', () => {
+  const fileObj = {
+    rel_path: 'fakepath',
+    edam_term: 'faketerm',
+    description: 'fakedescription',
+    file: 'fakefile',
+    is_qa_qc: true,
+    size: 1000,
+  };
+
+  const depth = 0;
+
+  render(
+    <FilesProviders>
+      <FileBrowserFile fileObj={fileObj} depth={depth} />
+    </FilesProviders>,
+  );
+
+  expect(screen.getByText('QA')).toBeInTheDocument();
+});
+
+test('does not display QA chip when is_qa_qc is not provided', () => {
+  const fileObj = {
+    rel_path: 'fakepath',
+    edam_term: 'faketerm',
+    description: 'fakedescription',
+    file: 'fakefile',
+    size: 1000,
+  };
+
+  const depth = 0;
+
+  render(
+    <FilesProviders>
+      <FileBrowserFile fileObj={fileObj} depth={depth} />
+    </FilesProviders>,
+  );
+
+  expect(screen.queryByText('QA')).toBeNull();
+});
+
+test('does not display QA chip when is_qa_qc is false', () => {
+  const fileObj = {
+    rel_path: 'fakepath',
+    edam_term: 'faketerm',
+    description: 'fakedescription',
+    file: 'fakefile',
+    size: 1000,
+    is_qa_qc: false,
+  };
+
+  const depth = 0;
+
+  render(
+    <FilesProviders>
+      <FileBrowserFile fileObj={fileObj} depth={depth} />
+    </FilesProviders>,
+  );
+
+  expect(screen.queryByText('QA')).toBeNull();
+});

--- a/context/app/static/js/components/files/FileBrowserFile/style.js
+++ b/context/app/static/js/components/files/FileBrowserFile/style.js
@@ -12,9 +12,10 @@ const StyledRow = styled(TableRow)`
   }
 `;
 
+// 24px the width of the directory arrow icon and is used to keep the file icon aligned with the directory icon
 const IndentedDiv = styled.div`
   padding: 10px 40px;
-  margin-left: ${(props) => props.theme.spacing(props.$depth * 1.5)}px;
+  margin-left: ${(props) => props.theme.spacing(props.$depth * 1.5) + 24}px;
   display: flex;
   align-items: center;
 `;

--- a/context/app/static/js/components/files/FileBrowserFile/style.js
+++ b/context/app/static/js/components/files/FileBrowserFile/style.js
@@ -2,10 +2,11 @@ import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import InsertDriveFileIcon from '@material-ui/icons/InsertDriveFileRounded';
 import InfoIcon from '@material-ui/icons/InfoRounded';
+import TableRow from '@material-ui/core/TableRow';
+import Chip from '@material-ui/core/Chip';
 
-const StyledDiv = styled.div`
+const StyledRow = styled(TableRow)`
   border-bottom: 1px solid ${(props) => props.theme.palette.divider};
-
   &:hover {
     background-color: rgb(0, 0, 0, 0.08);
   }
@@ -32,4 +33,10 @@ const StyledInfoIcon = styled(InfoIcon)`
   font-size: 1rem;
 `;
 
-export { StyledDiv, IndentedDiv, StyledFileIcon, FileSize, StyledInfoIcon };
+const QaChip = styled(Chip)`
+  padding-left: 10px;
+  padding-right: 10px;
+  border-radius: 8px;
+`;
+
+export { StyledRow, IndentedDiv, StyledFileIcon, FileSize, StyledInfoIcon, QaChip };

--- a/context/app/static/js/components/files/FileBrowserNode/FileBrowserNode.jsx
+++ b/context/app/static/js/components/files/FileBrowserNode/FileBrowserNode.jsx
@@ -3,20 +3,13 @@ import PropTypes from 'prop-types';
 
 import FileBrowserDirectory from '../FileBrowserDirectory';
 import FileBrowserFile from '../FileBrowserFile';
-import { Column } from './style';
 
 function FileBrowserNode(props) {
   const { fileSubTree, depth } = props;
   return Object.entries(fileSubTree).map(([k, v]) => {
     // if the object contains array of files, display all files
     if (k === 'files') {
-      return (
-        <Column key={`${k}-${depth}`}>
-          {v.map((file) => (
-            <FileBrowserFile key={file.rel_path} fileObj={file} depth={depth} />
-          ))}
-        </Column>
-      );
+      return v.map((file) => <FileBrowserFile key={file.rel_path} fileObj={file} depth={depth} />);
     }
     // if the object contains additional directories, display dir and continue down
     return (

--- a/context/app/static/js/components/files/FileBrowserNode/style.js
+++ b/context/app/static/js/components/files/FileBrowserNode/style.js
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-const Column = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-
-export { Column };

--- a/context/app/static/js/components/files/Files/Files.jsx
+++ b/context/app/static/js/components/files/Files/Files.jsx
@@ -57,11 +57,11 @@ Files.propTypes = {
   display_doi: PropTypes.string.isRequired,
   files: PropTypes.arrayOf(
     PropTypes.shape({
-      rel_path: PropTypes.string,
-      edam_term: PropTypes.string,
-      description: PropTypes.string,
-      size: PropTypes.number,
-      type: PropTypes.string,
+      rel_path: PropTypes.string.isRequired,
+      edam_term: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+      size: PropTypes.number.isRequired,
+      type: PropTypes.string.isRequired,
       is_qa_qc: PropTypes.bool,
     }),
   ),

--- a/context/app/static/js/components/files/Files/Files.jsx
+++ b/context/app/static/js/components/files/Files/Files.jsx
@@ -56,12 +56,13 @@ Files.propTypes = {
   uuid: PropTypes.string.isRequired,
   display_doi: PropTypes.string.isRequired,
   files: PropTypes.arrayOf(
-    PropTypes.exact({
+    PropTypes.shape({
       rel_path: PropTypes.string,
       edam_term: PropTypes.string,
       description: PropTypes.string,
       size: PropTypes.number,
       type: PropTypes.string,
+      is_qa_qc: PropTypes.bool,
     }),
   ),
 };

--- a/context/app/static/js/stores/useFilesStore.js
+++ b/context/app/static/js/stores/useFilesStore.js
@@ -1,0 +1,8 @@
+import create from 'zustand';
+
+const useFilesStore = create((set) => ({
+  displayOnlyQaQc: false,
+  toggleDisplayOnlyQaQc: () => set((state) => ({ displayOnlyQaQc: !state.displayOnlyQaQc })),
+}));
+
+export default useFilesStore;


### PR DESCRIPTION
Fix #1009. Arrow icons to be added in #1375. Tests to be added in #1376. May be worthwhile to run this locally.

@tsliaw the 'QA' chip in each row is a little farther to the right than in your mockup, but this is how the table positions it by default and leaves a little more room for longer file/dir names.

<img width="1109" alt="Screen Shot 2020-11-20 at 3 40 01 PM" src="https://user-images.githubusercontent.com/62477388/99983622-16fef600-2d7a-11eb-9f6c-67b707d46847.png">

<img width="1101" alt="Screen Shot 2020-11-20 at 3 39 45 PM" src="https://user-images.githubusercontent.com/62477388/99983631-19f9e680-2d7a-11eb-8432-66d610411114.png">
