### PR TITLE
Mccalluc/warning if not latest version

### DIFF
--- a/CHANGELOG-warning-if-not-latest-version.md
+++ b/CHANGELOG-warning-if-not-latest-version.md
@@ -1,0 +1,1 @@
+- Add a banner on the details page if it is not the latest version.

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useContext } from 'react';
 import Typography from '@material-ui/core/Typography';
 
+import { Alert } from 'js/shared-styles/alerts';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import Files from 'js/components/files/Files';
 import ProvSection from 'js/components/Detail/provenance/ProvSection';
@@ -67,6 +68,7 @@ function DatasetDetail(props) {
     status,
     mapped_data_access_level,
   } = assayMetadata;
+  const isLatest = !('next_revision_uuid' in assayMetadata);
 
   const { elasticsearchEndpoint, nexusToken } = useContext(AppContext);
 
@@ -96,6 +98,7 @@ function DatasetDetail(props) {
   // TODO: When all environments are clean, data_types array fallbacks shouldn't be needed.
   return (
     <DetailContext.Provider value={{ display_doi, uuid, mapped_data_access_level }}>
+      {!isLatest && <Alert severity="warning">Yo!</Alert>}
       <DetailLayout sectionOrder={sectionOrder}>
         <Summary
           uuid={uuid}

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -98,7 +98,18 @@ function DatasetDetail(props) {
   // TODO: When all environments are clean, data_types array fallbacks shouldn't be needed.
   return (
     <DetailContext.Provider value={{ display_doi, uuid, mapped_data_access_level }}>
-      {!isLatest && <Alert severity="warning">Yo!</Alert>}
+      {!isLatest && (
+        <Alert severity="warning">
+          <span>
+            {/* <span> to override "display: flex" which splits this on to multiple lines. */}
+            You are viewing an older version of this page. Navigate to a{' '}
+            <LightBlueLink href={`/browse/dataset/${assayMetadata.next_revision_uuid}`}>
+              more recent version
+            </LightBlueLink>
+            .
+          </span>
+        </Alert>
+      )}
       <DetailLayout sectionOrder={sectionOrder}>
         <Summary
           uuid={uuid}

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -99,7 +99,7 @@ function DatasetDetail(props) {
   return (
     <DetailContext.Provider value={{ display_doi, uuid, mapped_data_access_level }}>
       {!isLatest && (
-        <Alert severity="warning">
+        <Alert severity="warning" $marginBottom="16">
           <span>
             {/* <span> to override "display: flex" which splits this on to multiple lines. */}
             You are viewing an older version of this page. Navigate to a{' '}

--- a/context/app/static/js/shared-styles/alerts/index.js
+++ b/context/app/static/js/shared-styles/alerts/index.js
@@ -23,6 +23,7 @@ const StyledAlert = styled(OutlinedAlert)`
   :not(svg) {
     color: ${(props) => props.theme.palette.text.primary};
   }
+  margin-bottom: 16px;
 `;
 
 export { StyledAlert as Alert };

--- a/context/app/static/js/shared-styles/alerts/index.js
+++ b/context/app/static/js/shared-styles/alerts/index.js
@@ -23,7 +23,7 @@ const StyledAlert = styled(OutlinedAlert)`
   :not(svg) {
     color: ${(props) => props.theme.palette.text.primary};
   }
-  margin-bottom: 16px;
+  margin-bottom: ${(props) => props.$marginBotton || 0}px;
 `;
 
 export { StyledAlert as Alert };


### PR DESCRIPTION
Towards #1331. They are not providing a `latest` version, only `next`: I've put a question on the agenda: "Is it important to be able to link to the latest version? Or is next sufficient for now?"

- @tsliaw : Close enough to the mock up?
- @john-conroy
  - for the bottom margin, would it be better to have my own derived component just for this?
  - ... and maybe find a different approach to the flex, as well?
<img width="538" alt="Screen Shot 2021-04-01 at 3 01 15 PM" src="https://user-images.githubusercontent.com/730388/113342010-ed437600-92fb-11eb-85e8-6bd71b7977e3.png">
