### PR TITLE
Remove return_empty_json_if_error

### DIFF
--- a/CHANGELOG-vitessce-try-catch.md
+++ b/CHANGELOG-vitessce-try-catch.md
@@ -1,0 +1,1 @@
+- Remove the try-catch around Vitessce view-conf code.

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -22,8 +22,7 @@ from .base_confs import (
     ImagePyramidViewConf,
     SPRMJSONViewConf,
     SPRMAnnDataViewConf,
-    ViewConf,
-    return_empty_json_if_error
+    ViewConf
 )
 from .assays import (
     SEQFISH,
@@ -44,8 +43,6 @@ from .paths import (
 
 
 class SeqFISHViewConf(ImagingViewConf):
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         full_seqfish_reqex = "/".join(
@@ -102,8 +99,6 @@ class CytokitSPRMViewConfigError(Exception):
 
 
 class TiledSPRMConf(ViewConf):
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_tiles = get_matches(
@@ -170,7 +165,6 @@ class ATACSeqConf(ScatterplotViewConf):
 
 
 class StitchedCytokitSPRMConf(ViewConf):
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_regions = get_matches(file_paths_found, STITCHED_REGEX)
@@ -199,8 +193,6 @@ class StitchedCytokitSPRMConf(ViewConf):
 
 
 class RNASeqAnnDataZarrConf(ViewConf):
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         zarr_path = 'hubmap_ui/anndata-zarr/secondary_analysis.zarr'
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
@@ -249,8 +241,6 @@ class IMSConf(ImagePyramidViewConf):
 
 
 class NullConf():
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         return {}
 

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -1,7 +1,6 @@
 import urllib
 from pathlib import Path
 import re
-import traceback
 
 from flask import current_app
 from vitessce import (

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -20,21 +20,6 @@ from .paths import SPRM_JSON_DIR, IMAGE_PYRAMID_DIR, OFFSETS_DIR
 MOCK_URL = "https://example.com"
 
 
-def return_empty_json_if_error(func):
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception:
-            class_obj = args[0]
-            if not class_obj._is_mock:
-                current_app.logger.error(
-                    f"Building vitessce conf threw error: {traceback.format_exc()}"
-                )
-            return {}
-
-    return wrapper
-
-
 class ViewConf:
     def __init__(self, entity=None, nexus_token=None, is_mock=False):
         """Object for building the vitessce configuration.
@@ -132,7 +117,6 @@ class ImagePyramidViewConf(ImagingViewConf):
         self.image_pyramid_regex = IMAGE_PYRAMID_DIR
         super().__init__(entity, nexus_token, is_mock)
 
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_images = get_matches(
@@ -165,7 +149,6 @@ class ImagePyramidViewConf(ImagingViewConf):
 
 
 class ScatterplotViewConf(ViewConf):
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_expected = [file["rel_path"] for file in self._files]
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
@@ -211,7 +194,6 @@ class SPRMJSONViewConf(ImagingViewConf):
             },
         ]
 
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         image_file = f"{self._imaging_path}/{self._base_name}.ome.tiff"
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
@@ -262,7 +244,6 @@ class SPRMAnnDataViewConf(ImagePyramidViewConf):
         self._base_name = kwargs["base_name"]
         self._imaging_path = kwargs["imaging_path"]
 
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         image_file = f"{self.image_pyramid_regex}/{self._imaging_path}/{self._base_name}.ome.tiff"
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]


### PR DESCRIPTION
Fix #1645

This is a judgement call, so push back if you don't think it's wise. Justifications:
- The same reasons that we don't want to use try-catch to silently ignore all errors.
- While you and John are watching the logs now, that's an after-the-fact notice, and I think you're only looking at PROD: Is there's a problem with a new unpublished dataset, we want the problem to be unignorable.
- There are lots of places where we do depend on particular structures in API responses, and we have had errors when our assumptions were wrong... and that has forced us to fix our code, or get fixes into the APIs.
