### PR TITLE
Remove from ASCT+B from menu

### DIFF
--- a/CHANGELOG-no-asct-preview.md
+++ b/CHANGELOG-no-asct-preview.md
@@ -1,0 +1,1 @@
+- Remove the ASCT+B preview, since it is in the other menu.

--- a/context/app/static/js/components/Header/PreviewLinks/PreviewLinks.jsx
+++ b/context/app/static/js/components/Header/PreviewLinks/PreviewLinks.jsx
@@ -6,11 +6,7 @@ function PreviewLinks(props) {
   const { isIndented } = props;
   return (
     <>
-      {[
-        'Multimodal Molecular Imaging Data',
-        'Cell Type Annotations',
-        'Anatomical Structures, Cell Types, and Biomarkers Tables',
-      ].map((previewName) => (
+      {['Multimodal Molecular Imaging Data', 'Cell Type Annotations'].map((previewName) => (
         <DropdownLink
           key={previewName}
           href={`/preview/${previewName.toLowerCase().replace(/\W+/g, '-')}`}


### PR DESCRIPTION
Is this still needed if you have it in the other menu? The underlying document is still there, so links won't break.