### PR TITLE
Fix proptypes warning

### DIFF
--- a/CHANGELOG-props.md
+++ b/CHANGELOG-props.md
@@ -1,0 +1,1 @@
+- Fix proptypes warning.

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -162,6 +162,7 @@ Routes.propTypes = {
     collection: PropTypes.object,
     errorCode: PropTypes.number,
     list_uuid: PropTypes.string,
+    has_notebook: PropTypes.bool,
   }),
 };
 


### PR DESCRIPTION
Sorry to let this get through. When we're doing QA, I'd like to try to keep an eye on console warnings -- Often, they are harmless, but if we can get rid of the false alarms, the console can help us identify real problems.