### PR TITLE
Fix RNA-Seq Nonetype Issue

### DIFF
--- a/CHANGELOG-fix-rna-seq-issue.md
+++ b/CHANGELOG-fix-rna-seq-issue.md
@@ -1,0 +1,1 @@
+- Fix returning `self.conf` when it does not exist for XXX-seq assays with scatterplot conf.

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -142,7 +142,7 @@ class ScatterplotViewConf(ViewConf):
                 current_app.logger.info(
                     f'Files for uuid "{self._uuid}" not found as expected.'
                 )
-            return self.conf
+            return {}
         vc = VitessceConfig(name="HuBMAP Data Portal")
         dataset = vc.add_dataset(name="Visualization Files")
         for file in self._files:


### PR DESCRIPTION
Fixes #1638 separate from #1637.  `self.conf` does not exist on the class.

For example: https://portal.test.hubmapconsortium.org/browse/dataset/a598609e8a6c8ba6d0ca52b3e567040d on TEST should work now with this PR