### PR TITLE
Mccalluc/ccf menu

### DIFF
--- a/CHANGELOG-ccf-menu.md
+++ b/CHANGELOG-ccf-menu.md
@@ -1,0 +1,1 @@
+- Replace CCF link with menu.

--- a/context/app/static/js/components/Header/CCFLinks/CCFLinks.jsx
+++ b/context/app/static/js/components/Header/CCFLinks/CCFLinks.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import DropdownLink from '../DropdownLink';
+
+function CCFLinks(props) {
+  const { isIndented } = props;
+  return (
+    <>
+      <DropdownLink href="https://hubmapconsortium.github.io/ccf/" isIndented={isIndented}>
+        Common Coordinate Framework (CCF) Portal
+      </DropdownLink>
+      <DropdownLink href="https://hubmapconsortium.github.io/ccf-asct-reporter/" isIndented={isIndented}>
+        CCF Anatomical Structures, Cell Types and Biomarkers (ASCT+B) Tables/Reporter
+      </DropdownLink>
+      <DropdownLink href="https://portal.hubmapconsortium.org/ccf-eui" isIndented={isIndented}>
+        CCF Registration User Interface
+      </DropdownLink>
+      <DropdownLink href="https://hubmapconsortium.github.io/ccf-ui/rui/" isIndented={isIndented}>
+        CCF Exploration User Interface
+      </DropdownLink>
+    </>
+  );
+}
+
+CCFLinks.propTypes = {
+  isIndented: PropTypes.bool,
+};
+
+CCFLinks.defaultProps = {
+  isIndented: false,
+};
+
+export default CCFLinks;

--- a/context/app/static/js/components/Header/CCFLinks/index.js
+++ b/context/app/static/js/components/Header/CCFLinks/index.js
@@ -1,0 +1,3 @@
+import CCFLinks from './CCFLinks';
+
+export default CCFLinks;

--- a/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
+++ b/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Tooltip from '@material-ui/core/Tooltip';
 import Link from '@material-ui/core/Link';
 import { useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
@@ -9,6 +8,7 @@ import Menu from '../Menu';
 import PreviewLinks from '../PreviewLinks';
 import Dropdown from '../Dropdown';
 import LoginButton from '../LoginButton';
+import CCFLinks from '../CCFLinks';
 import DocumentationLinks from '../DocumentationLinks';
 import { HubmapLogo, Spacer, HeaderButton, FlexNoWrap } from './style';
 
@@ -38,11 +38,9 @@ function HeaderContent({ anchorRef }) {
           <Dropdown title="Previews" menuListId="preview-options">
             <PreviewLinks />
           </Dropdown>
-          <Tooltip title="Explore HuBMAP data using the Common Coordinate Framework">
-            <HeaderButton component={Link} href="/ccf-eui">
-              CCF
-            </HeaderButton>
-          </Tooltip>
+          <Dropdown title="CCF Atlas" menuListId="ccf-options">
+            <CCFLinks />
+          </Dropdown>
           <Dropdown title="Documentation" menuListId="documentation-options">
             <DocumentationLinks />
           </Dropdown>

--- a/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
+++ b/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
@@ -35,6 +35,11 @@ function HeaderContent({ anchorRef }) {
             </HeaderButton>
           </FlexNoWrap>
           <Spacer />
+
+          {/*
+              If this changes, remember to update Menu.jsx!
+          */}
+
           <Dropdown title="Previews" menuListId="preview-options">
             <PreviewLinks />
           </Dropdown>

--- a/context/app/static/js/components/Header/Menu/Menu.jsx
+++ b/context/app/static/js/components/Header/Menu/Menu.jsx
@@ -8,6 +8,7 @@ import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDownRounded';
 import ArrowDropUpIcon from '@material-ui/icons/ArrowDropUpRounded';
 
 import PreviewLinks from '../PreviewLinks';
+import CCFLinks from '../CCFLinks';
 import DocumentationLinks from '../DocumentationLinks';
 import { WidePopper, WidePaper, DropdownMenuItem } from './style';
 import DropdownLink from '../DropdownLink';
@@ -15,6 +16,7 @@ import DropdownLink from '../DropdownLink';
 function Menu(props) {
   const [open, toggle] = useReducer((v) => !v, false);
   const [openPreview, togglePreview] = useReducer((v) => !v, false);
+  const [openCCF, toggleCCF] = useReducer((v) => !v, false);
   const [openDocumentation, toggleDocumentation] = useReducer((v) => !v, false);
   const { anchorRef } = props;
 
@@ -26,22 +28,32 @@ function Menu(props) {
       <WidePopper id="main-menu" open={open} anchorEl={anchorRef.current}>
         <WidePaper>
           <MenuList>
-            {/* NOTE: Changes here should be in sync with HeaderContent.jsx. */}
             {['Donor', 'Sample', 'Dataset'].map((type) => (
               <DropdownLink key={type} href={`/search?entity_type[0]=${type}`}>{`${type}s`}</DropdownLink>
             ))}
             <DropdownLink href="/collections">Collections</DropdownLink>
+
+            {/*
+                If this changes, remember to update HeaderContent.jsx!
+            */}
+
             <DropdownMenuItem onClick={togglePreview}>
               Previews
               {openPreview ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
             </DropdownMenuItem>
             {openPreview && <PreviewLinks isIndented />}
+
+            <DropdownMenuItem onClick={toggleCCF}>
+              CCF Atlas
+              {openCCF ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
+            </DropdownMenuItem>
+            {openCCF && <CCFLinks isIndented />}
+
             <DropdownMenuItem onClick={toggleDocumentation}>
               Documentation
               {openDocumentation ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
             </DropdownMenuItem>
             {openDocumentation && <DocumentationLinks isIndented />}
-            <DropdownLink href="/ccf-eui">CCF</DropdownLink>
           </MenuList>
         </WidePaper>
       </WidePopper>


### PR DESCRIPTION
Fix #1571 

Look ok? I'm not having the links open a new page, thinking that they can count as part of the portal, in some sense? But either way: I don't really care.

I've changed the order of the menus to be consistent in narrow and full-width: Presume there was no particular reason for the difference?

Originally, there was some help text on the link to CCF... I'm not sure if that's available with the new structure, but it probably could be, if that would be a good thing?

<img width="805" alt="Screen Shot 2021-02-26 at 12 49 23 PM" src="https://user-images.githubusercontent.com/730388/109336283-28501680-7831-11eb-9e48-e04952b5790b.png">
<img width="554" alt="Screen Shot 2021-02-26 at 12 49 51 PM" src="https://user-images.githubusercontent.com/730388/109336294-2b4b0700-7831-11eb-9cf7-dd9d2cdb3c58.png">
