### PR TITLE
John conroy/proxy http version for gzip

### DIFF
--- a/CHANGELOG-proxy-http-version-for-gzip.md
+++ b/CHANGELOG-proxy-http-version-for-gzip.md
@@ -1,0 +1,1 @@
+- Set proxy http version for gzip in example nginx conf.

--- a/compose/nginx.conf
+++ b/compose/nginx.conf
@@ -8,6 +8,7 @@ http {
             proxy_pass        http://portal-ui;
             proxy_set_header  Host $http_host;
             proxy_set_header  X-Forwarded-Proto $scheme;
+            proxy_http_version  1.1;
 
             # If proxy_set_header is missing,
             # the redirect url passed to Globus will use "portal-ui" instead.

--- a/compose/nginx.conf
+++ b/compose/nginx.conf
@@ -8,11 +8,14 @@ http {
             proxy_pass        http://portal-ui;
             proxy_set_header  Host $http_host;
             proxy_set_header  X-Forwarded-Proto $scheme;
-            proxy_http_version  1.1;
 
             # If proxy_set_header is missing,
             # the redirect url passed to Globus will use "portal-ui" instead.
             # (Plain "$host" does not include port.)
+
+            proxy_http_version  1.1;
+            # gzip_http_version sets the minimum HTTP version of a request required to compress a response to 1.1 by default.
+            # proxy_http_version needs to be >= that, but is 1.0 by default.
         }
     }
 }


### PR DESCRIPTION
Gzip should work once this change is made to the real nginx configuration for deployment. 

`gzip_http_version` sets the minimum HTTP version of a request required to compress a response to 1.1 by default. `proxy_http_version` defaults to 1.0 so by upgrading the version, the portal-ui will serve gzipped files when possible. Alternatively we could set `gzip_http_version` to 1.0.