### PR TITLE
Mccalluc/indent docs details

### DIFF
--- a/CHANGELOG-indent-faqs.md
+++ b/CHANGELOG-indent-faqs.md
@@ -1,0 +1,1 @@
+- Indent the FAQs.

--- a/context/app/static/js/components/Markdown/style.js
+++ b/context/app/static/js/components/Markdown/style.js
@@ -72,6 +72,13 @@ const StyledPaper = styled(Paper)`
     font-weight: 300;
     line-height: 1.6;
   }
+
+  details {
+    margin-left: 2em;
+    summary {
+      margin-left: -2em;
+    }
+  }
 `;
 
 export { StyledPaper };


### PR DESCRIPTION
Fix #1147
<img width="243" alt="Screen Shot 2020-11-13 at 11 04 40 AM" src="https://user-images.githubusercontent.com/730388/99093383-5ff7c300-25a0-11eb-8235-79180083c1cf.png">

(Adding a border or something could be possible... but I wouldn't be enthusiastic about getting into that.)