### PR TITLE
John conroy/descendant prov

### DIFF
--- a/CHANGELOG-descendant-prov.md
+++ b/CHANGELOG-descendant-prov.md
@@ -1,0 +1,1 @@
+- Add button to show descendants of entity in provenance graph detail pane.

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -1,28 +1,12 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import Button from '@material-ui/core/Button';
 
 import SectionItem from 'js/components/Detail/SectionItem';
 import { LightBlueLink } from 'js/shared-styles/Links';
-import { AppContext } from 'js/components/Providers';
-import useImmediateDescendantProv from 'js/hooks/useImmediateDescendantProv';
-import useProvenanceStore from 'js/stores/useProvenanceStore';
+import ShowDerivedEntitiesButton from 'js/components/Detail/provenance/ShowDerivedEntitiesButton';
 import ProvVis from '../ProvVis';
-import { StyledTypography, FlexPaper } from './style';
+import { FlexPaper } from './style';
 import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
-import ProvData from '../ProvVis/ProvData';
-
-function createStepNameSet(steps) {
-  return new Set(steps.map((step) => step.name));
-}
-
-function removeExistingSteps(steps, newSteps) {
-  const nameSet = createStepNameSet(steps);
-  const uniqueNewSteps = newSteps.filter((step) => !nameSet.has(step.name));
-  return uniqueNewSteps;
-}
-
-const useProvenanceStoreSelector = (state) => ({ steps: state.steps, addDescendantSteps: state.addDescendantSteps });
 
 function ProvGraph(props) {
   const { provData } = props;
@@ -43,69 +27,38 @@ function ProvGraph(props) {
     return entity ? `${entity[typeKey]} - ${entity[idKey]}` : id;
   }
 
-  function renderDetailPane(prov) {
+  function renderDetailPane(node) {
     function DetailPanel() {
-      const { elasticsearchEndpoint, entityEndpoint, nexusToken } = useContext(AppContext);
-      const { steps, addDescendantSteps } = useProvenanceStore(useProvenanceStoreSelector);
-      const [newSteps, setNewSteps] = useState([]);
-
-      const { immediateDescendantsProvData } = useImmediateDescendantProv(
-        prov[idKey],
-        elasticsearchEndpoint,
-        entityEndpoint,
-        nexusToken,
-      );
-
-      useEffect(() => {
-        if (immediateDescendantsProvData) {
-          const immediateDescendantSteps = immediateDescendantsProvData
-            .map((result) => new ProvData(result, getNameForActivity, getNameForEntity).toCwl())
-            .flat();
-          setNewSteps(removeExistingSteps(steps, immediateDescendantSteps));
-        }
-      }, [immediateDescendantsProvData, steps]);
-
-      function handleShowDescendants() {
-        addDescendantSteps(newSteps);
-      }
+      const { prov } = node.meta;
 
       const typeEl =
         typeKey in prov ? (
-          <SectionItem label="Type">
-            <StyledTypography variant="body1">{prov[typeKey]}</StyledTypography>
-          </SectionItem>
+          <SectionItem label="Type">{prov[typeKey]}</SectionItem>
         ) : (
-          <SectionItem label="Type">
-            <StyledTypography variant="body1">{prov['prov:type']}</StyledTypography>
-          </SectionItem>
+          <SectionItem label="Type">{prov['prov:type']}</SectionItem>
         );
       const idEl =
         typeKey in prov && ['Donor', 'Sample', 'Dataset'].includes(prov[typeKey]) ? (
           <SectionItem label="ID" ml>
-            <StyledTypography variant="body1">
-              <LightBlueLink href={`/browse/${prov[typeKey].toLowerCase()}/${prov['hubmap:uuid']}`}>
-                {prov[idKey]}
-              </LightBlueLink>
-            </StyledTypography>
+            <LightBlueLink href={`/browse/${prov[typeKey].toLowerCase()}/${prov['hubmap:uuid']}`}>
+              {prov[idKey]}
+            </LightBlueLink>
           </SectionItem>
         ) : null;
       const createdEl =
         timeKey in prov ? (
           <SectionItem label="Created" ml>
-            <StyledTypography variant="body1">{prov[timeKey]}</StyledTypography>
+            {prov[timeKey]}
           </SectionItem>
         ) : null;
       const actionsEl =
         typeKey in prov && ['Donor', 'Sample', 'Dataset'].includes(prov[typeKey]) ? (
           <SectionItem ml>
-            <Button
-              color="primary"
-              variant="contained"
-              onClick={handleShowDescendants}
-              disabled={newSteps.length === 0}
-            >
-              Show Derived Entities
-            </Button>
+            <ShowDerivedEntitiesButton
+              id={prov[idKey]}
+              getNameForActivity={getNameForActivity}
+              getNameForEntity={getNameForEntity}
+            />
           </SectionItem>
         ) : null;
       return (
@@ -117,7 +70,7 @@ function ProvGraph(props) {
         </FlexPaper>
       );
     }
-    return <DetailPanel />;
+    return node?.meta?.prov && <DetailPanel />;
   }
 
   return (

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -13,7 +13,7 @@ import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
 import ProvData from '../ProvVis/ProvData';
 
 function createStepNameSet(steps) {
-  return new Set(steps.map((step)=> step.name));
+  return new Set(steps.map((step) => step.name));
 }
 
 function removeExistingSteps(steps, newSteps) {

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -45,7 +45,7 @@ function ProvGraph(props) {
     return entity ? `${entity[typeKey]} - ${entity[idKey]}` : id;
   }
 
-  function renderDetailPane(prov, nodeName) {
+  function renderDetailPane(prov) {
     function DetailPanel() {
       const { elasticsearchEndpoint, entityEndpoint, nexusToken } = useContext(AppContext);
       const { steps, addDescendantSteps } = useProvenanceStore(useProvenanceStoreSelector);
@@ -61,7 +61,7 @@ function ProvGraph(props) {
           .map((result) => new ProvData(result, getNameForActivity, getNameForEntity).toCwl())
           .flat();
         const uniqueNewSteps = removeExistingSteps(steps, moreSteps);
-        addDescendantSteps(nodeName, uniqueNewSteps);
+        addDescendantSteps(uniqueNewSteps);
       }
 
       function handleShowDescendants() {

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -13,14 +13,12 @@ import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
 import ProvData from '../ProvVis/ProvData';
 
 function createStepNameSet(steps) {
-  const nameSet = new Set([]);
-  steps.forEach((step) => nameSet.add(step.name));
-  return nameSet;
+  return new Set(steps.map((step)=> step.name));
 }
 
 function removeExistingSteps(steps, newSteps) {
   const nameSet = createStepNameSet(steps);
-  const uniqueNewSteps = [...newSteps].filter((step) => !nameSet.has(step.name));
+  const uniqueNewSteps = newSteps.filter((step) => !nameSet.has(step.name));
   return uniqueNewSteps;
 }
 

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -27,7 +27,7 @@ function removeExistingSteps(steps, newSteps) {
 const useProvenanceStoreSelector = (state) => ({ steps: state.steps, addDescendantSteps: state.addDescendantSteps });
 
 function ProvGraph(props) {
-  const { provData, display_doi } = props;
+  const { provData } = props;
   const isOld = 'ex' in provData.prefix;
   const idKey = isOld ? 'hubmap:displayDOI' : 'hubmap:hubmap_id';
   const timeKey = isOld ? 'prov:generatedAtTime' : 'hubmap:created_timestamp';
@@ -52,7 +52,7 @@ function ProvGraph(props) {
 
       async function getAndAddImmediateDescendants() {
         const results = await getImmediateDescendantProv(
-          display_doi,
+          prov[idKey],
           elasticsearchEndpoint,
           entityEndpoint,
           nexusToken,
@@ -117,7 +117,6 @@ function ProvGraph(props) {
   return (
     <ProvVis
       provData={provData}
-      display_doi={display_doi}
       getNameForActivity={getNameForActivity}
       getNameForEntity={getNameForEntity}
       renderDetailPane={renderDetailPane}

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -98,7 +98,7 @@ function ProvGraph(props) {
         typeKey in prov && ['Donor', 'Sample', 'Dataset'].includes(prov[typeKey]) ? (
           <SectionItem ml>
             <Button color="primary" variant="contained" onClick={handleShowDescendants}>
-              Show Descendants
+              Show Derived Entities
             </Button>
           </SectionItem>
         ) : null;

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -8,7 +8,7 @@ import { StyledTypography, FlexPaper } from './style';
 import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
 
 function ProvGraph(props) {
-  const { provData } = props;
+  const { provData, display_doi } = props;
   const isOld = 'ex' in provData.prefix;
   const idKey = isOld ? 'hubmap:displayDOI' : 'hubmap:hubmap_id';
   const timeKey = isOld ? 'prov:generatedAtTime' : 'hubmap:created_timestamp';
@@ -65,6 +65,7 @@ function ProvGraph(props) {
   return (
     <ProvVis
       provData={provData}
+      display_doi={display_doi}
       getNameForActivity={getNameForActivity}
       getNameForEntity={getNameForEntity}
       renderDetailPane={renderDetailPane}

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/style.js
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/style.js
@@ -1,21 +1,9 @@
 import styled from 'styled-components';
-import Typography from '@material-ui/core/Typography';
-import Link from '@material-ui/core/Link';
 import Paper from '@material-ui/core/Paper';
-
-// TODO: Copy and paste from Attribution.
-
-const StyledTypography = styled(Typography)`
-  margin: 2px 0px 2px 0px;
-`;
-
-const StyledLink = styled(Link)`
-  color: ${(props) => props.theme.palette.link.main};
-`;
 
 const FlexPaper = styled(Paper)`
   display: flex;
   padding: 30px 40px 30px 40px;
 `;
 
-export { StyledTypography, StyledLink, FlexPaper };
+export { FlexPaper };

--- a/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
@@ -10,7 +10,7 @@ import { hasDataTypes } from './utils';
 
 function ProvTabs(props) {
   const { uuid, assayMetadata, provData } = props;
-  const { metadata, entity_type, ancestors, data_types } = assayMetadata;
+  const { metadata, entity_type, ancestors, data_types, display_doi } = assayMetadata;
 
   const [open, setOpen] = React.useState(0);
   const handleChange = (event, newValue) => {
@@ -54,7 +54,7 @@ function ProvTabs(props) {
         </StyledTabPanel>
       )}
       <StyledTabPanel value={open} index={graphIndex}>
-        <ProvGraph provData={provData} />
+        <ProvGraph provData={provData} display_doi={display_doi} />
       </StyledTabPanel>
       {shouldDisplayDag && (
         <StyledTabPanel value={open} index={dagIndex} pad={1}>

--- a/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
@@ -10,7 +10,7 @@ import { hasDataTypes } from './utils';
 
 function ProvTabs(props) {
   const { uuid, assayMetadata, provData } = props;
-  const { metadata, entity_type, ancestors, data_types, display_doi } = assayMetadata;
+  const { metadata, entity_type, ancestors, data_types } = assayMetadata;
 
   const [open, setOpen] = React.useState(0);
   const handleChange = (event, newValue) => {
@@ -54,7 +54,7 @@ function ProvTabs(props) {
         </StyledTabPanel>
       )}
       <StyledTabPanel value={open} index={graphIndex}>
-        <ProvGraph provData={provData} display_doi={display_doi} />
+        <ProvGraph provData={provData} />
       </StyledTabPanel>
       {shouldDisplayDag && (
         <StyledTabPanel value={open} index={dagIndex} pad={1}>

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvData.js
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvData.js
@@ -3,6 +3,14 @@ import Ajv from 'ajv';
 
 import schema from './prov-schema.json';
 
+function getCwlMeta(isReference) {
+  return {
+    global: true,
+    in_path: true,
+    type: isReference ? 'reference file' : 'data file',
+  };
+}
+
 // export only to test.
 export function makeCwlInput(name, steps, extras, isReference) {
   const id = name;
@@ -25,17 +33,13 @@ export function makeCwlInput(name, steps, extras, isReference) {
     run_data: {
       file: [{ '@id': id }],
     },
-    meta: {
-      global: true,
-      in_path: true,
-      type: isReference ? 'reference file' : 'data file',
-    },
+    meta: getCwlMeta(isReference),
     prov: extras || {}, // TODO: real-prov has unmatched ID: https://github.com/hubmapconsortium/prov-vis/issues/15
   };
 }
 
 // export only to test.
-export function makeCwlOutput(name, steps, extras) {
+export function makeCwlOutput(name, steps, extras, isReference) {
   const id = name;
   return {
     name,
@@ -43,10 +47,7 @@ export function makeCwlOutput(name, steps, extras) {
     run_data: {
       file: [{ '@id': id }],
     },
-    meta: {
-      global: true,
-      in_path: true,
-    },
+    meta: getCwlMeta(isReference),
     // Domain-specific extras go here:
     prov: extras,
   };

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
@@ -21,17 +21,17 @@ export default function ProvVis(props) {
     }
   }
   return (
-      <GraphParser
-        parsingOptions={{
-          parseBasicIO: false,
-          showIndirectFiles: true,
-          showParameters: false,
-          showReferenceFiles: true,
-        }}
-        parentItem={{ name: 'Is this used?' }}
-        steps={steps}
-      >
-        <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPaneWithNode} />
-      </GraphParser>
+    <GraphParser
+      parsingOptions={{
+        parseBasicIO: false,
+        showIndirectFiles: true,
+        showParameters: false,
+        showReferenceFiles: true,
+      }}
+      parentItem={{ name: 'Is this used?' }}
+      steps={steps}
+    >
+      <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPaneWithNode} />
+    </GraphParser>
   );
 }

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
@@ -17,7 +17,7 @@ export default function ProvVis(props) {
   // eslint-disable-next-line consistent-return
   function renderDetailPaneWithNode(node) {
     if (renderDetailPane && node) {
-      return renderDetailPane(node.meta.prov, node.name);
+      return renderDetailPane(node.meta.prov);
     }
   }
   return (

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
@@ -14,12 +14,6 @@ export default function ProvVis(props) {
     setSteps(new ProvData(provData, getNameForActivity, getNameForEntity).toCwl());
   }, [provData, getNameForActivity, getNameForEntity, setSteps]);
 
-  // eslint-disable-next-line consistent-return
-  function renderDetailPaneWithNode(node) {
-    if (renderDetailPane && node) {
-      return renderDetailPane(node.meta.prov);
-    }
-  }
   return (
     <GraphParser
       parsingOptions={{
@@ -31,7 +25,7 @@ export default function ProvVis(props) {
       parentItem={{ name: 'Is this used?' }}
       steps={steps}
     >
-      <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPaneWithNode} />
+      <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPane} />
     </GraphParser>
   );
 }

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
@@ -1,30 +1,67 @@
-import React from 'react';
-
+import React, { useState, useContext } from 'react';
+import Button from '@material-ui/core/Button';
 import Graph, { GraphParser } from '@hms-dbmi-bgm/react-workflow-viz';
 
+import { AppContext } from 'js/components/Providers';
+import { getImmediateDescendantProv } from 'js/hooks/useImmediateDescendantProv';
 import ProvData from './ProvData';
 
+function createStepNameSet(steps) {
+  const nameSet = new Set([]);
+  steps.forEach((step) => nameSet.add(step.name));
+  return nameSet;
+}
+
+function removeExistingSteps(steps, newSteps) {
+  const nameSet = createStepNameSet(steps);
+  const uniqueNewSteps = [...newSteps].filter((step) => !nameSet.has(step.name));
+  return uniqueNewSteps;
+}
+
 export default function ProvVis(props) {
-  const { provData, getNameForActivity, getNameForEntity, renderDetailPane } = props;
-  const steps = new ProvData(provData, getNameForActivity, getNameForEntity).toCwl();
+  const { provData, display_doi, getNameForActivity, getNameForEntity, renderDetailPane } = props;
+  const defaultSteps = new ProvData(provData, getNameForActivity, getNameForEntity).toCwl();
+
+  const [steps, setSteps] = useState(defaultSteps);
+
+  const { elasticsearchEndpoint, entityEndpoint, nexusToken } = useContext(AppContext);
+
+  async function getMoreSteps() {
+    const results = await getImmediateDescendantProv(display_doi, elasticsearchEndpoint, entityEndpoint, nexusToken);
+    const moreSteps = results
+      .map((result) => new ProvData(result, getNameForActivity, getNameForEntity).toCwl())
+      .flat();
+    const uniqueNewSteps = removeExistingSteps(steps, moreSteps);
+
+    const stepsCopy = steps;
+    stepsCopy[0].outputs[0].target = [
+      { step: 'Create Sample Activity - HBM229.JTTG.749', name: 'Donor - HBM546.MHVZ.749' },
+    ];
+    const x = [...stepsCopy, ...uniqueNewSteps];
+    setSteps(x);
+  }
+
   // eslint-disable-next-line consistent-return
   function renderDetailPaneWithNode(node) {
     if (renderDetailPane && node) {
-      return renderDetailPane(node.meta.prov);
+      return renderDetailPane(node.meta.prov, node.name);
     }
   }
   return (
-    <GraphParser
-      parsingOptions={{
-        parseBasicIO: false,
-        showIndirectFiles: true,
-        showParameters: false,
-        showReferenceFiles: true,
-      }}
-      parentItem={{ name: 'Is this used?' }}
-      steps={steps}
-    >
-      <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPaneWithNode} />
-    </GraphParser>
+    <>
+      <GraphParser
+        parsingOptions={{
+          parseBasicIO: false,
+          showIndirectFiles: true,
+          showParameters: false,
+          showReferenceFiles: true,
+        }}
+        parentItem={{ name: 'Is this used?' }}
+        steps={steps}
+      >
+        <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPaneWithNode} />
+      </GraphParser>
+      <Button onClick={() => getMoreSteps()}> Hello </Button>
+    </>
   );
 }

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
@@ -21,7 +21,6 @@ export default function ProvVis(props) {
     }
   }
   return (
-    <>
       <GraphParser
         parsingOptions={{
           parseBasicIO: false,
@@ -34,6 +33,5 @@ export default function ProvVis(props) {
       >
         <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPaneWithNode} />
       </GraphParser>
-    </>
   );
 }

--- a/context/app/static/js/components/Detail/provenance/ProvVis/__tests__/ProvData.spec.js
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/__tests__/ProvData.spec.js
@@ -135,6 +135,7 @@ describe('CWL utils', () => {
       meta: {
         global: true,
         in_path: true,
+        type: 'data file',
       },
       name: 'name1',
       run_data: {

--- a/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/ShowDerivedEntitiesButton.jsx
+++ b/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/ShowDerivedEntitiesButton.jsx
@@ -1,0 +1,51 @@
+import React, { useContext, useEffect, useState } from 'react';
+import Button from '@material-ui/core/Button';
+
+import { AppContext } from 'js/components/Providers';
+import useImmediateDescendantProv from 'js/hooks/useImmediateDescendantProv';
+import useProvenanceStore from 'js/stores/useProvenanceStore';
+import ProvData from '../ProvVis/ProvData';
+
+function createStepNameSet(steps) {
+  return new Set(steps.map((step) => step.name));
+}
+
+function removeExistingSteps(steps, newSteps) {
+  const nameSet = createStepNameSet(steps);
+  const uniqueNewSteps = newSteps.filter((step) => !nameSet.has(step.name));
+  return uniqueNewSteps;
+}
+
+const useProvenanceStoreSelector = (state) => ({ steps: state.steps, addDescendantSteps: state.addDescendantSteps });
+
+function ShowDerivedEntitiesButton({ id, getNameForActivity, getNameForEntity }) {
+  const { elasticsearchEndpoint, entityEndpoint, nexusToken } = useContext(AppContext);
+  const { steps, addDescendantSteps } = useProvenanceStore(useProvenanceStoreSelector);
+  const [newSteps, setNewSteps] = useState([]);
+
+  const { immediateDescendantsProvData } = useImmediateDescendantProv(
+    id,
+    elasticsearchEndpoint,
+    entityEndpoint,
+    nexusToken,
+  );
+
+  useEffect(() => {
+    if (immediateDescendantsProvData) {
+      const immediateDescendantSteps = immediateDescendantsProvData
+        .map((result) => new ProvData(result, getNameForActivity, getNameForEntity).toCwl())
+        .flat();
+      setNewSteps(removeExistingSteps(steps, immediateDescendantSteps));
+    }
+  }, [immediateDescendantsProvData, steps, getNameForActivity, getNameForEntity]);
+  function handleShowDescendants() {
+    addDescendantSteps(newSteps);
+  }
+  return (
+    <Button color="primary" variant="contained" onClick={handleShowDescendants} disabled={newSteps.length === 0}>
+      Show Derived Entities
+    </Button>
+  );
+}
+
+export default ShowDerivedEntitiesButton;

--- a/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/index.js
+++ b/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/index.js
@@ -1,0 +1,3 @@
+import ShowDerivedEntitiesButton from './ShowDerivedEntitiesButton';
+
+export default ShowDerivedEntitiesButton;

--- a/context/app/static/js/hooks/useImmediateDescendantProv.js
+++ b/context/app/static/js/hooks/useImmediateDescendantProv.js
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { getAuthHeader } from 'js/helpers/functions';
+
+async function getEntityData(hubmapID, elasticsearchEndpoint, nexusToken) {
+  const authHeader = getAuthHeader(nexusToken);
+  const response = await fetch(elasticsearchEndpoint, {
+    method: 'POST',
+    body: JSON.stringify({ query: { match: { 'display_doi.keyword': hubmapID } } }),
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader,
+    },
+  });
+  if (!response.ok) {
+    console.error('Search API failed', response);
+    return {};
+  }
+  const results = await response.json();
+  // eslint-disable-next-line no-underscore-dangle
+  return results.hits.hits[0]._source;
+}
+
+function getProvRequest(uuid, entityEndpoint, nexusToken) {
+  const headers = getAuthHeader(nexusToken);
+  return { url: `${entityEndpoint}/entities/${uuid}/provenance`, options: { headers } };
+}
+
+function useImmediateDescendantProv(display_doi, elasticsearchEndpoint, entityEndpoint, nexusToken) {
+  const [immediateDescendantsProvData, setImmediateDescendantsProvData] = useState(undefined);
+  const [isLoading, setIsLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    async function getAndSetProvData() {
+      const hubmapID = display_doi;
+      const entityData = await getEntityData(hubmapID, elasticsearchEndpoint, nexusToken);
+      const immediateDescendants = entityData?.immediate_descendants;
+
+      const results = await Promise.all(
+        immediateDescendants.map((descendant) => {
+          const { url, options } = getProvRequest(descendant.uuid, entityEndpoint, nexusToken);
+          const result = fetch(url, options).then((res) => res.json());
+          return result;
+        }),
+      );
+      setImmediateDescendantsProvData(results);
+      setIsLoading(false);
+    }
+    getAndSetProvData();
+  }, [nexusToken, elasticsearchEndpoint, entityEndpoint, display_doi]);
+  return { immediateDescendantsProvData, isLoading };
+}
+
+async function getImmediateDescendantProv(display_doi, elasticsearchEndpoint, entityEndpoint, nexusToken) {
+  const hubmapID = display_doi;
+  const entityData = await getEntityData(hubmapID, elasticsearchEndpoint, nexusToken);
+  const immediateDescendants = entityData?.immediate_descendants;
+
+  const results = await Promise.all(
+    immediateDescendants.map((descendant) => {
+      const { url, options } = getProvRequest(descendant.uuid, entityEndpoint, nexusToken);
+      const result = fetch(url, options).then((res) => res.json());
+      return result;
+    }),
+  );
+  return results;
+}
+
+export { getImmediateDescendantProv };
+export default useImmediateDescendantProv;

--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -16,10 +16,12 @@ const useProvenanceStore = create(
         state.steps = [...state.steps, ...steps];
       }),
     stitchEntityDescendantSteps: (nodeName, descendantSteps) => {
+      // check new steps inputs to see if they exist in current steps
       descendantSteps.forEach((descendantStep) => {
         descendantStep.inputs.forEach((input) => {
           get().steps.forEach((step, stepIndex) => {
             const outputIndex = step.outputs.findIndex((output) => output.name === input.name);
+            // if input exists as an output of an existing step add new step as target
             if (outputIndex >= 0) {
               const output = { step: descendantStep.name, name: input.name };
               set((state) => {

--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -15,7 +15,7 @@ const useProvenanceStore = create(
       set((state) => {
         state.steps = [...state.steps, ...steps];
       }),
-    stitchEntityDescendantSteps: (nodeName, descendantSteps) => {
+    stitchEntityDescendantSteps: (descendantSteps) => {
       // check new steps inputs to see if they exist in current steps
       descendantSteps.forEach((descendantStep) => {
         descendantStep.inputs.forEach((input) => {
@@ -32,9 +32,9 @@ const useProvenanceStore = create(
         });
       });
     },
-    addDescendantSteps: (nodeName, descendantSteps) => {
+    addDescendantSteps: (descendantSteps) => {
       if (descendantSteps.length > 0) {
-        get().stitchEntityDescendantSteps(nodeName, descendantSteps);
+        get().stitchEntityDescendantSteps(descendantSteps);
         get().addSteps(descendantSteps);
       }
     },

--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -5,7 +5,7 @@ import create from 'zustand';
 import immer from './immerMiddleware';
 
 const useProvenanceStore = create(
-  immer((set) => ({
+  immer((set, get) => ({
     steps: [],
     setSteps: (steps) =>
       set((state) => {
@@ -15,6 +15,19 @@ const useProvenanceStore = create(
       set((state) => {
         state.steps = [...state.steps, ...steps];
       }),
+    stitchEntityDescendantSteps: (nodeName, descendantSteps) => {
+      const index = get().steps.findIndex((step) => step.outputs[0].name === nodeName);
+      const outputsArray = descendantSteps.map((step) => ({ step: step.name, name: nodeName }));
+      set((state) => {
+        state.steps[index].outputs[0].target = outputsArray;
+      });
+    },
+    addDescendantSteps: (nodeName, descendantSteps) => {
+      if (descendantSteps.length > 0) {
+        get().stitchEntityDescendantSteps(nodeName, descendantSteps);
+        get().addSteps(descendantSteps);
+      }
+    },
   })),
 );
 

--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-param-reassign */
+
+import create from 'zustand';
+
+import immer from './immerMiddleware';
+
+const useProvenanceStore = create(
+  immer((set) => ({
+    steps: [],
+    setSteps: (steps) =>
+      set((state) => {
+        state.steps = steps;
+      }),
+    addSteps: (steps) =>
+      set((state) => {
+        state.steps = [...state.steps, ...steps];
+      }),
+  })),
+);
+
+export default useProvenanceStore;

--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -16,10 +16,18 @@ const useProvenanceStore = create(
         state.steps = [...state.steps, ...steps];
       }),
     stitchEntityDescendantSteps: (nodeName, descendantSteps) => {
-      const index = get().steps.findIndex((step) => step.outputs[0].name === nodeName);
-      const outputsArray = descendantSteps.map((step) => ({ step: step.name, name: nodeName }));
-      set((state) => {
-        state.steps[index].outputs[0].target = outputsArray;
+      descendantSteps.forEach((descendantStep) => {
+        descendantStep.inputs.forEach((input) => {
+          get().steps.forEach((step, stepIndex) => {
+            const outputIndex = step.outputs.findIndex((output) => output.name === input.name);
+            if (outputIndex >= 0) {
+              const output = { step: descendantStep.name, name: input.name };
+              set((state) => {
+                state.steps[stepIndex].outputs[outputIndex].target.push(output);
+              });
+            }
+          });
+        });
       });
     },
     addDescendantSteps: (nodeName, descendantSteps) => {

--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -33,10 +33,8 @@ const useProvenanceStore = create(
       });
     },
     addDescendantSteps: (descendantSteps) => {
-      if (descendantSteps.length > 0) {
-        get().stitchEntityDescendantSteps(descendantSteps);
-        get().addSteps(descendantSteps);
-      }
+      get().stitchEntityDescendantSteps(descendantSteps);
+      get().addSteps(descendantSteps);
     },
   })),
 );


### PR DESCRIPTION
Fix #1595.

Adds a 'Show Descendants' button to show descendants of entity in provenance graph detail pane. This has worked for both simple cases such as this donor `190aec1937701a97952b34cfac5529a3` where the resulting provenance matches its only descendant sample `14e44841842d639b28bfdf9188a95a86` and sample `d1fe368864b494e4cace64d68c7c60ed` where multiple descendants exist. Incrementally revealing descendants seems to work, but it is hard to verify (such as instances where paths diverge only to converge later, but I haven't been able to find an example of this if it could exist).

We probably won't want to merge this to master until I add some tests and we do some manual testing.

Likely follow-ups:
- Fetch immediate descendants when detail pane is opened and disable the button if no immediate descendants exist. Should we display something else instead of the disabled button.
- Disable button if the button has already been clicked and immediate descendants are shown.

@tsliaw do we want to change the button to 'Show Derived Entities' instead of 'Show Descendants'?

<img width="1177" alt="Screen Shot 2021-03-01 at 3 20 08 PM" src="https://user-images.githubusercontent.com/62477388/109554175-e7126d80-7aa1-11eb-83de-c2b7f709d51f.png">

<img width="1160" alt="Screen Shot 2021-03-01 at 3 20 18 PM" src="https://user-images.githubusercontent.com/62477388/109554200-ed084e80-7aa1-11eb-996d-0a4a4055e64c.png">

