### PR TITLE
John conroy/refactor provenance

### DIFF
--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -55,8 +55,7 @@ function ProvGraph(props) {
         typeKey in prov && ['Donor', 'Sample', 'Dataset'].includes(prov[typeKey]) ? (
           <SectionItem ml>
             <ShowDerivedEntitiesButton
-              prov={prov}
-              idKey={idKey}
+              id={prov[idKey]}
               getNameForActivity={getNameForActivity}
               getNameForEntity={getNameForEntity}
             />

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/ProvGraph.jsx
@@ -8,7 +8,7 @@ import { AppContext } from 'js/components/Providers';
 import useImmediateDescendantProv from 'js/hooks/useImmediateDescendantProv';
 import useProvenanceStore from 'js/stores/useProvenanceStore';
 import ProvVis from '../ProvVis';
-import { StyledTypography, FlexPaper } from './style';
+import { FlexPaper } from './style';
 import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
 import ProvData from '../ProvVis/ProvData';
 
@@ -43,8 +43,10 @@ function ProvGraph(props) {
     return entity ? `${entity[typeKey]} - ${entity[idKey]}` : id;
   }
 
-  function renderDetailPane(prov) {
+  function renderDetailPane(node) {
     function DetailPanel() {
+      const { prov } = node.meta;
+
       const { elasticsearchEndpoint, entityEndpoint, nexusToken } = useContext(AppContext);
       const { steps, addDescendantSteps } = useProvenanceStore(useProvenanceStoreSelector);
       const [newSteps, setNewSteps] = useState([]);
@@ -71,28 +73,22 @@ function ProvGraph(props) {
 
       const typeEl =
         typeKey in prov ? (
-          <SectionItem label="Type">
-            <StyledTypography variant="body1">{prov[typeKey]}</StyledTypography>
-          </SectionItem>
+          <SectionItem label="Type">{prov[typeKey]}</SectionItem>
         ) : (
-          <SectionItem label="Type">
-            <StyledTypography variant="body1">{prov['prov:type']}</StyledTypography>
-          </SectionItem>
+          <SectionItem label="Type">{prov['prov:type']}</SectionItem>
         );
       const idEl =
         typeKey in prov && ['Donor', 'Sample', 'Dataset'].includes(prov[typeKey]) ? (
           <SectionItem label="ID" ml>
-            <StyledTypography variant="body1">
-              <LightBlueLink href={`/browse/${prov[typeKey].toLowerCase()}/${prov['hubmap:uuid']}`}>
-                {prov[idKey]}
-              </LightBlueLink>
-            </StyledTypography>
+            <LightBlueLink href={`/browse/${prov[typeKey].toLowerCase()}/${prov['hubmap:uuid']}`}>
+              {prov[idKey]}
+            </LightBlueLink>
           </SectionItem>
         ) : null;
       const createdEl =
         timeKey in prov ? (
           <SectionItem label="Created" ml>
-            <StyledTypography variant="body1">{prov[timeKey]}</StyledTypography>
+            {prov[timeKey]}
           </SectionItem>
         ) : null;
       const actionsEl =
@@ -117,7 +113,7 @@ function ProvGraph(props) {
         </FlexPaper>
       );
     }
-    return <DetailPanel />;
+    return node?.meta?.prov && <DetailPanel />;
   }
 
   return (

--- a/context/app/static/js/components/Detail/provenance/ProvGraph/style.js
+++ b/context/app/static/js/components/Detail/provenance/ProvGraph/style.js
@@ -1,21 +1,9 @@
 import styled from 'styled-components';
-import Typography from '@material-ui/core/Typography';
-import Link from '@material-ui/core/Link';
 import Paper from '@material-ui/core/Paper';
-
-// TODO: Copy and paste from Attribution.
-
-const StyledTypography = styled(Typography)`
-  margin: 2px 0px 2px 0px;
-`;
-
-const StyledLink = styled(Link)`
-  color: ${(props) => props.theme.palette.link.main};
-`;
 
 const FlexPaper = styled(Paper)`
   display: flex;
   padding: 30px 40px 30px 40px;
 `;
 
-export { StyledTypography, StyledLink, FlexPaper };
+export { FlexPaper };

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvData.js
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvData.js
@@ -35,7 +35,7 @@ export function makeCwlInput(name, steps, extras, isReference) {
 }
 
 // export only to test.
-export function makeCwlOutput(name, steps, extras) {
+export function makeCwlOutput(name, steps, extras, isReference) {
   const id = name;
   return {
     name,
@@ -46,6 +46,7 @@ export function makeCwlOutput(name, steps, extras) {
     meta: {
       global: true,
       in_path: true,
+      type: isReference ? 'reference file' : 'data file',
     },
     // Domain-specific extras go here:
     prov: extras,

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvData.js
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvData.js
@@ -3,6 +3,14 @@ import Ajv from 'ajv';
 
 import schema from './prov-schema.json';
 
+function getCwlMeta(isReference) {
+  return {
+    global: true,
+    in_path: true,
+    type: isReference ? 'reference file' : 'data file',
+  };
+}
+
 // export only to test.
 export function makeCwlInput(name, steps, extras, isReference) {
   const id = name;
@@ -25,11 +33,7 @@ export function makeCwlInput(name, steps, extras, isReference) {
     run_data: {
       file: [{ '@id': id }],
     },
-    meta: {
-      global: true,
-      in_path: true,
-      type: isReference ? 'reference file' : 'data file',
-    },
+    meta: getCwlMeta(isReference),
     prov: extras || {}, // TODO: real-prov has unmatched ID: https://github.com/hubmapconsortium/prov-vis/issues/15
   };
 }
@@ -43,11 +47,7 @@ export function makeCwlOutput(name, steps, extras, isReference) {
     run_data: {
       file: [{ '@id': id }],
     },
-    meta: {
-      global: true,
-      in_path: true,
-      type: isReference ? 'reference file' : 'data file',
-    },
+    meta: getCwlMeta(isReference),
     // Domain-specific extras go here:
     prov: extras,
   };

--- a/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/ProvVis.jsx
@@ -14,12 +14,6 @@ export default function ProvVis(props) {
     setSteps(new ProvData(provData, getNameForActivity, getNameForEntity).toCwl());
   }, [provData, getNameForActivity, getNameForEntity, setSteps]);
 
-  // eslint-disable-next-line consistent-return
-  function renderDetailPaneWithNode(node) {
-    if (renderDetailPane && node) {
-      return renderDetailPane(node.meta.prov);
-    }
-  }
   return (
     <GraphParser
       parsingOptions={{
@@ -31,7 +25,7 @@ export default function ProvVis(props) {
       parentItem={{ name: 'Is this used?' }}
       steps={steps}
     >
-      <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPaneWithNode} />
+      <Graph rowSpacingType="compact" minimumHeight={300} renderDetailPane={renderDetailPane} />
     </GraphParser>
   );
 }

--- a/context/app/static/js/components/Detail/provenance/ProvVis/__tests__/ProvData.spec.js
+++ b/context/app/static/js/components/Detail/provenance/ProvVis/__tests__/ProvData.spec.js
@@ -135,6 +135,7 @@ describe('CWL utils', () => {
       meta: {
         global: true,
         in_path: true,
+        type: 'data file',
       },
       name: 'name1',
       run_data: {

--- a/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/ShowDerivedEntitiesButton.jsx
+++ b/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/ShowDerivedEntitiesButton.jsx
@@ -18,13 +18,13 @@ function removeExistingSteps(steps, newSteps) {
 
 const useProvenanceStoreSelector = (state) => ({ steps: state.steps, addDescendantSteps: state.addDescendantSteps });
 
-function ShowDerivedEntitiesButton({ prov, idKey, getNameForActivity, getNameForEntity }) {
+function ShowDerivedEntitiesButton({ id, getNameForActivity, getNameForEntity }) {
   const { elasticsearchEndpoint, entityEndpoint, nexusToken } = useContext(AppContext);
   const { steps, addDescendantSteps } = useProvenanceStore(useProvenanceStoreSelector);
   const [newSteps, setNewSteps] = useState([]);
 
   const { immediateDescendantsProvData } = useImmediateDescendantProv(
-    prov[idKey],
+    id,
     elasticsearchEndpoint,
     entityEndpoint,
     nexusToken,

--- a/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/ShowDerivedEntitiesButton.jsx
+++ b/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/ShowDerivedEntitiesButton.jsx
@@ -1,0 +1,51 @@
+import React, { useContext, useEffect, useState } from 'react';
+import Button from '@material-ui/core/Button';
+
+import { AppContext } from 'js/components/Providers';
+import useImmediateDescendantProv from 'js/hooks/useImmediateDescendantProv';
+import useProvenanceStore from 'js/stores/useProvenanceStore';
+import ProvData from '../ProvVis/ProvData';
+
+function createStepNameSet(steps) {
+  return new Set(steps.map((step) => step.name));
+}
+
+function removeExistingSteps(steps, newSteps) {
+  const nameSet = createStepNameSet(steps);
+  const uniqueNewSteps = newSteps.filter((step) => !nameSet.has(step.name));
+  return uniqueNewSteps;
+}
+
+const useProvenanceStoreSelector = (state) => ({ steps: state.steps, addDescendantSteps: state.addDescendantSteps });
+
+function ShowDerivedEntitiesButton({ prov, idKey, getNameForActivity, getNameForEntity }) {
+  const { elasticsearchEndpoint, entityEndpoint, nexusToken } = useContext(AppContext);
+  const { steps, addDescendantSteps } = useProvenanceStore(useProvenanceStoreSelector);
+  const [newSteps, setNewSteps] = useState([]);
+
+  const { immediateDescendantsProvData } = useImmediateDescendantProv(
+    prov[idKey],
+    elasticsearchEndpoint,
+    entityEndpoint,
+    nexusToken,
+  );
+
+  useEffect(() => {
+    if (immediateDescendantsProvData) {
+      const immediateDescendantSteps = immediateDescendantsProvData
+        .map((result) => new ProvData(result, getNameForActivity, getNameForEntity).toCwl())
+        .flat();
+      setNewSteps(removeExistingSteps(steps, immediateDescendantSteps));
+    }
+  }, [immediateDescendantsProvData, steps, getNameForActivity, getNameForEntity]);
+  function handleShowDescendants() {
+    addDescendantSteps(newSteps);
+  }
+  return (
+    <Button color="primary" variant="contained" onClick={handleShowDescendants} disabled={newSteps.length === 0}>
+      Show Derived Entities
+    </Button>
+  );
+}
+
+export default ShowDerivedEntitiesButton;

--- a/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/index.js
+++ b/context/app/static/js/components/Detail/provenance/ShowDerivedEntitiesButton/index.js
@@ -1,0 +1,3 @@
+import ShowDerivedEntitiesButton from './ShowDerivedEntitiesButton';
+
+export default ShowDerivedEntitiesButton;


### PR DESCRIPTION
Still getting the below prop-types warnings when opening the provenance graph, but the other warnings and code style issues identified in #1593 have been addressed. The code in `ShowDerivedEntitiesButton` isn't new and was taken from `renderDetailPane` in `ProvGraph`. Filed #1602.

> Warning: Failed prop type: The prop `nodes` is marked as required in `Graph`, but its value is `undefined`.

> Warning: Failed prop type: The prop `edges` is marked as required in `Graph`, but its value is `undefined`.