### PR TITLE
John conroy/prettier should fail ci

### DIFF
--- a/CHANGELOG-prettier-should-fail-ci.md
+++ b/CHANGELOG-prettier-should-fail-ci.md
@@ -1,0 +1,1 @@
+- Add linting which includes prettier check to test script.

--- a/test.sh
+++ b/test.sh
@@ -57,16 +57,17 @@ start pytest
 pytest context/app
 end pytest
 
-start lint
 cd context
+
+start lint
 npm run lint
 end lint
 
 start npm-test
 npm run test
-cd -
 end npm-test
 
+cd -
 
 start docker
 ./docker.sh 5001  # Needs to match port in cypress.json.

--- a/test.sh
+++ b/test.sh
@@ -57,9 +57,12 @@ start pytest
 pytest context/app
 end pytest
 
+start lint
+cd context
+npm run lint
+end lint
 
 start npm-test
-cd context
 npm run test
 cd -
 end npm-test


### PR DESCRIPTION
Fix #1565. Add linting, which includes prettier, to test script. I think we previously got this from dev-start when it was in the test script, but lost it when it was removed.