### PR TITLE
Upgrade marked

### DIFF
--- a/CHANGELOG-marked.md
+++ b/CHANGELOG-marked.md
@@ -1,0 +1,1 @@
+- Upgrade marked, so processing conforms better to Github-flavored MD.

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -6840,7 +6840,7 @@
       "integrity": "sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU="
     },
     "css-element-queries": {
-      "version": "github:marcj/css-element-queries#4eae4654f4683923153d8dd8f5c0d1bc2067b2a8",
+      "version": "github:marcj/css-element-queries#ee21dfe74f096e8733183296ad34af89a18992ba",
       "from": "github:marcj/css-element-queries"
     },
     "css-loader": {
@@ -15104,9 +15104,9 @@
       }
     },
     "marked": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.0.0.tgz",
-      "integrity": "sha512-NqRSh2+LlN2NInpqTQnS614Y/3NkVMFFU6sJlRFEpxJ/LHuK/qJECH7/fXZjk4VZstPW/Pevjil/VtSONsLc7Q=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
     },
     "material-colors": {
       "version": "1.2.6",

--- a/context/package.json
+++ b/context/package.json
@@ -25,7 +25,7 @@
     "immer": "^8.0.1",
     "intersection-observer": "^0.11.0",
     "lodash": "^4.17.21",
-    "marked": "^2.0.0",
+    "marked": "^2.1.3",
     "nuka-carousel": "^4.7.7",
     "pretty-bytes": "^5.3.0",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
In the 2.0.0 version, lines that only contain whitespace caused the adjoining markdown to be rendered verbatim. Fixed in this version, and /docs/technical looks good, without any changes in the submodule.