### PR TITLE
Mccalluc/ilan gold/nonetype assays

### DIFF
--- a/CHANGELOG-vitessce-backend-bug.md
+++ b/CHANGELOG-vitessce-backend-bug.md
@@ -1,0 +1,1 @@
+Fix bug where no assay is found for Vitessce.

--- a/CHANGELOG-vitessce-backend-bug.md
+++ b/CHANGELOG-vitessce-backend-bug.md
@@ -1,1 +1,1 @@
-Fix bug where no assay is found for Vitessce.
+- Fix bug where no assay is found for Vitessce.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -140,7 +140,5 @@ class ApiClient():
             }
         else:
             vc = get_view_config_class_for_data_types(entity=entity, nexus_token=self.nexus_token)
-            if vc is None:
-                return {}
             conf = vc.build_vitessce_conf()
             return conf

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -140,5 +140,7 @@ class ApiClient():
             }
         else:
             vc = get_view_config_class_for_data_types(entity=entity, nexus_token=self.nexus_token)
+            if vc is None:
+                return {}
             conf = vc.build_vitessce_conf()
             return conf

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -101,7 +101,7 @@ class CytokitSPRMConf(ViewConf):
 
 
 class RNASeqConf(ScatterplotViewConf):
-    def __init__(self, entity, nexus_token, is_mock):
+    def __init__(self, entity, nexus_token, is_mock=False):
         super().__init__(entity, nexus_token, is_mock)
         # All "file" Vitessce objects that do not have wrappers.
         self._files = [
@@ -119,7 +119,7 @@ class RNASeqConf(ScatterplotViewConf):
 
 
 class ATACSeqConf(ScatterplotViewConf):
-    def __init__(self, entity, nexus_token, is_mock):
+    def __init__(self, entity, nexus_token, is_mock=False):
         super().__init__(entity, nexus_token, is_mock)
         # All "file" Vitessce objects that do not have wrappers.
         self._files = [
@@ -139,7 +139,7 @@ class ATACSeqConf(ScatterplotViewConf):
 
 
 class IMSConf(ImagePyramidViewConf):
-    def __init__(self, entity, nexus_token, is_mock):
+    def __init__(self, entity, nexus_token, is_mock=False):
         super().__init__(entity, nexus_token, is_mock)
         # Do not show the separated mass-spec images.
         self.image_pyramid_regex = (

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -174,3 +174,4 @@ def get_view_config_class_for_data_types(entity, nexus_token):
         return RNASeqConf(entity=entity, nexus_token=nexus_token, is_mock=False)
     if "atac" in hints:
         return ATACSeqConf(entity=entity, nexus_token=nexus_token, is_mock=False)
+    return None

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -147,6 +147,11 @@ class IMSConf(ImagePyramidViewConf):
         )
 
 
+class NullConf():
+    def build_vitessce_conf(self):
+        return {}
+
+
 def get_view_config_class_for_data_types(entity, nexus_token):
     data_types = entity["data_types"]
     tc = CommonsTypeClient()
@@ -174,4 +179,4 @@ def get_view_config_class_for_data_types(entity, nexus_token):
         return RNASeqConf(entity=entity, nexus_token=nexus_token, is_mock=False)
     if "atac" in hints:
         return ATACSeqConf(entity=entity, nexus_token=nexus_token, is_mock=False)
-    return None
+    return NullConf()

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -161,22 +161,19 @@ def get_view_config_class_for_data_types(entity, nexus_token):
     if "is_image" in hints:
         if "codex" in hints:
             return CytokitSPRMConf(
-                entity=entity, nexus_token=nexus_token, is_mock=False
-            )
+                entity=entity, nexus_token=nexus_token)
         if SEQFISH in assay_names:
             return SeqFISHViewConf(
-                entity=entity, nexus_token=nexus_token, is_mock=False
-            )
+                entity=entity, nexus_token=nexus_token)
         if (
             MALDI_IMS_NEG in assay_names
             or MALDI_IMS_POS in assay_names
         ):
-            return IMSConf(entity=entity, nexus_token=nexus_token, is_mock=False)
+            return IMSConf(entity=entity, nexus_token=nexus_token)
         return ImagePyramidViewConf(
-            entity=entity, nexus_token=nexus_token, is_mock=False
-        )
+            entity=entity, nexus_token=nexus_token)
     if "rna" in hints:
-        return RNASeqConf(entity=entity, nexus_token=nexus_token, is_mock=False)
+        return RNASeqConf(entity=entity, nexus_token=nexus_token)
     if "atac" in hints:
-        return ATACSeqConf(entity=entity, nexus_token=nexus_token, is_mock=False)
+        return ATACSeqConf(entity=entity, nexus_token=nexus_token)
     return NullConf()

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -102,7 +102,7 @@ class ImagingViewConf(ViewConf):
 
 
 class ImagePyramidViewConf(ImagingViewConf):
-    def __init__(self, entity, nexus_token, is_mock):
+    def __init__(self, entity, nexus_token, is_mock=False):
         self.image_pyramid_regex = IMAGE_PYRAMID_DIR
         super().__init__(entity, nexus_token, is_mock)
 
@@ -157,7 +157,7 @@ class ScatterplotViewConf(ViewConf):
 
 
 class SPRMViewConf(ImagingViewConf):
-    def __init__(self, entity, nexus_token, is_mock, **kwargs):
+    def __init__(self, entity, nexus_token, is_mock=False, **kwargs):
         # All "file" Vitessce objects that do not have wrappers.
         super().__init__(entity, nexus_token, is_mock)
         self._base_name = kwargs["base_name"]


### PR DESCRIPTION
Replace #1615. Fixes #1614.

- Consistent return types are good: whatever is returned, you can call the method.
- Give a default value for is_mock.

Are there public datasets that would have triggered this, or is there something special about the private datasets that the bug was reported for? Is the plan to keep in communication with IEC so as new types come along, we'll get new visualizations up?

