### PR TITLE
Mccalluc/serve notebooks plus introspection

### DIFF
--- a/CHANGELOG-notebook.md
+++ b/CHANGELOG-notebook.md
@@ -1,0 +1,1 @@
+- Add an endpoint which serves a Jupyter notebook with the viewconf for a dataset.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -105,7 +105,7 @@ class ApiClient():
         entity = hits[0]['_source']
         return entity
 
-    def get_vitessce_conf(self, entity):
+    def get_vitessce_conf_cells(self, entity):
         # First, try "vis-lifting": Display image pyramids on their parent entity pages.
         image_pyramid_descendants = _get_image_pyramid_descendants(entity)
         if image_pyramid_descendants:
@@ -116,20 +116,19 @@ class ApiClient():
             # about "files". Bill confirms that when the new structure comes in
             # there will be a period of backward compatibility to allow us to migrate.
             derived_entity['files'] = derived_entity['metadata']['files']
-            return self.get_vitessce_conf(derived_entity)
+            return self.get_vitessce_conf_cells(derived_entity)
 
         if 'files' not in entity or 'data_types' not in entity:
             return None
         if self.is_mock:
-            return self._get_mock_vitessce_conf()
+            return self._get_mock_vitessce_conf_cells()
 
         # Otherwise, just try to visualize the data for the entity itself:
         try:
             vc = get_view_config_class_for_data_types(
                 entity=entity, nexus_token=self.nexus_token
             )
-            conf = vc.build_vitessce_conf()
-            return conf
+            return vc.build_vitessce_conf_cells()
         except Exception:
             message = f'Building vitessce conf threw error: {traceback.format_exc()}'
             current_app.logger.error(message)

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -2,6 +2,7 @@ import urllib
 from pathlib import Path
 import re
 
+import nbformat
 from flask import current_app
 from vitessce import (
     VitessceConfig,
@@ -119,7 +120,10 @@ class ImagePyramidViewConf(ImagingViewConf):
         self.image_pyramid_regex = IMAGE_PYRAMID_DIR
         super().__init__(entity, nexus_token, is_mock)
 
-    def build_vitessce_conf(self):
+    def build_vitessce_conf_cells(self):
+        cells = [
+            nbformat.v4.new_code_cell('# TODO: vitessce_conf = ...')
+        ]
         file_paths_found = self._get_file_paths()
         found_images = get_matches(
             file_paths_found, self.image_pyramid_regex + r".*\.ome\.tiff?$",
@@ -147,7 +151,7 @@ class ImagePyramidViewConf(ImagingViewConf):
         conf = vc.to_dict()
         # Don't want to render all layers
         del conf["datasets"][0]["files"][0]["options"]["renderLayers"]
-        return conf
+        return (conf, cells)
 
 
 class ScatterplotViewConf(ViewConf):

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,3 +1,4 @@
+from context.app.api import vitessce_confs
 from os.path import dirname
 from urllib.parse import urlparse
 import json
@@ -122,9 +123,19 @@ def details_notebook(type, uuid):
         abort(404)
     client = _get_client()
     entity = client.get_entity(uuid)
+    vitessce_conf = client.get_vitessce_conf(entity)
+    if vitessce_conf is None:
+        abort(404)
     nb = nbformat.v4.new_notebook()
-    nb['cells'] = [nbformat.v4.new_markdown_cell('hello world!'),
-                   nbformat.v4.new_code_cell('2 + 2')]
+    nb['cells'] = [
+        nbformat.v4.new_markdown_cell(f"""
+Visualization for [{entity['display_doi']}]({request.base_url.replace('.ipynb','')})
+        """.strip()),
+        nbformat.v4.new_code_cell('% pip install vitessce==0.1.0a9'),
+        nbformat.v4.new_code_cell('import vitessce'),
+        nbformat.v4.new_code_cell(f'vitessce_conf = {vitessce_conf}'),
+        nbformat.v4.new_code_cell('# TODO: Render!')
+    ]
     return Response(
         response=nbformat.writes(nb),
         headers={'Content-Disposition': f"attachment; filename={entity['display_doi']}.ipynb"},

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -96,7 +96,7 @@ def details(type, uuid):
     flask_data = {
         'endpoints': _get_endpoints(),
         'entity': entity,
-        'vitessce_conf': client.get_vitessce_conf(entity)
+        'vitessce_conf': client.get_vitessce_conf_cells(entity)[0]
     }
     return render_template(
         template,
@@ -122,8 +122,8 @@ def details_notebook(type, uuid):
         abort(404)
     client = _get_client()
     entity = client.get_entity(uuid)
-    vitessce_conf = client.get_vitessce_conf(entity)
-    if vitessce_conf is None:
+    vitessce_cells = client.get_vitessce_conf_cells(entity)[1]
+    if vitessce_cells is None:
         abort(404)
     nb = nbformat.v4.new_notebook()
     nb['cells'] = [
@@ -135,8 +135,8 @@ Visualization for [{entity['display_doi']}]({request.base_url.replace('.ipynb','
             '!jupyter nbextension install --py --sys-prefix vitessce',
             '!jupyter nbextension enable --py --sys-prefix vitessce'
         ])),
-        nbformat.v4.new_code_cell('from vitessce import VitessceConfig'),
-        nbformat.v4.new_code_cell(f'vitessce_conf = {vitessce_conf}'),
+        nbformat.v4.new_code_cell('from vitessce import VitessceConfig')
+    ] + vitessce_cells + [
         nbformat.v4.new_code_cell('vc = VitessceConfig.from_dict(vitessce_conf)'),
         nbformat.v4.new_code_cell('vw = vc.widget()'),
         nbformat.v4.new_code_cell('vw')

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,6 +1,7 @@
 from os.path import dirname
 from urllib.parse import urlparse
 import json
+import nbformat
 
 from flask import (Blueprint, render_template, abort, current_app,
                    session, request, redirect, url_for, Response)
@@ -107,7 +108,7 @@ def details(type, uuid):
 
 
 @blueprint.route('/browse/<type>/<uuid>.json')
-def details_ext(type, uuid):
+def details_json(type, uuid):
     if type not in entity_types:
         abort(404)
     client = _get_client()
@@ -115,8 +116,21 @@ def details_ext(type, uuid):
     return entity
 
 
+@blueprint.route('/browse/<type>/<uuid>.ipynb')
+def details_notebook(type, uuid):
+    if type not in entity_types:
+        abort(404)
+    client = _get_client()
+    entity = client.get_entity(uuid)
+    nb = nbformat.v4.new_notebook()
+    nb['cells'] = [nbformat.v4.new_markdown_cell('hello world!'),
+                   nbformat.v4.new_code_cell('2 + 2')]
+    nb_json = nbformat.writes(nb)
+    return nb_json
+
+
 @blueprint.route('/browse/<type>/<uuid>.rui.json')
-def details_rui_ext(type, uuid):
+def details_rui_json(type, uuid):
     # Note that the API returns a blob of JSON as a string,
     # so, to return a JSON object, and not just a string, we need to decode.
     if type not in entity_types:

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -125,8 +125,11 @@ def details_notebook(type, uuid):
     nb = nbformat.v4.new_notebook()
     nb['cells'] = [nbformat.v4.new_markdown_cell('hello world!'),
                    nbformat.v4.new_code_cell('2 + 2')]
-    nb_json = nbformat.writes(nb)
-    return nb_json
+    return Response(
+        response=nbformat.writes(nb),
+        headers={'Content-Disposition': f"attachment; filename={entity['display_doi']}.ipynb"},
+        mimetype='application/x-ipynb+json'
+    )
 
 
 @blueprint.route('/browse/<type>/<uuid>.rui.json')

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -130,10 +130,16 @@ def details_notebook(type, uuid):
         nbformat.v4.new_markdown_cell(f"""
 Visualization for [{entity['display_doi']}]({request.base_url.replace('.ipynb','')})
         """.strip()),
-        nbformat.v4.new_code_cell('% pip install vitessce==0.1.0a9'),
-        nbformat.v4.new_code_cell('import vitessce'),
+        nbformat.v4.new_code_cell('\n'.join([
+            '!pip install vitessce==0.1.0a9',
+            '!jupyter nbextension install --py --sys-prefix vitessce',
+            '!jupyter nbextension enable --py --sys-prefix vitessce'
+        ])),
+        nbformat.v4.new_code_cell('from vitessce import VitessceConfig'),
         nbformat.v4.new_code_cell(f'vitessce_conf = {vitessce_conf}'),
-        nbformat.v4.new_code_cell('# TODO: Render!')
+        nbformat.v4.new_code_cell('vc = VitessceConfig.from_dict(vitessce_conf)'),
+        nbformat.v4.new_code_cell('vw = vc.widget()'),
+        nbformat.v4.new_code_cell('vw')
     ]
     return Response(
         response=nbformat.writes(nb),

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,4 +1,3 @@
-from context.app.api import vitessce_confs
 from os.path import dirname
 from urllib.parse import urlparse
 import json

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -106,24 +106,20 @@ def details(type, uuid):
     )
 
 
-@blueprint.route('/browse/<type>/<uuid>.<ext>')
-def details_ext(type, uuid, ext):
+@blueprint.route('/browse/<type>/<uuid>.json')
+def details_ext(type, uuid):
     if type not in entity_types:
-        abort(404)
-    if ext != 'json':
         abort(404)
     client = _get_client()
     entity = client.get_entity(uuid)
     return entity
 
 
-@blueprint.route('/browse/<type>/<uuid>.rui.<ext>')
-def details_rui_ext(type, uuid, ext):
+@blueprint.route('/browse/<type>/<uuid>.rui.json')
+def details_rui_ext(type, uuid):
     # Note that the API returns a blob of JSON as a string,
     # so, to return a JSON object, and not just a string, we need to decode.
     if type not in entity_types:
-        abort(404)
-    if ext != 'json':
         abort(404)
     client = _get_client()
     entity = client.get_entity(uuid)

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -56,7 +56,7 @@ function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMainten
 
   if (errorCode === 404) {
     if (urlPath && urlPath.startsWith('/browse/')) {
-      const uuid = urlPath.split('/').pop();
+      const uuid = urlPath.split('/').pop().split('.')[0];
       if (uuid.length !== 32) {
         return (
           <>

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -1,4 +1,4 @@
-nbformat=5.1.2
+nbformat==5.1.2
 Flask==1.1.2
 globus-sdk==2.0.1
 requests==2.22.0

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -1,3 +1,4 @@
+nbformat=5.1.2
 Flask==1.1.2
 globus-sdk==2.0.1
 requests==2.22.0


### PR DESCRIPTION
Proof of concept -- breaks a lot of things -- but it also produces a notebook for http://localhost:5001/browse/dataset/3d2c9295c0e05f4d81d23ee95e9dad23.ipynb that looks like:

```
vc = VitessceConfig(name="HuBMAP Data Portal")
vc.add_dataset(name="Visualization Files")
images = []
images.append(OmeTiffWrapper(img_url='https://assets.test.hubmapconsortium.org/ca224d0c1a0144240858490e3df46f83/ometiff-pyramids/processedMicroscopy/VAN0013-LK-206-2-PAS_FFPE.ome.tif?token=', offsets_url='https://assets.test.hubmapconsortium.org/ca224d0c1a0144240858490e3df46f83/output_offsets/processedMicroscopy/VAN0013-LK-206-2-PAS_FFPE.offsets.json?token=', name=Path('ometiff-pyramids/processedMicroscopy/VAN0013-LK-206-2-PAS_FFPE.ome.tif').name))
dataset = dataset.add_object(MultiImageWrapper(images))
vc = self._setup_view_config_raster(vc, dataset)
```
ie, the steps to build the viewconf are spelled out, instead of just giving the JSON that comes out the end of the pipe.

The idea is that on each `ViewConf` subclass, we would change `build_vitessce_conf` to `build_vitessce_conf_cells`: This would return a (named) tuple containing both a viewconf, and a list of notebook cells to construct the same conf. (I think keeping it as a single method, instead of splitting it in two, makes sense for development purposes, since the two flows need to be kept in sync.)

I think we have close to 20 of these classes, and this is one of the simpler ones: _This is a big job._ To make it more tractable, a couple pieces of preliminary work may help:
- For all the internal classes, make sure there is a `repr()` which can be executed to reproduce the object. That will allow us to drop completed datastructures into the notebook, instead of repeating the steps it took to build them.
- Pull out functions so that their definitions could be included into the notebook via introspection.

-----------------

## Alternatives (which I don't like any better)
- Dump the whole class definition into the notebook using inspection... we could dump only the the classes needed for a particular data set, but it would still be a lot of opaque code.
- Make the notebook the primary representation of some of this code, with code and text cells interleaved.
- Give up on getting the same viewconf into the notebook as on the website: If the notebook view was simpler and more generic, that might save work.
- Work on vitessce, so the view-conf object has mutator methods: The setup would still be somewhat opaque, but we could make it easier for them to tweak just the things they want to tweak.