### PR TITLE
Prevent Unnecessary Auth for Published Zarr Stores

### DIFF
--- a/CHANGELOG-prevent-cors-preflight.md
+++ b/CHANGELOG-prevent-cors-preflight.md
@@ -1,0 +1,1 @@
+- Unnecessary auth headers for published zarr stores cause unecessary CORS preflight requests.

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -219,7 +219,6 @@ class NullConf():
 
 
 def get_view_config_class_for_data_types(entity, nexus_token):
-    print(entity)
     data_types = entity["data_types"]
     tc = CommonsTypeClient()
     assay_objs = [tc.get_assay(dt) for dt in data_types]

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -187,11 +187,7 @@ class RNASeqAnnDataZarrConf(ViewConf):
                 "marker_gene_3",
                 "marker_gene_4"
             ],
-            request_init={
-                "headers": {
-                    "Authorization": f"Bearer {self._nexus_token}"
-                }
-            }
+            request_init=self._get_request_init()
         )
         )
         vc = self._setup_anndata_view_config(vc, dataset)
@@ -223,6 +219,7 @@ class NullConf():
 
 
 def get_view_config_class_for_data_types(entity, nexus_token):
+    print(entity)
     data_types = entity["data_types"]
     tc = CommonsTypeClient()
     assay_objs = [tc.get_assay(dt) for dt in data_types]

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -85,6 +85,18 @@ class ViewConf:
         token_param = urllib.parse.urlencode({"token": self._nexus_token})
         return f'{base_url}?{token_param}' if use_token else base_url
 
+    def _get_request_init(self):
+        request_init = {
+            "headers": {
+                "Authorization": f"Bearer {self._nexus_token}"
+            }
+        }
+        # Extra headers outside of a select few cause extra CORS-preflight requests which
+        # can slow down the webpage.  If the dataset is published, we don't need to use
+        # heaeder to authenticate access to the assets API.
+        use_request_init = False if self._entity['status'] == 'Published' else True
+        return request_init if use_request_init else None
+
 
 class ImagingViewConf(ViewConf):
     def _get_img_and_offset_url(self, img_path, img_dir):

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -94,6 +94,7 @@ class ViewConf:
         # Extra headers outside of a select few cause extra CORS-preflight requests which
         # can slow down the webpage.  If the dataset is published, we don't need to use
         # heaeder to authenticate access to the assets API.
+        # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests
         use_request_init = False if self._entity['status'] == 'Published' else True
         return request_init if use_request_init else None
 

--- a/context/app/api/vitessce_confs/fixtures/input_entity/atac_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/atac_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "sn_atac_seq"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "alignment_qc.json"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/codex_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/codex_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "codex_cytokit"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "data.json"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/image_pyramid_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/image_pyramid_entity.json
@@ -3,6 +3,7 @@
         "image_pyramid",
         "PAS"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "ometiff-pyramids/processedMicroscopy/VAN0003-LK-33-2-PAS_FFPE.ome.tif"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/ims_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/ims_entity.json
@@ -3,6 +3,7 @@
         "image_pyramid",
         "MALDI-IMS-neg"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "ometiff-pyramids/ometiffs/separate/VAN0003-LK-32-21-IMS_NegMode_mz909.606.ome.tif"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_atac_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_atac_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "sn_atac_seq"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "alignment_qc.json"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_codex_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_codex_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "codex_cytokit"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "data.json"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_image_pyramid_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_image_pyramid_entity.json
@@ -3,6 +3,7 @@
         "image_pyramid",
         "PAS"
     ],
+    "status": "QA",
     "files": [ ],
     "uuid": "f9ae931b8b49252f150d7f8bf1d2d13f"
 }

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_ims_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_ims_entity.json
@@ -3,6 +3,7 @@
         "image_pyramid",
         "MALDI-IMS-neg"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "ometiff-pyramids/ometiffs/separate/VAN0003-LK-32-21-IMS_NegMode_mz909.606.ome.tif"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_rna_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_rna_entity.json
@@ -1,5 +1,6 @@
 {
   "data_types": ["salmon_rnaseq_10x"],
+  "status": "QA",
   "files": [
     {
       "rel_path": "cluster-marker-genes/cluster_marker_genes.h5ad"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_rna_zarr_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_rna_zarr_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "salmon_rnaseq_10x"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "'hubmap_ui/broken_file_path_anndata-zarr/secondary_analysis.zarr/.zgroup'"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_seqfish_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_seqfish_entity.json
@@ -3,6 +3,7 @@
         "image_pyramid",
         "seqFish"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "ometiff-pyramids/final_mRNA_background/MMStack_foo_Pos12.ome.tif"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/malformed_sprm_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/malformed_sprm_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "codex_cytokit"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "data.json"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/rna_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/rna_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "salmon_rnaseq_10x"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "cluster-marker-genes/cluster_marker_genes.h5ad"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/rna_zarr_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/rna_zarr_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "salmon_rnaseq_10x"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "hubmap_ui/anndata-zarr/secondary_analysis.zarr/.zgroup"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/seqfish_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/seqfish_entity.json
@@ -3,6 +3,7 @@
         "image_pyramid",
         "seqFish"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "ometiff-pyramids/final_mRNA_background/MMStack_Pos12.ome.tif"

--- a/context/app/api/vitessce_confs/fixtures/input_entity/sprm_entity.json
+++ b/context/app/api/vitessce_confs/fixtures/input_entity/sprm_entity.json
@@ -2,6 +2,7 @@
     "data_types": [
         "sprm"
     ],
+    "status": "QA",
     "files": [
         {
             "rel_path": "data.json"


### PR DESCRIPTION
For published datasets, the `assets` API should not need to authenticate requests (and in fact when people are not signed in, cannot).  Authenticating requests via a header (needed for zarr stores) causes pre-flight `OPTIONS` requests to be sent out: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#simple_requests (You can see this by opening the network tab on a zarr-backed AnnData RNA-seq dataset).

This PR takes away the header for published datasets as it is unnecessary, which should give us a nice performance bump.

This also fixes an issue where an empty auth header returns a 401 regardless of whether or not the dataset is published (which can happen for people who are not signed in but datasets which are "Published").  I don' t think it's a bug with `assets`, but it does cause this dataset to not work when published.  This PR also (inadvertently) resolves that.

Example:
https://portal.test.hubmapconsortium.org/browse/dataset/3b066aa664e1a32eaea957927baf92e2