### PR TITLE
John conroy/lazy load vitessce share button

### DIFF
--- a/CHANGELOG-lazy-load-vitessce-share-button.md
+++ b/CHANGELOG-lazy-load-vitessce-share-button.md
@@ -1,0 +1,1 @@
+- Lazy load vitessce share button in entity header to keep vitessce out of bundle entry points.

--- a/context/app/static/js/components/Detail/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
+++ b/context/app/static/js/components/Detail/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { useTransition, animated } from 'react-spring';
 
 import VizualizationThemeSwitch from 'js/components/Detail/visualization/VisualizationThemeSwitch';
-import VisualizationShareButton from 'js/components/Detail/visualization/VisualizationShareButton';
 import VisualizationCollapseButton from 'js/components/Detail/visualization/VisualizationCollapseButton';
 import { StyledDatasetIcon, StyledSampleIcon, StyledDonorIcon, FlexContainer, RightDiv } from './style';
 import EntityHeaderItem from '../EntityHeaderItem';
+import VisualizationShareButtonWrapper from '../VisualizationShareButtonWrapper';
 
 const iconMap = {
   Dataset: <StyledDatasetIcon />,
@@ -34,7 +34,7 @@ function EntityHeaderContent({ display_doi, entity_type, data, shouldDisplayHead
           ))}
           {vizIsFullscreen && (
             <RightDiv>
-              <VisualizationShareButton />
+              <VisualizationShareButtonWrapper />
               <VizualizationThemeSwitch />
               <VisualizationCollapseButton />
             </RightDiv>

--- a/context/app/static/js/components/Detail/entityHeader/VisualizationShareButtonWrapper/VisualizationShareButtonWrapper.jsx
+++ b/context/app/static/js/components/Detail/entityHeader/VisualizationShareButtonWrapper/VisualizationShareButtonWrapper.jsx
@@ -1,0 +1,27 @@
+import React, { Suspense, lazy } from 'react';
+import ShareIcon from '@material-ui/icons/Share';
+
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
+
+const VisualizationShareButton = lazy(() => import('js/components/Detail/visualization/VisualizationShareButton'));
+
+function ShareButtonFallback() {
+  return (
+    <SecondaryBackgroundTooltip title="Share Visualization">
+      <WhiteBackgroundIconButton disabled>
+        <ShareIcon color="disabled" />
+      </WhiteBackgroundIconButton>
+    </SecondaryBackgroundTooltip>
+  );
+}
+
+function VisualizationShareButtonWrapper() {
+  return (
+    <Suspense fallback={<ShareButtonFallback />}>
+      <VisualizationShareButton />
+    </Suspense>
+  );
+}
+
+export default VisualizationShareButtonWrapper;

--- a/context/app/static/js/components/Detail/entityHeader/VisualizationShareButtonWrapper/index.js
+++ b/context/app/static/js/components/Detail/entityHeader/VisualizationShareButtonWrapper/index.js
@@ -1,0 +1,3 @@
+import VisualizationShareButtonWrapper from './VisualizationShareButtonWrapper';
+
+export default VisualizationShareButtonWrapper;


### PR DESCRIPTION
Fixes #1394.

@ilan-gold I decided to go ahead and just lazy load the share button so I can evaluate the application's performance with gzip and the other changes we're making. This removes Vitessce from our bundle's entry points. Once Vitessce is tree-shakeable, we can remove the wrapper component. 

@tsliaw It should only show the disabled button while Vitessce is loading. Once Vitessce is loaded, it will display the regular share button.

<img width="1792" alt="Screen Shot 2020-11-30 at 2 54 41 PM" src="https://user-images.githubusercontent.com/62477388/100658079-7f227e80-331c-11eb-8110-6c10ce922d2f.png">
