### PR TITLE
Show RUI JSON for Samples

### DIFF
--- a/CHANGELOG-show-rui-location.md
+++ b/CHANGELOG-show-rui-location.md
@@ -1,0 +1,1 @@
+- Show RUI location as a blob of JSON.

--- a/CHANGELOG-spatial-dev-search.md
+++ b/CHANGELOG-spatial-dev-search.md
@@ -1,0 +1,1 @@
+- Add a dev search facet to find spatially located datasets; Fix a bug in the facet for spatially located samples.

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import SectionContainer from 'js/shared-styles/sections/SectionContainer';
-import { FlexPaper } from './style';
+import { FlexPaper, Pre } from './style';
 import SectionItem from '../SectionItem';
 
 function MetadataItem(props) {
@@ -16,9 +16,19 @@ function MetadataItem(props) {
   );
 }
 
+function LocationDetails(props) {
+  const { locationJson } = props;
+  const prettyLocation = JSON.stringify(JSON.parse(locationJson), null, 2);
+  return (
+    <details>
+      <summary>RUI JSON</summary>
+      <Pre>{prettyLocation}</Pre>
+    </details>
+  );
+}
+
 function SampleTissue(props) {
   const { mapped_organ, mapped_specimen_type, rui_location } = props;
-  const pretty_rui_location = JSON.stringify(JSON.parse(rui_location), null, 2);
   return (
     <SectionContainer id="tissue">
       <SectionHeader>Tissue</SectionHeader>
@@ -37,7 +47,7 @@ function SampleTissue(props) {
             </LightBlueLink>
             .
           </>
-          <pre>{pretty_rui_location}</pre>
+          <LocationDetails locationJson={rui_location} />
         </MetadataItem>
       </FlexPaper>
     </SectionContainer>

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -41,13 +41,11 @@ function SampleTissue(props) {
         </MetadataItem>
         {rui_location && (
           <MetadataItem label="Tissue Location" ml={1}>
-            <>
-              The spatial coordinates of this sample have been registered and it can be found in the{' '}
-              <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
-                Common Coordinate Framework Exploration User Interface
-              </LightBlueLink>
-              .
-            </>
+            The spatial coordinates of this sample have been registered and it can be found in the{' '}
+            <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
+              Common Coordinate Framework Exploration User Interface
+            </LightBlueLink>
+            .
             <LocationDetails locationJson={rui_location} />
           </MetadataItem>
         )}

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -17,7 +17,8 @@ function MetadataItem(props) {
 }
 
 function SampleTissue(props) {
-  const { mapped_organ, mapped_specimen_type } = props;
+  const { mapped_organ, mapped_specimen_type, rui_location } = props;
+  const pretty_rui_location = JSON.stringify(JSON.parse(rui_location), null, 2);
   return (
     <SectionContainer id="tissue">
       <SectionHeader>Tissue</SectionHeader>
@@ -36,6 +37,7 @@ function SampleTissue(props) {
             </LightBlueLink>
             .
           </>
+          <pre>{pretty_rui_location}</pre>
         </MetadataItem>
       </FlexPaper>
     </SectionContainer>
@@ -45,6 +47,7 @@ function SampleTissue(props) {
 SampleTissue.propTypes = {
   mapped_organ: PropTypes.string.isRequired,
   mapped_specimen_type: PropTypes.string.isRequired,
+  rui_location: PropTypes.string.isRequired,
 };
 
 export default SampleTissue;

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -39,16 +39,18 @@ function SampleTissue(props) {
         <MetadataItem label="Specimen Type" ml={1} flexBasis="25%">
           {mapped_specimen_type}
         </MetadataItem>
-        <MetadataItem label="Tissue Location" ml={1}>
-          <>
-            The spatial coordinates of this sample have been registered and it can be found in the{' '}
-            <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
-              Common Coordinate Framework Exploration User Interface
-            </LightBlueLink>
-            .
-          </>
-          <LocationDetails locationJson={rui_location} />
-        </MetadataItem>
+        {rui_location && (
+          <MetadataItem label="Tissue Location" ml={1}>
+            <>
+              The spatial coordinates of this sample have been registered and it can be found in the{' '}
+              <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
+                Common Coordinate Framework Exploration User Interface
+              </LightBlueLink>
+              .
+            </>
+            <LocationDetails locationJson={rui_location} />
+          </MetadataItem>
+        )}
       </FlexPaper>
     </SectionContainer>
   );

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
@@ -4,7 +4,13 @@ import { render, screen } from 'test-utils/functions';
 import SampleTissue from './SampleTissue';
 
 test('text displays properly when all props provided', () => {
-  render(<SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" />);
+  render(
+    <SampleTissue
+      mapped_organ="Fake Organ"
+      mapped_specimen_type="Fake Specimen Type"
+      rui_location='{"expecting": "a JSON blob"}'
+    />,
+  );
 
   expect(screen.getByText('Tissue')).toBeInTheDocument();
 
@@ -21,12 +27,12 @@ test('text displays properly when all props provided', () => {
   expect(screen.getByRole('link')).toHaveAttribute('href', '/ccf-eui');
 });
 
-test('displays label not defined when values are undefined', () => {
+test('displays label not defined when values are undefined, and skips CCF', () => {
   render(<SampleTissue />);
 
   expect(screen.getByText('Tissue')).toBeInTheDocument();
 
-  const labelsToTest = ['Organ Type', 'Specimen Type', 'Tissue Location'];
+  const labelsToTest = ['Organ Type', 'Specimen Type'];
   labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 
   const valuesToTest = ['Organ Type not defined', 'Specimen Type not defined'];

--- a/context/app/static/js/components/Detail/SampleTissue/style.js
+++ b/context/app/static/js/components/Detail/SampleTissue/style.js
@@ -6,4 +6,9 @@ const FlexPaper = styled(Paper)`
   padding: 30px 40px 30px 40px;
 `;
 
-export { FlexPaper };
+const Pre = styled.pre`
+  font-size: 12px;
+  white-space: pre-wrap;
+`;
+
+export { FlexPaper, Pre };

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -33,6 +33,7 @@ function SampleDetail(props) {
     last_modified_timestamp,
     description,
     metadata,
+    rui_location,
   } = assayMetadata;
 
   const shouldDisplaySection = {
@@ -69,7 +70,11 @@ function SampleDetail(props) {
             {mapped_specimen_type}
           </Typography>
         </Summary>
-        <SampleTissue mapped_specimen_type={mapped_specimen_type} mapped_organ={mapped_organ} />
+        <SampleTissue
+          mapped_specimen_type={mapped_specimen_type}
+          mapped_organ={mapped_organ}
+          rui_location={rui_location}
+        />
         <Attribution
           group_name={group_name}
           created_by_user_displayname={created_by_user_displayname}

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -56,8 +56,10 @@ function DevSearch() {
         checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata.metadata'))),
         checkboxFilter('has_files', 'Has files?', ExistsQuery('files')),
         checkboxFilter('no_files', 'No files?', BoolMustNot(ExistsQuery('files'))),
-        checkboxFilter('has_files', 'Spatially Located (CCF)?', ExistsQuery('rui_location')),
-        checkboxFilter('no_files', 'Not Spatially Located (CCF)?', BoolMustNot(ExistsQuery('rui_location'))),
+        checkboxFilter('has_rui_sample', 'Spatial Sample?', ExistsQuery('rui_location')),
+        checkboxFilter('no_rui_sample', 'Not Spatial Sample?', BoolMustNot(ExistsQuery('rui_location'))),
+        checkboxFilter('has_rui_dataset', 'Spatial Dataset?', ExistsQuery('ancestors.rui_location')),
+        checkboxFilter('no_rui_dataset', 'Not Spatial Dataset?', BoolMustNot(ExistsQuery('ancestors.rui_location'))),
         checkboxFilter('has_errors', 'Validation Errors?', ExistsQuery('mapper_metadata.validation_errors')),
         checkboxFilter(
           'no_errors',


### PR DESCRIPTION
Might move us towards #1439... but I think the goal / design needs to be thought out more clearly. The `rui_location` is accessible... but is showing it (either as a blob of JSON, or as a set of numbers) useful to anyone? Should the real goal be to have the transparent human here?

(Whatever direction this takes, do we want analogous designs for Samples and Datasets? Only on Sample right now.)

(Branched from PR  #1458.)