### PR TITLE
Update client-side and server-side 401 messages

### DIFF
--- a/CHANGELOG-friendlier-401.md
+++ b/CHANGELOG-friendlier-401.md
@@ -1,0 +1,1 @@
+- Help users who may be logged into the wrong globus account.

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -30,7 +30,17 @@ function ErrorBody({ errorCode, isAuthenticated, isGlobus401, isMaintenancePage 
   if (errorCode === 401) {
     return (
       <>
-        You have not been added to the HuBMAP Group on Globus. Request access at <HelpEmailLink />.
+        Could not confirm your Globus credentials.
+        <ul>
+          <li>
+            You may not have been added to the HuBMAP Group on Globus. Request access at <HelpEmailLink />.
+          </li>
+          <li>
+            Or, you may be logged into a different Globus account from the one in the HuBMAP Group. Check{' '}
+            <OutboundLink href="http://app.globus.org/">http://app.globus.org/</OutboundLink> for details on your
+            account.
+          </li>
+        </ul>
       </>
     );
   }

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -30,17 +30,10 @@ function ErrorBody({ errorCode, isAuthenticated, isGlobus401, isMaintenancePage 
   if (errorCode === 401) {
     return (
       <>
-        Could not confirm your Globus credentials.
-        <ul>
-          <li>
-            You may not have been added to the HuBMAP Group on Globus. Request access at <HelpEmailLink />.
-          </li>
-          <li>
-            Or, you may be logged into a different Globus account from the one in the HuBMAP Group. Check{' '}
-            <OutboundLink href="http://app.globus.org/">http://app.globus.org/</OutboundLink> for details on your
-            account.
-          </li>
-        </ul>
+        Could not confirm your Globus credentials. You may not have been added to the HuBMAP Group on Globus. Request
+        access at <HelpEmailLink />. Or, you may be logged into a different Globus account from the one in the HuBMAP
+        Group. Check <OutboundLink href="http://app.globus.org/">http://app.globus.org/</OutboundLink> for details on
+        account.
       </>
     );
   }

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.spec.js
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.spec.js
@@ -23,9 +23,7 @@ test('Globus 401', () => {
 
 test('401', () => {
   render(<ErrorBody errorCode={401} />);
-  expect(
-    screen.getByText('You have not been added to the HuBMAP Group on Globus.', { exact: false }),
-  ).toBeInTheDocument();
+  expect(screen.getByText('Could not confirm your Globus credentials.', { exact: false })).toBeInTheDocument();
   expect(screen.getByRole('link', { name: help.name })).toHaveAttribute('href', help.url);
 });
 

--- a/context/app/templates/errors/401-no-hubmap-group.html
+++ b/context/app/templates/errors/401-no-hubmap-group.html
@@ -6,7 +6,12 @@
 
 {% block content %}
 <p>
-  Unauthorized: You have not been added to the HuBMAP Group on Globus.
-  Request access <a href="https://profile.hubmapconsortium.org/">here</a>.
+  Could not confirm your Globus credentials.
 </p>
+<ul>
+  <li>You may not have been added to the HuBMAP Group on Globus. Request access at
+    <a href="mailto:help@hubmapconsortium.org">help@hubmapconsortium.org</a>.</li>
+  <li>Or, you may be logged into a different Globus account from the one in the HuBMAP Group.
+    Check <a href="http://app.globus.org/">http://app.globus.org/</a> for details on your account.</li>
+</ul>
 {% endblock %}


### PR DESCRIPTION
Fix #1607

I don't think the client-side error message is being shown right now... but understanding why not is a separate, low priority issue, and I think it makes sense to just keep the messages in sync for now.