### PR TITLE
Show type derived from

### DIFF
--- a/CHANGELOG-derived-from-type.md
+++ b/CHANGELOG-derived-from-type.md
@@ -1,0 +1,1 @@
+- On a derived search, show the assay type it is derived from.

--- a/context/app/static/js/components/Search/AncestorNote.jsx
+++ b/context/app/static/js/components/Search/AncestorNote.jsx
@@ -11,9 +11,11 @@ function AncestorNote(props) {
   if (entity) {
     const { entity_type, uuid, display_doi } = entity;
     const lcType = entity_type.toLowerCase();
+    const dataTypes = (entity?.mapped_data_types || []).join('/');
     message = (
       <>
-        Derived from {lcType} <LightBlueLink href={`/browse/${lcType}/${uuid}`}>{display_doi}</LightBlueLink>
+        Derived from {dataTypes} {lcType}{' '}
+        <LightBlueLink href={`/browse/${lcType}/${uuid}`}>{display_doi}</LightBlueLink>
       </>
     );
   }


### PR DESCRIPTION
Fix #1802. If it's a Donor or Sample, there won't be anything in the slot, but extra spaces are collapsed when the browser renders it.

One small point: The assay types are capitalized, so maybe we don't need to lowercase the entity type? I don't care strongly.