### PR TITLE
John conroy/change expand icon

### DIFF
--- a/CHANGELOG-change-expand-icon.md
+++ b/CHANGELOG-change-expand-icon.md
@@ -1,0 +1,1 @@
+- Change fullscreen visualization icon.

--- a/context/app/static/js/components/Detail/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/Detail/visualization/Visualization/Visualization.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Vitessce } from 'vitessce';
 import Paper from '@material-ui/core/Paper';
 import Link from '@material-ui/core/Link';
-import ZoomOutMapIcon from '@material-ui/icons/ZoomOutMapRounded';
+import FullscreenRoundedIcon from '@material-ui/icons/FullscreenRounded';
 
 import { Alert } from 'js/shared-styles/alerts';
 import DropdownListbox from 'js/shared-styles/dropdowns/DropdownListbox';
@@ -84,7 +84,7 @@ function Visualization(props) {
           <VisualizationThemeSwitch />
           <SecondaryBackgroundTooltip title="Switch to Fullscreen">
             <ExpandButton size="small" onClick={expandViz} variant="contained">
-              <ZoomOutMapIcon color="primary" />
+              <FullscreenRoundedIcon color="primary" />
             </ExpandButton>
           </SecondaryBackgroundTooltip>
           {Array.isArray(vitData) ? (


### PR DESCRIPTION
We could possibly make the icon a little larger?

<img width="230" alt="Screen Shot 2020-11-19 at 4 41 13 PM" src="https://user-images.githubusercontent.com/62477388/99727631-436af780-2a86-11eb-8bfd-c2e4d8992afb.png">
