### PR TITLE
Upgrade flask

### DIFF
--- a/CHANGELOG-upgrade-flask.md
+++ b/CHANGELOG-upgrade-flask.md
@@ -1,0 +1,1 @@
+- Upgrade Flask, primarily to silence warnings during tests.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -1,5 +1,5 @@
 nbformat==5.1.2
-Flask==1.1.2
+Flask==2.0.1
 globus-sdk==2.0.1
 requests==2.22.0
 pyyaml==5.4


### PR DESCRIPTION
Fix #1986. Python tests run without warnings. I've looked at their [release notes](https://flask.palletsprojects.com/en/2.0.x/changes/), and don't see anything that concerns me.