### PR TITLE
John conroy/disable descendant prov button

### DIFF
--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -33,10 +33,8 @@ const useProvenanceStore = create(
       });
     },
     addDescendantSteps: (descendantSteps) => {
-      if (descendantSteps.length > 0) {
-        get().stitchEntityDescendantSteps(descendantSteps);
-        get().addSteps(descendantSteps);
-      }
+      get().stitchEntityDescendantSteps(descendantSteps);
+      get().addSteps(descendantSteps);
     },
   })),
 );


### PR DESCRIPTION
Disables the 'Show Derived Entities' button if new steps don't exist. Since `steps` is in the dependency array for the `useEffect` which creates the steps from provenance data and determines if the steps don't exist in the current graph, the `useEffect` would be run an additional time after the steps have first been updated. Probably not a big deal, but I could rework things to avoid it if needed.