### PR TITLE
docs update

### DIFF
--- a/CHANGELOG-docs.md
+++ b/CHANGELOG-docs.md
@@ -1,0 +1,1 @@
+- Manually update docs repo.


### PR DESCRIPTION
We haven't been updating docs. :(

```
git submodule foreach '
  echo "was:" `git rev-parse HEAD`
  git checkout master || git checkout main
  git pull
  echo "now:" `git rev-parse HEAD`
'
```
I think the problem is that even if github now is on `main`, developers may still have the `master` branch around... it just isn't getting any updates.

I think just getting rid of the `master` branch in your local checkout will fix this, but I'd like a more robust script, too.

(Docs people would like to see this new page out.)