### PR TITLE
John conroy/fix summary date alignment

### DIFF
--- a/CHANGELOG-fix-summary-date-alignment.md
+++ b/CHANGELOG-fix-summary-date-alignment.md
@@ -1,0 +1,1 @@
+- Fix spacing for detail summary creation and modification dates.

--- a/context/app/static/js/components/Detail/DetailDescription/DetailDescription.jsx
+++ b/context/app/static/js/components/Detail/DetailDescription/DetailDescription.jsx
@@ -3,7 +3,7 @@ import Typography from '@material-ui/core/Typography';
 import format from 'date-fns/format';
 
 import SectionItem from '../SectionItem';
-import { FlexColumnRight, StyledPaper } from './style';
+import { FlexColumnRight, StyledPaper, StyledSectionItem } from './style';
 
 function DetailDescription({ subtitle, description, createdTimestamp, modifiedTimestamp }) {
   const dateFormat = 'MMMM dd, yyyy';
@@ -21,7 +21,7 @@ function DetailDescription({ subtitle, description, createdTimestamp, modifiedTi
       </div>
 
       <FlexColumnRight>
-        <SectionItem label="Creation Date">{formattedCreationDate}</SectionItem>
+        <StyledSectionItem label="Creation Date">{formattedCreationDate}</StyledSectionItem>
         <SectionItem label="Modification Date">{formattedModificationDate}</SectionItem>
       </FlexColumnRight>
     </StyledPaper>

--- a/context/app/static/js/components/Detail/DetailDescription/style.js
+++ b/context/app/static/js/components/Detail/DetailDescription/style.js
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
 import Paper from '@material-ui/core/Paper';
+import SectionItem from '../SectionItem';
 
 const FlexColumnRight = styled.div`
   display: flex;
   margin-left: auto;
   flex-direction: column;
-  justify-content: space-evenly;
   white-space: nowrap;
   padding-left: ${(props) => props.theme.spacing(1)}px;
 `;
@@ -16,4 +16,8 @@ const StyledPaper = styled(Paper)`
   padding: 30px 40px 30px 40px;
 `;
 
-export { FlexColumnRight, StyledPaper };
+const StyledSectionItem = styled(SectionItem)`
+  margin-bottom: ${(props) => props.theme.spacing(1)}px;
+`;
+
+export { FlexColumnRight, StyledPaper, StyledSectionItem };

--- a/context/app/static/js/components/Detail/SectionItem.jsx
+++ b/context/app/static/js/components/Detail/SectionItem.jsx
@@ -9,10 +9,10 @@ const StyledDiv = styled.div`
 `;
 
 function SectionItem(props) {
-  const { children, ml, label, flexBasis } = props;
+  const { children, ml, label, flexBasis, ...rest } = props;
   const childrenArray = Array.isArray(children) ? children : [children];
   return (
-    <StyledDiv ml={ml} flexBasis={flexBasis}>
+    <StyledDiv ml={ml} flexBasis={flexBasis} {...rest}>
       <Typography variant="subtitle2" component="h3" color="primary">
         {label}
       </Typography>


### PR DESCRIPTION
Fix #1869. Is this what you both were thinking it should look like? I opted to just pass props to the div to allow us to use `styled`, but I could expand using margin specific props.

<img width="1341" alt="Screen Shot 2021-06-08 at 4 35 49 PM" src="https://user-images.githubusercontent.com/62477388/121254114-e430d100-c877-11eb-84fa-050bfc0c02a5.png">
<img width="1123" alt="Screen Shot 2021-06-08 at 4 35 55 PM" src="https://user-images.githubusercontent.com/62477388/121254115-e430d100-c877-11eb-8644-60b634654948.png">
