### PR TITLE
Update the styles used in the EUI

### DIFF
--- a/CHANGELOG-eui-styles.md
+++ b/CHANGELOG-eui-styles.md
@@ -1,0 +1,1 @@
+Updated styles for CCF EUI v1.6.0

--- a/CHANGELOG-eui-styles.md
+++ b/CHANGELOG-eui-styles.md
@@ -1,1 +1,1 @@
-Updated styles for CCF EUI v1.6.0
+- Updated styles for CCF EUI v1.6.0

--- a/context/app/templates/pages/ccf-eui.html
+++ b/context/app/templates/pages/ccf-eui.html
@@ -28,8 +28,8 @@
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&amp;display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
 

--- a/context/app/templates/pages/ccf-eui.html
+++ b/context/app/templates/pages/ccf-eui.html
@@ -28,7 +28,7 @@
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500&amp;display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>


### PR DESCRIPTION
The EUI now uses Inter and includes outlined material icons. This commit aligns it with CCF-EUI v1.6.0.