### PR TITLE
John conroy/track web vitals

### DIFF
--- a/CHANGELOG-track-web-vitals.md
+++ b/CHANGELOG-track-web-vitals.md
@@ -1,0 +1,1 @@
+- Track web vitals and send to Google Analytics.

--- a/context/app/static/js/components/Routes/Route/Route.jsx
+++ b/context/app/static/js/components/Routes/Route/Route.jsx
@@ -2,10 +2,13 @@ import React, { Suspense } from 'react';
 import PropTypes from 'prop-types';
 
 import RouteLoader from '../RouteLoader';
+import useSendWebVitals from '../useSendWebVitals';
 import { StyledContainer, MainWrapper } from './style';
 
 function Route({ children, disableWidthConstraint }) {
   const constrainWidthProps = disableWidthConstraint ? { maxWidth: false, disableGutters: true } : { maxWidth: 'lg' };
+
+  useSendWebVitals();
 
   return (
     <Suspense fallback={<RouteLoader />}>

--- a/context/app/static/js/components/Routes/useSendWebVitals.js
+++ b/context/app/static/js/components/Routes/useSendWebVitals.js
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import ReactGA from 'react-ga';
 import { getCLS, getFID, getLCP, getTTFB } from 'web-vitals';
 
+// copy-and-paste from https://github.com/GoogleChrome/web-vitals#using-analyticsjs
 function sendVitalsToGA({ name, delta, id }) {
   ReactGA.event({
     category: 'Web Vitals',

--- a/context/app/static/js/components/Routes/useSendWebVitals.js
+++ b/context/app/static/js/components/Routes/useSendWebVitals.js
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import ReactGA from 'react-ga';
+import { getCLS, getFID, getLCP, getTTFB } from 'web-vitals';
+
+function sendVitalsToGA({ name, delta, id }) {
+  ReactGA.event({
+    category: 'Web Vitals',
+    action: name,
+    // From web-vitals: The `id` value will be unique to the current page load. When sending
+    // multiple values from the same page (e.g. for CLS), Google Analytics can
+    // compute a total by grouping on this ID (note: requires `eventLabel` to
+    // be a dimension in your report).
+    label: id,
+    // From web-vitals: Google Analytics metrics must be integers, so the value is rounded.
+    // For CLS the value is first multiplied by 1000 for greater precision
+    // (note: increase the multiplier for greater precision if needed).
+    value: Math.round(name === 'CLS' ? delta * 1000 : delta),
+    nonInteraction: true,
+  });
+}
+
+function useSendWebVitals() {
+  useEffect(() => {
+    getTTFB(sendVitalsToGA);
+    getCLS(sendVitalsToGA);
+    getFID(sendVitalsToGA);
+    getLCP(sendVitalsToGA);
+  }, []);
+}
+
+export default useSendWebVitals;

--- a/context/app/static/js/components/Routes/useSendWebVitals.js
+++ b/context/app/static/js/components/Routes/useSendWebVitals.js
@@ -6,7 +6,7 @@ import { getCLS, getFID, getLCP, getTTFB } from 'web-vitals';
 function sendVitalsToGA({ name, delta, id }) {
   ReactGA.event({
     category: 'Web Vitals',
-    action: name,
+    action: (name === 'CLS' ? 'CLS * 1000' : name),
     // From web-vitals: The `id` value will be unique to the current page load. When sending
     // multiple values from the same page (e.g. for CLS), Google Analytics can
     // compute a total by grouping on this ID (note: requires `eventLabel` to

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -22165,6 +22165,11 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "web-vitals": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-1.1.0.tgz",
+      "integrity": "sha512-1cx54eRxY/+M0KNKdNpNnuXAXG+vJEvwScV4DiV9rOYDguHoeDIzm09ghBohOPtkqPO5OtPC14FWkNva3SDisg=="
+    },
     "webidl-conversions": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",

--- a/context/package.json
+++ b/context/package.json
@@ -35,6 +35,7 @@
     "vega": "^5.13.0",
     "vega-lite": "^4.13.1",
     "vitessce": "^1.1.0",
+    "web-vitals": "^1.1.0",
     "whatwg-fetch": "^3.0.0",
     "zustand": "^3.3.1"
   },


### PR DESCRIPTION
Fix #1511.

Adds tracking to each route for the four big web vitals metrics. The event will be linked to a page view but it will be the full path not the simplified path we use (so uuids will be included), if you think it makes sense I could add the simplified page view to one of the fields we send over.

@tsliaw you may want to look at the information you get for the events eventually and see if there's anything else you'd like me to add.