### PR TITLE
Fix Offsets Location for Cytokit AnnData

### DIFF
--- a/CHANGELOG-fix-offsets-file.md
+++ b/CHANGELOG-fix-offsets-file.md
@@ -1,0 +1,1 @@
+- Fix where Vitessce confs look for `offsets` file.

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -189,14 +189,6 @@ class SPRMViewConfBuilder(ImagePyramidViewConfBuilder):
         found_image_file = found_image_files[0]
         return found_image_file
 
-    def _get_ometiff_image_wrapper(self, found_image_file):
-        img_url, offsets_url = self._get_img_and_offset_url(
-            found_image_file, self._imaging_path_regex,
-        )
-        return OmeTiffWrapper(
-            img_url=img_url, offsets_url=offsets_url, name=self._image_name
-        )
-
 
 class SPRMJSONViewConfBuilder(SPRMViewConfBuilder):
     def __init__(self, entity, nexus_token, is_mock=False, **kwargs):
@@ -224,6 +216,14 @@ class SPRMJSONViewConfBuilder(SPRMViewConfBuilder):
                 "data_type": dt.EXPRESSION_MATRIX,
             },
         ]
+    
+    def _get_ometiff_image_wrapper(self, found_image_file):
+        img_url, offsets_url = self._get_img_and_offset_url(
+            found_image_file, self._imaging_path_regex,
+        )
+        return OmeTiffWrapper(
+            img_url=img_url, offsets_url=offsets_url, name=self._image_name
+        )
 
     def get_conf_cells(self):
         found_image_file = self._check_sprm_image(self._get_full_image_path())
@@ -274,12 +274,21 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
         self._imaging_path_regex = f"{self.image_pyramid_regex}/{kwargs['imaging_path']}"
         self._mask_path_regex = f"{self.image_pyramid_regex}/{kwargs['mask_path']}"
 
+    def _get_ometiff_image_wrapper(self, found_image_file):
+        img_url, offsets_url = self._get_img_and_offset_url(
+            found_image_file, self.image_pyramid_regex,
+        )
+        return OmeTiffWrapper(
+            img_url=img_url, offsets_url=offsets_url, name=self._image_name
+        )
+
+
     def _get_bitmask_image_path(self):
         return f"{self._mask_path_regex}/{self._mask_name}.ome.tiff?"
 
     def _get_ometiff_mask_wrapper(self, found_bitmask_file):
         bitmask_img_url, bitmask_offsets_url = self._get_img_and_offset_url(
-            found_bitmask_file, self._mask_path_regex,
+            found_bitmask_file, self.image_pyramid_regex,
         )
         return OmeTiffWrapper(
             img_url=bitmask_img_url,

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -191,7 +191,7 @@ class SPRMViewConfBuilder(ImagePyramidViewConfBuilder):
 
     def _get_ometiff_image_wrapper(self, found_image_file, found_image_path):
         img_url, offsets_url = self._get_img_and_offset_url(
-            found_image_file, found_image_path,
+            found_image_file, re.escape(found_image_path),
         )
         return OmeTiffWrapper(
             img_url=img_url, offsets_url=offsets_url, name=self._image_name

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -216,7 +216,7 @@ class SPRMJSONViewConfBuilder(SPRMViewConfBuilder):
                 "data_type": dt.EXPRESSION_MATRIX,
             },
         ]
-    
+
     def _get_ometiff_image_wrapper(self, found_image_file):
         img_url, offsets_url = self._get_img_and_offset_url(
             found_image_file, self._imaging_path_regex,
@@ -281,7 +281,6 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
         return OmeTiffWrapper(
             img_url=img_url, offsets_url=offsets_url, name=self._image_name
         )
-
 
     def _get_bitmask_image_path(self):
         return f"{self._mask_path_regex}/{self._mask_name}.ome.tiff?"

--- a/context/app/api/vitessce_confs/fixtures/output_expected/cytokit_anndata_conf.json
+++ b/context/app/api/vitessce_confs/fixtures/output_expected/cytokit_anndata_conf.json
@@ -91,7 +91,7 @@
                                 "url": "https://example.com/2f8d43199ca3167e991b320038024b77/ometiff-pyramids/stitched/expressions/reg1_stitched_expressions.ome.tiff?token=nexus_token",
                                 "metadata": {
                                     "isBitmask": false,
-                                    "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/reg1_stitched_expressions.offsets.json?token=nexus_token"
+                                    "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/stitched/expressions/reg1_stitched_expressions.offsets.json?token=nexus_token"
                                 }
                             },
                             {
@@ -100,7 +100,7 @@
                               "url": "https://example.com/2f8d43199ca3167e991b320038024b77/ometiff-pyramids/stitched/mask/reg1_stitched_mask.ome.tiff?token=nexus_token",
                               "metadata": {
                                 "isBitmask": true,
-                                "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/reg1_stitched_mask.offsets.json?token=nexus_token"
+                                "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/stitched/mask/reg1_stitched_mask.offsets.json?token=nexus_token"
                               }
                             }
                         ]
@@ -273,7 +273,7 @@
                                 "url": "https://example.com/2f8d43199ca3167e991b320038024b77/ometiff-pyramids/stitched/expressions/reg2_stitched_expressions.ome.tiff?token=nexus_token",
                                 "metadata": {
                                     "isBitmask": false,
-                                    "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/reg2_stitched_expressions.offsets.json?token=nexus_token"
+                                    "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/stitched/expressions/reg2_stitched_expressions.offsets.json?token=nexus_token"
                                 }
                             },
                             {
@@ -282,7 +282,7 @@
                               "url": "https://example.com/2f8d43199ca3167e991b320038024b77/ometiff-pyramids/stitched/mask/reg2_stitched_mask.ome.tiff?token=nexus_token",
                               "metadata": {
                                 "isBitmask": true,
-                                "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/reg2_stitched_mask.offsets.json?token=nexus_token"
+                                "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/stitched/mask/reg2_stitched_mask.offsets.json?token=nexus_token"
                               }
                             }
                         ]

--- a/context/app/api/vitessce_confs/fixtures/output_expected/sprm_anndata_conf.json
+++ b/context/app/api/vitessce_confs/fixtures/output_expected/sprm_anndata_conf.json
@@ -91,7 +91,7 @@
                                 "url": "https://example.com/2f8d43199ca3167e991b320038024b77/ometiff-pyramids/imaging_path/expressions.ome.tiff?token=nexus_token",
                                 "metadata": {
                                     "isBitmask": false,
-                                    "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/expressions.offsets.json?token=nexus_token"
+                                    "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/imaging_path/expressions.offsets.json?token=nexus_token"
                                 }
                             },
                             {
@@ -100,7 +100,7 @@
                               "url": "https://example.com/2f8d43199ca3167e991b320038024b77/ometiff-pyramids/imaging_path/mask.ome.tiff?token=nexus_token",
                               "metadata": {
                                 "isBitmask": true,
-                                "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/mask.offsets.json?token=nexus_token"
+                                "omeTiffOffsetsUrl": "https://example.com/2f8d43199ca3167e991b320038024b77/output_offsets/imaging_path/mask.offsets.json?token=nexus_token"
                               }
                             }
                         ]


### PR DESCRIPTION
I think my assumption that the `offsets.json` file is in the wrong place from #1904 was wrong, and based on the fact that the offsets file is in that place from the old SPRM which led me to believe it was run on the non-image pyramid, which was to be somewhat expected given that we hadn't seen a completely clean run yet.  To recap, the only runs we had seen included the incorrect offsets file, but in the right place, which led me to believe it was in the wrong place given past behavior.  Hopefully the change in test case behavior and the two different new `_get_ometiff_image_wrapper` (one for the old way, one for the new) functions highlight how this current change makes (more) sense.