### PR TITLE
"software" in footer

### DIFF
--- a/CHANGELOG-software-footer.md
+++ b/CHANGELOG-software-footer.md
@@ -1,0 +1,1 @@
+- Add "Software" section to footer.

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -33,6 +33,12 @@ function Footer(props) {
               <LightBlueLink variant="body2" href="mailto:help@hubmapconsortium.org">
                 Submit Feedback
               </LightBlueLink>
+            </FlexColumn>
+            <FlexColumn $mr={1}>
+              <Typography variant="subtitle2">Software</Typography>
+              <LightBlueLink variant="body2" href="https://github.com/hubmapconsortium">
+                GitHub
+              </LightBlueLink>
               <LightBlueLink variant="body2" href="/services">
                 Services
               </LightBlueLink>


### PR DESCRIPTION
New footer section. Fix  #1192
<img width="689" alt="Screen Shot 2020-11-13 at 11 14 46 AM" src="https://user-images.githubusercontent.com/730388/99094497-e5c83e00-25a1-11eb-9005-ceb814ee910b.png">
