### PR TITLE
dev search view toggle

### DIFF
--- a/CHANGELOG-dev-search-toggle.md
+++ b/CHANGELOG-dev-search-toggle.md
@@ -1,0 +1,2 @@
+- Provide two different view toggles, one for the main search, and one for dev.
+- For the dev search, provide a stub where a CCF view could be filled in.

--- a/context/app/static/js/components/Search/DevResults/DevResults.jsx
+++ b/context/app/static/js/components/Search/DevResults/DevResults.jsx
@@ -1,13 +1,41 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Hits } from 'searchkit'; // eslint-disable-line import/no-duplicates
+import { ViewSwitcherHits } from 'searchkit';
 
 import ResultsTable from '../ResultsTable';
+import ResultsCCF from '../ResultsCCF';
 
 function DevResults(props) {
   const { sortOptions, hitsPerPage, tableResultFields, detailsUrlPrefix, idField, resultFieldIds } = props;
 
   return (
+    <ViewSwitcherHits
+      hitsPerPage={hitsPerPage}
+      hitComponents={[
+        {
+          key: 'table',
+          title: 'Table',
+          listComponent: (
+            <ResultsTable
+              resultFields={tableResultFields}
+              detailsUrlPrefix={detailsUrlPrefix}
+              idField={idField}
+              sortOptions={sortOptions}
+            />
+          ),
+          defaultOption: true,
+        },
+        { key: 'ccf', title: 'CCF', listComponent: <ResultsCCF /> },
+      ]}
+      sourceFilter={resultFieldIds}
+      customHighlight={{
+        fields: { everything: { type: 'plain' } },
+      }}
+    />
+  );
+}
+
+/*
     <Hits
       hitsPerPage={hitsPerPage}
       listComponent={
@@ -23,8 +51,7 @@ function DevResults(props) {
         fields: { everything: { type: 'plain' } },
       }}
     />
-  );
-}
+*/
 
 DevResults.propTypes = {
   sortOptions: PropTypes.arrayOf(PropTypes.object).isRequired,

--- a/context/app/static/js/components/Search/DevResults/DevResults.jsx
+++ b/context/app/static/js/components/Search/DevResults/DevResults.jsx
@@ -35,24 +35,6 @@ function DevResults(props) {
   );
 }
 
-/*
-    <Hits
-      hitsPerPage={hitsPerPage}
-      listComponent={
-        <ResultsTable
-          resultFields={tableResultFields}
-          detailsUrlPrefix={detailsUrlPrefix}
-          idField={idField}
-          sortOptions={sortOptions}
-        />
-      }
-      sourceFilter={resultFieldIds}
-      customHighlight={{
-        fields: { everything: { type: 'plain' } },
-      }}
-    />
-*/
-
 DevResults.propTypes = {
   sortOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
   hitsPerPage: PropTypes.number.isRequired,

--- a/context/app/static/js/components/Search/Results/Results.jsx
+++ b/context/app/static/js/components/Search/Results/Results.jsx
@@ -4,6 +4,7 @@ import { ViewSwitcherHits } from 'searchkit'; // eslint-disable-line import/no-d
 
 import ResultsTable from '../ResultsTable';
 import ResultsTiles from '../ResultsTiles';
+import ResultsCCF from '../ResultsCCF';
 
 function Results(props) {
   const { sortOptions, hitsPerPage, tableResultFields, detailsUrlPrefix, idField, resultFieldIds, type } = props;
@@ -26,6 +27,7 @@ function Results(props) {
           defaultOption: true,
         },
         { key: 'tile', title: 'Tile', listComponent: <ResultsTiles type={type} /> },
+        { key: 'ccf', title: 'CCF', listComponent: <ResultsCCF type={type} /> },
       ]}
       sourceFilter={resultFieldIds}
       customHighlight={{

--- a/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
+++ b/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import '@vaadin/vaadin-button'; // TODO: When this is removed, please nmp uninstall!
+
 function ResultsCCF(props) {
   // eslint-disable-next-line no-unused-vars
   const { hits, resultFields, detailsUrlPrefix, idField, sortOptions } = props;
-  return <div>TODO</div>;
+  return <vaadin-button> A Web Component! </vaadin-button>;
 }
 
 ResultsCCF.propTypes = {

--- a/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
+++ b/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
@@ -1,19 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import '@vaadin/vaadin-button'; // TODO: When this is removed, please nmp uninstall!
+function ReplaceMeWithWebComponent(props) {
+  // TODO: This will be replaced with a Web Component from Bruce.
+  const { spatialResults } = props;
+  return (
+    <div>
+      {spatialResults.map((result) => (
+        <pre key={result.uuid}>{JSON.stringify(result, null, 2)}</pre>
+      ))}
+    </div>
+  );
+}
 
 function ResultsCCF(props) {
   // eslint-disable-next-line no-unused-vars
   const { hits, resultFields, detailsUrlPrefix, idField, sortOptions } = props;
-  return <vaadin-button> A Web Component! </vaadin-button>;
+  const spatialResults = hits
+    // eslint-disable-next-line no-underscore-dangle
+    .map((hit) => hit._source)
+    .filter((source) => source.rui_location)
+    .map((source) => ({
+      uuid: source.uuid,
+      rui_location: JSON.parse(source.rui_location),
+    }));
+  return <ReplaceMeWithWebComponent spatialResults={spatialResults} />;
 }
 
 ResultsCCF.propTypes = {
-  sortOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
-  resultFields: PropTypes.arrayOf(PropTypes.object).isRequired,
-  detailsUrlPrefix: PropTypes.string.isRequired,
-  idField: PropTypes.string.isRequired,
   hits: PropTypes.arrayOf(
     PropTypes.shape({
       sort: PropTypes.array,

--- a/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
+++ b/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function ResultsCCF(props) {
+  // eslint-disable-next-line no-unused-vars
+  const { hits, resultFields, detailsUrlPrefix, idField, sortOptions } = props;
+  return <div>TODO</div>;
+}
+
+export default ResultsCCF;

--- a/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
+++ b/context/app/static/js/components/Search/ResultsCCF/ResultsCCF.jsx
@@ -1,9 +1,31 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function ResultsCCF(props) {
   // eslint-disable-next-line no-unused-vars
   const { hits, resultFields, detailsUrlPrefix, idField, sortOptions } = props;
   return <div>TODO</div>;
 }
+
+ResultsCCF.propTypes = {
+  sortOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
+  resultFields: PropTypes.arrayOf(PropTypes.object).isRequired,
+  detailsUrlPrefix: PropTypes.string.isRequired,
+  idField: PropTypes.string.isRequired,
+  hits: PropTypes.arrayOf(
+    PropTypes.shape({
+      sort: PropTypes.array,
+      _id: PropTypes.string,
+      _index: PropTypes.string,
+      _score: PropTypes.number,
+      _source: PropTypes.object,
+      _type: PropTypes.string,
+    }),
+  ),
+};
+
+ResultsCCF.defaultProps = {
+  hits: undefined,
+};
 
 export default ResultsCCF;

--- a/context/app/static/js/components/Search/ResultsCCF/index.js
+++ b/context/app/static/js/components/Search/ResultsCCF/index.js
@@ -1,0 +1,3 @@
+import ResultsCCF from './ResultsCCF';
+
+export default ResultsCCF;

--- a/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
+++ b/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
@@ -2,18 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { SearchBox, SortingSelector, ViewSwitcherToggle } from 'searchkit';
 
-import SearchViewSwitch from '../SearchViewSwitch';
+import SearchViewSwitch, { DevSearchViewSwitch } from './SearchViewSwitch';
 import TilesSortDropdown from '../TilesSortDropdown';
 import { Flex, StyledDiv } from './style';
 
 function SearchBarLayout(props) {
-  const { queryFields, sortOptions } = props;
+  const { queryFields, sortOptions, isDevSearch } = props;
   return (
     <Flex>
       <SearchBox autofocus queryFields={queryFields} />
       <StyledDiv>
         <SortingSelector options={sortOptions} listComponent={TilesSortDropdown} />
-        <ViewSwitcherToggle listComponent={SearchViewSwitch} />
+        <ViewSwitcherToggle listComponent={isDevSearch ? DevSearchViewSwitch : SearchViewSwitch} />
       </StyledDiv>
     </Flex>
   );

--- a/context/app/static/js/components/Search/SearchBarLayout/SearchViewSwitch.jsx
+++ b/context/app/static/js/components/Search/SearchBarLayout/SearchViewSwitch.jsx
@@ -55,11 +55,18 @@ function createSearchViewSwitch(labelIconPairs) {
 const SearchViewSwitch = createSearchViewSwitch([
   { label: 'Table', Icon: ListRoundedIcon },
   { label: 'Tile', Icon: GridOnRoundedIcon },
+]);
+
+const DevSearchViewSwitch = createSearchViewSwitch([
+  { label: 'Table', Icon: ListRoundedIcon },
   { label: 'CCF', Icon: BodyRoundedIcon },
 ]);
 
 SearchViewSwitch.propTypes = {
   toggleItem: PropTypes.func.isRequired,
 };
+DevSearchViewSwitch.propTypes = {
+  toggleItem: PropTypes.func.isRequired,
+};
 
-export default SearchViewSwitch;
+export { SearchViewSwitch as default, DevSearchViewSwitch };

--- a/context/app/static/js/components/Search/SearchViewSwitch/SearchViewSwitch.jsx
+++ b/context/app/static/js/components/Search/SearchViewSwitch/SearchViewSwitch.jsx
@@ -15,43 +15,48 @@ const searchViewStoreSelector = (state) => ({
   setToggleItem: state.setToggleItem,
 });
 
-function SearchViewSwitch(props) {
-  const { toggleItem } = props;
-  const { searchView, setSearchView, setToggleItem } = useSearchViewStore(searchViewStoreSelector);
+function createSearchViewSwitch(labelIconPairs) {
+  return function SearchViewSwitch(props) {
+    const { toggleItem } = props;
+    const { searchView, setSearchView, setToggleItem } = useSearchViewStore(searchViewStoreSelector);
 
-  useEffect(() => {
-    setToggleItem(toggleItem);
-  }, [setToggleItem, toggleItem]);
+    useEffect(() => {
+      setToggleItem(toggleItem);
+    }, [setToggleItem, toggleItem]);
 
-  function handleChangeView(view) {
-    if (!['table', 'tile', 'ccf'].includes(view)) {
-      return;
+    function handleChangeView(view) {
+      const validViews = labelIconPairs.map(({ label }) => label.toLowerCase());
+      if (!validViews.includes(view)) {
+        return;
+      }
+      setSearchView(view);
+      toggleItem(view);
     }
-    setSearchView(view);
-    toggleItem(view);
-  }
 
-  return (
-    <ToggleButtonGroup value={searchView} exclusive onChange={(e, view) => handleChangeView(view)}>
-      {[
-        { label: 'Table', Icon: ListRoundedIcon },
-        { label: 'Tile', Icon: GridOnRoundedIcon },
-        { label: 'CCF', Icon: BodyRoundedIcon },
-      ].map(({ label, Icon }) => (
-        <TooltipToggleButton
-          tooltipComponent={SecondaryBackgroundTooltip}
-          tooltipTitle={`Switch to ${label} View`}
-          disableRipple
-          value={label.toLowerCase()}
-          id={`${label.toLowerCase()}-view-toggle-button`}
-          key={label}
-        >
-          <Icon color={searchView === label.toLowerCase() ? 'primary' : 'secondary'} />
-        </TooltipToggleButton>
-      ))}
-    </ToggleButtonGroup>
-  );
+    return (
+      <ToggleButtonGroup value={searchView} exclusive onChange={(e, view) => handleChangeView(view)}>
+        {labelIconPairs.map(({ label, Icon }) => (
+          <TooltipToggleButton
+            tooltipComponent={SecondaryBackgroundTooltip}
+            tooltipTitle={`Switch to ${label} View`}
+            disableRipple
+            value={label.toLowerCase()}
+            id={`${label.toLowerCase()}-view-toggle-button`}
+            key={label}
+          >
+            <Icon color={searchView === label.toLowerCase() ? 'primary' : 'secondary'} />
+          </TooltipToggleButton>
+        ))}
+      </ToggleButtonGroup>
+    );
+  };
 }
+
+const SearchViewSwitch = createSearchViewSwitch([
+  { label: 'Table', Icon: ListRoundedIcon },
+  { label: 'Tile', Icon: GridOnRoundedIcon },
+  { label: 'CCF', Icon: BodyRoundedIcon },
+]);
 
 SearchViewSwitch.propTypes = {
   toggleItem: PropTypes.func.isRequired,

--- a/context/app/static/js/components/Search/SearchViewSwitch/SearchViewSwitch.jsx
+++ b/context/app/static/js/components/Search/SearchViewSwitch/SearchViewSwitch.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import ListRoundedIcon from '@material-ui/icons/ListRounded';
 import GridOnRoundedIcon from '@material-ui/icons/GridOnRounded';
+import BodyRoundedIcon from '@material-ui/icons/AccessibilityNewRounded';
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 
 import { TooltipToggleButton } from 'js/shared-styles/buttons';
@@ -23,7 +24,7 @@ function SearchViewSwitch(props) {
   }, [setToggleItem, toggleItem]);
 
   function handleChangeView(view) {
-    if (!['table', 'tile'].includes(view)) {
+    if (!['table', 'tile', 'ccf'].includes(view)) {
       return;
     }
     setSearchView(view);
@@ -48,7 +49,16 @@ function SearchViewSwitch(props) {
         value="tile"
         id="tile-view-toggle-button"
       >
-        <GridOnRoundedIcon color={searchView !== 'table' ? 'primary' : 'secondary'} />
+        <GridOnRoundedIcon color={searchView === 'tile' ? 'primary' : 'secondary'} />
+      </TooltipToggleButton>
+      <TooltipToggleButton
+        tooltipComponent={SecondaryBackgroundTooltip}
+        tooltipTitle="Switch to CCF View"
+        disableRipple
+        value="ccf"
+        id="ccf-view-toggle-button"
+      >
+        <BodyRoundedIcon color={searchView === 'ccf' ? 'primary' : 'secondary'} />
       </TooltipToggleButton>
     </ToggleButtonGroup>
   );

--- a/context/app/static/js/components/Search/SearchViewSwitch/SearchViewSwitch.jsx
+++ b/context/app/static/js/components/Search/SearchViewSwitch/SearchViewSwitch.jsx
@@ -33,33 +33,22 @@ function SearchViewSwitch(props) {
 
   return (
     <ToggleButtonGroup value={searchView} exclusive onChange={(e, view) => handleChangeView(view)}>
-      <TooltipToggleButton
-        tooltipComponent={SecondaryBackgroundTooltip}
-        tooltipTitle="Switch to Table View"
-        disableRipple
-        value="table"
-        id="table-view-toggle-button"
-      >
-        <ListRoundedIcon color={searchView === 'table' ? 'primary' : 'secondary'} />
-      </TooltipToggleButton>
-      <TooltipToggleButton
-        tooltipComponent={SecondaryBackgroundTooltip}
-        tooltipTitle="Switch to Tile View"
-        disableRipple
-        value="tile"
-        id="tile-view-toggle-button"
-      >
-        <GridOnRoundedIcon color={searchView === 'tile' ? 'primary' : 'secondary'} />
-      </TooltipToggleButton>
-      <TooltipToggleButton
-        tooltipComponent={SecondaryBackgroundTooltip}
-        tooltipTitle="Switch to CCF View"
-        disableRipple
-        value="ccf"
-        id="ccf-view-toggle-button"
-      >
-        <BodyRoundedIcon color={searchView === 'ccf' ? 'primary' : 'secondary'} />
-      </TooltipToggleButton>
+      {[
+        { label: 'Table', Icon: ListRoundedIcon },
+        { label: 'Tile', Icon: GridOnRoundedIcon },
+        { label: 'CCF', Icon: BodyRoundedIcon },
+      ].map(({ label, Icon }) => (
+        <TooltipToggleButton
+          tooltipComponent={SecondaryBackgroundTooltip}
+          tooltipTitle={`Switch to ${label} View`}
+          disableRipple
+          value={label.toLowerCase()}
+          id={`${label.toLowerCase()}-view-toggle-button`}
+          key={label}
+        >
+          <Icon color={searchView === label.toLowerCase() ? 'primary' : 'secondary'} />
+        </TooltipToggleButton>
+      ))}
     </ToggleButtonGroup>
   );
 }

--- a/context/app/static/js/components/Search/SearchViewSwitch/index.js
+++ b/context/app/static/js/components/Search/SearchViewSwitch/index.js
@@ -1,3 +1,0 @@
-import SearchViewSwitch from './SearchViewSwitch';
-
-export default SearchViewSwitch;

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -26,6 +26,7 @@ function SearchWrapper(props) {
     queryFields,
     type,
     isLoggedIn,
+    isDevSearch,
     resultsComponent: ResultsComponent,
   } = props;
 
@@ -47,7 +48,7 @@ function SearchWrapper(props) {
   return (
     <SearchkitProvider searchkit={searchkit}>
       <>
-        <SearchBarLayout queryFields={queryFields} sortOptions={sortOptions} />
+        <SearchBarLayout queryFields={queryFields} sortOptions={sortOptions} isDevSearch={isDevSearch} />
         <LayoutBody>
           <StyledSideBar>
             <Accordions filters={filters} />

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -31,7 +31,9 @@ function SearchWrapper(props) {
   } = props;
 
   const sortOptions = resultFieldsToSortOptions(resultFields.table);
-  const resultFieldIds = [...resultFields.table, ...resultFields.tile].map((field) => field.id).concat(idField);
+  const resultFieldIds = [...resultFields.table, ...resultFields.tile, ...resultFields.ccf]
+    .map((field) => field.id)
+    .concat(idField);
   const searchkit = new SearchkitManager(apiUrl, { httpHeaders, searchUrlPath });
 
   const setSearchHitsCount = useSearchViewStore(searchViewStoreSelector);
@@ -86,6 +88,13 @@ SearchWrapper.propTypes = {
       }),
     ),
     tile: PropTypes.arrayOf(
+      PropTypes.exact({
+        id: PropTypes.string.isRequired,
+        name: PropTypes.string.isRequired,
+        translations: PropTypes.objectOf(PropTypes.string),
+      }),
+    ),
+    ccf: PropTypes.arrayOf(
       PropTypes.exact({
         id: PropTypes.string.isRequired,
         name: PropTypes.string.isRequired,

--- a/context/app/static/js/components/Search/config.js
+++ b/context/app/static/js/components/Search/config.js
@@ -40,6 +40,7 @@ const donorConfig = {
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],
     tile: [...sharedTileFields, field(`mapped_metadata.${ageUnitField}`, 'Age Unit')],
+    ccf: [],
   },
 };
 
@@ -61,6 +62,7 @@ const sampleConfig = {
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],
     tile: sharedTileFields,
+    ccf: [],
   },
 };
 
@@ -86,6 +88,7 @@ const datasetConfig = {
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],
     tile: sharedTileFields,
+    ccf: [],
   },
 };
 

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -31,6 +31,7 @@ function DevSearch() {
         field('mapper_metadata.size', 'Doc Size'),
       ],
       tile: [],
+      ccf: [field('rui_location', 'Location JSON')],
     },
     // Default hitsPerPage is 10:
     hitsPerPage: 20,

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -74,7 +74,7 @@ function DevSearch() {
 
   const allProps = { ...searchProps, apiUrl: elasticsearchEndpoint };
 
-  const wrappedSearch = <SearchWrapper {...allProps} resultsComponent={DevResults} />;
+  const wrappedSearch = <SearchWrapper {...allProps} resultsComponent={DevResults} isDevSearch />;
   return (
     <>
       <SearchHeader component="h1" variant="h2">

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -3259,6 +3259,49 @@
         }
       }
     },
+    "@polymer/iron-flex-layout": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
+      "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-icon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
+      "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-iconset-svg": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
+      "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
+      "requires": {
+        "@polymer/iron-meta": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/iron-meta": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
+      "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@polymer/polymer": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.4.1.tgz",
+      "integrity": "sha512-KPWnhDZibtqKrUz7enIPOiO4ZQoJNOuLwqrhV2MXzIt3VVnUVJVG5ORz4Z2sgO+UZ+/UZnPD0jqY+jmw/+a9mQ==",
+      "requires": {
+        "@webcomponents/shadycss": "^1.9.1"
+      }
+    },
     "@probe.gl/stats": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.3.0.tgz",
@@ -4671,6 +4714,77 @@
         }
       }
     },
+    "@vaadin/vaadin-button": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-button/-/vaadin-button-2.4.0.tgz",
+      "integrity": "sha512-C94F07OOb5Ciq2BY4CklIQG+WJFA6QoTFDQl8JJloJgPI12b9kmyP8uRgfq4VAHHusqKqIvA8AB6VZuGg5lagg==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-control-state-mixin": "^2.2.1",
+        "@vaadin/vaadin-element-mixin": "^2.4.1",
+        "@vaadin/vaadin-lumo-styles": "^1.3.3",
+        "@vaadin/vaadin-material-styles": "^1.2.0",
+        "@vaadin/vaadin-themable-mixin": "^1.6.1"
+      }
+    },
+    "@vaadin/vaadin-control-state-mixin": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.4.tgz",
+      "integrity": "sha512-oGsNaWbM6RisY1LkyWYtwnw+DtSRSpkFDbemEOtkYezj+Hhsd9+07LqILaUU4pB0zPaRq+uq+2tKba/TL3t23g==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@vaadin/vaadin-development-mode-detector": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.4.tgz",
+      "integrity": "sha512-S+PaFrZpK8uBIOnIHxjntTrgumd5ztuCnZww96ydGKXgo9whXfZsbMwDuD/102a/IuPUMyF+dh/n3PbWzJ6igA=="
+    },
+    "@vaadin/vaadin-element-mixin": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-2.4.2.tgz",
+      "integrity": "sha512-VSDVK0XUsFe/RohpwSzQwgqb2Pwpok6sDNhIDS4CARr3HPhq2voMzT/FowFbkEy0J1hFtN/ZfC7tkv3kdEKKIQ==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
+        "@vaadin/vaadin-usage-statistics": "^2.1.0"
+      }
+    },
+    "@vaadin/vaadin-lumo-styles": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.1.tgz",
+      "integrity": "sha512-Yh9ZcekpY7byXP1QJnfx94rVvK71xHBEspsVV7LL7YMvqXU4EAYuzQGYsljryV4PGS9PFPD6sqbGqhEkIhHPnQ==",
+      "requires": {
+        "@polymer/iron-icon": "^3.0.0",
+        "@polymer/iron-iconset-svg": "^3.0.0",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@vaadin/vaadin-material-styles": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-1.3.2.tgz",
+      "integrity": "sha512-EFrvGScoxhLNrPnWtT2Ia77whjF2TD4jrcyeh1jv9joCA2n5SUba+4XJciVSGmopqqQato6lwRnZSvMLJX7cyw==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
+    "@vaadin/vaadin-themable-mixin": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.6.2.tgz",
+      "integrity": "sha512-PZZOZnke3KUlZsDrRVbWxAGEeFBPRyRayNRCvip0XnQK+Zs3cLuRgdgbdro3Ir9LZ3Izsw6HqA6XNMKffEP67A==",
+      "requires": {
+        "@polymer/polymer": "^3.0.0",
+        "lit-element": "^2.0.0"
+      }
+    },
+    "@vaadin/vaadin-usage-statistics": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.0.tgz",
+      "integrity": "sha512-e81nbqY5zsaYhLJuOVkJkB/Um1pGK5POIqIlTNhUfjeoyGaJ63tiX8+D5n6F+GgVxUTLUarsKa6SKRcQel0AzA==",
+      "requires": {
+        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -4845,6 +4959,11 @@
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@webcomponents/shadycss": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+      "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -14906,6 +15025,19 @@
           }
         }
       }
+    },
+    "lit-element": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
+      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
+      "requires": {
+        "lit-html": "^1.1.1"
+      }
+    },
+    "lit-html": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
+      "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
     "load-json-file": {
       "version": "2.0.0",

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -3259,49 +3259,6 @@
         }
       }
     },
-    "@polymer/iron-flex-layout": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-flex-layout/-/iron-flex-layout-3.0.1.tgz",
-      "integrity": "sha512-7gB869czArF+HZcPTVSgvA7tXYFze9EKckvM95NB7SqYF+NnsQyhoXgKnpFwGyo95lUjUW9TFDLUwDXnCYFtkw==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-icon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-icon/-/iron-icon-3.0.1.tgz",
-      "integrity": "sha512-QLPwirk+UPZNaLnMew9VludXA4CWUCenRewgEcGYwdzVgDPCDbXxy6vRJjmweZobMQv/oVLppT2JZtJFnPxX6g==",
-      "requires": {
-        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
-        "@polymer/iron-meta": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-iconset-svg": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-iconset-svg/-/iron-iconset-svg-3.0.1.tgz",
-      "integrity": "sha512-XNwURbNHRw6u2fJe05O5fMYye6GSgDlDqCO+q6K1zAnKIrpgZwf2vTkBd5uCcZwsN0FyCB3mvNZx4jkh85dRDw==",
-      "requires": {
-        "@polymer/iron-meta": "^3.0.0-pre.26",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/iron-meta": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@polymer/iron-meta/-/iron-meta-3.0.1.tgz",
-      "integrity": "sha512-pWguPugiLYmWFV9UWxLWzZ6gm4wBwQdDy4VULKwdHCqR7OP7u98h+XDdGZsSlDPv6qoryV/e3tGHlTIT0mbzJA==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@polymer/polymer": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.4.1.tgz",
-      "integrity": "sha512-KPWnhDZibtqKrUz7enIPOiO4ZQoJNOuLwqrhV2MXzIt3VVnUVJVG5ORz4Z2sgO+UZ+/UZnPD0jqY+jmw/+a9mQ==",
-      "requires": {
-        "@webcomponents/shadycss": "^1.9.1"
-      }
-    },
     "@probe.gl/stats": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-3.3.0.tgz",
@@ -4714,77 +4671,6 @@
         }
       }
     },
-    "@vaadin/vaadin-button": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-button/-/vaadin-button-2.4.0.tgz",
-      "integrity": "sha512-C94F07OOb5Ciq2BY4CklIQG+WJFA6QoTFDQl8JJloJgPI12b9kmyP8uRgfq4VAHHusqKqIvA8AB6VZuGg5lagg==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-control-state-mixin": "^2.2.1",
-        "@vaadin/vaadin-element-mixin": "^2.4.1",
-        "@vaadin/vaadin-lumo-styles": "^1.3.3",
-        "@vaadin/vaadin-material-styles": "^1.2.0",
-        "@vaadin/vaadin-themable-mixin": "^1.6.1"
-      }
-    },
-    "@vaadin/vaadin-control-state-mixin": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.2.4.tgz",
-      "integrity": "sha512-oGsNaWbM6RisY1LkyWYtwnw+DtSRSpkFDbemEOtkYezj+Hhsd9+07LqILaUU4pB0zPaRq+uq+2tKba/TL3t23g==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@vaadin/vaadin-development-mode-detector": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-development-mode-detector/-/vaadin-development-mode-detector-2.0.4.tgz",
-      "integrity": "sha512-S+PaFrZpK8uBIOnIHxjntTrgumd5ztuCnZww96ydGKXgo9whXfZsbMwDuD/102a/IuPUMyF+dh/n3PbWzJ6igA=="
-    },
-    "@vaadin/vaadin-element-mixin": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-element-mixin/-/vaadin-element-mixin-2.4.2.tgz",
-      "integrity": "sha512-VSDVK0XUsFe/RohpwSzQwgqb2Pwpok6sDNhIDS4CARr3HPhq2voMzT/FowFbkEy0J1hFtN/ZfC7tkv3kdEKKIQ==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0",
-        "@vaadin/vaadin-usage-statistics": "^2.1.0"
-      }
-    },
-    "@vaadin/vaadin-lumo-styles": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.1.tgz",
-      "integrity": "sha512-Yh9ZcekpY7byXP1QJnfx94rVvK71xHBEspsVV7LL7YMvqXU4EAYuzQGYsljryV4PGS9PFPD6sqbGqhEkIhHPnQ==",
-      "requires": {
-        "@polymer/iron-icon": "^3.0.0",
-        "@polymer/iron-iconset-svg": "^3.0.0",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@vaadin/vaadin-material-styles": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-material-styles/-/vaadin-material-styles-1.3.2.tgz",
-      "integrity": "sha512-EFrvGScoxhLNrPnWtT2Ia77whjF2TD4jrcyeh1jv9joCA2n5SUba+4XJciVSGmopqqQato6lwRnZSvMLJX7cyw==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
-    "@vaadin/vaadin-themable-mixin": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-themable-mixin/-/vaadin-themable-mixin-1.6.2.tgz",
-      "integrity": "sha512-PZZOZnke3KUlZsDrRVbWxAGEeFBPRyRayNRCvip0XnQK+Zs3cLuRgdgbdro3Ir9LZ3Izsw6HqA6XNMKffEP67A==",
-      "requires": {
-        "@polymer/polymer": "^3.0.0",
-        "lit-element": "^2.0.0"
-      }
-    },
-    "@vaadin/vaadin-usage-statistics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.0.tgz",
-      "integrity": "sha512-e81nbqY5zsaYhLJuOVkJkB/Um1pGK5POIqIlTNhUfjeoyGaJ63tiX8+D5n6F+GgVxUTLUarsKa6SKRcQel0AzA==",
-      "requires": {
-        "@vaadin/vaadin-development-mode-detector": "^2.0.0"
-      }
-    },
     "@webassemblyjs/ast": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
@@ -4959,11 +4845,6 @@
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
-    },
-    "@webcomponents/shadycss": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
-      "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -15025,19 +14906,6 @@
           }
         }
       }
-    },
-    "lit-element": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
-      "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
-      "requires": {
-        "lit-html": "^1.1.1"
-      }
-    },
-    "lit-html": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
-      "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
     },
     "load-json-file": {
       "version": "2.0.0",

--- a/context/package.json
+++ b/context/package.json
@@ -7,7 +7,6 @@
     "@material-ui/core": "^4.9.4",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.45",
-    "@vaadin/vaadin-button": "^2.4.0",
     "ajv": "^6.12.3",
     "bowser": "^2.11.0",
     "d3": "^5.16.0",

--- a/context/package.json
+++ b/context/package.json
@@ -7,6 +7,7 @@
     "@material-ui/core": "^4.9.4",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.45",
+    "@vaadin/vaadin-button": "^2.4.0",
     "ajv": "^6.12.3",
     "bowser": "^2.11.0",
     "d3": "^5.16.0",


### PR DESCRIPTION
- Provide two different view toggles, one for the main search, and one for dev.
- For the dev search, provide a stub where a CCF view could be filled in.

On dev-search, we now have this:
<img width="99" alt="Screen Shot 2021-01-19 at 3 08 20 PM" src="https://user-images.githubusercontent.com/730388/105087254-36f42280-5a68-11eb-9bc5-2366725cfd4d.png">

@tsliaw : Only question for you right now is whether that is a good button for CCF view?

@bherr2 : I'm thinking that you will be responsible for filling in the React in `ResultsCCF.jsx`... Does that sound ok to you, or do we need to provide some intermediate wrapper that will handle an interface that you'll specify?

@john-conroy : Code review; As usual, there may be some questionable decisions here. There are now two `SearchViewSwitch` exports:
```
export { SearchViewSwitch as default, DevSearchViewSwitch };
```
Both of these components are created with a factory function, and separating them into two separate files would mean exposing that factory to the outside... but I'd prefer not to do that, just to keep the exports as components. The other consequence is that, now that there's not just a default export, that would need to be copied to the index.js as well... So instead I just got rid of the directory, and moved it `SearchViewSwitch.jsx` inside `SearchBarLayout/`. Thoughts?