### PR TITLE
If there is a problem generating vitessce conf, show an error in the UI

### DIFF
--- a/CHANGELOG-make-vitessce-louder.md
+++ b/CHANGELOG-make-vitessce-louder.md
@@ -1,0 +1,1 @@
+- If there is a problem generating vitessce conf, show an error in the UI.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -114,11 +114,12 @@ class ApiClient():
             derived_entity['files'] = derived_entity['metadata']['files']
             return self.get_vitessce_conf(derived_entity)
 
-        # Otherwise, just try to visualize the data for the entity itself:
         if 'files' not in entity or 'data_types' not in entity:
-            return {}
+            return None
         if self.is_mock:
             return self._get_mock_vitessce_conf()
+
+        # Otherwise, just try to visualize the data for the entity itself:
         try:
             vc = get_view_config_class_for_data_types(
                 entity=entity, nexus_token=self.nexus_token
@@ -129,7 +130,17 @@ class ApiClient():
             current_app.logger.error(
                 f'Building vitessce conf threw error: {traceback.format_exc()}'
             )
-            return {}
+            message = 'Error in Vitessce configuration. Please copy the URL and report this to help@hubmapconsortium.org.'
+            return {
+                'name': 'Vitessce error',
+                'version': '0.1.0',
+                'layers': [],
+                "staticLayout": [{
+                    "component": "description",
+                    "props": {"description": message},
+                    "x": 2, "y": 1, "w": 8, "h": 1,
+                }]
+            }
 
     def _get_mock_vitessce_conf(self):
         cellsData = json.dumps({'cell-id-1': {'mappings': {'t-SNE': [1, 1]}}})

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -127,20 +127,9 @@ class ApiClient():
             conf = vc.build_vitessce_conf()
             return conf
         except Exception:
-            current_app.logger.error(
-                f'Building vitessce conf threw error: {traceback.format_exc()}'
-            )
-            message = 'Error in Vitessce configuration. Please copy the URL and report this to help@hubmapconsortium.org.'
-            return {
-                'name': 'Vitessce error',
-                'version': '0.1.0',
-                'layers': [],
-                "staticLayout": [{
-                    "component": "description",
-                    "props": {"description": message},
-                    "x": 2, "y": 1, "w": 8, "h": 1,
-                }]
-            }
+            message = f'Building vitessce conf threw error: {traceback.format_exc()}'
+            current_app.logger.error(message)
+            return {'error': message}
 
     def _get_mock_vitessce_conf(self):
         cellsData = json.dumps({'cell-id-1': {'mappings': {'t-SNE': [1, 1]}}})

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -22,8 +22,7 @@ from .base_confs import (
     ImagePyramidViewConf,
     SPRMJSONViewConf,
     SPRMAnnDataViewConf,
-    ViewConf,
-    return_empty_json_if_error
+    ViewConf
 )
 from .assays import (
     SEQFISH,
@@ -44,8 +43,6 @@ from .paths import (
 
 
 class SeqFISHViewConf(ImagingViewConf):
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         full_seqfish_reqex = "/".join(
@@ -102,8 +99,6 @@ class CytokitSPRMViewConfigError(Exception):
 
 
 class TiledSPRMConf(ViewConf):
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_tiles = get_matches(
@@ -170,7 +165,6 @@ class ATACSeqConf(ScatterplotViewConf):
 
 
 class StitchedCytokitSPRMConf(ViewConf):
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_regions = get_matches(file_paths_found, STITCHED_REGEX)
@@ -199,8 +193,6 @@ class StitchedCytokitSPRMConf(ViewConf):
 
 
 class RNASeqAnnDataZarrConf(ViewConf):
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         zarr_path = 'hubmap_ui/anndata-zarr/secondary_analysis.zarr'
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
@@ -249,10 +241,8 @@ class IMSConf(ImagePyramidViewConf):
 
 
 class NullConf():
-
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
-        return {}
+        return None
 
 
 _assays = None

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -1,7 +1,6 @@
 import urllib
 from pathlib import Path
 import re
-import traceback
 
 from flask import current_app
 from vitessce import (

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -20,21 +20,6 @@ from .paths import SPRM_JSON_DIR, IMAGE_PYRAMID_DIR, OFFSETS_DIR
 MOCK_URL = "https://example.com"
 
 
-def return_empty_json_if_error(func):
-    def wrapper(*args, **kwargs):
-        try:
-            return func(*args, **kwargs)
-        except Exception:
-            class_obj = args[0]
-            if not class_obj._is_mock:
-                current_app.logger.error(
-                    f"Building vitessce conf threw error: {traceback.format_exc()}"
-                )
-            return {}
-
-    return wrapper
-
-
 class ViewConf:
     def __init__(self, entity=None, nexus_token=None, is_mock=False):
         """Object for building the vitessce configuration.
@@ -132,7 +117,6 @@ class ImagePyramidViewConf(ImagingViewConf):
         self.image_pyramid_regex = IMAGE_PYRAMID_DIR
         super().__init__(entity, nexus_token, is_mock)
 
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_images = get_matches(
@@ -165,7 +149,6 @@ class ImagePyramidViewConf(ImagingViewConf):
 
 
 class ScatterplotViewConf(ViewConf):
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         file_paths_expected = [file["rel_path"] for file in self._files]
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
@@ -211,7 +194,6 @@ class SPRMJSONViewConf(ImagingViewConf):
             },
         ]
 
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         image_file = f"{self._imaging_path}/{self._base_name}.ome.tiff"
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
@@ -262,7 +244,6 @@ class SPRMAnnDataViewConf(ImagePyramidViewConf):
         self._base_name = kwargs["base_name"]
         self._imaging_path = kwargs["imaging_path"]
 
-    @return_empty_json_if_error
     def build_vitessce_conf(self):
         image_file = f"{self.image_pyramid_regex}/{self._imaging_path}/{self._base_name}.ome.tiff"
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]

--- a/context/app/api/vitessce_confs/test_confs.py
+++ b/context/app/api/vitessce_confs/test_confs.py
@@ -2,6 +2,8 @@ import json
 from pathlib import Path
 import re
 
+import pytest
+
 from .base_confs import ImagePyramidViewConf, SPRMJSONViewConf
 from .assay_confs import (
     SeqFISHViewConf,
@@ -83,6 +85,5 @@ def test_assays():
             vc = AssayViewConfClass(
                 entity=malformed_entity, nexus_token=MOCK_NEXUS_TOKEN, is_mock=True
             )
-        conf = vc.build_vitessce_conf()
-        conf_expected = {}
-        assert conf_expected == conf
+        with pytest.raises(FileNotFoundError):
+            vc.build_vitessce_conf()

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -75,8 +75,12 @@ function DatasetDetail(props) {
   const allCollections = useCollectionsData(elasticsearchEndpoint, nexusToken);
   const collectionsData = getCollectionsWhichContainDataset(uuid, allCollections);
 
+  const shouldDisplayVisualization = vitData && ('name' in vitData || (vitData[0] && 'name' in vitData[0]));
+  if (vitData && !shouldDisplayVisualization) {
+    throw Error('Vitessce config does not have expected structure');
+  }
   const shouldDisplaySection = {
-    visualization: 'name' in vitData || (vitData[0] && 'name' in vitData[0]),
+    visualization: shouldDisplayVisualization,
     protocols: Boolean(protocol_url),
     metadata: metadata && 'metadata' in metadata,
     files: true,

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -75,12 +75,8 @@ function DatasetDetail(props) {
   const allCollections = useCollectionsData(elasticsearchEndpoint, nexusToken);
   const collectionsData = getCollectionsWhichContainDataset(uuid, allCollections);
 
-  const shouldDisplayVisualization = vitData && ('name' in vitData || (vitData[0] && 'name' in vitData[0]));
-  if (vitData && !shouldDisplayVisualization) {
-    throw Error('Vitessce config does not have expected structure');
-  }
   const shouldDisplaySection = {
-    visualization: shouldDisplayVisualization,
+    visualization: Boolean(vitData),
     protocols: Boolean(protocol_url),
     metadata: metadata && 'metadata' in metadata,
     files: true,


### PR DESCRIPTION
Fix #1645

- No longer return `{}` as a placeholder -- Semantics were ambiguous.
  - If there is no visualization, return `None`
  - If there is an error, raise it, and at `client.py:129` return a valid vitessce conf with a user-facing message.
- Remove `@return_empty_json_if_error`: Just let the error go up to `client.py:129`: This avoids needing to copy-and-paste boilerplate with new subclasses.
- In `Dataset.jsx` throw an error if we get and invalid vitessce conf. We do not expect to see `{}` any longer.

If this still doesn't seem right, please push back!