### PR TITLE
Log config during docker startup

### DIFF
--- a/CHANGELOG-docker-config-logging.md
+++ b/CHANGELOG-docker-config-logging.md
@@ -1,0 +1,1 @@
+- Log config during docker startup.

--- a/context/prestart.sh
+++ b/context/prestart.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Only designed to be called from the base Docker image on startup:
+# https://github.com/tiangolo/uwsgi-nginx-flask-docker#custom-appprestartsh
+
+echo 'app.conf:'
+cat /app/instance/app.conf
+echo '---------'


### PR DESCRIPTION
Fix  #1430

Using docker.sh locally, and `docker logs`, confirmed that the config is in there.
- @john-conroy : code review
- @yuanzhou : Is this what you need? Is there anything else you'd like recorded?

I think the security on the logs is the same as the security on the config itself, but we could use `grep -v SECRET` instead of `cat`, if anyone would prefer?