### PR TITLE
Change container name to prod-portal-ui

### DIFF
--- a/CHANGELOG-container-names.md
+++ b/CHANGELOG-container-names.md
@@ -1,0 +1,1 @@
+- Tweak container names to be in sync with gateway.

--- a/compose/hubmap.stage.yml
+++ b/compose/hubmap.stage.yml
@@ -20,9 +20,9 @@ services:
     networks:
       - gateway_hubmap
 
-  portal-ui-prod:
-    hostname: portal-ui-prod
-    container_name: portal-ui-prod
+  prod-portal-ui:
+    hostname: prod-portal-ui
+    container_name: prod-portal-ui
     image: hubmap/portal-ui:latest
 
     # Mount the app config in container to keep it outside the image.

--- a/compose/hubmap.stage.yml
+++ b/compose/hubmap.stage.yml
@@ -20,6 +20,9 @@ services:
     networks:
       - gateway_hubmap
 
+  # Service names need to be kept in sync with gateway:
+  # https://github.com/hubmapconsortium/gateway/blob/f2c2d5d/nginx/conf.d-stage/prod-portal-ui.conf
+  # Some part of the routing seems to be be based on left substrings, rather than names, so make sure left substrings are unique.
   prod-portal-ui:
     hostname: prod-portal-ui
     container_name: prod-portal-ui


### PR DESCRIPTION
Issue: https://portal-prod.stage.hubmapconsortium.org/ uses the PROD search-api configuration, but sometimes this domain returns results from the actual STAGE search-api. 

Fix: in case the gateway nginx confuses `portal-ui` with `portal-ui-prod` hostnames due to name-based matching rule when forwarding the domain to the container, I'm changing the hostname to be totally unique to nginx.

Will make the corresponding changes in gateway nginx configuration.