### PR TITLE
Fix empty donor metadata

### DIFF
--- a/CHANGELOG-donor-metadata.md
+++ b/CHANGELOG-donor-metadata.md
@@ -1,0 +1,1 @@
+- Bug fix: Donor metadata is now shown.

--- a/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
@@ -30,8 +30,9 @@ function MetadataTable(props) {
   ];
 
   const tableRows = Object.entries(tableData)
-    // To suppress nested objects, like nested "metadata" for Samples:
-    .filter((entry) => typeof entry[1] !== 'object')
+    // Filter out nested objects, like nested "metadata" for Samples...
+    // but allow arrays. Remember, in JS: typeof [] === 'object'
+    .filter((entry) => typeof entry[1] !== 'object' || Array.isArray(entry[1]))
     .map((entry) => ({
       key: entry[0],
       value: Array.isArray(entry[1]) ? entry[1].join(', ') : entry[1].toString(),

--- a/context/app/static/js/pages/Donor/Donor.jsx
+++ b/context/app/static/js/pages/Donor/Donor.jsx
@@ -27,8 +27,8 @@ function DonorDetail(props) {
     last_modified_timestamp,
     description,
     mapped_metadata = {},
-    // Missing on some unpublished data. Not sure if there's a deeper bug.
-    // Filed: https://github.com/hubmapconsortium/search-api/issues/236
+    // As data comes in from other consortia, we won't be able
+    // to rely on donor metadata always being available.
   } = assayMetadata;
 
   const { sex, race, age_value, age_unit } = mapped_metadata;

--- a/context/app/static/js/pages/Donor/Donor.jsx
+++ b/context/app/static/js/pages/Donor/Donor.jsx
@@ -29,6 +29,7 @@ function DonorDetail(props) {
     mapped_metadata = {},
     // As data comes in from other consortia, we won't be able
     // to rely on donor metadata always being available.
+    // Unpublished HuBMAP data may also be missing donor metadata.
   } = assayMetadata;
 
   const { sex, race, age_value, age_unit } = mapped_metadata;


### PR DESCRIPTION
Fix #1713.

Note: for purposes of indexing and search, if you only have a single value for a field, Elasticsearch doesn't care whether you represent it as `"key": "value"` or `"key": ["value"]`. In fact, I don't think you could distinguish between these two at search time even if you wanted to. However, when it returns the source document, the original structure is preserved. For whatever reason, the donor metadata values are all single element lists.

(I introduced this bug when I added the filter to hide objects... and that itself was kludge, to give us something at `metadata.metadata` for all entity types, so that "Has metadata?" would work in dev-search.)