### PR TITLE
Mccalluc/expose rui take 2

### DIFF
--- a/CHANGELOG-ccf-json.md
+++ b/CHANGELOG-ccf-json.md
@@ -1,0 +1,1 @@
+- Add a link to the CCF JSON, and a new route to serve the JSON.

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -127,16 +127,18 @@ def details_rui_ext(type, uuid, ext):
         abort(404)
     client = _get_client()
     entity = client.get_entity(uuid)
+    # For Samples...
     if 'rui_location' in entity:
         return json.loads(entity['rui_location'])
+    # For Datasets...
     if 'ancestors' not in entity:
         abort(404)
     located_ancestors = [a for a in entity['ancestors'] if 'rui_location' in a]
     if not located_ancestors:
         abort(404)
-    if not len(located_ancestors) == 1:
-        raise Exception('Expected only on spatially located ancestor')
-    return json.loads(located_ancestors[0]['rui_location'])
+    # There may be multiple: The last should be the closest...
+    # but this should be confirmed, when there are examples.
+    return json.loads(located_ancestors[-1]['rui_location'])
 
 
 @blueprint.route('/search')

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,5 +1,6 @@
 from os.path import dirname
 from urllib.parse import urlparse
+import json
 
 from flask import (Blueprint, render_template, abort, current_app,
                    session, request, redirect, url_for, Response)
@@ -112,9 +113,30 @@ def details_ext(type, uuid, ext):
     if ext != 'json':
         abort(404)
     client = _get_client()
-
     entity = client.get_entity(uuid)
     return entity
+
+
+@blueprint.route('/browse/<type>/<uuid>.rui.<ext>')
+def details_rui_ext(type, uuid, ext):
+    # Note that the API returns a blob of JSON as a string,
+    # so, to return a JSON object, and not just a string, we need to decode.
+    if type not in entity_types:
+        abort(404)
+    if ext != 'json':
+        abort(404)
+    client = _get_client()
+    entity = client.get_entity(uuid)
+    if 'rui_location' in entity:
+        return json.loads(entity['rui_location'])
+    if 'ancestors' not in entity:
+        abort(404)
+    located_ancestors = [a for a in entity['ancestors'] if 'rui_location' in a]
+    if not located_ancestors:
+        abort(404)
+    if not len(located_ancestors) == 1:
+        raise Exception('Expected only on spatially located ancestor')
+    return json.loads(located_ancestors[0]['rui_location'])
 
 
 @blueprint.route('/search')

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -17,7 +17,7 @@ function MetadataItem(props) {
 }
 
 function SampleTissue(props) {
-  const { mapped_organ, mapped_specimen_type } = props;
+  const { uuid, mapped_organ, mapped_specimen_type, hasRUI } = props;
   return (
     <SectionContainer id="tissue">
       <SectionHeader>Tissue</SectionHeader>
@@ -28,23 +28,31 @@ function SampleTissue(props) {
         <MetadataItem label="Specimen Type" ml={1} flexBasis="25%">
           {mapped_specimen_type}
         </MetadataItem>
-        <MetadataItem label="Tissue Location" ml={1}>
-          <>
-            The spatial coordinates of this sample have been registered and it can be found in the{' '}
-            <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
-              Common Coordinate Framework Exploration User Interface
-            </LightBlueLink>
-            .
-          </>
-        </MetadataItem>
+        {hasRUI && (
+          <MetadataItem label="Tissue Location" ml={1}>
+            <>
+              The spatial coordinates of this sample have been registered and it can be found in the{' '}
+              <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
+                Common Coordinate Framework Exploration User Interface
+              </LightBlueLink>
+              .{' '}
+              <LightBlueLink href={`/browse/sample/${uuid}.rui.json`} target="_blank" rel="noopener noreferrer">
+                RUI JSON is also available
+              </LightBlueLink>
+              .
+            </>
+          </MetadataItem>
+        )}
       </FlexPaper>
     </SectionContainer>
   );
 }
 
 SampleTissue.propTypes = {
+  uuid: PropTypes.string.isRequired,
   mapped_organ: PropTypes.string.isRequired,
   mapped_specimen_type: PropTypes.string.isRequired,
+  hasRUI: PropTypes.bool.isRequired,
 };
 
 export default SampleTissue;

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -31,13 +31,13 @@ function SampleTissue(props) {
         {hasRUI && (
           <MetadataItem label="Tissue Location" ml={1}>
             <>
-              The spatial coordinates of this sample have been registered and it can be found in the{' '}
+              The{' '}
+              <LightBlueLink href={`/browse/sample/${uuid}.rui.json`} target="_blank" rel="noopener noreferrer">
+                spatial coordinates of this sample
+              </LightBlueLink>{' '}
+              have been registered and it can be found in the{' '}
               <LightBlueLink href="/ccf-eui" target="_blank" rel="noopener noreferrer">
                 Common Coordinate Framework Exploration User Interface
-              </LightBlueLink>
-              .{' '}
-              <LightBlueLink href={`/browse/sample/${uuid}.rui.json`} target="_blank" rel="noopener noreferrer">
-                RUI JSON is also available
               </LightBlueLink>
               .
             </>

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
@@ -4,7 +4,7 @@ import { render, screen } from 'test-utils/functions';
 import SampleTissue from './SampleTissue';
 
 test('text displays properly when all props provided', () => {
-  render(<SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" />);
+  render(<SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" hasRUI />);
 
   expect(screen.getByText('Tissue')).toBeInTheDocument();
 

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.spec.js
@@ -3,31 +3,27 @@ import React from 'react';
 import { render, screen } from 'test-utils/functions';
 import SampleTissue from './SampleTissue';
 
+function expectLabelsPresent() {
+  expect(screen.getByText('Tissue')).toBeInTheDocument();
+  const labelsToTest = ['Organ Type', 'Specimen Type'];
+  labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+}
+
 test('text displays properly when all props provided', () => {
   render(<SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" hasRUI />);
+  expectLabelsPresent();
 
-  expect(screen.getByText('Tissue')).toBeInTheDocument();
-
-  const labelsToTest = ['Organ Type', 'Specimen Type', 'Tissue Location'];
-  labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+  expect(screen.getByText('Tissue Location')).toBeInTheDocument();
 
   const valuesToTest = ['Fake Organ', 'Fake Specimen Type'];
   valuesToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
-  expect(
-    screen.getByText('Common Coordinate Framework Exploration User Interface', {
-      exact: false,
-    }),
-  ).toBeInTheDocument();
-  expect(screen.getByRole('link')).toHaveAttribute('href', '/ccf-eui');
 });
 
 test('displays label not defined when values are undefined', () => {
   render(<SampleTissue />);
+  expectLabelsPresent();
 
-  expect(screen.getByText('Tissue')).toBeInTheDocument();
-
-  const labelsToTest = ['Organ Type', 'Specimen Type', 'Tissue Location'];
-  labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+  expect(screen.queryByText('Tissue Location')).not.toBeInTheDocument();
 
   const valuesToTest = ['Organ Type not defined', 'Specimen Type not defined'];
   valuesToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -33,6 +33,7 @@ function SampleDetail(props) {
     last_modified_timestamp,
     description,
     metadata,
+    rui_location,
   } = assayMetadata;
 
   const shouldDisplaySection = {
@@ -53,6 +54,8 @@ function SampleDetail(props) {
 
   useSendUUIDEvent(entity_type, uuid);
 
+  const hasRUI = Boolean(rui_location);
+
   return (
     <DetailContext.Provider value={{ display_doi, uuid }}>
       <DetailLayout sectionOrder={sectionOrder}>
@@ -69,7 +72,12 @@ function SampleDetail(props) {
             {mapped_specimen_type}
           </Typography>
         </Summary>
-        <SampleTissue mapped_specimen_type={mapped_specimen_type} mapped_organ={mapped_organ} />
+        <SampleTissue
+          uuid={uuid}
+          mapped_specimen_type={mapped_specimen_type}
+          mapped_organ={mapped_organ}
+          hasRUI={hasRUI}
+        />
         <Attribution
           group_name={group_name}
           created_by_user_displayname={created_by_user_displayname}


### PR DESCRIPTION
@ngehlenborg : Looks like this.

<img width="631" alt="Screen Shot 2021-01-25 at 5 30 43 PM" src="https://user-images.githubusercontent.com/730388/105774492-517c3f00-5f33-11eb-8e66-952368c483b5.png">

Any tweaks to the wording? Or you can delegate this to Tiffany.

*draft*: Need to handle  Datasets.

Fix #1439