### PR TITLE
Split browse routes to own file

### DIFF
--- a/CHANGELOG-reorg-routes.md
+++ b/CHANGELOG-reorg-routes.md
@@ -1,0 +1,1 @@
+- In the python code, split the `/browse/*` routes to their own file, to keep things reasonable.

--- a/context/app/main.py
+++ b/context/app/main.py
@@ -1,6 +1,6 @@
 from flask import Flask, session, render_template
 
-from . import routes_main, routes_auth, routes_cells, routes_markdown, default_config
+from . import routes_main, routes_browse, routes_auth, routes_cells, routes_markdown, default_config
 from .flask_static_digest import FlaskStaticDigest
 flask_static_digest = FlaskStaticDigest()
 
@@ -52,6 +52,7 @@ def create_app(testing=False):
     flask_static_digest.init_app(app)
 
     app.register_blueprint(routes_main.blueprint)
+    app.register_blueprint(routes_browse.blueprint)
     app.register_blueprint(routes_cells.blueprint)
     app.register_blueprint(routes_auth.blueprint)
     app.register_blueprint(routes_markdown.blueprint)

--- a/context/app/main.py
+++ b/context/app/main.py
@@ -1,6 +1,8 @@
 from flask import Flask, session, render_template
 
-from . import routes_main, routes_browse, routes_auth, routes_cells, routes_markdown, default_config
+from . import (
+    routes_main, routes_browse, routes_auth, routes_cells, routes_markdown,
+    default_config)
 from .flask_static_digest import FlaskStaticDigest
 flask_static_digest = FlaskStaticDigest()
 

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -54,7 +54,7 @@ def login():
          param
     '''
     # The redirect URI, as a complete URI (not relative path)
-    redirect_uri = url_for('routes_auth.login', _external=True)
+    redirect_uri = url_for('auth.login', _external=True)
 
     client = load_app_client()
     client.oauth2_start_flow(redirect_uri)
@@ -116,7 +116,7 @@ def logout():
     redirect_to_globus_param = 'redirect_to_globus'
 
     if redirect_to_globus_param in request.args:
-        redirect_uri = url_for('routes.index', _external=True)
+        redirect_uri = url_for('main.index', _external=True)
         globus_logout_url = 'https://auth.globus.org/v2/web/logout?' + urlencode({
             'client': current_app.config['APP_CLIENT_ID'],
             'redirect_uri': redirect_uri,
@@ -142,5 +142,5 @@ def logout():
 
     kwargs = {redirect_to_globus_param: True}
     response = make_response(
-        redirect(url_for('routes_auth.logout', _external=True, **kwargs)))
+        redirect(url_for('auth.logout', _external=True, **kwargs)))
     return response

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -11,7 +11,7 @@ import globus_sdk
 # https://globus-sdk-python.readthedocs.io/en/stable/examples/three_legged_oauth/
 
 
-blueprint = Blueprint('auth', __name__, template_folder='templates')
+blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
 
 
 def load_app_client():
@@ -54,7 +54,7 @@ def login():
          param
     '''
     # The redirect URI, as a complete URI (not relative path)
-    redirect_uri = url_for('auth.login', _external=True)
+    redirect_uri = url_for('routes_auth.login', _external=True)
 
     client = load_app_client()
     client.oauth2_start_flow(redirect_uri)
@@ -142,5 +142,5 @@ def logout():
 
     kwargs = {redirect_to_globus_param: True}
     response = make_response(
-        redirect(url_for('auth.logout', _external=True, **kwargs)))
+        redirect(url_for('routes_auth.logout', _external=True, **kwargs)))
     return response

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -116,7 +116,7 @@ def logout():
     redirect_to_globus_param = 'redirect_to_globus'
 
     if redirect_to_globus_param in request.args:
-        redirect_uri = url_for('main.index', _external=True)
+        redirect_uri = url_for('routes_main.index', _external=True)
         globus_logout_url = 'https://auth.globus.org/v2/web/logout?' + urlencode({
             'client': current_app.config['APP_CLIENT_ID'],
             'redirect_uri': redirect_uri,

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -11,7 +11,7 @@ import globus_sdk
 # https://globus-sdk-python.readthedocs.io/en/stable/examples/three_legged_oauth/
 
 
-blueprint = Blueprint('routes_auth', __name__, template_folder='templates')
+blueprint = Blueprint('auth', __name__, template_folder='templates')
 
 
 def load_app_client():

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -1,7 +1,7 @@
 from urllib.parse import urlencode, unquote
 
 from flask import (
-    Blueprint, make_response, current_app, url_for,
+    make_response, current_app, url_for,
     request, redirect, render_template, session)
 import requests
 import globus_sdk

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -6,12 +6,14 @@ from flask import (
 import requests
 import globus_sdk
 
+from .utils import make_blueprint
+
 
 # This is mostly copy-and-paste from
 # https://globus-sdk-python.readthedocs.io/en/stable/examples/three_legged_oauth/
 
 
-blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
+blueprint = make_blueprint(__name__)
 
 
 def load_app_client():

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -15,6 +15,7 @@ blueprint = Blueprint('browse', __name__, template_folder='templates')
 
 entity_types = ['donor', 'sample', 'dataset', 'support', 'collection']
 
+
 def _get_client():
     try:
         is_mock = current_app.config['IS_MOCK']

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -41,7 +41,7 @@ def hbm_redirect(hbm_suffix):
     client = _get_client()
     entity = client.get_entity(hbm_id=f'HBM{hbm_suffix}')
     return redirect(
-        url_for('routes.details', type=entity['entity_type'].lower(), uuid=entity['uuid']))
+        url_for('browse.details', type=entity['entity_type'].lower(), uuid=entity['uuid']))
 
 
 @blueprint.route('/browse/<type>/<uuid>.<unknown_ext>')
@@ -60,7 +60,7 @@ def details(type, uuid):
     entity = client.get_entity(uuid)
     actual_type = entity['entity_type'].lower()
     if type != actual_type:
-        return redirect(url_for('routes.details', type=actual_type, uuid=uuid))
+        return redirect(url_for('browse.details', type=actual_type, uuid=uuid))
 
     template = 'pages/base_react.html'
     conf_cells = client.get_vitessce_conf_cells(entity)

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -1,7 +1,7 @@
 import json
 from urllib.parse import urlparse
 
-from flask import (Blueprint, current_app, session, render_template,
+from flask import (current_app, session, render_template,
                    abort, request, redirect, url_for, Response)
 
 import nbformat

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -1,0 +1,169 @@
+import json
+from urllib.parse import urlparse
+
+from flask import (Blueprint, current_app, session, render_template,
+                   abort, request, redirect, url_for, Response)
+
+import nbformat
+from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
+
+from .api.client import ApiClient
+from .utils import get_default_flask_data
+
+
+blueprint = Blueprint('browse', __name__, template_folder='templates')
+
+entity_types = ['donor', 'sample', 'dataset', 'support', 'collection']
+
+def _get_client():
+    try:
+        is_mock = current_app.config['IS_MOCK']
+    except KeyError:
+        is_mock = False
+    if is_mock:
+        return ApiClient(is_mock=is_mock)
+    return ApiClient(
+        current_app.config['ENTITY_API_BASE'],
+        session['nexus_token']
+    )
+
+
+def get_url_base_from_request():
+    parsed = urlparse(request.base_url)
+    scheme = parsed.scheme
+    netloc = parsed.netloc
+    return f'{scheme}://{netloc}'
+
+
+@blueprint.route('/browse/HBM<hbm_suffix>')
+def hbm_redirect(hbm_suffix):
+    client = _get_client()
+    entity = client.get_entity(hbm_id=f'HBM{hbm_suffix}')
+    return redirect(
+        url_for('routes.details', type=entity['entity_type'].lower(), uuid=entity['uuid']))
+
+
+@blueprint.route('/browse/<type>/<uuid>.<unknown_ext>')
+def unknown_ext(type, uuid, unknown_ext):
+    # https://github.com/pallets/werkzeug/blob/b01fa1817343d2a36a9d8bb17f61ddf209c27c2b/src/werkzeug/routing.py#L1126
+    # Rules with static parts come before variable routes...
+    # so the known extensions will come before this.
+    abort(404)
+
+
+@blueprint.route('/browse/<type>/<uuid>')
+def details(type, uuid):
+    if type not in entity_types:
+        abort(404)
+    client = _get_client()
+    entity = client.get_entity(uuid)
+    actual_type = entity['entity_type'].lower()
+    if type != actual_type:
+        return redirect(url_for('routes.details', type=actual_type, uuid=uuid))
+
+    template = 'pages/base_react.html'
+    conf_cells = client.get_vitessce_conf_cells(entity)
+    flask_data = {
+        **get_default_flask_data(),
+        'entity': entity,
+        'vitessce_conf': conf_cells.conf,
+        'has_notebook': conf_cells.cells is not None
+    }
+    return render_template(
+        template,
+        type=type,
+        uuid=uuid,
+        title=f'{entity["hubmap_id"]} | {type.title()}',
+        flask_data=flask_data
+    )
+
+
+@blueprint.route('/browse/<type>/<uuid>.json')
+def details_json(type, uuid):
+    if type not in entity_types:
+        abort(404)
+    client = _get_client()
+    entity = client.get_entity(uuid)
+    return entity
+
+
+@blueprint.route('/browse/<type>/<uuid>.ipynb')
+def details_notebook(type, uuid):
+    if type not in entity_types:
+        abort(404)
+    client = _get_client()
+    entity = client.get_entity(uuid)
+    vitessce_conf = client.get_vitessce_conf_cells(entity)
+    if (vitessce_conf is None
+            or vitessce_conf.conf is None
+            or vitessce_conf.cells is None):
+        abort(404)
+    nb = new_notebook()
+    nb['cells'] = [
+        new_markdown_cell(f"""
+Visualization for [{entity['hubmap_id']}]({request.base_url.replace('.ipynb','')})
+        """.strip()),
+        new_code_cell("""
+!pip install vitessce==0.1.0a9
+!jupyter nbextension install --py --sys-prefix vitessce
+!jupyter nbextension enable --py --sys-prefix vitessce
+        """.strip()),
+        new_code_cell('from vitessce import VitessceConfig')
+    ] + vitessce_conf.cells + [
+        new_code_cell('conf.widget()')
+    ]
+    return Response(
+        response=nbformat.writes(nb),
+        headers={'Content-Disposition': f"attachment; filename={entity['hubmap_id']}.ipynb"},
+        mimetype='application/x-ipynb+json'
+    )
+
+
+@blueprint.route('/browse/<type>/<uuid>.rui.json')
+def details_rui_json(type, uuid):
+    # Note that the API returns a blob of JSON as a string,
+    # so, to return a JSON object, and not just a string, we need to decode.
+    if type not in entity_types:
+        abort(404)
+    client = _get_client()
+    entity = client.get_entity(uuid)
+    # For Samples...
+    if 'rui_location' in entity:
+        return json.loads(entity['rui_location'])
+    # For Datasets...
+    if 'ancestors' not in entity:
+        abort(404)
+    located_ancestors = [a for a in entity['ancestors'] if 'rui_location' in a]
+    if not located_ancestors:
+        abort(404)
+    # There may be multiple: The last should be the closest...
+    # but this should be confirmed, when there are examples.
+    return json.loads(located_ancestors[-1]['rui_location'])
+
+
+@blueprint.route('/sitemap.txt')
+def sitemap_txt():
+    client = _get_client()
+    uuids = client.get_all_dataset_uuids()
+    url_base = get_url_base_from_request()
+    return Response(
+        '\n'.join(
+            f'{url_base}/browse/dataset/{uuid}' for uuid in uuids
+        ),
+        mimetype='text/plain')
+
+
+@blueprint.route('/robots.txt')
+def robots_txt():
+    allowed_hostname = 'portal.hubmapconsortium.org'
+    hostname = urlparse(request.base_url).hostname
+    disallow = '/search' if hostname == allowed_hostname else '/'
+    return Response(
+        f'''
+# This host: {hostname}
+# Allowed host: {allowed_hostname}
+User-agent: *
+Disallow: {disallow}
+Sitemap: {get_url_base_from_request()}/sitemap.txt
+''',
+        mimetype='text/plain')

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -11,7 +11,7 @@ from .api.client import ApiClient
 from .utils import get_default_flask_data
 
 
-blueprint = Blueprint('browse', __name__, template_folder='templates')
+blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
 
 entity_types = ['donor', 'sample', 'dataset', 'support', 'collection']
 
@@ -41,7 +41,7 @@ def hbm_redirect(hbm_suffix):
     client = _get_client()
     entity = client.get_entity(hbm_id=f'HBM{hbm_suffix}')
     return redirect(
-        url_for('browse.details', type=entity['entity_type'].lower(), uuid=entity['uuid']))
+        url_for('routes_browse.details', type=entity['entity_type'].lower(), uuid=entity['uuid']))
 
 
 @blueprint.route('/browse/<type>/<uuid>.<unknown_ext>')
@@ -60,7 +60,7 @@ def details(type, uuid):
     entity = client.get_entity(uuid)
     actual_type = entity['entity_type'].lower()
     if type != actual_type:
-        return redirect(url_for('browse.details', type=actual_type, uuid=uuid))
+        return redirect(url_for('routes_browse.details', type=actual_type, uuid=uuid))
 
     template = 'pages/base_react.html'
     conf_cells = client.get_vitessce_conf_cells(entity)

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -8,10 +8,10 @@ import nbformat
 from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 
 from .api.client import ApiClient
-from .utils import get_default_flask_data
+from .utils import get_default_flask_data, make_blueprint
 
 
-blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
+blueprint = make_blueprint(__name__)
 
 entity_types = ['donor', 'sample', 'dataset', 'support', 'collection']
 

--- a/context/app/routes_cells.py
+++ b/context/app/routes_cells.py
@@ -4,10 +4,10 @@ from flask import (Blueprint, render_template, current_app, request)
 
 from hubmap_api_py_client import Client
 
-from .routes_main import get_default_flask_data
+from .utils import get_default_flask_data
 
 
-blueprint = Blueprint('routes_cells', __name__, template_folder='templates')
+blueprint = Blueprint('cells', __name__, template_folder='templates')
 
 
 @blueprint.route('/cells')

--- a/context/app/routes_cells.py
+++ b/context/app/routes_cells.py
@@ -4,10 +4,10 @@ from flask import (Blueprint, render_template, current_app, request)
 
 from hubmap_api_py_client import Client
 
-from .utils import get_default_flask_data
+from .utils import get_default_flask_data, make_blueprint
 
 
-blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
+blueprint = make_blueprint(__name__)
 
 
 @blueprint.route('/cells')

--- a/context/app/routes_cells.py
+++ b/context/app/routes_cells.py
@@ -7,7 +7,7 @@ from hubmap_api_py_client import Client
 from .utils import get_default_flask_data
 
 
-blueprint = Blueprint('cells', __name__, template_folder='templates')
+blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
 
 
 @blueprint.route('/cells')

--- a/context/app/routes_cells.py
+++ b/context/app/routes_cells.py
@@ -1,6 +1,6 @@
 from itertools import islice
 
-from flask import (Blueprint, render_template, current_app, request)
+from flask import render_template, current_app, request
 
 from hubmap_api_py_client import Client
 

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -8,7 +8,7 @@ import frontmatter
 from .utils import get_default_flask_data
 
 
-blueprint = Blueprint('main', __name__, template_folder='templates')
+blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
 
 
 @blueprint.route('/')

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,6 +1,6 @@
 from os.path import dirname
 
-from flask import (Blueprint, render_template, current_app,
+from flask import (render_template, current_app,
                    session, request)
 
 import frontmatter

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -5,10 +5,10 @@ from flask import (Blueprint, render_template, current_app,
 
 import frontmatter
 
-from .utils import get_default_flask_data
+from .utils import get_default_flask_data, make_blueprint
 
 
-blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
+blueprint = make_blueprint(__name__)
 
 
 @blueprint.route('/')

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,46 +1,14 @@
 from os.path import dirname
-from urllib.parse import urlparse
-import json
-import nbformat
-from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 
-from flask import (Blueprint, render_template, abort, current_app,
-                   session, request, redirect, url_for, Response)
+from flask import (Blueprint, render_template, current_app,
+                   session, request)
 
 import frontmatter
 
-from .api.client import ApiClient
+from .utils import get_default_flask_data
 
 
-entity_types = ['donor', 'sample', 'dataset', 'support', 'collection']
-blueprint = Blueprint('routes', __name__, template_folder='templates')
-
-
-def _get_client():
-    try:
-        is_mock = current_app.config['IS_MOCK']
-    except KeyError:
-        is_mock = False
-    if is_mock:
-        return ApiClient(is_mock=is_mock)
-    return ApiClient(
-        current_app.config['ENTITY_API_BASE'],
-        session['nexus_token']
-    )
-
-
-def get_default_flask_data():
-    return {
-        'endpoints': {
-            'elasticsearchEndpoint': current_app.config['ELASTICSEARCH_ENDPOINT']
-            + current_app.config['PORTAL_INDEX_PATH'],
-            'assetsEndpoint': current_app.config['ASSETS_ENDPOINT'],
-            'entityEndpoint': current_app.config['ENTITY_API_BASE'],
-            'xmodalityEndpoint': current_app.config['XMODALITY_ENDPOINT'],
-            'gatewayEndpoint': current_app.config['GATEWAY_ENDPOINT'],
-        },
-        'globalAlertMd': current_app.config.get('GLOBAL_ALERT_MD')
-    }
+blueprint = Blueprint('main', __name__, template_folder='templates')
 
 
 @blueprint.route('/')
@@ -48,7 +16,6 @@ def index():
     flask_data = {**get_default_flask_data()}
     return render_template(
         'pages/base_react.html',
-        types=entity_types,
         flask_data=flask_data,
         title='HuBMAP Data Portal',
         is_home_page=True
@@ -60,7 +27,6 @@ def service_status():
     flask_data = {**get_default_flask_data()}
     return render_template(
         'pages/base_react.html',
-        types=entity_types,
         flask_data=flask_data,
         title='Services'
     )
@@ -80,112 +46,6 @@ def ccf_eui():
     )
 
 
-@blueprint.route('/browse/HBM<hbm_suffix>')
-def hbm_redirect(hbm_suffix):
-    client = _get_client()
-    entity = client.get_entity(hbm_id=f'HBM{hbm_suffix}')
-    return redirect(
-        url_for('routes.details', type=entity['entity_type'].lower(), uuid=entity['uuid']))
-
-
-@blueprint.route('/browse/<type>/<uuid>.<unknown_ext>')
-def unknown_ext(type, uuid, unknown_ext):
-    # https://github.com/pallets/werkzeug/blob/b01fa1817343d2a36a9d8bb17f61ddf209c27c2b/src/werkzeug/routing.py#L1126
-    # Rules with static parts come before variable routes...
-    # so the known extensions will come before this.
-    abort(404)
-
-
-@blueprint.route('/browse/<type>/<uuid>')
-def details(type, uuid):
-    if type not in entity_types:
-        abort(404)
-    client = _get_client()
-    entity = client.get_entity(uuid)
-    actual_type = entity['entity_type'].lower()
-    if type != actual_type:
-        return redirect(url_for('routes.details', type=actual_type, uuid=uuid))
-
-    template = 'pages/base_react.html'
-    conf_cells = client.get_vitessce_conf_cells(entity)
-    flask_data = {
-        **get_default_flask_data(),
-        'entity': entity,
-        'vitessce_conf': conf_cells.conf,
-        'has_notebook': conf_cells.cells is not None
-    }
-    return render_template(
-        template,
-        type=type,
-        uuid=uuid,
-        title=f'{entity["hubmap_id"]} | {type.title()}',
-        flask_data=flask_data
-    )
-
-
-@blueprint.route('/browse/<type>/<uuid>.json')
-def details_json(type, uuid):
-    if type not in entity_types:
-        abort(404)
-    client = _get_client()
-    entity = client.get_entity(uuid)
-    return entity
-
-
-@blueprint.route('/browse/<type>/<uuid>.ipynb')
-def details_notebook(type, uuid):
-    if type not in entity_types:
-        abort(404)
-    client = _get_client()
-    entity = client.get_entity(uuid)
-    vitessce_conf = client.get_vitessce_conf_cells(entity)
-    if (vitessce_conf is None
-            or vitessce_conf.conf is None
-            or vitessce_conf.cells is None):
-        abort(404)
-    nb = new_notebook()
-    nb['cells'] = [
-        new_markdown_cell(f"""
-Visualization for [{entity['hubmap_id']}]({request.base_url.replace('.ipynb','')})
-        """.strip()),
-        new_code_cell("""
-!pip install vitessce==0.1.0a9
-!jupyter nbextension install --py --sys-prefix vitessce
-!jupyter nbextension enable --py --sys-prefix vitessce
-        """.strip()),
-        new_code_cell('from vitessce import VitessceConfig')
-    ] + vitessce_conf.cells + [
-        new_code_cell('conf.widget()')
-    ]
-    return Response(
-        response=nbformat.writes(nb),
-        headers={'Content-Disposition': f"attachment; filename={entity['hubmap_id']}.ipynb"},
-        mimetype='application/x-ipynb+json'
-    )
-
-
-@blueprint.route('/browse/<type>/<uuid>.rui.json')
-def details_rui_json(type, uuid):
-    # Note that the API returns a blob of JSON as a string,
-    # so, to return a JSON object, and not just a string, we need to decode.
-    if type not in entity_types:
-        abort(404)
-    client = _get_client()
-    entity = client.get_entity(uuid)
-    # For Samples...
-    if 'rui_location' in entity:
-        return json.loads(entity['rui_location'])
-    # For Datasets...
-    if 'ancestors' not in entity:
-        abort(404)
-    located_ancestors = [a for a in entity['ancestors'] if 'rui_location' in a]
-    if not located_ancestors:
-        abort(404)
-    # There may be multiple: The last should be the closest...
-    # but this should be confirmed, when there are examples.
-    return json.loads(located_ancestors[-1]['rui_location'])
-
-
 @blueprint.route('/search')
 @blueprint.route('/cells-search')
 def search():
@@ -198,7 +58,6 @@ def search():
     return render_template(
         'pages/base_react.html',
         title=title,
-        types=entity_types,
         flask_data=flask_data,
     )
 
@@ -213,7 +72,6 @@ def dev_search():
     return render_template(
         'pages/base_react.html',
         title=title,
-        types=entity_types,
         flask_data=flask_data
     )
 
@@ -228,7 +86,6 @@ def vis():
     return render_template(
         'pages/base_react.html',
         title=title,
-        types=entity_types,
         flask_data=flask_data
     )
 
@@ -289,38 +146,3 @@ def list_page(saved_list_uuid):
         title='Saved List',
         flask_data=flask_data
     )
-
-
-@blueprint.route('/robots.txt')
-def robots_txt():
-    allowed_hostname = 'portal.hubmapconsortium.org'
-    hostname = urlparse(request.base_url).hostname
-    disallow = '/search' if hostname == allowed_hostname else '/'
-    return Response(
-        f'''
-# This host: {hostname}
-# Allowed host: {allowed_hostname}
-User-agent: *
-Disallow: {disallow}
-Sitemap: {get_url_base_from_request()}/sitemap.txt
-''',
-        mimetype='text/plain')
-
-
-@blueprint.route('/sitemap.txt')
-def sitemap_txt():
-    client = _get_client()
-    uuids = client.get_all_dataset_uuids()
-    url_base = get_url_base_from_request()
-    return Response(
-        '\n'.join(
-            f'{url_base}/browse/dataset/{uuid}' for uuid in uuids
-        ),
-        mimetype='text/plain')
-
-
-def get_url_base_from_request():
-    parsed = urlparse(request.base_url)
-    scheme = parsed.scheme
-    netloc = parsed.netloc
-    return f'{scheme}://{netloc}'

--- a/context/app/routes_markdown.py
+++ b/context/app/routes_markdown.py
@@ -4,12 +4,12 @@ from os.path import dirname
 
 from flask import Blueprint, render_template, request, redirect
 
-from .utils import get_default_flask_data
+from .utils import get_default_flask_data, make_blueprint
 
 # NOTE: A better approach might be to look again at the handful of libraries
 # that handle this, or to pre-render everything when flask starts.
 
-blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
+blueprint = make_blueprint(__name__)
 
 
 def _title_from_md(md):

--- a/context/app/routes_markdown.py
+++ b/context/app/routes_markdown.py
@@ -4,12 +4,12 @@ from os.path import dirname
 
 from flask import Blueprint, render_template, request, redirect
 
-from .routes_main import get_default_flask_data
+from .utils import get_default_flask_data
 
 # NOTE: A better approach might be to look again at the handful of libraries
 # that handle this, or to pre-render everything when flask starts.
 
-blueprint = Blueprint('routes_markdown', __name__, template_folder='templates')
+blueprint = Blueprint('markdown', __name__, template_folder='templates')
 
 
 def _title_from_md(md):

--- a/context/app/routes_markdown.py
+++ b/context/app/routes_markdown.py
@@ -2,7 +2,7 @@ import re
 from glob import glob
 from os.path import dirname
 
-from flask import Blueprint, render_template, request, redirect
+from flask import render_template, request, redirect
 
 from .utils import get_default_flask_data, make_blueprint
 

--- a/context/app/routes_markdown.py
+++ b/context/app/routes_markdown.py
@@ -9,7 +9,7 @@ from .utils import get_default_flask_data
 # NOTE: A better approach might be to look again at the handful of libraries
 # that handle this, or to pre-render everything when flask starts.
 
-blueprint = Blueprint('markdown', __name__, template_folder='templates')
+blueprint = Blueprint(__name__.split('.')[-1], __name__, template_folder='templates')
 
 
 def _title_from_md(md):

--- a/context/app/test_routes_errors.py
+++ b/context/app/test_routes_errors.py
@@ -2,7 +2,7 @@ import pytest
 import requests
 
 from .main import create_app
-from .routes_main import entity_types
+from .routes_browse import entity_types
 
 
 @pytest.fixture

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from .main import create_app
-from .routes_main import entity_types
+from .routes_browse import entity_types
 
 
 @pytest.fixture

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -1,0 +1,15 @@
+from flask import current_app
+
+
+def get_default_flask_data():
+    return {
+        'endpoints': {
+            'elasticsearchEndpoint': current_app.config['ELASTICSEARCH_ENDPOINT']
+            + current_app.config['PORTAL_INDEX_PATH'],
+            'assetsEndpoint': current_app.config['ASSETS_ENDPOINT'],
+            'entityEndpoint': current_app.config['ENTITY_API_BASE'],
+            'xmodalityEndpoint': current_app.config['XMODALITY_ENDPOINT'],
+            'gatewayEndpoint': current_app.config['GATEWAY_ENDPOINT'],
+        },
+        'globalAlertMd': current_app.config.get('GLOBAL_ALERT_MD')
+    }

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -1,4 +1,4 @@
-from flask import current_app
+from flask import (current_app, Blueprint)
 
 
 def get_default_flask_data():
@@ -13,3 +13,7 @@ def get_default_flask_data():
         },
         'globalAlertMd': current_app.config.get('GLOBAL_ALERT_MD')
     }
+
+
+def make_blueprint(name):
+    return Blueprint(name.split('.')[-1], name, template_folder='templates')


### PR DESCRIPTION
Moving out the `browse` routes cuts `routes_main` in half. Also delete some vestigial code, and cleanup.