### PR TITLE
Kludge for Safari text color

### DIFF
--- a/CHANGELOG-safari-text-color.md
+++ b/CHANGELOG-safari-text-color.md
@@ -1,0 +1,1 @@
+- Add CSS `!important` to fix a problem with rendering on Safari.

--- a/context/app/static/js/components/tutorials/DatasetSearchPrompt/style.js
+++ b/context/app/static/js/components/tutorials/DatasetSearchPrompt/style.js
@@ -32,7 +32,6 @@ const StyledInfoIcon = styled(InfoIcon)`
 `;
 
 const StyledButton = styled(Button)`
-  color: #fff !important; // Safari sees the color, but doesn't always respect it unless forced.
   padding: 6px 36px;
 `;
 

--- a/context/app/static/js/components/tutorials/DatasetSearchPrompt/style.js
+++ b/context/app/static/js/components/tutorials/DatasetSearchPrompt/style.js
@@ -32,7 +32,7 @@ const StyledInfoIcon = styled(InfoIcon)`
 `;
 
 const StyledButton = styled(Button)`
-  color: #fff !important; // Chrome sees the color, but doesn't always respect it unless forced.
+  color: #fff !important; // Safari sees the color, but doesn't always respect it unless forced.
   padding: 6px 36px;
 `;
 

--- a/context/app/static/js/components/tutorials/DatasetSearchPrompt/style.js
+++ b/context/app/static/js/components/tutorials/DatasetSearchPrompt/style.js
@@ -32,6 +32,7 @@ const StyledInfoIcon = styled(InfoIcon)`
 `;
 
 const StyledButton = styled(Button)`
+  color: #fff !important; // Chrome sees the color, but doesn't always respect it unless forced.
   padding: 6px 36px;
 `;
 


### PR DESCRIPTION
I feel like at the root, it's a safari bug: When I go to dev tools, it does list the color as `#fff`, and I think the rendering has fixed itself while I was inspecting, without making any actual changes. Fix #1790.