### PR TITLE
hierarchical facets

### DIFF
--- a/CHANGELOG-hierarchical-facets.md
+++ b/CHANGELOG-hierarchical-facets.md
@@ -1,0 +1,1 @@
+- Demo hierarchical facets with publication status.

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -30,11 +30,11 @@ $secondary-gray: #636363;
 }
 
 .sk-layout__filters {
-  height: fit-content;
-  height:-webkit-fit-content;
-  height:-ms-fit-content;
-  height:-moz-fit-content;
-  background-color: white;
+    height: fit-content;
+    height:-webkit-fit-content;
+    height:-ms-fit-content;
+    height:-moz-fit-content;
+    background-color: white;
 }
 
 .sk-layout__filters {
@@ -64,11 +64,11 @@ $secondary-gray: #636363;
 }
 
 .sk-pagination-navigation {
-  margin: 0px;
+    margin: 0px;
 }
 
 .sk-pagination-navigation .sk-toggle-option:first-child,
-  .sk-pagination-navigation .sk-toggle-option:last-child {
+.sk-pagination-navigation .sk-toggle-option:last-child {
     color: $primary-purple;
 }
 
@@ -77,30 +77,30 @@ $secondary-gray: #636363;
 }
 
 .sk-toggle-option.is-active {
-background-color: $primary-purple;
-border-color: $primary-purple;
+    background-color: $primary-purple;
+    border-color: $primary-purple;
 }
 
 .sk-pagination-navigation .sk-toggle-option:first-child.is-disabled,
-  .sk-pagination-navigation .sk-toggle-option:last-child.is-disabled {
+.sk-pagination-navigation .sk-toggle-option:last-child.is-disabled {
     color: #ddd
-  }
+}
 
-  .sk-search-box form{
+.sk-search-box form{
     border: 1px solid $secondary-gray;
     border-radius: 8px;
-  }
+}
 
-  .sk-search-box {
+.sk-search-box {
     background-color: white;
     max-width: 925px;
-  }
+}
 
-  .sk-search-box__icon{
-      opacity: 1;
-  }
+.sk-search-box__icon{
+    opacity: 1;
+}
 
-  .sk-search-box__icon:before{
+.sk-search-box__icon:before{
     fill: $primary-purple;
     background: url('~images/search-icon.svg') no-repeat top left;
-  }
+}

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -20,8 +20,8 @@ $secondary-gray: #636363;
 
 .sk-layout__results {
     box-shadow: none;
-    background-color:transparent;
-    display:flex;
+    background-color: transparent;
+    display: flex;
     flex-direction: column;
 }
 
@@ -61,6 +61,10 @@ $secondary-gray: #636363;
 
 .sk-refinement-list__view-more-action {
     color: #3781D1;
+}
+
+.sk-hierarchical-menu-list__root {
+    padding-left: 20px; // Aligns with the labels that are preceded by checkboxes.
 }
 
 .sk-pagination-navigation {

--- a/context/app/static/js/components/Search/__tests__/accordionFilters.spec.js
+++ b/context/app/static/js/components/Search/__tests__/accordionFilters.spec.js
@@ -8,6 +8,7 @@ import accordionFilters from '../accordionFilters';
 test('default export has the right keys', () => {
   expect(Object.keys(accordionFilters).sort()).toEqual([
     'AccordionCheckboxFilter',
+    'AccordionHierarchicalMenuFilter',
     'AccordionListFilter',
     'AccordionRangeFilter',
   ]);

--- a/context/app/static/js/components/Search/accordionFilters.jsx
+++ b/context/app/static/js/components/Search/accordionFilters.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RefinementListFilter, RangeFilter, CheckboxFilter } from 'searchkit';
+import { RefinementListFilter, RangeFilter, CheckboxFilter, HierarchicalMenuFilter } from 'searchkit';
 import Typography from '@material-ui/core/Typography';
 import PropTypes from 'prop-types';
 
@@ -13,7 +13,7 @@ function Details(props) {
   }
   if (
     !Array.isArray(children) &&
-    children.props.items.map((bucket) => bucket.doc_count).every((count) => count === 0)
+    children.props.items?.map((bucket) => bucket.doc_count).every((count) => count === 0)
   ) {
     // Presumably a range filter...
     return null;
@@ -29,6 +29,19 @@ function Details(props) {
     </InnerAccordion>
   );
 }
+
+function AccordionHierarchicalMenuFilter(props) {
+  const innerProps = {
+    containerComponent: Details,
+    ...props,
+  };
+  return <HierarchicalMenuFilter {...innerProps} />;
+}
+
+AccordionHierarchicalMenuFilter.propTypes = {
+  fields: PropTypes.arrayOf(PropTypes.string).isRequired,
+  title: PropTypes.string.isRequired,
+};
 
 function AccordionListFilter(props) {
   const innerProps = {
@@ -79,4 +92,4 @@ AccordionCheckboxFilter.propTypes = {
   filter: PropTypes.object.isRequired,
 };
 
-export default { AccordionListFilter, AccordionRangeFilter, AccordionCheckboxFilter };
+export default { AccordionHierarchicalMenuFilter, AccordionListFilter, AccordionRangeFilter, AccordionCheckboxFilter };

--- a/context/app/static/js/components/Search/config.js
+++ b/context/app/static/js/components/Search/config.js
@@ -1,6 +1,6 @@
 /* eslint-disable prettier/prettier */
 // eslint-disable-next-line import/named
-import { listFilter, rangeFilter, field } from './utils';
+import { listFilter, rangeFilter, field, hierarchicalFilter } from './utils';
 
 const bmiField = 'body_mass_index_value';
 const ageField = 'age_value';
@@ -70,8 +70,7 @@ const datasetConfig = {
       listFilter('mapped_data_types', 'Data Type'),
       listFilter('origin_sample.mapped_organ', 'Organ'),
       listFilter('source_sample.mapped_specimen_type', 'Specimen Type'),
-      listFilter('mapped_status', 'Status'),
-      listFilter('mapped_data_access_level', 'Access Level'),
+      hierarchicalFilter(['mapped_status', 'mapped_data_access_level'], 'Status'),
     ],
     'Donor Metadata': makeDonorMetadataFilters(false),
     Affiliation: affiliationFilters,

--- a/context/app/static/js/components/Search/utils.js
+++ b/context/app/static/js/components/Search/utils.js
@@ -9,6 +9,18 @@ export function field(id, name, translations) {
   return def;
 }
 
+export function hierarchicalFilter(ids, name) {
+  const def = {
+    type: 'AccordionHierarchicalMenuFilter',
+    props: {
+      fields: ids.map((id) => `${id}.keyword`),
+      title: name,
+      id: ids.join('-'),
+    },
+  };
+  return def;
+}
+
 export function listFilter(id, name, translations) {
   const def = {
     type: 'AccordionListFilter',


### PR DESCRIPTION
Demo hierarchical facets by combining the existing status and access level facets. 
<img width="237" alt="Screen Shot 2021-01-19 at 5 12 37 PM" src="https://user-images.githubusercontent.com/730388/105099640-00270800-5a7a-11eb-936b-2a9fd7ad344d.png">

Note that this UI does not include checkboxes, and that unlike the other facets, only one option can be selected at a time. There is a separate [HierarchicalRefinementFilter](http://searchkit.github.io/searchkit/stable/components/navigation/hierarchical-refinement-filter.html) that can handle multiple values... but it also requires a significantly different index structure.

questions, mostly for Tiffany:
- Do you think this will be sufficient? or should we prioritize the indexing work for `HierarchicalRefinementFilter`? Or maybe we use this for now, while not excluding a change to the index in the future...
- For demo, does it make sense to treat the status as a hierarchy? Or maybe something in dev-search?
- Are there other facets that really should be treated as hierarchical now? Down the road, perhaps anatomy, but right now the metadata doesn't say anything about anatomy below the organ level

Fix #1438 
