### PR TITLE
John conroy/fix master changelog test

### DIFF
--- a/CHANGELOG-fix-master-changelog-test.md
+++ b/CHANGELOG-fix-master-changelog-test.md
@@ -1,0 +1,1 @@
+- Fix changelog test for master build.

--- a/test.sh
+++ b/test.sh
@@ -23,7 +23,7 @@ start changelog
 echo "GITHUB_REF: $GITHUB_REF"
 echo "GITHUB_HEAD_REF: $GITHUB_HEAD_REF"
 echo "GITHUB_BASE_REF: $GITHUB_BASE_REF"
-if [ "$GITHUB_BASE_REF" != 'master' ] && [[ "$GITHUB_REF" != *'dependabot'* ]]; then
+if [ "$GITHUB_REF" != 'refs/heads/master' ] && [[ "$GITHUB_REF" != *'dependabot'* ]]; then
   git remote set-branches --add origin master
   git fetch
   # "--stat=1000" ensures that filenames are not truncated. 


### PR DESCRIPTION
Fixing `test.sh` issue introduced by a dependabot change causing master builds to fail without a changelog (should pass).