### PR TITLE
John conroy/fix description

### DIFF
--- a/CHANGELOG-fix-description.md
+++ b/CHANGELOG-fix-description.md
@@ -1,0 +1,1 @@
+- Fix eslint errors from description component export.

--- a/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/Detail/SampleTissue/SampleTissue.jsx
@@ -37,10 +37,7 @@ function SampleTissue(props) {
                 spatial coordinates of this sample
               </LightBlueLink>{' '}
               have been registered and it can be found in the{' '}
-              <OutboundLink href="/ccf-eui">
-                Common Coordinate Framework Exploration User Interface
-              </OutboundLink>
-              .
+              <OutboundLink href="/ccf-eui">Common Coordinate Framework Exploration User Interface</OutboundLink>.
             </>
           </MetadataItem>
         )}

--- a/context/app/static/js/components/savedLists/LocalStorageDescription/LocalStorageDescription.jsx
+++ b/context/app/static/js/components/savedLists/LocalStorageDescription/LocalStorageDescription.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { Description } from 'js/shared-styles/sections/Description';
+import Description from 'js/shared-styles/sections/Description';
 
 function LocalStorageDescription() {
   return (
-    <Description padding="20px 20px">
+    <Description padding="20px">
       Your lists are currently stored on local storage and are not transferable between devices.
     </Description>
   );

--- a/context/app/static/js/pages/Collections/Collections.jsx
+++ b/context/app/static/js/pages/Collections/Collections.jsx
@@ -2,10 +2,9 @@ import React, { useContext } from 'react';
 import Typography from '@material-ui/core/Typography';
 
 import { AppContext } from 'js/components/Providers';
-import Description from 'js/shared-styles/sections/Description';
 import Panel from 'js/components/Collections/Panel';
 import useCollectionsData from 'js/hooks/useCollectionsData';
-import { PageWrapper, ScrollBox } from './style';
+import { PageWrapper, ScrollBox, StyledDescription } from './style';
 
 function Collections() {
   const { elasticsearchEndpoint, nexusToken } = useContext(AppContext);
@@ -20,11 +19,11 @@ function Collections() {
       <Typography variant="subtitle1" color="primary">
         {collectionsData.length > 0 && `${collectionsData.length} Collections`}
       </Typography>
-      <Description>
+      <StyledDescription>
         Collections of HuBMAP datasets represent data from related experiments—such as assays performed on the same
         organ—or data that has been grouped for other reasons. In the future, it will be possible to reference
         collections through Document Object Identifiers (DOIs).
-      </Description>
+      </StyledDescription>
       <ScrollBox>
         {collectionsData.length > 0 &&
           collectionsData.map(({ _source }) => (

--- a/context/app/static/js/pages/Collections/style.js
+++ b/context/app/static/js/pages/Collections/style.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import Paper from '@material-ui/core/Paper';
+
+import Description from 'js/shared-styles/sections/Description';
 import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 
 // 88px = header height + header margin
@@ -20,4 +22,8 @@ const ScrollBox = styled(Paper)`
   }
 `;
 
-export { PageWrapper, ScrollBox };
+const StyledDescription = styled(Description)`
+  margin-bottom: ${(props) => props.theme.spacing(2)}px;
+`;
+
+export { PageWrapper, ScrollBox, StyledDescription };

--- a/context/app/static/js/pages/Preview/Preview.jsx
+++ b/context/app/static/js/pages/Preview/Preview.jsx
@@ -6,7 +6,7 @@ import VisualizationWrapper from 'js/components/Detail/visualization/Visualizati
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import SectionContainer from 'js/shared-styles/sections/SectionContainer';
 import Attribution from 'js/components/Detail/Attribution';
-import Description from 'js/shared-styles/sections/Description';
+import { StyledDescription } from './style';
 
 function Preview(props) {
   const { vitData, title, assayMetadata, markdown } = props;
@@ -20,11 +20,11 @@ function Preview(props) {
         <SectionHeader variant="h1" component="h1">
           {title}
         </SectionHeader>
-        <Description>
+        <StyledDescription>
           HuBMAP Data Portal Previews demonstrate functionality and resources that will become available in future
           releases. Previews may rely on externally hosted data or analysis results that were generated with processing
           pipelines that are not yet integrated into the HuBMAP Data Portal infrastructure.
-        </Description>
+        </StyledDescription>
         <Markdown markdown={markdown} />
       </SectionContainer>
       <Attribution

--- a/context/app/static/js/pages/Preview/style.js
+++ b/context/app/static/js/pages/Preview/style.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import Description from 'js/shared-styles/sections/Description';
+
+const StyledDescription = styled(Description)`
+  margin-bottom: ${(props) => props.theme.spacing(2)}px;
+`;
+
+export { StyledDescription };

--- a/context/app/static/js/pages/SavedList/SavedList.jsx
+++ b/context/app/static/js/pages/SavedList/SavedList.jsx
@@ -8,7 +8,7 @@ import SavedListMenuButton from 'js/components/savedLists/SavedListMenuButton';
 import EditListButton from 'js/components/savedLists/EditListButton';
 import SavedEntitiesTable from 'js/components/savedLists/SavedEntitiesTable';
 import { LightBlueLink } from 'js/shared-styles/Links';
-import { Description } from 'js/shared-styles/sections/Description';
+import Description from 'js/shared-styles/sections/Description';
 import { StyledButtonRow, BottomAlignedTypography, SpacingDiv, PageSpacing, StyledHeader } from './style';
 
 const usedSavedEntitiesSelector = (state) => ({

--- a/context/app/static/js/pages/SavedLists/SavedLists.jsx
+++ b/context/app/static/js/pages/SavedLists/SavedLists.jsx
@@ -4,7 +4,7 @@ import SavedEntitiesTable from 'js/components/savedLists/SavedEntitiesTable';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import useSavedEntitiesStore from 'js/stores/useSavedEntitiesStore';
 import LocalStorageDescription from 'js/components/savedLists/LocalStorageDescription';
-import { Description } from 'js/shared-styles/sections/Description';
+import Description from 'js/shared-styles/sections/Description';
 import SavedListScrollbox from 'js/components/savedLists/SavedListScrollbox';
 import { StyledAlert, StyledHeader, SpacingDiv, PageSpacing } from './style';
 

--- a/context/app/static/js/shared-styles/sections/Description/Description.jsx
+++ b/context/app/static/js/shared-styles/sections/Description/Description.jsx
@@ -1,25 +1,15 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-import SectionContainer from 'js/shared-styles/sections/SectionContainer';
 import { StyledPaper, StyledInfoIcon } from './style';
 
-function Description({ padding, children }) {
+function Description({ padding, children, ...props }) {
   return (
-    <StyledPaper $padding={padding}>
+    <StyledPaper $padding={padding} {...props}>
       <StyledInfoIcon color="primary" />
       <Typography variant="body1">{children}</Typography>
     </StyledPaper>
   );
 }
 
-function DescriptionSection({ children, padding }) {
-  return (
-    <SectionContainer>
-      <Description padding={padding}>{children}</Description>
-    </SectionContainer>
-  );
-}
-
-export { Description };
-export default DescriptionSection;
+export default Description;

--- a/context/app/static/js/shared-styles/sections/Description/index.js
+++ b/context/app/static/js/shared-styles/sections/Description/index.js
@@ -1,4 +1,3 @@
-import DescriptionSection, { Description } from './Description';
+import Description from './Description';
 
-export { Description };
-export default DescriptionSection;
+export default Description;

--- a/context/app/static/js/shared-styles/sections/SectionContainer.jsx
+++ b/context/app/static/js/shared-styles/sections/SectionContainer.jsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
-/* Anchor offset for fixed header
+/* Anchor offset for fixed header.
+Only to be used on pages with table of contents.
 74px = fixed header height + 10px */
 const SectionContainer = styled.div`
   margin-bottom: ${(props) => props.theme.spacing(5)}px;


### PR DESCRIPTION
Fix #1555. Revises description into a single component. The component with `SectionContainer` was only needed on detail pages with the table of contents sidebar to fix anchor tag positioning. That's no longer needed for these description components. The new margin styles are only used to keep a similar appearance to what already existed.

Also fixes a prettier error from a code review suggestion from an earlier PR. These keep popping up, should we make prettier fail our ci to catch these earlier?