### PR TITLE
pin ubuntu version

### DIFF
--- a/.github/workflows/portal-ci.yml
+++ b/.github/workflows/portal-ci.yml
@@ -5,7 +5,9 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    # Available versions:
+    # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG-pin-ubuntu.md
+++ b/CHANGELOG-pin-ubuntu.md
@@ -1,0 +1,1 @@
+- Pin the Ubuntu version used by github CI.


### PR DESCRIPTION
Noticed a warning that the `latest` version is going to change. In general, a preference for pinning version numbers... but this might be an exception: One more thing to worry about, and if it ever did break, we could handle the problem then. I'm ambivalent. Thoughts?