### PR TITLE
emulate travis [skip ci]

### DIFF
--- a/.github/workflows/portal-ci.yml
+++ b/.github/workflows/portal-ci.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG-skip-ci.md
+++ b/CHANGELOG-skip-ci.md
@@ -1,0 +1,1 @@
+- Emulate travis `[skip ci]`.


### PR DESCRIPTION
Suggestion taken from: https://github.community/t/github-actions-does-not-respect-skip-ci/17325/9.

... though, unlike Travis, we still get a green checkmark, even when it skips, so may this isn't the safest idea? I'm ambivalent.