### PR TITLE
Fix Submodule Pulls for Deployment

### DIFF
--- a/CHANGELOG-fix-submodule-pulls.md
+++ b/CHANGELOG-fix-submodule-pulls.md
@@ -1,0 +1,1 @@
+- Add `git checkout main` to the deployment process for pulling new submodule repos.

--- a/push.sh
+++ b/push.sh
@@ -9,7 +9,7 @@ git pull
 
 git submodule foreach '
   echo "was:" `git rev-parse HEAD`
-  git checkout master
+  git checkout master || git checkout main
   git pull
   echo "now:" `git rev-parse HEAD`
 '


### PR DESCRIPTION
`portal-images` uses `main` not `master`.  We'll be migrating all of our repos now but for now this provides a hot-fix.