### PR TITLE
John conroy/fix saved list links

### DIFF
--- a/context/app/static/js/components/savedLists/CreateListDialog/CreateListDialog.jsx
+++ b/context/app/static/js/components/savedLists/CreateListDialog/CreateListDialog.jsx
@@ -5,16 +5,19 @@ import useSavedEntitiesStore from 'js/stores/useSavedEntitiesStore';
 import DialogModal from 'js/shared-styles/DialogModal';
 import { StyledTitleTextField, StyledDescriptionTextField } from './style';
 
-const useSavedEntitiesStoreSelector = (state) => state.createList;
+const useSavedEntitiesStoreSelector = (state) => ({ createList: state.createList, savedLists: state.savedLists });
 
 function CreateListDialog({ dialogIsOpen, setDialogIsOpen }) {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-
-  const createList = useSavedEntitiesStore(useSavedEntitiesStoreSelector);
+  const [shouldDisplayWarning, setShouldDisplayWarning] = useState(false);
+  const { createList, savedLists } = useSavedEntitiesStore(useSavedEntitiesStoreSelector);
 
   function handleTitleChange(event) {
     setTitle(event.target.value);
+    if (shouldDisplayWarning) {
+      setShouldDisplayWarning(false);
+    }
   }
 
   function handleDescriptionChange(event) {
@@ -25,14 +28,24 @@ function CreateListDialog({ dialogIsOpen, setDialogIsOpen }) {
     setDialogIsOpen(false);
   };
 
+  function handleExit() {
+    setTitle('');
+    setDescription('');
+  }
+
   function handleSubmit() {
-    createList({ title, description });
-    setDialogIsOpen(false);
+    if (!(title in savedLists)) {
+      createList({ title, description });
+      setDialogIsOpen(false);
+    } else {
+      setShouldDisplayWarning(true);
+    }
   }
 
   return (
     <DialogModal
       title="Create New List"
+      warning={shouldDisplayWarning && 'A list with that title already exists.'}
       content={
         <>
           <StyledTitleTextField handleChange={handleTitleChange} title={title} />
@@ -51,6 +64,7 @@ function CreateListDialog({ dialogIsOpen, setDialogIsOpen }) {
       }
       isOpen={dialogIsOpen}
       handleClose={handleClose}
+      onExited={handleExit}
     />
   );
 }

--- a/context/app/static/js/components/savedLists/EditListDialog/EditListDialog.jsx
+++ b/context/app/static/js/components/savedLists/EditListDialog/EditListDialog.jsx
@@ -5,16 +5,24 @@ import useSavedEntitiesStore from 'js/stores/useSavedEntitiesStore';
 import DialogModal from 'js/shared-styles/DialogModal';
 import { StyledTitleTextField, StyledDescriptionTextField } from './style';
 
-const useSavedEntitiesStoreSelector = (state) => ({ createList: state.createList, deleteList: state.deleteList });
+const useSavedEntitiesStoreSelector = (state) => ({
+  createList: state.createList,
+  deleteList: state.deleteList,
+  savedLists: state.savedLists,
+});
 
 function EditListDialog({ dialogIsOpen, setDialogIsOpen, listDescription, listTitle, setEditedListTitle }) {
   const [title, setTitle] = useState(listTitle);
   const [description, setDescription] = useState(listDescription);
+  const [shouldDisplayWarning, setShouldDisplayWarning] = useState(false);
 
-  const { createList, deleteList } = useSavedEntitiesStore(useSavedEntitiesStoreSelector);
+  const { createList, deleteList, savedLists } = useSavedEntitiesStore(useSavedEntitiesStoreSelector);
 
   function handleTitleChange(event) {
     setTitle(event.target.value);
+    if (shouldDisplayWarning) {
+      setShouldDisplayWarning(false);
+    }
   }
 
   function handleDescriptionChange(event) {
@@ -28,15 +36,20 @@ function EditListDialog({ dialogIsOpen, setDialogIsOpen, listDescription, listTi
   };
 
   function handleSubmit() {
-    createList({ title, description });
-    setEditedListTitle(title);
-    deleteList(listTitle);
-    setDialogIsOpen(false);
+    if (!(title in savedLists)) {
+      createList({ title, description });
+      setEditedListTitle(title);
+      deleteList(listTitle);
+      setDialogIsOpen(false);
+    } else {
+      setShouldDisplayWarning(true);
+    }
   }
 
   return (
     <DialogModal
       title={`Edit ${listTitle}`}
+      warning={shouldDisplayWarning && 'A list with that title already exists.'}
       content={
         <>
           <StyledTitleTextField handleChange={handleTitleChange} title={title} />

--- a/context/app/static/js/components/savedLists/SavedEntitiesTable/SavedEntitiesTable.jsx
+++ b/context/app/static/js/components/savedLists/SavedEntitiesTable/SavedEntitiesTable.jsx
@@ -92,8 +92,8 @@ function SavedEntitiesTable({ savedEntities, deleteCallback, isSavedListPage }) 
         <StyledTableContainer>
           <Table stickyHeader>
             <TableHead>
-              <TableRow onClick={headerRowIsSelected ? deselectAllRows : selectAllRows}>
-                <HeaderCell padding="checkbox">
+              <TableRow>
+                <HeaderCell padding="checkbox" onClick={headerRowIsSelected ? deselectAllRows : selectAllRows}>
                   <Checkbox
                     checked={headerRowIsSelected}
                     inputProps={{ 'aria-labelledby': `saved-entities-header-row-checkbox` }}

--- a/context/app/static/js/components/savedLists/SavedEntitiesTableRow/SavedEntitiesTableRow.jsx
+++ b/context/app/static/js/components/savedLists/SavedEntitiesTableRow/SavedEntitiesTableRow.jsx
@@ -4,17 +4,20 @@ import TableRow from '@material-ui/core/TableRow';
 import Checkbox from '@material-ui/core/Checkbox';
 
 import TableCell from '@material-ui/core/TableCell';
+import { LightBlueLink } from 'js/shared-styles/Links';
 
 function SavedEntitiesTableRow({ uuid, rowData, index, isSelected, addToSelectedRows, removeFromSelectedRows }) {
   const handleClick = isSelected ? removeFromSelectedRows : addToSelectedRows;
 
   const { display_doi, group_name, entity_type, dateSaved, dateAddedToList } = rowData;
   return (
-    <TableRow onClick={() => handleClick(uuid)}>
-      <TableCell padding="checkbox">
+    <TableRow>
+      <TableCell padding="checkbox" onClick={() => handleClick(uuid)}>
         <Checkbox checked={isSelected} inputProps={{ 'aria-labelledby': `saved-entities-row-${index}-checkbox` }} />
       </TableCell>
-      <TableCell>{display_doi}</TableCell>
+      <TableCell>
+        <LightBlueLink href={`/browse/${display_doi}`}>{display_doi}</LightBlueLink>
+      </TableCell>
       <TableCell>{group_name}</TableCell>
       <TableCell>{entity_type}</TableCell>
       <TableCell>{format(dateSaved || dateAddedToList, 'yyyy-MM-dd')}</TableCell>

--- a/context/app/static/js/components/savedLists/SavedListScrollbox/SavedListScrollbox.jsx
+++ b/context/app/static/js/components/savedLists/SavedListScrollbox/SavedListScrollbox.jsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+import Description from 'js/shared-styles/sections/Description';
+import CreateListDialog from 'js/components/savedLists/CreateListDialog';
+import SavedListPanel from 'js/components/savedLists/SavedListPanel';
+import { SeparatedFlexRow, FlexBottom, MaxHeightScrollbox } from './style';
+
+function SavedListScrollbox({ savedLists }) {
+  const [dialogIsOpen, setDialogIsOpen] = useState(false);
+
+  return (
+    <>
+      <SeparatedFlexRow>
+        <div>
+          <Typography variant="h3" component="h2">
+            All Created Lists
+          </Typography>
+          <Typography variant="subtitle1">{Object.keys(savedLists).length} Lists</Typography>
+        </div>
+        <FlexBottom>
+          <Button variant="contained" color="primary" onClick={() => setDialogIsOpen(true)}>
+            Create New List
+          </Button>
+          <CreateListDialog dialogIsOpen={dialogIsOpen} setDialogIsOpen={setDialogIsOpen} />
+        </FlexBottom>
+      </SeparatedFlexRow>
+      {Object.keys(savedLists).length === 0 ? (
+        <Description padding="20px">No lists created yet.</Description>
+      ) : (
+        <MaxHeightScrollbox>
+          {Object.entries(savedLists).map(([key, value]) => {
+            return <SavedListPanel key={key} title={key} entityObject={value} />;
+          })}
+        </MaxHeightScrollbox>
+      )}
+    </>
+  );
+}
+
+export default SavedListScrollbox;

--- a/context/app/static/js/components/savedLists/SavedListScrollbox/index.js
+++ b/context/app/static/js/components/savedLists/SavedListScrollbox/index.js
@@ -1,0 +1,3 @@
+import SavedListScrollbox from './SavedListScrollbox';
+
+export default SavedListScrollbox;

--- a/context/app/static/js/components/savedLists/SavedListScrollbox/style.js
+++ b/context/app/static/js/components/savedLists/SavedListScrollbox/style.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components';
+
+import { PanelScrollBox } from 'js/shared-styles/panels';
+
+const SeparatedFlexRow = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: ${(props) => props.theme.spacing(0.5)}px;
+`;
+
+const FlexBottom = styled.div`
+  display: flex;
+  align-items: flex-end;
+`;
+
+const MaxHeightScrollbox = styled(PanelScrollBox)`
+  max-height: 415px;
+`;
+export { SeparatedFlexRow, FlexBottom, MaxHeightScrollbox };

--- a/context/app/static/js/pages/SavedLists/SavedLists.jsx
+++ b/context/app/static/js/pages/SavedLists/SavedLists.jsx
@@ -1,16 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import Typography from '@material-ui/core/Typography';
-import Button from '@material-ui/core/Button';
 
-import CreateListDialog from 'js/components/savedLists/CreateListDialog';
 import SavedEntitiesTable from 'js/components/savedLists/SavedEntitiesTable';
 import { LightBlueLink } from 'js/shared-styles/Links';
-import { PanelScrollBox } from 'js/shared-styles/panels';
 import useSavedEntitiesStore from 'js/stores/useSavedEntitiesStore';
 import LocalStorageDescription from 'js/components/savedLists/LocalStorageDescription';
 import Description from 'js/shared-styles/sections/Description';
-import SavedListPanel from 'js/components/savedLists/SavedListPanel';
-import { SeparatedFlexRow, FlexBottom, StyledAlert } from './style';
+import SavedListScrollbox from 'js/components/savedLists/SavedListScrollbox';
+import { StyledAlert } from './style';
 
 const usedSavedEntitiesSelector = (state) => ({
   savedLists: state.savedLists,
@@ -24,7 +21,6 @@ function SavedLists() {
   const { savedLists, savedEntities, listsToBeDeleted, deleteQueuedLists, deleteEntities } = useSavedEntitiesStore(
     usedSavedEntitiesSelector,
   );
-  const [dialogIsOpen, setDialogIsOpen] = useState(false);
   const [shouldDisplayDeleteAlert, setShouldDisplayDeleteAlert] = useState(false);
 
   useEffect(() => {
@@ -58,29 +54,7 @@ function SavedLists() {
       ) : (
         <SavedEntitiesTable savedEntities={savedEntities} deleteCallback={deleteEntities} />
       )}
-      <SeparatedFlexRow>
-        <div>
-          <Typography variant="h3" component="h2">
-            All Created Lists
-          </Typography>
-          <Typography variant="subtitle1">{Object.keys(savedLists).length} Lists</Typography>
-        </div>
-        <FlexBottom>
-          <Button variant="contained" color="primary" onClick={() => setDialogIsOpen(true)}>
-            Create New List
-          </Button>
-          <CreateListDialog dialogIsOpen={dialogIsOpen} setDialogIsOpen={setDialogIsOpen} />
-        </FlexBottom>
-      </SeparatedFlexRow>
-      {Object.keys(savedLists).length === 0 ? (
-        <Description padding="20px 20px">No lists created yet.</Description>
-      ) : (
-        <PanelScrollBox>
-          {Object.entries(savedLists).map(([key, value]) => {
-            return <SavedListPanel key={key} title={key} entityObject={value} />;
-          })}
-        </PanelScrollBox>
-      )}
+      <SavedListScrollbox savedLists={savedLists} />
     </>
   );
 }

--- a/context/app/static/js/pages/SavedLists/style.js
+++ b/context/app/static/js/pages/SavedLists/style.js
@@ -1,19 +1,8 @@
 import styled from 'styled-components';
 import { Alert } from 'js/shared-styles/alerts';
 
-const SeparatedFlexRow = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: ${(props) => props.theme.spacing(0.5)}px;
-`;
-
-const FlexBottom = styled.div`
-  display: flex;
-  align-items: flex-end;
-`;
-
 const StyledAlert = styled(Alert)`
   margin-bottom: ${(props) => props.theme.spacing(1.5)}px;
 `;
 
-export { SeparatedFlexRow, FlexBottom, StyledAlert };
+export { StyledAlert };

--- a/context/app/static/js/shared-styles/DialogModal/DialogModal.jsx
+++ b/context/app/static/js/shared-styles/DialogModal/DialogModal.jsx
@@ -3,14 +3,27 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import Typography from '@material-ui/core/Typography';
 
 import { StyledDivider } from './style';
 
-function DialogModal({ title, content, actions, isOpen, handleClose }) {
+function DialogModal({ title, warning, content, actions, isOpen, handleClose, ...props }) {
   return (
-    <Dialog open={isOpen} onClose={handleClose} fullWidth>
-      <DialogTitle>{title}</DialogTitle>
-      <DialogContent>{content}</DialogContent>
+    <Dialog open={isOpen} onClose={handleClose} fullWidth {...props}>
+      <DialogTitle disableTypography>
+        <Typography variant="h3" component="h2">
+          {title}
+        </Typography>
+      </DialogTitle>
+      <DialogContent>
+        {warning && (
+          <DialogContentText color="error" variant="body2">
+            {warning}
+          </DialogContentText>
+        )}
+        {content}
+      </DialogContent>
       <StyledDivider />
       <DialogActions>{actions}</DialogActions>
     </Dialog>

--- a/context/app/static/js/shared-styles/panels/index.js
+++ b/context/app/static/js/shared-styles/panels/index.js
@@ -1,14 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 
 import { capitalizeString } from 'js/helpers/functions';
+import { LightBlueLink } from 'js/shared-styles/Links';
 
-const Link = styled.a`
-  text-decoration: inherit;
-  color: inherit;
+const overflowCss = css`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 const PanelWrapper = styled.div`
@@ -31,9 +33,11 @@ const MaxWidthDiv = styled.div`
 `;
 
 const TruncatedText = styled(Typography)`
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  ${overflowCss};
+`;
+
+const TruncatedLink = styled(LightBlueLink)`
+  ${overflowCss};
 `;
 
 const StyledTypography = styled(Typography)`
@@ -51,23 +55,21 @@ const PanelScrollBox = styled(Paper)`
 function Panel(props) {
   const { title, href, secondaryText, entityCounts } = props;
   return (
-    <Link href={href}>
-      <PanelWrapper>
-        <MaxWidthDiv>
-          <TruncatedText variant="subtitle1" component="h3">
-            {title}
-          </TruncatedText>
-          <TruncatedText variant="body2" color="secondary">
-            {secondaryText}
-          </TruncatedText>
-        </MaxWidthDiv>
-        <div>
-          {Object.entries(entityCounts).map(([key, value]) => (
-            <StyledTypography key={key} variant="caption">{`${value} ${capitalizeString(key)}`}</StyledTypography>
-          ))}
-        </div>
-      </PanelWrapper>
-    </Link>
+    <PanelWrapper>
+      <MaxWidthDiv>
+        <TruncatedLink variant="subtitle1" href={href}>
+          {title}
+        </TruncatedLink>
+        <TruncatedText variant="body2" color="secondary">
+          {secondaryText}
+        </TruncatedText>
+      </MaxWidthDiv>
+      <div>
+        {Object.entries(entityCounts).map(([key, value]) => (
+          <StyledTypography key={key} variant="caption">{`${value} ${capitalizeString(key)}`}</StyledTypography>
+        ))}
+      </div>
+    </PanelWrapper>
   );
 }
 


### PR DESCRIPTION
Adds links to table IDs and moves select row on click to the checkbox only. Moves link in saved list panels from entire panel to the title.

Do we want the panels used elsewhere (Collections page) to look and function the same way?

<img width="1291" alt="Screen Shot 2021-02-08 at 10 13 31 AM" src="https://user-images.githubusercontent.com/62477388/107239056-77efaf00-69f6-11eb-8ed8-7cd936ac1757.png">
