### PR TITLE
Caching

### DIFF
--- a/CHANGELOG-caching.md
+++ b/CHANGELOG-caching.md
@@ -1,0 +1,2 @@
+- Tweak NGINX settings to allow caching on client.
+- Rearrange Dockerfile to improve layer caching.

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -8,19 +8,28 @@ COPY package-lock.json .
 
 RUN npm ci
 
-# Most of our changes are in the JS, so don't worry about blowing away cache.
-COPY . .
+COPY .babelrc .babelrc
+COPY build-utils build-utils
+COPY app app
+COPY ingest-validation-tools ingest-validation-tools
+
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 
 FROM tiangolo/uwsgi-nginx-flask:python3.7
 
+COPY requirements.txt /app
+RUN pip install -r /app/requirements.txt
+
 # NGINX should serve static content directly.
 # https://github.com/tiangolo/uwsgi-nginx-flask-docker#custom-static-path
 ENV STATIC_PATH /app/app/static
 
-COPY requirements.txt /app
-RUN pip install -r /app/requirements.txt
+# Additional NGINX config that can't be handled with envvars.
+# Be sure not to clobber nginx.conf from base image!
+# Docs:   https://github.com/tiangolo/uwsgi-nginx-flask-docker#customizing-nginx-additional-configurations
+# Source: https://github.com/tiangolo/uwsgi-nginx-docker/blob/c1e6eb2/docker-images/entrypoint.sh#L37
+COPY portal.nginx.conf /etc/nginx/conf.d/
 
 COPY --from=builder /work/app/static/public ${STATIC_PATH}/public
 COPY . /app

--- a/context/portal.nginx.conf
+++ b/context/portal.nginx.conf
@@ -1,0 +1,8 @@
+server {
+    # "~": Case-sensitive regex matching
+    # http://nginx.org/en/docs/http/ngx_http_core_module.html#location
+    location ~ \.(js|css|png|jpg|jpeg|gif|ico)$ {
+        expires 5m; # TODO: Set this higher when we're happy with it.
+        add_header Cache-Control "public";
+    }
+}


### PR DESCRIPTION
Towards #1348 ... For now, out of an abundance of caution, just caching for 5 minutes, but this can be increased, perhaps even before merging. (Since we will be pushing out new versions every couple days, I'd suggest we not cache for more than a week... anything more is just wasting disk space on the client.)

Checked in devtools, and works locally. In FF, in devtools, there's a checkbox that disables caching by default, but it worked when turned off. In Chrome, still shows as 200 response, and there's another column that shows its coming from cache.