### PR TITLE
Add client methods to fetch all data types with visualizations

### DIFF
--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -208,13 +208,13 @@ class ApiClient():
     def get_assays_with_visualizations(self):
         tc = TypeClient(current_app.config["TYPE_SERVICE_ENDPOINT"])
         assays_with_visualizations = []
-        assays = [assay.name for assay in tc.iterAssays()]
+        assays = [assay for assay in tc.iterAssays()]
         for assay in assays:
-            entity = self.get_most_recent_dataset_for_assay(assay)
+            entity = self.get_most_recent_dataset_for_assay(assay.name)
             if entity:
                 vc = self.get_vitessce_conf(entity)
                 if any(vc):
-                    assays_with_visualizations.append(assay)
+                    assays_with_visualizations.append(assay.description)
         return assays_with_visualizations
 
 

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -51,6 +51,8 @@ def index():
 @blueprint.route('/home-revision')
 def home_revision():
     flask_data = {'endpoints': _get_endpoints()}
+    client = _get_client()
+    print(client.get_assays_with_visualizations())
     return render_template(
         'pages/base_react.html',
         types=entity_types,

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -51,8 +51,6 @@ def index():
 @blueprint.route('/home-revision')
 def home_revision():
     flask_data = {'endpoints': _get_endpoints()}
-    client = _get_client()
-    print(client.get_assays_with_visualizations())
     return render_template(
         'pages/base_react.html',
         types=entity_types,

--- a/context/app/static/js/components/home-revision/CarouselButton/CarouselButton.jsx
+++ b/context/app/static/js/components/home-revision/CarouselButton/CarouselButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+
+function CarouselButton({ href, ...props }) {
+  return (
+    <Button variant="outlined" color="primary" component="a" href={href} {...props}>
+      Get Started
+    </Button>
+  );
+}
+
+export default CarouselButton;

--- a/context/app/static/js/components/home-revision/CarouselButton/index.js
+++ b/context/app/static/js/components/home-revision/CarouselButton/index.js
@@ -1,0 +1,3 @@
+import CarouselButton from './CarouselButton';
+
+export default CarouselButton;

--- a/context/app/static/js/components/home-revision/ImageCarouselCallToAction/ImageCarouselCallToAction.jsx
+++ b/context/app/static/js/components/home-revision/ImageCarouselCallToAction/ImageCarouselCallToAction.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import Typography from '@material-ui/core/Typography';
+
+import CarouselButton from 'js/components/home-revision/CarouselButton';
 import { StyledTypography } from './style';
 
-function ImageCarouselCallToAction({ title, body }) {
+function ImageCarouselCallToAction({ title, body, buttonHref }) {
   return (
     <div>
       <StyledTypography variant="h3">{title}</StyledTypography>
-      <Typography variant="h6" component="p">
+      <StyledTypography variant="h6" component="p">
         {body}
-      </Typography>
+      </StyledTypography>
+      <CarouselButton href={buttonHref} />
     </div>
   );
 }

--- a/context/app/static/js/components/home-revision/ImageCarouselContainer/ImageCarouselContainer.jsx
+++ b/context/app/static/js/components/home-revision/ImageCarouselContainer/ImageCarouselContainer.jsx
@@ -17,7 +17,22 @@ import CCFSlide1392w from 'portal-images/ccf-slide-1392w.png';
 import ImageCarousel from '../ImageCarousel';
 import ImageCarouselControlButtons from '../ImageCarouselControlButtons';
 import ImageCarouselCallToAction from '../ImageCarouselCallToAction';
+import { getMappedDataTypesParams } from './utils';
 import { Flex, CallToActionWrapper } from './style';
+
+const assaysWithVisualizations = [
+  'Autofluorescence Microscopy',
+  'CODEX [Cytokit + SPRM]',
+  'Imaging Mass Cytometry',
+  'MALDI IMS negative',
+  'MALDI IMS positive',
+  'PAS Stained Microscopy',
+  'scRNA-seq (10x Genomics) [Salmon]',
+  'sciATAC-seq [SnapATAC]',
+  'seqFISH',
+  'snATAC-seq [SnapATAC]',
+  'snRNA-seq [Salmon]',
+];
 
 function ImageCarouselContainer() {
   const slides = [
@@ -34,6 +49,7 @@ function ImageCarouselContainer() {
           alt="Vitessce"
         />
       ),
+      buttonHref: `/search?entity_type[0]=Dataset${getMappedDataTypesParams(assaysWithVisualizations)}`,
     },
     {
       title: 'Navigate healthy human cells with the Common Coordinate Framework',
@@ -48,6 +64,7 @@ function ImageCarouselContainer() {
           alt="CCF Portal"
         />
       ),
+      buttonHref: 'https://hubmapconsortium.github.io/ccf/',
     },
     {
       title: 'Analyze single-cell RNA-seq experiments with Azimuth',
@@ -62,15 +79,16 @@ function ImageCarouselContainer() {
           alt="Azimuth"
         />
       ),
+      buttonHref: 'https://azimuth.hubmapconsortium.org/',
     },
   ];
   // Set random intial image index:
   const [selectedImageIndex, setSelectedImageIndex] = useState(Math.floor(Math.random() * slides.length));
-  const { title, body } = slides[selectedImageIndex];
+  const { title, body, buttonHref } = slides[selectedImageIndex];
   return (
     <Flex>
       <CallToActionWrapper>
-        <ImageCarouselCallToAction title={title} body={body} />
+        <ImageCarouselCallToAction title={title} body={body} buttonHref={buttonHref} />
         <ImageCarouselControlButtons
           selectedImageIndex={selectedImageIndex}
           setSelectedImageIndex={setSelectedImageIndex}

--- a/context/app/static/js/components/home-revision/ImageCarouselContainer/utils.js
+++ b/context/app/static/js/components/home-revision/ImageCarouselContainer/utils.js
@@ -1,0 +1,8 @@
+function getMappedDataTypesParams(mappedDataTypes) {
+  const queryParams = mappedDataTypes.map(
+    (mappedDataType, i) => `&mapped_data_types[${i}]=${encodeURIComponent(mappedDataType)}`,
+  );
+  return queryParams.join('');
+}
+
+export { getMappedDataTypesParams };


### PR DESCRIPTION
Currently returns `['AF', 'codex_cytokit', 'IMC', 'MALDI-IMS-neg', 'MALDI-IMS-pos', 'PAS', 'salmon_rnaseq_10x', 'sc_atac_seq_sci', 'seqFish', 'sn_atac_seq', 'salmon_sn_rnaseq_10x']`

I've only attached the method to the `/home-revision` endpoint for debugging. Ideally we'd like to rework this as a script which can write the assay types to a file, but I'm having issues providing an app context for it to work similar to the pytest fixtures in `test_routes_main.py` and `test_routes_errors.py`.