### PR TITLE
Explanatory warning at the top of support pages

### DIFF
--- a/CHANGELOG-support-warning.md
+++ b/CHANGELOG-support-warning.md
@@ -1,0 +1,1 @@
+- Add an explanatory warning at the top of Support pages.

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -110,6 +110,12 @@ function DatasetDetail(props) {
           </span>
         </Alert>
       )}
+      {entity_type === 'Support' && (
+        <Alert severity="warning" $marginBottom="16">
+          “Support” entities provide derived, low-level data for visualizations. Navigate to a parent entity for a view
+          of this information in context.
+        </Alert>
+      )}
       <DetailLayout sectionOrder={sectionOrder}>
         <Summary
           uuid={uuid}


### PR DESCRIPTION
Fix #1805. The exact language wasn't specified... Does this seem good?

(While it might not be too hard to have a link to the parent, I'd prefer to do the simplest thing, until it's clear that we need something more complex.)