### PR TITLE
"previous" should be spelled out

### DIFF
--- a/CHANGELOG-prev.md
+++ b/CHANGELOG-prev.md
@@ -1,0 +1,1 @@
+- For versioning, "previous" will be spelled out in the API response. Fix dev search.

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -72,7 +72,7 @@ function DevSearch() {
           BoolMustNot(ExistsQuery('mapper_metadata.validation_errors')),
         ),
         checkboxFilter('has_next', 'Has next?', ExistsQuery('next_revision_uuid')),
-        checkboxFilter('has_prev', 'Has prev?', ExistsQuery('prev_revision_uuid')),
+        checkboxFilter('has_previous', 'Has previous?', ExistsQuery('previous_revision_uuid')),
       ],
     },
     queryFields: ['everything'],


### PR DESCRIPTION
I don't know how long this example on dev will stay around, but: https://portal.dev.hubmapconsortium.org/browse/dataset/8f528475e216c283851e6941841d7173.json
```
"previous_revision_uuid": "8f528475e216c283851e6941841d7173"
```

Can you confirm that this doubly-linked list structure works with your designs, and then put the implementation issues in the v0.15 milestone? Thanks!

(Related back-end issue: https://github.com/hubmapconsortium/search-api/issues/233)