### PR TITLE
John conroy/fix bar chart responsiveness

### DIFF
--- a/CHANGELOG-fix-bar-chart-responsiveness.md
+++ b/CHANGELOG-fix-bar-chart-responsiveness.md
@@ -1,0 +1,1 @@
+- Fix homepage bar chart responsiveness.

--- a/context/app/static/js/components/home/AssayTypeBarChartContainer/style.js
+++ b/context/app/static/js/components/home/AssayTypeBarChartContainer/style.js
@@ -5,7 +5,9 @@ const Flex = styled.div`
 `;
 
 const ChartWrapper = styled.div`
-  width: 1000px;
+  flex-grow: 1;
+  max-width: 1000px;
+  width: 0px;
   height: 500px;
 `;
 


### PR DESCRIPTION
Fix #1883. Adding `width: 0px` seems to be the fix and forces another dimensions recalc. Please take a look locally and let me know what you think.