### PR TITLE
Add cloudwatch to routine

### DIFF
--- a/CHANGELOG-cloudwatch.md
+++ b/CHANGELOG-cloudwatch.md
@@ -1,0 +1,1 @@
+- Add a check on Cloudwatch to the deployment routine.

--- a/README-deploy-qa.md
+++ b/README-deploy-qa.md
@@ -3,6 +3,7 @@
 ## Deployment
 
 Monday/Wednesday, before 5pm:
+*   **John/Ilan** will review warnings from the portal in CloudWatch, and triage as approapriate. There should be no errors we get used to ignoring.
 *   **John/Ilan** will look at [portal PRs](https://github.com/hubmapconsortium/portal-ui/pulls), and nudge people to merge approved PRs, or get approvals on older PRs. 
 
 Monday/Wednesday, after 5pm: (Or any time that Nils asks for a release...)


### PR DESCRIPTION
IEC has set us up with CloudWatch: #1707. Unless you really want more direction, I'm not planning to log in to AWS myself, so how to go about this is up to you. I'll also leave it to you two to decide whether you want to have a shared dashboard/queries, or whether you each have your own, and maybe spot different issues.

Let me know if you think I should be more involved?