### PR TITLE
`descendant_counts` fallback

### DIFF
--- a/CHANGELOG-descendant_counts-fallback.md
+++ b/CHANGELOG-descendant_counts-fallback.md
@@ -1,0 +1,1 @@
+- Provide a fallback if `descendant_counts` is empty.

--- a/context/app/static/js/components/Detail/provenance/ProvTable/ProvTable.jsx
+++ b/context/app/static/js/components/Detail/provenance/ProvTable/ProvTable.jsx
@@ -20,7 +20,7 @@ function ProvTable(props) {
     typesToSplit.map(() => []),
   );
 
-  const descendantCounts = assayMetadata.descendant_counts.entity_type;
+  const descendantCounts = assayMetadata.descendant_counts.entity_type || {};
 
   return (
     <FlexContainer>


### PR DESCRIPTION
@yuanzhou, if you log in, you can see that https://portal.hubmapconsortium.org/browse/sample/6de04b223f7a976ef1129f10816cd5cb.json just has 
```
"descendant_counts": {}
```
This change gets the portal working again...
We don't have a definitive schema, so I can't say this JSON is "wrong", but it does seem like something has changed. If you think the upstream code is doing what you want, we can accommodate it... but if you're not sure why this changed, I would prefer not to sweep it under the rug.

Involve Bill if needed?