### PR TITLE
Supply metadata for spiders, even when donor is missing

### DIFF
--- a/CHANGELOG-donor-missing.md
+++ b/CHANGELOG-donor-missing.md
@@ -1,0 +1,1 @@
+- Supply metadata for webspiders, even when the donor is missing.

--- a/context/app/static/js/schema.org.js
+++ b/context/app/static/js/schema.org.js
@@ -9,8 +9,8 @@ function getDatasetLD(entity) {
     const shortDonorString = `${donor.sex || '(Unknown sex)'}, ${donor.age_value || '(Unknown age)'} ${
       donor.age_unit || '(Unknown age unit)'
     } old`;
-    const heightString = `${donor.height_value || ''}${donor.height_unit || ''}`;
-    const weightString = `${donor.weight_value || ''}${donor.weight_unit || ''}`;
+    const heightString = `${donor.height_value || ''} ${donor.height_unit || ''}`;
+    const weightString = `${donor.weight_value || ''} ${donor.weight_unit || ''}`;
     const longDonorString = `${heightString}, ${weightString}, ${donor.race || ''} ${shortDonorString}`;
     const medicalHistory = donor.medicalHistory ? `${donor.medicalHistory.join(', ')}` : 'no medical history';
     name = `${assayOrganString} from ${shortDonorString}`;

--- a/context/app/static/js/schema.org.js
+++ b/context/app/static/js/schema.org.js
@@ -4,7 +4,7 @@ function getDatasetLD(entity) {
   let name = `${assayOrganString} from unknown donor`;
   let fallbackDescription = name;
 
-  const donor = entity?.donor.mapped_metadata;
+  const donor = entity.donor?.mapped_metadata;
   if (donor) {
     const shortDonorString = `${donor.sex || '(Unknown sex)'}, ${donor.age_value || '(Unknown age)'} ${
       donor.age_unit || '(Unknown age unit)'

--- a/context/app/static/js/schema.org.js
+++ b/context/app/static/js/schema.org.js
@@ -1,16 +1,21 @@
 function getDatasetLD(entity) {
   // Based on https://developers.google.com/search/docs/data-types/dataset#guidelines
-  const donor = entity.donor.mapped_metadata;
-  const shortDonorString = `${donor.sex || '(Unknown sex)'}, ${donor.age_value || '(Unknown age)'} ${
-    donor.age_unit || '(Unknown age unit)'
-  } old`;
-  const heightString = `${donor.height_value || ''}${donor.height_unit || ''}`;
-  const weightString = `${donor.weight_value || ''}${donor.weight_unit || ''}`;
-  const longDonorString = `${heightString}, ${weightString}, ${donor.race || ''} ${shortDonorString}`;
   const assayOrganString = `${entity.mapped_data_types} of ${entity.origin_sample.mapped_organ}`;
-  const medicalHistory = donor.medicalHistory ? `${donor.medicalHistory.join(', ')}` : 'no medical history';
-  const name = `${assayOrganString} from ${shortDonorString}`;
-  const fallbackDescription = `${assayOrganString} from ${longDonorString} with ${medicalHistory}`;
+  let name = `${assayOrganString} from unknown donor`;
+  let fallbackDescription = name;
+
+  const donor = entity?.donor.mapped_metadata;
+  if (donor) {
+    const shortDonorString = `${donor.sex || '(Unknown sex)'}, ${donor.age_value || '(Unknown age)'} ${
+      donor.age_unit || '(Unknown age unit)'
+    } old`;
+    const heightString = `${donor.height_value || ''}${donor.height_unit || ''}`;
+    const weightString = `${donor.weight_value || ''}${donor.weight_unit || ''}`;
+    const longDonorString = `${heightString}, ${weightString}, ${donor.race || ''} ${shortDonorString}`;
+    const medicalHistory = donor.medicalHistory ? `${donor.medicalHistory.join(', ')}` : 'no medical history';
+    name = `${assayOrganString} from ${shortDonorString}`;
+    fallbackDescription = `${assayOrganString} from ${longDonorString} with ${medicalHistory}`;
+  }
 
   return {
     '@context': 'https://schema.org/',

--- a/context/app/static/js/schema.org.spec.js
+++ b/context/app/static/js/schema.org.spec.js
@@ -1,5 +1,47 @@
 import { getDatasetLD } from './schema.org';
 
+test('full', () => {
+  const entity = {
+    mapped_data_types: ['Nifty Assay'],
+    origin_sample: {
+      mapped_organ: 'Elbow',
+    },
+    donor: {
+      mapped_metadata: {
+        sex: 'male',
+        race: 'white',
+        age_value: 44,
+        age_unit: 'years',
+        height_value: 6.25,
+        height_unit: 'feet',
+        weight_value: 135,
+        weight_unit: 'pounds',
+        medicalHistory: ['ITP', 'melanoma'],
+      },
+    },
+    created_by_user_displayname: 'Lisa',
+    group_name: 'The Simpsons',
+    description: 'too short :(',
+  };
+  expect(getDatasetLD(entity)).toEqual({
+    '@context': 'https://schema.org/',
+    '@type': 'Dataset',
+    creator: [
+      {
+        '@type': 'Person',
+        name: 'Lisa',
+      },
+      {
+        '@type': 'Organization',
+        name: 'The Simpsons',
+      },
+    ],
+    description:
+      'Nifty Assay of Elbow from 6.25 feet, 135 pounds, white male, 44 years old with ITP, melanoma. too short :(',
+    name: 'Nifty Assay of Elbow from male, 44 years old',
+  });
+});
+
 test('minimal, with donor', () => {
   const entity = {
     mapped_data_types: ['Nifty Assay'],
@@ -27,7 +69,7 @@ test('minimal, with donor', () => {
       },
     ],
     description:
-      'Nifty Assay of Elbow from , ,  (Unknown sex), (Unknown age) (Unknown age unit) old with no medical history. too short :(',
+      'Nifty Assay of Elbow from  ,  ,  (Unknown sex), (Unknown age) (Unknown age unit) old with no medical history. too short :(',
     name: 'Nifty Assay of Elbow from (Unknown sex), (Unknown age) (Unknown age unit) old',
   });
 });

--- a/context/app/static/js/schema.org.spec.js
+++ b/context/app/static/js/schema.org.spec.js
@@ -1,6 +1,6 @@
 import { getDatasetLD } from './schema.org';
 
-test('minimal', () => {
+test('minimal, with donor', () => {
   const entity = {
     mapped_data_types: ['Nifty Assay'],
     origin_sample: {
@@ -29,5 +29,33 @@ test('minimal', () => {
     description:
       'Nifty Assay of Elbow from , ,  (Unknown sex), (Unknown age) (Unknown age unit) old with no medical history. too short :(',
     name: 'Nifty Assay of Elbow from (Unknown sex), (Unknown age) (Unknown age unit) old',
+  });
+});
+
+test('no donor', () => {
+  const entity = {
+    mapped_data_types: ['Nifty Assay'],
+    origin_sample: {
+      mapped_organ: 'Elbow',
+    },
+    created_by_user_displayname: 'Lisa',
+    group_name: 'The Simpsons',
+    description: 'too short :(',
+  };
+  expect(getDatasetLD(entity)).toEqual({
+    '@context': 'https://schema.org/',
+    '@type': 'Dataset',
+    creator: [
+      {
+        '@type': 'Person',
+        name: 'Lisa',
+      },
+      {
+        '@type': 'Organization',
+        name: 'The Simpsons',
+      },
+    ],
+    description: 'Nifty Assay of Elbow from unknown donor. too short :(',
+    name: 'Nifty Assay of Elbow from unknown donor',
   });
 });


### PR DESCRIPTION
Fix #1675. Don't worry over the details too much: For #1723 , the IEC is committed to providing good descriptions on datasets, so this will all be moot.