### PR TITLE
John conroy/fix css injection order

### DIFF
--- a/CHANGELOG-fix-css-injection-order.md
+++ b/CHANGELOG-fix-css-injection-order.md
@@ -1,0 +1,1 @@
+- Fix injection order for Search stylesheet.

--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -7,6 +7,8 @@ import Routes from './Routes';
 import Footer from './Footer';
 import Header from './Header';
 
+import 'js/components/Search/Search.scss';
+
 function App(props) {
   const { flaskData } = props;
   const { title, entity, vitessce_conf, endpoints, markdown, collection, errorCode } = flaskData;

--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -7,6 +7,7 @@ import Routes from './Routes';
 import Footer from './Footer';
 import Header from './Header';
 
+// Importing Search styles here so the CSS import order is correct.
 import 'js/components/Search/Search.scss';
 
 function App(props) {

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -8,7 +8,6 @@ import PaginationWrapper from './PaginationWrapper';
 import SearchBarLayout from './SearchBarLayout';
 import { resultFieldsToSortOptions } from './utils';
 import { StyledSideBar } from './style';
-import './Search.scss';
 import { NoResults, SearchError } from './noHitsComponents';
 
 function SearchWrapper(props) {


### PR DESCRIPTION
Fix #1355. Since we code split the search page, the searchkit stylesheet and our modifications were being injected after and taking precedence over our styled components.

We chose this option out of the three solutions proposed below.

1. Increase styled components specificity globally.
2. Import the stylesheet in `App.js` so our styled components will be injected last. (This solution).
3. Specify style-loader to inject css/scss styles in a specific location.

Closing #1357 as we did not choose to increase specificity.