### PR TITLE
Mccalluc/missing timestamp

### DIFF
--- a/CHANGELOG-last_modified_timestamp.md
+++ b/CHANGELOG-last_modified_timestamp.md
@@ -1,0 +1,1 @@
+- Handle missing last_modified_timestamp.

--- a/context/app/static/js/components/entity-tile/EntityTileBottom/EntityTileBottom.jsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBottom/EntityTileBottom.jsx
@@ -18,7 +18,9 @@ function EntityTileBottom(props) {
           <StyledDivider flexItem orientation="vertical" $invertColors={invertColors} />
         </React.Fragment>
       ))}
-      <Typography variant="body2">Modified {format(entityData.last_modified_timestamp, 'yyyy-MM-dd')}</Typography>
+      {entityData.last_modified_timestamp && (
+        <Typography variant="body2">Modified {format(entityData.last_modified_timestamp, 'yyyy-MM-dd')}</Typography>
+      )}
     </FixedWidthFlex>
   );
 }


### PR DESCRIPTION
With the new backend, (https://portal.dev.hubmapconsortium.org/browse/dataset/ae217499cd4a8b73bda077ee2893b399 ... requires login) Bill and Zhou noticed that some pages had react errors. Root problem is that the front end code expects `last_modified_timestamp` to be present.

- @yuanzhou : Perhaps it used to be the case that if an entity hadn't actually be modified, the create timestamp was filled in for the modified? I have a slight preference for retaining the former behavior... but it's a slight preference.
- @john-conroy : In `DetailDescription.jsx` this is already handled, but it's handled differently:
```
  const formattedModificationDate = modifiedTimestamp ? format(modifiedTimestamp, dateFormat) : 'Undefined';
```
Would that be preferable?