### PR TITLE
Remove references to "everything"

### DIFF
--- a/context/app/static/js/components/Search/DevResults/DevResults.jsx
+++ b/context/app/static/js/components/Search/DevResults/DevResults.jsx
@@ -29,7 +29,7 @@ function DevResults(props) {
       ]}
       sourceFilter={resultFieldIds}
       customHighlight={{
-        fields: { everything: { type: 'plain' } },
+        fields: { description: { type: 'plain' } },
       }}
     />
   );

--- a/context/app/static/js/components/Search/Results/Results.jsx
+++ b/context/app/static/js/components/Search/Results/Results.jsx
@@ -31,7 +31,7 @@ function Results(props) {
       ]}
       sourceFilter={resultFieldIds}
       customHighlight={{
-        fields: { everything: { type: 'plain' } },
+        fields: { description: { type: 'plain' } },
       }}
     />
   );

--- a/context/app/static/js/components/Search/ResultsTable/ResultsTable.jsx
+++ b/context/app/static/js/components/Search/ResultsTable/ResultsTable.jsx
@@ -33,7 +33,7 @@ function ResultsTable(props) {
               <StyledTableCell colSpan={resultFields.length}>
                 <p
                   dangerouslySetInnerHTML={{
-                    __html: hit.highlight.everything.join(' ... '),
+                    __html: hit.highlight.description.join(' ... '),
                   }}
                 />
               </StyledTableCell>

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -75,7 +75,7 @@ function DevSearch() {
         checkboxFilter('has_previous', 'Has previous?', ExistsQuery('previous_revision_uuid')),
       ],
     },
-    queryFields: ['everything'],
+    queryFields: ['all_text'],
     isLoggedIn: Boolean(nexusToken),
   };
 

--- a/context/app/static/js/pages/search/Search.jsx
+++ b/context/app/static/js/pages/search/Search.jsx
@@ -79,7 +79,7 @@ function Search(props) {
     type,
     // Sidebar facet configuration:
     filters: filtersByType[type],
-    queryFields: ['everything'],
+    queryFields: ['all_text', 'description'],
     isLoggedIn: Boolean(nexusToken),
     apiUrl: elasticsearchEndpoint,
     defaultQuery: BoolMustNot(ExistsQuery('next_revision_uuid')),

--- a/end-to-end/cypress/fixtures/dataset-search/default.js
+++ b/end-to-end/cypress/fixtures/dataset-search/default.js
@@ -176,7 +176,7 @@ Request body:
   },
   size: 18,
   sort: [{ "mapped_last_modified_timestamp.keyword": "desc" }],
-  highlight: { fields: { everything: { type: "plain" } } },
+  highlight: { fields: { description: { type: "plain" } } },
   _source: [
     "display_doi",
     "group_name",

--- a/end-to-end/cypress/fixtures/dataset-search/heart-only-5-or-less-data-types.js
+++ b/end-to-end/cypress/fixtures/dataset-search/heart-only-5-or-less-data-types.js
@@ -241,7 +241,7 @@ Request body:
   },
   size: 18,
   sort: [{ "mapped_last_modified_timestamp.keyword": "desc" }],
-  highlight: { fields: { everything: { type: "plain" } } },
+  highlight: { fields: { description: { type: "plain" } } },
   _source: [
     "display_doi",
     "group_name",


### PR DESCRIPTION
@yuanzhou , can you post an update here when the index changes have made it to production? No hurry, I just want to make sure that hand-off happens. Keeping it as a draft until then.

@ilan-gold / @tsliaw / @john-conroy : While we can search against the new `all_text` field, we can't use it to highlight results: ES can't tell us what is in `all_text`, only that there was a match. For now, I'm just specifying the `description` field as the place to look when highlighting. If it's not there, there won't be highlighting. For example:

<img width="522" alt="Screen Shot 2021-04-05 at 8 33 57 PM" src="https://user-images.githubusercontent.com/730388/113642641-47bb3a00-964e-11eb-8508-09e9a1bcb1a8.png">

(This is from an instance pointing at the DEV index, which has the new structure.)

Thinking about why there could be a hit, but no highlighting:
- `all_text` might be grabbing too much: Looking at the example here, I remember that we're excluding some parts of the document from `everything`, and that should be replicated with `all_text`. (I think ancestors and descendants should be excluded, but I'll need to check.)
- The match might be in a facet field, but just showing the value of the facet in bold doesn't really give us much: I think it would be fine to skip the highlighting in these cases.
- There might be other fields besides `description` where showing a match in context is useful.

After this is merged (probably with some tweaks) there will be a follow-up PR in `search-api` to get rid of `everything`