### PR TITLE
Remove one CSS rule to fix pagination position

### DIFF
--- a/CHANGELOG-search-pagination-position.md
+++ b/CHANGELOG-search-pagination-position.md
@@ -1,0 +1,1 @@
+- Search pagination control immediately follows the table.

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -23,7 +23,6 @@ $secondary-gray: #636363;
     background-color:transparent;
     display:flex;
     flex-direction: column;
-    justify-content: space-between;
 }
 
 .sk-results-list {


### PR DESCRIPTION
Fix #1350. Works on Chrome and FF.
<img width="444" alt="Screen Shot 2020-11-13 at 11 48 04 AM" src="https://user-images.githubusercontent.com/730388/99097811-25912480-25a6-11eb-9d08-250ef02838c9.png">

