### PR TITLE
"login" -> "Member Login"

### DIFF
--- a/CHANGELOG-login-text.md
+++ b/CHANGELOG-login-text.md
@@ -1,0 +1,1 @@
+- Change "Login" to "Member Login".

--- a/context/app/static/js/components/Header/LoginButton/LoginButton.jsx
+++ b/context/app/static/js/components/Header/LoginButton/LoginButton.jsx
@@ -21,7 +21,7 @@ function LoginButton(props) {
     </Dropdown>
   ) : (
     <WhiteButton component="a" href="/login">
-      login
+      Member Login
     </WhiteButton>
   );
 }

--- a/context/app/static/js/components/Header/LoginButton/LoginButton.spec.js
+++ b/context/app/static/js/components/Header/LoginButton/LoginButton.spec.js
@@ -7,7 +7,7 @@ import LoginButton from './LoginButton';
 
 test('should be login button when not authenticated', () => {
   render(<LoginButton isAuthenticated={false} />);
-  expect(screen.getByText('login')).toBeInTheDocument();
+  expect(screen.getByText('Member Login')).toBeInTheDocument();
   expect(screen.getByRole('link')).toHaveAttribute('href', '/login');
 });
 


### PR DESCRIPTION
"HuBMAP Member Login" would linewrap, and just look weird. Is this sufficient to fix #1393?

<img width="163" alt="Screen Shot 2021-01-20 at 12 07 47 PM" src="https://user-images.githubusercontent.com/730388/105209890-56e31f00-5b18-11eb-9295-24cb2c56265c.png">
