### PR TITLE
John conroy/fix collection title text overflow

### DIFF
--- a/CHANGELOG-fix-collection-title-text-overflow.md
+++ b/CHANGELOG-fix-collection-title-text-overflow.md
@@ -1,0 +1,1 @@
+- Fix text overflow for collections panel titles.

--- a/context/app/static/js/shared-styles/panels/index.js
+++ b/context/app/static/js/shared-styles/panels/index.js
@@ -9,8 +9,8 @@ import { LightBlueLink } from 'js/shared-styles/Links';
 
 const overflowCss = css`
   white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+  overflow: hidden;
 `;
 
 const PanelWrapper = styled.div`
@@ -28,8 +28,10 @@ const PanelWrapper = styled.div`
   }
 `;
 
-const MaxWidthDiv = styled.div`
-  max-width: 900px;
+const TextWrapper = styled.div`
+  white-space: nowrap;
+  min-width: 0px; // needed to handle overflow
+  margin-right: ${(props) => props.theme.spacing(1)}px;
 `;
 
 const TruncatedText = styled(Typography)`
@@ -38,6 +40,11 @@ const TruncatedText = styled(Typography)`
 
 const TruncatedLink = styled(LightBlueLink)`
   ${overflowCss};
+  display: block; //text-overflow only applies to block elements
+`;
+
+const CountsWrapper = styled.div`
+  flex-shrink: 0;
 `;
 
 const StyledTypography = styled(Typography)`
@@ -56,19 +63,19 @@ function Panel(props) {
   const { title, href, secondaryText, entityCounts } = props;
   return (
     <PanelWrapper>
-      <MaxWidthDiv>
+      <TextWrapper>
         <TruncatedLink variant="subtitle1" href={href}>
           {title}
         </TruncatedLink>
         <TruncatedText variant="body2" color="secondary">
           {secondaryText}
         </TruncatedText>
-      </MaxWidthDiv>
-      <div>
+      </TextWrapper>
+      <CountsWrapper>
         {Object.entries(entityCounts).map(([key, value]) => (
           <StyledTypography key={key} variant="caption">{`${value} ${capitalizeString(key)}`}</StyledTypography>
         ))}
-      </div>
+      </CountsWrapper>
     </PanelWrapper>
   );
 }


### PR DESCRIPTION
Fix #1862. Also applies to similar saved list panels.

<img width="1316" alt="Screen Shot 2021-06-08 at 3 15 27 PM" src="https://user-images.githubusercontent.com/62477388/121244104-7df28100-c86c-11eb-8928-1ac5f973cb6d.png">
