### PR TITLE
Mccalluc/everything to all text

### DIFF
--- a/CHANGELOG-use-all-text.md
+++ b/CHANGELOG-use-all-text.md
@@ -1,0 +1,1 @@
+- Stop using `everything`: Instead, use `all_text`, and highlight matches from `description`.

--- a/context/app/static/js/components/Search/DevResults/DevResults.jsx
+++ b/context/app/static/js/components/Search/DevResults/DevResults.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ViewSwitcherHits } from 'searchkit';
 
+import { customHighlight } from 'js/components/Search/config';
+
 import ResultsTable from '../ResultsTable';
 import ResultsCCF from '../ResultsCCF';
 
@@ -28,9 +30,7 @@ function DevResults(props) {
         { key: 'ccf', title: 'CCF', listComponent: <ResultsCCF /> },
       ]}
       sourceFilter={resultFieldIds}
-      customHighlight={{
-        fields: { description: { type: 'plain' } },
-      }}
+      customHighlight={customHighlight}
     />
   );
 }

--- a/context/app/static/js/components/Search/DevResults/DevResults.jsx
+++ b/context/app/static/js/components/Search/DevResults/DevResults.jsx
@@ -29,7 +29,7 @@ function DevResults(props) {
       ]}
       sourceFilter={resultFieldIds}
       customHighlight={{
-        fields: { everything: { type: 'plain' } },
+        fields: { description: { type: 'plain' } },
       }}
     />
   );

--- a/context/app/static/js/components/Search/Results/Results.jsx
+++ b/context/app/static/js/components/Search/Results/Results.jsx
@@ -31,7 +31,7 @@ function Results(props) {
       ]}
       sourceFilter={resultFieldIds}
       customHighlight={{
-        fields: { everything: { type: 'plain' } },
+        fields: { description: { type: 'plain' } },
       }}
     />
   );

--- a/context/app/static/js/components/Search/Results/Results.jsx
+++ b/context/app/static/js/components/Search/Results/Results.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ViewSwitcherHits } from 'searchkit'; // eslint-disable-line import/no-duplicates
 
+import { customHighlight } from 'js/components/Search/config';
+
 import ResultsTable from '../ResultsTable';
 import ResultsTiles from '../ResultsTiles';
 import ResultsCCF from '../ResultsCCF';
 
 function Results(props) {
   const { sortOptions, hitsPerPage, tableResultFields, detailsUrlPrefix, idField, resultFieldIds, type } = props;
+
   // one of the sort components must stay mounted to preserve sort history between views.
   return (
     <ViewSwitcherHits
@@ -30,9 +33,7 @@ function Results(props) {
         { key: 'ccf', title: 'CCF', listComponent: <ResultsCCF type={type} /> },
       ]}
       sourceFilter={resultFieldIds}
-      customHighlight={{
-        fields: { description: { type: 'plain' } },
-      }}
+      customHighlight={customHighlight}
     />
   );
 }

--- a/context/app/static/js/components/Search/ResultsTable/ResultsTable.jsx
+++ b/context/app/static/js/components/Search/ResultsTable/ResultsTable.jsx
@@ -33,7 +33,7 @@ function ResultsTable(props) {
               <StyledTableCell colSpan={resultFields.length}>
                 <p
                   dangerouslySetInnerHTML={{
-                    __html: hit.highlight.everything.join(' ... '),
+                    __html: hit.highlight.description.join(' ... '),
                   }}
                 />
               </StyledTableCell>

--- a/context/app/static/js/components/Search/ResultsTable/ResultsTable.jsx
+++ b/context/app/static/js/components/Search/ResultsTable/ResultsTable.jsx
@@ -33,7 +33,7 @@ function ResultsTable(props) {
               <StyledTableCell colSpan={resultFields.length}>
                 <p
                   dangerouslySetInnerHTML={{
-                    __html: hit.highlight.description.join(' ... '),
+                    __html: Object.values(hit.highlight).join(' ... '),
                   }}
                 />
               </StyledTableCell>

--- a/context/app/static/js/components/Search/config.js
+++ b/context/app/static/js/components/Search/config.js
@@ -91,4 +91,9 @@ const datasetConfig = {
   },
 };
 
-export { donorConfig, sampleConfig, datasetConfig };
+const fieldsToHighlight = ['description'];
+const customHighlight = {
+  fields: Object.fromEntries(fieldsToHighlight.map((fieldName) => [fieldName, { type: 'plain' }])),
+};
+
+export { donorConfig, sampleConfig, datasetConfig, fieldsToHighlight, customHighlight };

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -4,6 +4,7 @@ import { ExistsQuery, BoolMustNot } from 'searchkit';
 import { getAuthHeader } from 'js/helpers/functions';
 import { AppContext } from 'js/components/Providers';
 import { field, listFilter, checkboxFilter, hierarchicalFilter } from 'js/components/Search/utils';
+import { fieldsToHighlight } from 'js/components/Search/config';
 import SearchWrapper from 'js/components/Search/SearchWrapper';
 import DevResults from 'js/components/Search/DevResults';
 import { SearchHeader } from './style';
@@ -75,7 +76,7 @@ function DevSearch() {
         checkboxFilter('has_previous', 'Has previous?', ExistsQuery('previous_revision_uuid')),
       ],
     },
-    queryFields: ['all_text', 'description'],
+    queryFields: ['all_text', ...fieldsToHighlight],
     isLoggedIn: Boolean(nexusToken),
   };
 

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -75,7 +75,7 @@ function DevSearch() {
         checkboxFilter('has_previous', 'Has previous?', ExistsQuery('previous_revision_uuid')),
       ],
     },
-    queryFields: ['everything'],
+    queryFields: ['all_text', 'description'],
     isLoggedIn: Boolean(nexusToken),
   };
 

--- a/context/app/static/js/pages/search/Search.jsx
+++ b/context/app/static/js/pages/search/Search.jsx
@@ -8,7 +8,7 @@ import { AppContext } from 'js/components/Providers';
 import LookupEntity from 'js/helpers/LookupEntity';
 import { getAuthHeader } from 'js/helpers/functions';
 import SearchWrapper from 'js/components/Search/SearchWrapper';
-import { donorConfig, sampleConfig, datasetConfig } from 'js/components/Search/config';
+import { donorConfig, sampleConfig, datasetConfig, fieldsToHighlight } from 'js/components/Search/config';
 import { listFilter } from 'js/components/Search/utils';
 import AncestorNote from 'js/components/Search/AncestorNote';
 import Results from 'js/components/Search/Results';
@@ -79,7 +79,7 @@ function Search(props) {
     type,
     // Sidebar facet configuration:
     filters: filtersByType[type],
-    queryFields: ['all_text', 'description'],
+    queryFields: ['all_text', ...fieldsToHighlight],
     isLoggedIn: Boolean(nexusToken),
     apiUrl: elasticsearchEndpoint,
     defaultQuery: BoolMustNot(ExistsQuery('next_revision_uuid')),

--- a/context/app/static/js/pages/search/Search.jsx
+++ b/context/app/static/js/pages/search/Search.jsx
@@ -79,7 +79,7 @@ function Search(props) {
     type,
     // Sidebar facet configuration:
     filters: filtersByType[type],
-    queryFields: ['everything'],
+    queryFields: ['all_text', 'description'],
     isLoggedIn: Boolean(nexusToken),
     apiUrl: elasticsearchEndpoint,
     defaultQuery: BoolMustNot(ExistsQuery('next_revision_uuid')),


### PR DESCRIPTION
This builds on [earlier work in `search-api`](https://github.com/hubmapconsortium/search-api/pull/283/files#diff-e855724d0ae950616ef6c6ea7a3923e655591f3dbf74e5b8bb5a2d8d5a9b9b4dR15) -- We now have field, `all_text`, which is indexed but not stored. We can use it as the target for search, but to get highlighting, he also need to specify one or more additional stored fields. 

This PR does that, and in `config.js` specifies that  we are only interested in highlighting matches from the `description` field. One consequence of this is some searches will not produce highlighted matches. There are a couple ways of looking at this:
- When the match is against a short field, just showing me the value isn't a big gain. ie, if I search for "liver" and the only match is the organ, it's not doing much for the user just to print out an additional line with "liver" in bold for each search result.
- If there are additional fields we would like to search, we can add them to `fieldsToHighlight`... but [we want to minimize the number of fields we search](https://www.elastic.co/guide/en/elasticsearch/reference/current/tune-for-search-speed.html#search-as-few-fields-as-possible).
- Or, alternatively, if we really want to be able to highlight on every hit, we could make `all_text` a stored field. We'd lose the space savings in the index that were an original motivation, but it would still simplify the the index-time python, so it's not an unreasonable approach.

I'm happy with this PR as-is... but you might not be, and that would be good feedback.