### PR TITLE
Vitessce 1.1.11

### DIFF
--- a/CHANGELOG-vitessce-1-1-11.md
+++ b/CHANGELOG-vitessce-1-1-11.md
@@ -1,0 +1,1 @@
+- Upgrade Vitessce to version 1.1.11 and adapt view confs for new 3D feature.

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -66,7 +66,8 @@ class SeqFISHViewConfBuilder(ImagingViewConfBuilder):
             pos_name = self._get_pos_name(images[0])
             vc = VitessceConfig(name=pos_name)
             dataset = vc.add_dataset(name=pos_name)
-            for img_path in sorted(images, key=self._get_hybcycle):
+            sorted_images = sorted(images, key=self._get_hybcycle)
+            for img_path in sorted_images:
                 img_url, offsets_url = self._get_img_and_offset_url(
                     img_path, IMAGE_PYRAMID_DIR
                 )
@@ -78,7 +79,11 @@ class SeqFISHViewConfBuilder(ImagingViewConfBuilder):
                     )
                 )
             dataset = dataset.add_object(MultiImageWrapper(image_wrappers))
-            vc = self._setup_view_config_raster(vc, dataset)
+            vc = self._setup_view_config_raster(
+                vc,
+                dataset,
+                disable3d=[self._get_hybcycle(img_path) for img_path in sorted_images]
+            )
             conf = vc.to_dict()
             # Don't want to render all layers
             del conf["datasets"][0]["files"][0]["options"]["renderLayers"]

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -82,7 +82,7 @@ class SeqFISHViewConfBuilder(ImagingViewConfBuilder):
             vc = self._setup_view_config_raster(
                 vc,
                 dataset,
-                disable3d=[self._get_hybcycle(img_path) for img_path in sorted_images]
+                disable_3d=[self._get_hybcycle(img_path) for img_path in sorted_images]
             )
             conf = vc.to_dict()
             # Don't want to render all layers

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -110,10 +110,12 @@ class ImagingViewConfBuilder(ViewConfBuilder):
             ),
         )
 
-    def _setup_view_config_raster(self, vc, dataset):
+    def _setup_view_config_raster(self, vc, dataset, disable3d=[]):
         vc.add_view(dataset, cm.SPATIAL, x=3, y=0, w=9, h=12)
         vc.add_view(dataset, cm.DESCRIPTION, x=0, y=8, w=3, h=4)
-        vc.add_view(dataset, cm.LAYER_CONTROLLER, x=0, y=0, w=3, h=8)
+        vc.add_view(dataset, cm.LAYER_CONTROLLER, x=0, y=0, w=3, h=8).set_props(
+            disable3d=disable3d
+        )
         return vc
 
 
@@ -253,7 +255,9 @@ class SPRMJSONViewConfBuilder(SPRMViewConfBuilder):
     def _setup_view_config_raster_cellsets_expression_segmentation(self, vc, dataset):
         vc.add_view(dataset, cm.SPATIAL, x=3, y=0, w=7, h=8)
         vc.add_view(dataset, cm.DESCRIPTION, x=0, y=8, w=3, h=4)
-        vc.add_view(dataset, cm.LAYER_CONTROLLER, x=0, y=0, w=3, h=8)
+        vc.add_view(dataset, cm.LAYER_CONTROLLER, x=0, y=0, w=3, h=8).set_props(
+            disable3d=[self._image_name]
+        )
         vc.add_view(dataset, cm.CELL_SETS, x=10, y=5, w=2, h=7)
         vc.add_view(dataset, cm.GENES, x=10, y=0, w=2, h=5).set_props(
             variablesLabelOverride="antigen"

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -110,11 +110,11 @@ class ImagingViewConfBuilder(ViewConfBuilder):
             ),
         )
 
-    def _setup_view_config_raster(self, vc, dataset, disable3d=[]):
+    def _setup_view_config_raster(self, vc, dataset, disable_3d=[]):
         vc.add_view(dataset, cm.SPATIAL, x=3, y=0, w=9, h=12)
         vc.add_view(dataset, cm.DESCRIPTION, x=0, y=8, w=3, h=4)
         vc.add_view(dataset, cm.LAYER_CONTROLLER, x=0, y=0, w=3, h=8).set_props(
-            disable3d=disable3d
+            disable3d=disable_3d
         )
         return vc
 
@@ -236,7 +236,7 @@ class SPRMJSONViewConfBuilder(SPRMViewConfBuilder):
         file_paths_found = self._get_file_paths()
         # This tile has no segmentations
         if self._files[0]["rel_path"] not in file_paths_found:
-            vc = self._setup_view_config_raster(vc, dataset)
+            vc = self._setup_view_config_raster(vc, dataset, disable_3d=[self._image_name])
         else:
             for file in self._files:
                 path = file["rel_path"]

--- a/context/app/api/vitessce_confs/fixtures/output_expected/cytokit_json_conf.json
+++ b/context/app/api/vitessce_confs/fixtures/output_expected/cytokit_json_conf.json
@@ -72,6 +72,9 @@
       },
       {
         "component": "layerController",
+        "props": {
+          "disable3d": ["R001_X001_Y001"]
+        },
         "coordinationScopes": {
           "dataset": "A"
         },
@@ -193,6 +196,9 @@
       },
       {
         "component": "layerController",
+        "props": {
+          "disable3d": ["R001_X001_Y002"]
+        },
         "coordinationScopes": {
           "dataset": "A"
         },

--- a/context/app/api/vitessce_confs/fixtures/output_expected/image_pyramid_conf.json
+++ b/context/app/api/vitessce_confs/fixtures/output_expected/image_pyramid_conf.json
@@ -57,6 +57,9 @@
     },
     {
       "component": "layerController",
+      "props": {
+        "disable3d": []
+      },
       "coordinationScopes": {
         "dataset": "A"
       },

--- a/context/app/api/vitessce_confs/fixtures/output_expected/ims_conf.json
+++ b/context/app/api/vitessce_confs/fixtures/output_expected/ims_conf.json
@@ -57,6 +57,9 @@
     },
     {
       "component": "layerController",
+      "props": {
+        "disable3d": []
+      },
       "coordinationScopes": {
         "dataset": "A"
       },

--- a/context/app/api/vitessce_confs/fixtures/output_expected/seqfish_conf.json
+++ b/context/app/api/vitessce_confs/fixtures/output_expected/seqfish_conf.json
@@ -67,6 +67,9 @@
       },
       {
         "component": "layerController",
+        "props": {
+          "disable3d": ["HybCycle_12", "final_mRNA_background"]
+        },
         "coordinationScopes": {
           "dataset": "A"
         },
@@ -146,6 +149,9 @@
       },
       {
         "component": "layerController",
+        "props": {
+          "disable3d": ["HybCycle_12", "final_mRNA_background"]
+        },
         "coordinationScopes": {
           "dataset": "A"
         },

--- a/context/app/api/vitessce_confs/fixtures/output_expected/sprm_conf.json
+++ b/context/app/api/vitessce_confs/fixtures/output_expected/sprm_conf.json
@@ -71,6 +71,7 @@
     },
     {
       "component": "layerController",
+      "props": { "disable3d": ["BASE_NAME"] },
       "coordinationScopes": {
         "dataset": "A"
       },

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -1329,9 +1329,9 @@
       }
     },
     "@deck.gl/aggregation-layers": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.4.16.tgz",
-      "integrity": "sha512-LREnqBWMAdlTrwykZsLUO2lDd2oLENQOinqzD7eslpwR6KBhAry1FthoO3+fL95eBnUVvTYspiDM+jX9nUBQyw==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/aggregation-layers/-/aggregation-layers-8.4.18.tgz",
+      "integrity": "sha512-mFUrBy9LVdC2z7OZ7XY8F8qiWnlqxZXgpG6tCq5/toK1BJ2qBXbIuQDg6NY4fT9aIQqBvTRQW+VaoWL9mJOQeg==",
       "requires": {
         "@luma.gl/shadertools": "^8.4.1",
         "@math.gl/web-mercator": "^3.4.2",
@@ -1339,9 +1339,9 @@
       }
     },
     "@deck.gl/carto": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.4.16.tgz",
-      "integrity": "sha512-aPdbUbuaYn3ZoCxGxrf/EImwA4mKr7yAFjhkt/WWeo/XeVLY7uJKhnWcFaphejGrIZey7fb0vqpNa7PknWTqSA==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/carto/-/carto-8.4.18.tgz",
+      "integrity": "sha512-qnNKjJDCWZFS0lwDoQYSXL3ageBv2G1q3euuwW8cxjStRTbp6ipkv08UAUh2Pbgsz7K/PwMtU8vB3zE0Os99tw==",
       "requires": {
         "@loaders.gl/loader-utils": "^2.3.13",
         "@loaders.gl/mvt": "^2.3.13",
@@ -1382,9 +1382,9 @@
       }
     },
     "@deck.gl/core": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.16.tgz",
-      "integrity": "sha512-8rNAj2/wB0zsQ3kDgatdx4pgkKdobdiK78+DAvmiomDGI74DJIbBYd2eVEw55B7UXKydiMwTcRHb0fskfcGEhw==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-8.4.18.tgz",
+      "integrity": "sha512-tO/FjMZEU0kDMZv4Az0zfDnMlfymiklBLJ65iykghqPnK6KLQDIYGM5mB3iBWkFgx/YgSIGpPQfKpGtNZXnDhg==",
       "requires": {
         "@loaders.gl/core": "^2.3.13",
         "@loaders.gl/images": "^2.3.13",
@@ -1397,17 +1397,17 @@
       }
     },
     "@deck.gl/extensions": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.4.16.tgz",
-      "integrity": "sha512-dHT7tUow5597mkuZ146Hb+g7N1et3G+ngoi7j+YP/C2UT1DS8QFE6ER0r4k0kiyImJ5Y5qZ+XkEwjOlucNPf3Q==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-8.4.18.tgz",
+      "integrity": "sha512-zqWzQ9/HDyvD1GoEn6qVahGUlQV3qUUrYOpLm6QbPUnjkgj2Yb7/WBVsSoVJN5bP3z28cjJwM3Jk7mTEntgFmg==",
       "requires": {
         "@luma.gl/shadertools": "^8.4.1"
       }
     },
     "@deck.gl/geo-layers": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.16.tgz",
-      "integrity": "sha512-2g8gDZUtb2DvhXGKVRAOaheEFtxO3thgzvQbWjeoMbw0hMSR9Qht8QX2YiKOfzOXjj5hoQSDLs83F99kJDAhFg==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-8.4.18.tgz",
+      "integrity": "sha512-lO4AhL4gh73yHBKdGWPCZX2tcPqJSyUM7KYzxM9oBAL/yfK94ez84TB2FvAJvZ2ImCA4Yg7NND/8Jd1jdtGXBA==",
       "requires": {
         "@loaders.gl/3d-tiles": "^2.3.13",
         "@loaders.gl/gis": "^2.3.13",
@@ -1423,23 +1423,23 @@
       }
     },
     "@deck.gl/google-maps": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.4.16.tgz",
-      "integrity": "sha512-5+L3/YcMPTDZJbDco+XYRtqf8ruKjhl11YUBN5zYTXk+tlT2mKoBNwXBIP1k3P2TcXz3QFAjd0kAr0EPanvlhw=="
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/google-maps/-/google-maps-8.4.18.tgz",
+      "integrity": "sha512-euifQG9ERg8jOJ7TRzdmgBg9GQNZJV3gS+6KZLy8pJG0jefsPvrdxGfBAosz+MK50wtEGmJ8XvzKTb+NT8bYCQ=="
     },
     "@deck.gl/json": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.4.16.tgz",
-      "integrity": "sha512-P4N0hpMN0q16dKLETxmXYVC+Ms7TZabMvwplem41pBk3QijYH9vwgQc+hYlXHUjB4sNDJwripaBgCUWVFNd4+A==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/json/-/json-8.4.18.tgz",
+      "integrity": "sha512-Ov6xKgEA89IR+vAmxiDmSWFjqu0nLDns01uH5nZ8ogKaLlzw0sxw0X8riC5qcWG7FjfBjAwiZd1jK0Gnl7tFeA==",
       "requires": {
         "d3-dsv": "^1.0.8",
         "expression-eval": "^2.0.0"
       }
     },
     "@deck.gl/layers": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.16.tgz",
-      "integrity": "sha512-IvXrcXqH4z0Co+i5v6TPxyBcuyiJ4na5a7Lgz8bb+k7nG5PpqArBE6qVc4H88oxlJlkGrsou68/40VkZMER9VQ==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-8.4.18.tgz",
+      "integrity": "sha512-2hkuLVq1oRdyO1YFQ1pdRi5ynGHeSq96I71iQvXgC6X99//AYkOsXI/b79Yb5xc6fojKOQ+3s6BtXRMJXWbP9w==",
       "requires": {
         "@loaders.gl/images": "^2.3.13",
         "@mapbox/tiny-sdf": "^1.1.0",
@@ -1448,14 +1448,14 @@
       }
     },
     "@deck.gl/mapbox": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.4.16.tgz",
-      "integrity": "sha512-otE4nchOqNr2NsuKD/Fe+Ga8IDwZeNVnWOZUJGaJ7MWPwFiWxott+2AI4w3hfFCMbzz3NZkapgiftMWcH0sHkA=="
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mapbox/-/mapbox-8.4.18.tgz",
+      "integrity": "sha512-mxBkY2L3TGgXMtXzYF/lhjejpfWTUK+uxXeTzXwspnwR2welJtiznMiws07MXzqk5Od9Zr8kBHplgB1hc5dYbg=="
     },
     "@deck.gl/mesh-layers": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.16.tgz",
-      "integrity": "sha512-/XrVwCtTUUTNqHCkU3/pJfnGnQt2hMtJHJar9dl/NMwq7dxiW/oia8r6Jwzz9F5HglHieZJ130jHBsZG0LTXWA==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-8.4.18.tgz",
+      "integrity": "sha512-yaCFaIQZf74+hHULZTEJDzwQ4OddKHo9Wz4X4uJlE99xvK6RKMf0/2t/Rbnhj0WpuH8KPsDB2/hxZ4z98ilVOg==",
       "requires": {
         "@loaders.gl/gltf": "^2.3.13",
         "@luma.gl/experimental": "^8.4.1",
@@ -1463,9 +1463,9 @@
       }
     },
     "@deck.gl/react": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.16.tgz",
-      "integrity": "sha512-Apx8sH8hEaSVGcE3Q4M404ermU0Oc/aJ0EV6ySlXmBufPj+8N1s9HIr2W9DX7xAl2xoX6EbDxxA+cdkvzpjNug==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/@deck.gl/react/-/react-8.4.18.tgz",
+      "integrity": "sha512-bHpB6TSbyc/zfq3IeXosH0aNU0iraS0SEoINmuo8o9f3PZ2mkwlSZKlSRME5K5Xv/qNedmQT8GqP9Sz+NXmHng==",
       "requires": {
         "prop-types": "^15.6.0"
       }
@@ -1508,10 +1508,11 @@
       }
     },
     "@hms-dbmi/viv": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.9.5.tgz",
-      "integrity": "sha512-jEIJg8SysOZ7MHdJOn9NZRkjZAg8KSIJewCh5dIoG9iCHyHpAfCmym9GN+eC7V6CMaZoGWlzGtNA68nHjSySwg==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.10.4.tgz",
+      "integrity": "sha512-ezZFwLQwh3RdThFg6UmhZFq9z+wMgVpAgwGj8SPO/VRE4Vl0sZ5embb0GUm97SIXZHWX7jYXvMLuZFhrf4oz4w==",
       "requires": {
+        "@math.gl/culling": "^3.4.2",
         "fast-deep-equal": "^3.1.3",
         "fast-xml-parser": "^3.16.0",
         "geotiff": "github:ilan-gold/geotiff.js#ilan-gold/viv_094",
@@ -2827,9 +2828,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2847,9 +2848,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2867,9 +2868,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -2894,9 +2895,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -3323,105 +3324,105 @@
       }
     },
     "@turf/bbox": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.3.0.tgz",
-      "integrity": "sha512-N4ue5Xopu1qieSHP2MA/CJGWHPKaTrVXQJjzHRNcY1vtsO126xbSaJhWUrFc5x5vVkXp0dcucGryO0r5m4o/KA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.4.0.tgz",
+      "integrity": "sha512-eASq6Op3sGAA293Qo3gTwuQAvdoQCKah4rgA5FZkQ2xvkYquQnkUhV2U18bFgw58aSP1g2Y+rpmSEPHDFX6/6g==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/meta": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/meta": "^6.4.0"
       }
     },
     "@turf/bbox-polygon": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.3.0.tgz",
-      "integrity": "sha512-CCyTBM8LzGRu/lReNlgDyjRO8NojtJ7EPPvSl3bdKQbNFsCm25gwe7Y3xsaCkWLNn5g89lQJI9Izf9xdEsENjQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox-polygon/-/bbox-polygon-6.4.0.tgz",
+      "integrity": "sha512-r0flYt3PivNcZLioCBHZcTcLC4sbHLzKw4VPLknvKvet4cK6A33s8OguXp+hd4ITnby2LFUH5WquwS5oglkM6Q==",
       "requires": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.4.0"
       }
     },
     "@turf/bearing": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.3.0.tgz",
-      "integrity": "sha512-apuUm9xN6VQLO33m7F2mmzlm3dHfeesJjMSzh9iehGtgmp1IaVndjdcIvs0ieiwm8bN9UhwXpfPtO3pV0n9SFw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.4.0.tgz",
+      "integrity": "sha512-CmMsT8hSzzhZWe0+49OP48m/EAXryZjNh/7D/0nqMIlayslRZ+bHuV3KcrOCD20xoDFtBuSEdwEd6i4+2Nw3LA==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/boolean-clockwise": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-6.3.0.tgz",
-      "integrity": "sha512-zW0j8uPjBS5QJqNmJIeatTH02E1S7OCuBNBvkoOUPifC/c2xJ120a1r73prBj1zMFr6k3UCjwG9V8whUMxIAYA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-6.4.0.tgz",
+      "integrity": "sha512-zLft4OSQTwNWOmwy/9Ub4fIgrGtPjh2TAjU80yZUDBSFZIDU4FSfZaH5pVcXf2p1mQbg94j9wHS2PGSSfkZ/Kg==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/boolean-contains": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.3.0.tgz",
-      "integrity": "sha512-1MW7B5G5tIu1lnAv3pXyFzl75wfBYnbA2GhwHDb4okIXMhloy/r5uIqAZHo0fOXykKVJS/gIfA/MioKIftoTug==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-contains/-/boolean-contains-6.4.0.tgz",
+      "integrity": "sha512-VqxLZRmCEclmu0POZSc2tezMxp9zX95MUl5/9zAU1+Zey53Yk7mN4CtmvuzWnXFcfEvQacZ77OT30XhjKr6Ifw==",
       "requires": {
-        "@turf/bbox": "^6.3.0",
-        "@turf/boolean-point-in-polygon": "^6.3.0",
-        "@turf/boolean-point-on-line": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/bbox": "^6.4.0",
+        "@turf/boolean-point-in-polygon": "^6.4.0",
+        "@turf/boolean-point-on-line": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/boolean-overlap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-6.3.0.tgz",
-      "integrity": "sha512-rWh8JKTqlJ1m27FY8YeWcGoXutLyCVfSi2/8AOkXi2F+36P9GM4tHz19yKY3btbnHJTgSZf1xO2YhX2d0BmNqg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-overlap/-/boolean-overlap-6.4.0.tgz",
+      "integrity": "sha512-mM/X0gBVVa6LjqPcg8XQiTLoSRpIGaz+yXwkOPRRU8XMMiS+Cxu0rH0Mq/pVo+4Y9BwwzxoX3yo38Afs1UMpNQ==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/line-intersect": "^6.3.0",
-        "@turf/line-overlap": "^6.3.0",
-        "@turf/meta": "^6.3.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/line-intersect": "^6.4.0",
+        "@turf/line-overlap": "^6.4.0",
+        "@turf/meta": "^6.4.0",
         "geojson-equality": "0.1.6"
       }
     },
     "@turf/boolean-point-in-polygon": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.3.0.tgz",
-      "integrity": "sha512-NqFSsoE6OwhDK19IllDQRhEQEkF7UVEOlqH9vgS1fGg4T6NcyKvACJs05c9457tL7QSbV9ZS53f2qiLneFL+qg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.4.0.tgz",
+      "integrity": "sha512-hJnhasLc2HyVozzQmWYAiN9D1z/JbuAJkyzfnp3HvGUp0Xdt6BsARqcLgRXbsm+AJNKG1D8d0549YKOuLGRhzA==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/boolean-point-on-line": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.3.0.tgz",
-      "integrity": "sha512-eScH8sfKJVjfbEX5Hgkt1nA7A8DUoiYD1riUVqTp2xikujrMfnYRjFpL/UAo01v33cPKZlhCXp7NE86bdOSrYg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.4.0.tgz",
+      "integrity": "sha512-Xz/SUVTyJ/0LPuU4mE7N9uujrXPKrx5+p8QUWroLxi9am3YgmcYPWWt/FVvJvwoUgOQ6xXGoGR95b94ASVQAHg==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/boolean-within": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-6.3.0.tgz",
-      "integrity": "sha512-8XtVbzPp6J+lqZtDWVyIwSyVAVcnuie82ub56JEAhCf9w8FX5Db3qXQ76pFcOyy/woeXLZY/nIR58Q79PusrRw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-6.4.0.tgz",
+      "integrity": "sha512-oNbNgc9aKq7D1UJIn2AXH80hh9wlEngl+2tbUzG0epLg9WzzpuaKTVadiTU+VpZ3OQ4jHnm3XbFLxM8ibyd8oQ==",
       "requires": {
-        "@turf/bbox": "^6.3.0",
-        "@turf/boolean-point-in-polygon": "^6.3.0",
-        "@turf/boolean-point-on-line": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/bbox": "^6.4.0",
+        "@turf/boolean-point-in-polygon": "^6.4.0",
+        "@turf/boolean-point-on-line": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/buffer": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-6.3.0.tgz",
-      "integrity": "sha512-B0GWgJzmTaaw1GvTd+Df+ToKSYphz9d6hPCOwXbE2vS5DdZryoxBfxQ32LSX/hW/vx7TLf7E4M0VJBb+Sn1DKA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-6.4.0.tgz",
+      "integrity": "sha512-d5HO+1DP7+f8aw9LZKmtkpDWCpMlcGopa3TF145Tf99FxC9OoztINNAeG0Ru1ZeHTpazyuh8TOKFKLmb2tsSrA==",
       "requires": {
-        "@turf/bbox": "^6.3.0",
-        "@turf/center": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/meta": "^6.3.0",
-        "@turf/projection": "^6.3.0",
+        "@turf/bbox": "^6.4.0",
+        "@turf/center": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/meta": "^6.4.0",
+        "@turf/projection": "^6.4.0",
         "d3-geo": "1.7.1",
         "turf-jsts": "*"
       },
@@ -3437,285 +3438,285 @@
       }
     },
     "@turf/center": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.3.0.tgz",
-      "integrity": "sha512-41g/ZYwoBs2PK7tpAHhf4D6llHdRvY827HLXCld5D0IOnzsWPqDk7WnV8P5uq4g/gyH1/WfKQYn5SgfSj4sSfw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.4.0.tgz",
+      "integrity": "sha512-qCeAsdAY9hfh/3hFcYOkaWjNN/qJn6PosiLm4jnx1NDzXmUymFFRwEix5SfNzjvKGBoKrojPOs22im/BlFRNKQ==",
       "requires": {
-        "@turf/bbox": "^6.3.0",
-        "@turf/helpers": "^6.3.0"
+        "@turf/bbox": "^6.4.0",
+        "@turf/helpers": "^6.4.0"
       }
     },
     "@turf/centroid": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.3.0.tgz",
-      "integrity": "sha512-7KTyqhUEqXDoyR/nf/jAXiW8ZVszEnrp5XZkgYyrf2GWdSovSO0iCN1J3bE2jkJv7IWyeDmGYL61GGzuTSZS2Q==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-6.4.0.tgz",
+      "integrity": "sha512-p78MVeJ3InVZzkBP4rpoWTUspsRqsW6a/fGuigfjizHz+YqTRXyG7HDkqoR8IwLwpQC83Nlw5kyacgMlgEbN+Q==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/meta": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/meta": "^6.4.0"
       }
     },
     "@turf/circle": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.3.0.tgz",
-      "integrity": "sha512-5N3J4YQr1efidvPgvtIQYpxb7gBVEoo00IFC0JNH6KqIVBMttFZw3Wsqor34ya91m58A5m6HTiz9Cdm1ktrEdw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/circle/-/circle-6.4.0.tgz",
+      "integrity": "sha512-VP+wJVkkkeyxBd/qOiy65DXaAtYs7G59vHdGiHG2WE+lpg/BgH8QBYGAUEpkQkZJZHl3NaweFYn103kD12h0vw==",
       "requires": {
-        "@turf/destination": "^6.3.0",
-        "@turf/helpers": "^6.3.0"
+        "@turf/destination": "^6.4.0",
+        "@turf/helpers": "^6.4.0"
       }
     },
     "@turf/clone": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.3.0.tgz",
-      "integrity": "sha512-GAgN89/9GCqUKECB1oY2hcTs0K2rZj+a2tY6VfM0ef9wwckuQZCKi+kKGUzhKVrmHee15jKV8n6DY0er8OndKg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.4.0.tgz",
+      "integrity": "sha512-m0MzpW601CQJ7al3XireJNPrKz6KHMnbWysS6p4qkG7E70c+S8ST0y6gj1CfdkdS7ee3GevEg7V6sxdj2lCs4w==",
       "requires": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.4.0"
       }
     },
     "@turf/destination": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.3.0.tgz",
-      "integrity": "sha512-aLt3U/XkJWyZW08Ln1qZwBNAGh27yhmYLu892+dBj3gKP6UUiR6ZopXxrBwjBVe00A6k2ktftKDn79qe0hptuw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.4.0.tgz",
+      "integrity": "sha512-jSZtFhwG2JMUc3MLH5z6IVbvk/MYfsQmqOhjc7Lv6twjdipJ/KzKfLD8FRClaDm/ByCMcO7ZYG3z5AagyQu31g==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/difference": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-6.3.0.tgz",
-      "integrity": "sha512-f4P0ra0jBOFk4HO8n/9FZ3NEmOX7FHCXHy/4Z1RSUUQsUQDCkx6/cyqbi8BCy2ZSDUSCGHV+iPgs4fRphMzCHQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/difference/-/difference-6.4.0.tgz",
+      "integrity": "sha512-J8mpLL57e1r4sjH8xjN5cHvUlk/KMivkFSRsAPEN54g00gqCqOPT2MkOJ0r+Rf4YNgDsJcqfJZiewDGU5c4SeQ==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
         "polygon-clipping": "^0.15.2"
       }
     },
     "@turf/distance": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.3.0.tgz",
-      "integrity": "sha512-basi24ssNFnH3iXPFjp/aNUrukjObiFWoIyDRqKyBJxVwVOwAWvfk4d38QQyBj5nDo5IahYRq/Q+T47/5hSs9w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.4.0.tgz",
+      "integrity": "sha512-EyNEfHfFNVwLHsD31hIpaDInoxlwUFZAVryTWxDu6O+XNE+VfVomMUxLYPm3t0tVqVNUGwOhYo5Z4HfTlr6V1g==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/ellipse": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-6.3.0.tgz",
-      "integrity": "sha512-r+EvUK+IGgc3shvS/T1Wof2uCptS2fYmtcwMSFHnHjRnmUyrD4YFjPZT7ygxcDB91+UClZ6cdozR6vqBYzPAog==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/ellipse/-/ellipse-6.4.0.tgz",
+      "integrity": "sha512-clD18HiJv088bnoCKu0R8IZYWKSGbwXXtDZrgFPbW00E3XyanR8Drcf/t6pbBOTlmoC1vATe1E3L4D9BjEvFpg==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/rhumb-destination": "^6.3.0",
-        "@turf/transform-rotate": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/rhumb-destination": "^6.4.0",
+        "@turf/transform-rotate": "^6.4.0"
       }
     },
     "@turf/helpers": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
-      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.4.0.tgz",
+      "integrity": "sha512-7vVpWZwHP0Qn8DDSlM++nhs3/6zfPt+GODjvLVZ+sWIG4S3vOtUUOfO5eIjRzxsUHHqhgiIL0QA17u79uLM+mQ=="
     },
     "@turf/intersect": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.3.0.tgz",
-      "integrity": "sha512-1YCIkyKjuTlX7HaTjtyE7ZRxLCmcu0BYr6jqoVl7TjyF2NUiNpPm3m4X1ZrSF6MfjIt5NFSGYCdNMEPgREq19w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/intersect/-/intersect-6.4.0.tgz",
+      "integrity": "sha512-+vGjy/TDS9PXuTPu5Flh/zcjPmC1lluBqtYO03hqB673Ly1Zk9SBcnNoZQjlpyjFdUkutYM2McYgIKsumTbd1Q==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
         "polygon-clipping": "^0.15.2"
       }
     },
     "@turf/invariant": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.3.0.tgz",
-      "integrity": "sha512-2OFOi9p+QOrcIMySEnr+WlOiKaFZ1bY56jA98YyECewJHfhPFWUBZEhc4nWGRT0ahK08Vus9+gcuBX8QIpCIIw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.4.0.tgz",
+      "integrity": "sha512-ncAiOLkL6Ul6NnyOZSSmEbTwcZZ8PTx7O1IzB89Ed/mAe1g5PvFnyFieWbcnERGmuqH1ftzgtWMFFHFi2PQLsg==",
       "requires": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.4.0"
       }
     },
     "@turf/line-intersect": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.3.0.tgz",
-      "integrity": "sha512-3naxR7XpkPd2vst3Mw6DFry4C9m3o0/f2n/xu5UAyxb88Ie4m2k+1eqkhzMMx/0L+E6iThWpLx7DASM6q6o9ow==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.4.0.tgz",
+      "integrity": "sha512-Zpe5XAz5qCH/8hVKCULvV2ZEfFK+0xS0wlA4TqSIKLLUBOG3zvy2a0M1aCse+/9OSE5kyb/X+q4i5CrYqLORfw==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/line-segment": "^6.3.0",
-        "@turf/meta": "^6.3.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/line-segment": "^6.4.0",
+        "@turf/meta": "^6.4.0",
         "geojson-rbush": "3.x"
       }
     },
     "@turf/line-overlap": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-6.3.0.tgz",
-      "integrity": "sha512-fVyXfTpr/A+ZXZWG6PbuYz5rAGbTQWyrMZveCl2049SbOXSkVXGjUfpnLaklP0p+adw7eRR0LhZn6FGz9CQaFg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-overlap/-/line-overlap-6.4.0.tgz",
+      "integrity": "sha512-2wxFkeHgftV34KzW+vad0rMxV9YEspCGZm+kEm+Uf5JK3BDbD/vYtMeLo5TZT/GoRe+sxjJjmT9uOjUY8zuZBg==",
       "requires": {
-        "@turf/boolean-point-on-line": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/line-segment": "^6.3.0",
-        "@turf/meta": "^6.3.0",
-        "@turf/nearest-point-on-line": "^6.3.0",
+        "@turf/boolean-point-on-line": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/line-segment": "^6.4.0",
+        "@turf/meta": "^6.4.0",
+        "@turf/nearest-point-on-line": "^6.4.0",
         "deep-equal": "1.x",
         "geojson-rbush": "3.x"
       }
     },
     "@turf/line-segment": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.3.0.tgz",
-      "integrity": "sha512-M+aDy83V+E7jYWNaf+b+A88yhnMrJhyg/lhAj6mU6UeB2PbruXB2qgSmmVDSE2dIknOvZZuIWNzEzUI07RO2kw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.4.0.tgz",
+      "integrity": "sha512-avtrD2mZd0z+tbOK+qirNASQ79XWVaCDP7Dy2/QHv68ruWdp839QwO4/ZssRwTTkTPIwS9bLjon1hUIFLGRi5w==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/meta": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/meta": "^6.4.0"
       }
     },
     "@turf/meta": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.3.0.tgz",
-      "integrity": "sha512-qBJjaAJS9H3ap0HlGXyF/Bzfl0qkA9suafX/jnDsZvWMfVLt+s+o6twKrXOGk5t7nnNON2NFRC8+czxpu104EQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.4.0.tgz",
+      "integrity": "sha512-fMra6vMskwz1knn0/tb22ppOeE8CCmpvOvTIxLdV1WYWAoC4bJ4WdXKvZRsJKpHOX5iFehx4DT8aaGdROA4Y3Q==",
       "requires": {
-        "@turf/helpers": "^6.3.0"
+        "@turf/helpers": "^6.4.0"
       }
     },
     "@turf/nearest-point-on-line": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-6.3.0.tgz",
-      "integrity": "sha512-b4C9Md1VbGn9chMgdSj2grJD4w4t0owEWOKEBwOZfdhrcksyOedVvKB7XqOFdj/8Jitel40EKAC5LQTNu24kEQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-6.4.0.tgz",
+      "integrity": "sha512-r/F7rR6yuKa/ezJjbscRaWlIsTGj+SW75B7zFkfNBn85hy6jU/uKERvA/KR2Rrfqrt0s4/QxEiSoVdG9QTRbJA==",
       "requires": {
-        "@turf/bearing": "^6.3.0",
-        "@turf/destination": "^6.3.0",
-        "@turf/distance": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/line-intersect": "^6.3.0",
-        "@turf/meta": "^6.3.0"
+        "@turf/bearing": "^6.4.0",
+        "@turf/destination": "^6.4.0",
+        "@turf/distance": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/line-intersect": "^6.4.0",
+        "@turf/meta": "^6.4.0"
       }
     },
     "@turf/point-to-line-distance": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-6.3.0.tgz",
-      "integrity": "sha512-AqCcj4A0GPzKb3w+q+C9ex0r5mC+u+Ee6VN2jY1p25dxBQJNpMZKDE5LcWtaXeD+pAk3ZGmvea8LR5S0AJukxA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/point-to-line-distance/-/point-to-line-distance-6.4.0.tgz",
+      "integrity": "sha512-A9s2WZtM7n+dfLFV4Q7q0EO9O2749P+SFUYObV/gAa+1Z5HZyrvOjoG0NyTAigELtitlifcZ32Cba6+onIIQKQ==",
       "requires": {
-        "@turf/bearing": "^6.3.0",
-        "@turf/distance": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/meta": "^6.3.0",
-        "@turf/projection": "^6.3.0",
-        "@turf/rhumb-bearing": "^6.3.0",
-        "@turf/rhumb-distance": "^6.3.0"
+        "@turf/bearing": "^6.4.0",
+        "@turf/distance": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/meta": "^6.4.0",
+        "@turf/projection": "^6.4.0",
+        "@turf/rhumb-bearing": "^6.4.0",
+        "@turf/rhumb-distance": "^6.4.0"
       }
     },
     "@turf/polygon-to-line": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.3.0.tgz",
-      "integrity": "sha512-KFGlQlGOBayBvELz+tip1zCa3eB8xyZePZUZ3I3OnU7mk0FFzJzvLTmPUc7MupgqORT4LkNGmyKSVWaz38NTig==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.4.0.tgz",
+      "integrity": "sha512-4Bp/Nl6Ew5P9z/aEqxBTNBaMHHlhNj+l8xeJ/Rm5C6xASQxZ6M/3skRQiRU68A9kFuW/205KklFgT4pnKzgycQ==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/projection": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.3.0.tgz",
-      "integrity": "sha512-IpSs7Q6G6xi47ynVlYYVegPLy6Jc0yo3/DcIm83jaJa4NnzPFXIFZT0v9Fe1N8MraHZqiqaSPbVnJXCGwR12lg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.4.0.tgz",
+      "integrity": "sha512-UtirO+dz0XMgQUG1y50anzHpFsfGObSwT3zsYJIWm3nsJmYMWOBJpsSQ6hMNua3P9GeQrzphG4qJTsQPQveOcA==",
       "requires": {
-        "@turf/clone": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/meta": "^6.3.0"
+        "@turf/clone": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/meta": "^6.4.0"
       }
     },
     "@turf/rewind": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-6.3.0.tgz",
-      "integrity": "sha512-56HwvOZ4r4/wXr8l8zCpdjZ3bxY6Ee7aokuJr/+BlVqikHdRHRx+FJpLGpykZU1YWdO7IiLK7ajX+clYPaqRKg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/rewind/-/rewind-6.4.0.tgz",
+      "integrity": "sha512-7/ebaLR5c9PwqnL5Q/Fi8TgeAcX0e4ieVjpz7eyKW6EuUjQyiPR8bezhEQe54/dDfcMlItz8nsWH27GoNrSlmQ==",
       "requires": {
-        "@turf/boolean-clockwise": "^6.3.0",
-        "@turf/clone": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/meta": "^6.3.0"
+        "@turf/boolean-clockwise": "^6.4.0",
+        "@turf/clone": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/meta": "^6.4.0"
       }
     },
     "@turf/rhumb-bearing": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.3.0.tgz",
-      "integrity": "sha512-/c/BE3huEUrwN6gx7Bg2FzfJqeU+TWk/slQPDHpbVunlIPbS6L28brqSVD+KXfMG8HQIzynz6Pm4Y+j5Iv4aWA==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-bearing/-/rhumb-bearing-6.4.0.tgz",
+      "integrity": "sha512-6KeNTzKsTjmvladtKKtaF3/QLPey9Ui954PuNvb6YGW6FSvS4qlMgznyYz18YYhBAkN1OqSjcqTeVvFjXfzoRw==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/rhumb-destination": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-6.3.0.tgz",
-      "integrity": "sha512-MaQf5wldfERfn8cjtbkD/6GUurAwD+sjedvDgV/chZ83yx7kXmRgrVMpRSGUbmGQ3Ww8dn38sUCapnM6M07+Rg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-destination/-/rhumb-destination-6.4.0.tgz",
+      "integrity": "sha512-eG1Ptlp5hr+L71bRBuoVsGG/ioKymYnCfqOA0FCdG7Wk4dOpPdWesrqIYcIQcFDLMZEiRs4GzVVnpNgWtUSbSA==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/rhumb-distance": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.3.0.tgz",
-      "integrity": "sha512-wMIQVvznusonnp/POeucFdA4Rubn0NrkcEMdxdcCgFK7OmTz0zU4CEnNONF2IUGkQ5WwoKiuS7MOTQ8OuCjSfQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/rhumb-distance/-/rhumb-distance-6.4.0.tgz",
+      "integrity": "sha512-r4dsy8sPyp8k5rR6FwXek8c1RG+nLNH1B43yjmIpaLDKcRYoXJSGt1K8SWOkFOGHl36nukq46Meh2IcH43K6aw==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0"
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0"
       }
     },
     "@turf/transform-rotate": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-6.3.0.tgz",
-      "integrity": "sha512-6CPfmDdaXjbBoPeyHkui704vz6MD3MoI09LGRVJ/RIo1uH/OL6RDSlCfLxFtkE33FJ7VV4giczc3LF1UP5Oh9w==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-rotate/-/transform-rotate-6.4.0.tgz",
+      "integrity": "sha512-R82wadzvJusPWNBvbQnicCGATd+nwai8K1+Y/WleaS1P0zmveqX/jhWBjzBc/DO+IuqGHVQBtox55NsaZZerQQ==",
       "requires": {
-        "@turf/centroid": "^6.3.0",
-        "@turf/clone": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/meta": "^6.3.0",
-        "@turf/rhumb-bearing": "^6.3.0",
-        "@turf/rhumb-destination": "^6.3.0",
-        "@turf/rhumb-distance": "^6.3.0"
+        "@turf/centroid": "^6.4.0",
+        "@turf/clone": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/meta": "^6.4.0",
+        "@turf/rhumb-bearing": "^6.4.0",
+        "@turf/rhumb-destination": "^6.4.0",
+        "@turf/rhumb-distance": "^6.4.0"
       }
     },
     "@turf/transform-scale": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-6.3.0.tgz",
-      "integrity": "sha512-UnLWEXAUdZy7JYbylMjYczPUkxXlUK1nMgv7zEzQ+8mczysPVsgB/FDyiexY2bgVEEBMeDqFSHtqLRavXljI0A==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-scale/-/transform-scale-6.4.0.tgz",
+      "integrity": "sha512-ICY33itdNjKQF0pGXlkoEWIQW5mPxSEo1N+L0vo8/GLARHZS1a19jgb84okFNJndOI9VPXun0giPfpvlJIAbPA==",
       "requires": {
-        "@turf/bbox": "^6.3.0",
-        "@turf/center": "^6.3.0",
-        "@turf/centroid": "^6.3.0",
-        "@turf/clone": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/meta": "^6.3.0",
-        "@turf/rhumb-bearing": "^6.3.0",
-        "@turf/rhumb-destination": "^6.3.0",
-        "@turf/rhumb-distance": "^6.3.0"
+        "@turf/bbox": "^6.4.0",
+        "@turf/center": "^6.4.0",
+        "@turf/centroid": "^6.4.0",
+        "@turf/clone": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/meta": "^6.4.0",
+        "@turf/rhumb-bearing": "^6.4.0",
+        "@turf/rhumb-destination": "^6.4.0",
+        "@turf/rhumb-distance": "^6.4.0"
       }
     },
     "@turf/transform-translate": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-6.3.0.tgz",
-      "integrity": "sha512-ZGAK3T6wdYLOIKr/FHl+i09b1vhPV3XWHw4/M27xA6US2rNcO6/jkLjskdME/3JzJDFmGa8F2vlPqlhtWWoRSw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/transform-translate/-/transform-translate-6.4.0.tgz",
+      "integrity": "sha512-L2edcrFO6YEDFJ0opcX5rmylh0/vHXJxZMQRl1mJhv9mMRHt/W1q6j/vEnnf2UPun86vClaVpBMdAFjgC4UbuQ==",
       "requires": {
-        "@turf/clone": "^6.3.0",
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
-        "@turf/meta": "^6.3.0",
-        "@turf/rhumb-destination": "^6.3.0"
+        "@turf/clone": "^6.4.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
+        "@turf/meta": "^6.4.0",
+        "@turf/rhumb-destination": "^6.4.0"
       }
     },
     "@turf/union": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.3.0.tgz",
-      "integrity": "sha512-m8yh13Q5E0Y+YC10+iI/Qq0Txt7UmSIFByc7DfNVlMMGTceqLFa8xGwSVdFuB/d6MWwKuzKonQMl1PUx/Vd2Iw==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@turf/union/-/union-6.4.0.tgz",
+      "integrity": "sha512-AbyUJosbYgUaSNm3JSGSW5mgtt5rwv2pd76eCxqgoOtoNcQqsWjkXzGgQTLFD5DPB6gEGXz4u/T8na4lxtkyVw==",
       "requires": {
-        "@turf/helpers": "^6.3.0",
-        "@turf/invariant": "^6.3.0",
+        "@turf/helpers": "^6.4.0",
+        "@turf/invariant": "^6.4.0",
         "polygon-clipping": "^0.15.2"
       }
     },
@@ -5513,15 +5514,16 @@
       }
     },
     "broadcast-channel": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.6.0.tgz",
-      "integrity": "sha512-0x87tKJULniTOfECZP/LCsqWyMEbz0Oa+4yJ4i5dosOMxWUjx6mZ6nt9QmD2ox0r3MaCPojHrTQ2dj4ASZupeA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
       "requires": {
         "@babel/runtime": "^7.7.2",
         "detect-node": "^2.1.0",
         "js-sha3": "0.8.0",
         "microseconds": "0.2.0",
         "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
         "rimraf": "3.0.2",
         "unload": "2.2.0"
       },
@@ -6087,17 +6089,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
-    },
-    "clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -7407,21 +7398,21 @@
       "dev": true
     },
     "deck.gl": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.16.tgz",
-      "integrity": "sha512-A5WMNxV7dzPrc2oqMLpl/izxi1V3H8RnsBUrtft3UTSgj70oLpQxuYrNTEaN4sRw6NcLn3/HSzzebjq6HmwLYA==",
+      "version": "8.4.18",
+      "resolved": "https://registry.npmjs.org/deck.gl/-/deck.gl-8.4.18.tgz",
+      "integrity": "sha512-lMdfRheGI2s0Pi40Sb0N4RDqrI1I+oHP5f4gPzt7Ex3tna7WklaI3dZ8XHvkHoxsZVm0x3FW7R3kcZQGyzVUVw==",
       "requires": {
-        "@deck.gl/aggregation-layers": "8.4.16",
-        "@deck.gl/carto": "8.4.16",
-        "@deck.gl/core": "8.4.16",
-        "@deck.gl/extensions": "8.4.16",
-        "@deck.gl/geo-layers": "8.4.16",
-        "@deck.gl/google-maps": "8.4.16",
-        "@deck.gl/json": "8.4.16",
-        "@deck.gl/layers": "8.4.16",
-        "@deck.gl/mapbox": "8.4.16",
-        "@deck.gl/mesh-layers": "8.4.16",
-        "@deck.gl/react": "8.4.16"
+        "@deck.gl/aggregation-layers": "8.4.18",
+        "@deck.gl/carto": "8.4.18",
+        "@deck.gl/core": "8.4.18",
+        "@deck.gl/extensions": "8.4.18",
+        "@deck.gl/geo-layers": "8.4.18",
+        "@deck.gl/google-maps": "8.4.18",
+        "@deck.gl/json": "8.4.18",
+        "@deck.gl/layers": "8.4.18",
+        "@deck.gl/mapbox": "8.4.18",
+        "@deck.gl/mesh-layers": "8.4.18",
+        "@deck.gl/react": "8.4.18"
       }
     },
     "decode-uri-component": {
@@ -7594,12 +7585,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -9989,15 +9974,6 @@
           "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
           "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
         }
-      }
-    },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -15151,13 +15127,13 @@
       }
     },
     "mathjs": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.4.2.tgz",
-      "integrity": "sha512-xu0AU6bpjxbDgCB824s/yDpAe0KR1TMUYz/yY7rYyRcEH56OuG8JPgxJhqlUyhhRpY++ZFDnRxRNGChYx1FLKQ==",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.4.3.tgz",
+      "integrity": "sha512-UgIalR0ICCu1Me4kVPEXb8Xtw7S62XMpP7qSXfImQsoIc1pOX/IxZkLw33VdFYlmXpma3zcRoMq5auwB2fg1AA==",
       "requires": {
-        "@babel/runtime": "^7.14.0",
+        "@babel/runtime": "^7.14.6",
         "complex.js": "^2.0.13",
-        "decimal.js": "^10.2.1",
+        "decimal.js": "^10.3.0",
         "escape-latex": "^1.2.0",
         "fraction.js": "^4.1.1",
         "javascript-natural-sort": "^0.7.1",
@@ -15167,17 +15143,17 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "decimal.js": {
-          "version": "10.2.1",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-          "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+          "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
         }
       }
     },
@@ -15605,9 +15581,9 @@
       }
     },
     "mjolnir.js": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.5.1.tgz",
-      "integrity": "sha512-nwqN1llv2i9V4hfwcbxk2ZywG5ViCqhaoHrotRJgxyd2mI1GXDQ3/L2NBkoyX/w+bpcw3LvrYHzPQIN/7LNocQ==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mjolnir.js/-/mjolnir.js-2.5.2.tgz",
+      "integrity": "sha512-mn20ZhxsWqs41HZS7I2ha0h+FipNSwwuHXeo885YIhj3+4GhIWIBozKLObwR9cnX7sTyIxDQMQiyEUneuCFNkg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "hammerjs": "^2.0.8"
@@ -15882,9 +15858,9 @@
       }
     },
     "nanoid": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-      "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -16455,6 +16431,11 @@
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
+    },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "observable-fns": {
       "version": "0.6.1",
@@ -17157,12 +17138,9 @@
       }
     },
     "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+      "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
     },
     "private": {
       "version": "0.1.8",
@@ -17558,9 +17536,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -17727,13 +17705,13 @@
       }
     },
     "react-checkbox-tree": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/react-checkbox-tree/-/react-checkbox-tree-1.6.0.tgz",
-      "integrity": "sha512-Hi5FeRCtyxClxZEiLvmCT5e/7w8iz0ppkoQyIEayZ35Nscdo4fbwow57EIs+MW0f7L+qnAHGTDmpfHnhxkljXg==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/react-checkbox-tree/-/react-checkbox-tree-1.7.1.tgz",
+      "integrity": "sha512-RkDEj9hqh2eORdvbIsHcAxjYsD6OCWqjejQzUTNUhQkh1rsjkEZDLNbsMN446voY99azP/ZyN0vLXWQKkn+OAw==",
       "requires": {
         "classnames": "^2.2.5",
         "lodash": "^4.17.10",
-        "nanoid": "^2.0.0",
+        "nanoid": "^3.0.0",
         "prop-types": "^15.5.8"
       }
     },
@@ -17833,9 +17811,9 @@
           }
         },
         "react-resizable": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.1.tgz",
-          "integrity": "sha512-wban8GguvXrmeObSVTmhxs99G9eUgYSGugf0i32qHXyqKDTzQsCKLhm3VJW24TpTBKJvM+cybNExskOCYkYF5Q==",
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-3.0.4.tgz",
+          "integrity": "sha512-StnwmiESiamNzdRHbSSvA65b0ZQJ7eVQpPusrSmcpyGKzC0gojhtO62xxH6YOBmepk9dQTBi9yxidL3W4s3EBA==",
           "requires": {
             "prop-types": "15.x",
             "react-draggable": "^4.0.3"
@@ -18957,12 +18935,6 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
       "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "select-hose": {
       "version": "2.0.0",
@@ -21776,11 +21748,11 @@
       }
     },
     "vitessce": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.10.tgz",
-      "integrity": "sha512-XDqUpDkOEkLcIMjpOc4ldXiW1zJJGRO0Hya1S0j9/pmej1cp3e/0cZLWzM6Tpz3i4eReY4YXejrhxzAs6r9DBw==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.11.tgz",
+      "integrity": "sha512-wE9G5fAVdoN2M382WGX4cMh8nVk9bJAV4gv1tIh0+vcm8FZjzHiHWYPUP6+vUztWPk7aWkHJFBo4rLUhDpZomA==",
       "requires": {
-        "@hms-dbmi/viv": "^0.9.4",
+        "@hms-dbmi/viv": "^0.10.4",
         "@loaders.gl/3d-tiles": "^2.3.0",
         "@loaders.gl/core": "^2.3.0",
         "@loaders.gl/images": "^2.3.0",
@@ -21838,9 +21810,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.6",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+          "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }

--- a/context/package.json
+++ b/context/package.json
@@ -45,7 +45,7 @@
     "uuid": "^8.3.2",
     "vega": "^5.13.0",
     "vega-lite": "^4.13.1",
-    "vitessce": "^1.1.10",
+    "vitessce": "^1.1.11",
     "web-vitals": "^1.1.0",
     "whatwg-fetch": "^3.0.0",
     "zustand": "^3.3.1"


### PR DESCRIPTION
Closes 1673

To test:

- [Lightsheet](http://localhost:5001/search?mapped_data_types[0]=Lightsheet%20Microscopy&entity_type[0]=Dataset) should allow 3D and be functional
- [IMC](http://localhost:5001/search?mapped_data_types[0]=Imaging%20Mass%20Cytometry&entity_type[0]=Dataset) should be the same (both of the above, only the datasets in QA)

Other than that everything should look/work identical to what is on PROD right now with the exception of the small UI change of the z-slider placement (for example, for [seqFish](http://localhost:5001/browse/dataset/eaad5ed4b3aa2186bd87e05ff28b593e)) - importantly, there should be no visual cues for 3D outside of the above two data types even though the unstitched CODEX and seqFISH both do have z-stacks.