### PR TITLE
John conroy/saved list route tracking

### DIFF
--- a/CHANGELOG-saved-list-route-tracking.md
+++ b/CHANGELOG-saved-list-route-tracking.md
@@ -1,0 +1,1 @@
+- Fix page view tracking to track vists to a saved list page together instead of separating by uuid.

--- a/CHANGELOG-saved-list-route-tracking.md
+++ b/CHANGELOG-saved-list-route-tracking.md
@@ -1,1 +1,1 @@
-- Fix page view tracking to track vists to a saved list page together instead of separating by uuid.
+- Fix page view tracking to track visits to a saved list page together instead of separating by uuid.

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -132,7 +132,7 @@ function Routes(props) {
     );
   }
 
-  if (urlPath.startsWith('/my-lists')) {
+  if (urlPath.startsWith('/my-lists/')) {
     return (
       <Route>
         <SavedList listUUID={list_uuid} />

--- a/context/app/static/js/components/Routes/useSendPageView.js
+++ b/context/app/static/js/components/Routes/useSendPageView.js
@@ -8,6 +8,11 @@ function useSendPageView(path) {
       ReactGA.pageview(pathWithoutUUID);
       return;
     }
+    // send path without ID for specific saved list page
+    if (path.match(/\/my-lists\/[\w-]+/)) {
+      ReactGA.pageview('/my-lists/saved-list');
+      return;
+    }
     if (path.startsWith('/search') || path.startsWith('/dev-search')) {
       const urlParams = new URLSearchParams(window.location.search);
       const entityTypeKey = 'entity_type[0]';

--- a/context/app/static/js/components/Routes/useSendPageView.js
+++ b/context/app/static/js/components/Routes/useSendPageView.js
@@ -9,7 +9,7 @@ function useSendPageView(path) {
       return;
     }
     // send path without ID for specific saved list page
-    if (path.startswith('/my-lists/')) {
+    if (path.startsWith('/my-lists/')) {
       // Distinguished by final slash.
       ReactGA.pageview('/my-lists/saved-list');
       return;

--- a/context/app/static/js/components/Routes/useSendPageView.js
+++ b/context/app/static/js/components/Routes/useSendPageView.js
@@ -9,7 +9,8 @@ function useSendPageView(path) {
       return;
     }
     // send path without ID for specific saved list page
-    if (path.startswith('/my-lists/') { // Distinguished by final slash. 
+    if (path.startswith('/my-lists/')) {
+      // Distinguished by final slash.
       ReactGA.pageview('/my-lists/saved-list');
       return;
     }

--- a/context/app/static/js/components/Routes/useSendPageView.js
+++ b/context/app/static/js/components/Routes/useSendPageView.js
@@ -9,7 +9,7 @@ function useSendPageView(path) {
       return;
     }
     // send path without ID for specific saved list page
-    if (path.match(/\/my-lists\/[\w-]+/)) {
+    if (path.startswith('/my-lists/') { // Distinguished by final slash. 
       ReactGA.pageview('/my-lists/saved-list');
       return;
     }


### PR DESCRIPTION
Fix page view tracking to track visits to a saved list page together instead of separating by uuid. Visits to any saved list page should show as `/my-lists/saved-list` instead of `/my-lists/{uuid}`.
