### PR TITLE
Mccalluc/fix summary prop error

### DIFF
--- a/CHANGELOG-summary-prop-types.md
+++ b/CHANGELOG-summary-prop-types.md
@@ -1,0 +1,1 @@
+- Fix prop-types error on Summary.

--- a/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/Detail/MetadataTable/MetadataTable.jsx
@@ -91,7 +91,12 @@ function MetadataTable(props) {
 }
 
 MetadataTable.propTypes = {
-  metadata: PropTypes.objectOf(PropTypes.string).isRequired,
+  metadata: PropTypes.objectOf(
+    PropTypes.oneOfType(
+      // Usually a string, but placeholder metadata.metadata is an object.
+      [PropTypes.string, PropTypes.object],
+    ),
+  ).isRequired,
   display_doi: PropTypes.string.isRequired,
 };
 

--- a/context/app/static/js/components/Detail/Summary/Summary.jsx
+++ b/context/app/static/js/components/Detail/Summary/Summary.jsx
@@ -54,7 +54,7 @@ Summary.propTypes = {
   collectionName: PropTypes.string,
   mapped_data_access_level: PropTypes.string,
   entityCanBeSaved: PropTypes.bool,
-  children: PropTypes.element,
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
 };
 
 Summary.defaultProps = {

--- a/context/app/static/js/components/Detail/Summary/Summary.jsx
+++ b/context/app/static/js/components/Detail/Summary/Summary.jsx
@@ -54,7 +54,6 @@ Summary.propTypes = {
   collectionName: PropTypes.string,
   mapped_data_access_level: PropTypes.string,
   entityCanBeSaved: PropTypes.bool,
-  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.element), PropTypes.element]),
 };
 
 Summary.defaultProps = {
@@ -65,7 +64,6 @@ Summary.defaultProps = {
   mapped_data_access_level: '',
   collectionName: '',
   entityCanBeSaved: true,
-  children: undefined,
 };
 
 export default Summary;

--- a/context/app/static/js/components/Detail/SummaryData/SummaryData.jsx
+++ b/context/app/static/js/components/Detail/SummaryData/SummaryData.jsx
@@ -84,12 +84,10 @@ SummaryData.propTypes = {
   status: PropTypes.string.isRequired,
   mapped_data_access_level: PropTypes.string.isRequired,
   entityCanBeSaved: PropTypes.bool,
-  children: PropTypes.element,
 };
 
 SummaryData.defaultProps = {
   entityCanBeSaved: true,
-  children: undefined,
 };
 
 export default SummaryData;


### PR DESCRIPTION
Fix #1744. http://localhost:5001/browse/sample/cc6cec8b0cfe36d53ade47f3eaca0827 loads without proptype errors. Even if proptypes are generally a good thing, I think checks on `children` tend to bring up false positives, when you use one element instead of many, or many instead of one.