### PR TITLE
John conroy/always show search term

### DIFF
--- a/CHANGELOG-always-show-search-term.md
+++ b/CHANGELOG-always-show-search-term.md
@@ -1,0 +1,1 @@
+- Show search terms when the search input is focused or unfocused.

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -115,6 +115,8 @@ $text-primary: rgba(0, 0, 0, 0.87);
     background: url('~portal-images/search-icon.svg') no-repeat top left;
 }
 
-.sk-search-box.is-focused input.sk-search-box__text, .sk-search-box input.sk-search-box__text {
+.sk-search-box.is-focused, .sk-search-box {
+    input.sk-search-box__text {
     color: $text-primary;
+    }
 }

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -2,6 +2,7 @@
 
 $primary-purple: #444A65;
 $secondary-gray: #636363;
+$text-primary: rgba(0, 0, 0, 0.87);
 
 .sk-layout__body {
     margin: 16px 0px 32px 0px;
@@ -112,4 +113,8 @@ $secondary-gray: #636363;
 .sk-search-box__icon:before{
     fill: $primary-purple;
     background: url('~portal-images/search-icon.svg') no-repeat top left;
+}
+
+.sk-search-box.is-focused input.sk-search-box__text, .sk-search-box input.sk-search-box__text {
+    color: $text-primary;
 }


### PR DESCRIPTION
Fix #1476.

Also now uses our primary text color for the search input. There might be a better way to use theme vars with `Search.scss`.