### PR TITLE
Mccalluc/support support

### DIFF
--- a/CHANGELOG-support-support.md
+++ b/CHANGELOG-support-support.md
@@ -1,0 +1,1 @@
+- UI support for new Support entity type.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -102,7 +102,7 @@ class ApiClient():
         return entity
 
     def get_vitessce_conf(self, entity):
-        # First, try "vis-lifting": Display image pyramids on their parent entity pages, if possible.
+        # First, try "vis-lifting": Display image pyramids on their parent entity pages.
         if 'descendants' in entity \
                 and len(entity['descendants']) \
                 and 'data_types' in entity['descendants'][0] \

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -102,6 +102,7 @@ class ApiClient():
         return entity
 
     def get_vitessce_conf(self, entity):
+        # First, try "vis-lifting": Display image pyramids on their parent entity pages, if possible.
         if 'descendants' in entity \
                 and len(entity['descendants']) \
                 and 'data_types' in entity['descendants'][0] \
@@ -114,6 +115,8 @@ class ApiClient():
             # there will be a period of backward compatibility to allow us to migrate.
             derived_entity['files'] = derived_entity['metadata']['files']
             return self.get_vitessce_conf(derived_entity)
+
+        # Otherwise, just try to visualize the data for the entity itself:
         if 'files' not in entity or 'data_types' not in entity:
             return {}
         if self.is_mock:

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -10,7 +10,7 @@ import frontmatter
 from .api.client import ApiClient
 
 
-entity_types = ['donor', 'sample', 'dataset', 'collection']
+entity_types = ['donor', 'sample', 'dataset', 'support', 'collection']
 blueprint = Blueprint('routes', __name__, template_folder='templates')
 
 

--- a/context/app/static/js/components/Detail/provenance/ProvTable/ProvTable.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvTable/ProvTable.jsx
@@ -18,7 +18,7 @@ function ProvTable(props) {
       acc[typesToSplit.indexOf(item.entity_type)].push(item);
       return acc;
     },
-    [[], [], [], []], // Four initial arrays for four entity types.
+    typesToSplit.map(() => []),
   );
 
   const descendantCounts = useDescendantCounts(assayMetadata, typesToSplit);

--- a/context/app/static/js/components/Detail/provenance/ProvTable/ProvTable.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvTable/ProvTable.jsx
@@ -18,7 +18,7 @@ function ProvTable(props) {
       acc[typesToSplit.indexOf(item.entity_type)].push(item);
       return acc;
     },
-    [[], [], []],
+    [[], [], [], []], // Four initial arrays for four entity types.
   );
 
   const descendantCounts = useDescendantCounts(assayMetadata, typesToSplit);

--- a/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvTabs/ProvTabs.jsx
@@ -47,7 +47,7 @@ function ProvTabs(props) {
         <StyledTabPanel value={open} index={0} pad={1}>
           <ProvTable
             uuid={uuid}
-            typesToSplit={['Donor', 'Sample', 'Dataset']}
+            typesToSplit={['Donor', 'Sample', 'Dataset', 'Support']}
             ancestors={ancestors}
             assayMetadata={assayMetadata}
           />

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -51,7 +51,7 @@ function Routes(props) {
     );
   }
 
-  if (urlPath.startsWith('/browse/dataset/')) {
+  if (urlPath.startsWith('/browse/dataset/') || urlPath.startsWith('/browse/support/')) {
     return (
       <Route>
         <Dataset assayMetadata={entity} vitData={vitessce_conf} />


### PR DESCRIPTION
Make sure the new "Support" pages work. 
- Prov-grid is a little weird, with a new group for the "Support" entity. 
- <strike>Currently, no visualization, because `files` is missing in the JSON... this seems like an index problem? https://github.com/hubmapconsortium/search-api/issues/303 </strike> Bad test data: This one works: http://localhost:5001/browse/support/f9ae931b8b49252f150d7f8bf1d2d13f
- Also have proptype errors (#1764) as well as a failure from the Entities API (#1765) -- I don't think these are related to the details of this PR.

Fix #1762 (bug I just filed)
Fix #1576 (vis-lifting high-level)
Follow up to https://github.com/hubmapconsortium/search-api/pull/267