### PR TITLE
Donors/Samples/Datasets TSVs

### DIFF
--- a/CHANGELOG-donor-metadata.md
+++ b/CHANGELOG-donor-metadata.md
@@ -1,0 +1,1 @@
+- Add an endpoint for easy download of donor metadata.

--- a/CHANGELOG-mock-client.md
+++ b/CHANGELOG-mock-client.md
@@ -1,0 +1,1 @@
+- Refactor `ApiClient` mocking with OO.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -71,6 +71,9 @@ class ApiClient():
     def get_all_samples(self, non_metadata_fields):
         return self._get_all_entities_of_type(non_metadata_fields, 'Sample')
 
+    def get_all_datasets(self, non_metadata_fields):
+        return self._get_all_entities_of_type(non_metadata_fields, 'Dataset')
+
     def _get_all_entities_of_type(self, non_metadata_fields, entity_type):
         size = 10000  # Default ES limit
         query = {

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -189,7 +189,8 @@ class ApiClient():
 
 def _flatten_sources(sources, non_metadata_fields):
     '''
-    >>> sources = [
+    >>> from pprint import pp
+    >>> donor_sources = [
     ...     {'uuid': 'abcd1234', 'name': 'Ann',
     ...      'other': 'skipped',
     ...      'mapped_metadata': {'age': [40], 'weight': [150]}
@@ -197,10 +198,18 @@ def _flatten_sources(sources, non_metadata_fields):
     ...     {'uuid': 'wxyz1234', 'name': 'Bob',
     ...      'mapped_metadata': {'age': [50], 'multi': ['A', 'B', 'C']}
     ...     }]
-    >>> from pprint import pp
-    >>> pp(_flatten_sources(sources, ['uuid', 'name']))
+    >>> pp(_flatten_sources(donor_sources, ['uuid', 'name']))
     [{'uuid': 'abcd1234', 'name': 'Ann', 'age': '40', 'weight': '150'},
      {'uuid': 'wxyz1234', 'name': 'Bob', 'age': '50', 'multi': 'A, B, C'}]
+
+    >>> sample_sources = [
+    ...     {'uuid': 'abcd1234',
+    ...      'metadata': {'organ': 'belly button',
+    ...                   'organ_donor_data': {'example': 'Should remove!'},
+    ...                   'metadata': {'example': 'Should remove!'}}
+    ...     }]
+    >>> pp(_flatten_sources(sample_sources, ['uuid', 'name']))
+    [{'uuid': 'abcd1234', 'name': None, 'organ': 'belly button'}]
     '''
     flat_sources = [
         {

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -1,9 +1,7 @@
 from collections import namedtuple
-import json
 import traceback
 from copy import deepcopy
 
-from datauri import DataURI
 from flask import abort, current_app
 import requests
 
@@ -14,10 +12,9 @@ Entity = namedtuple('Entity', ['uuid', 'type', 'name'], defaults=['TODO: name'])
 
 
 class ApiClient():
-    def __init__(self, url_base=None, nexus_token=None, is_mock=False):
+    def __init__(self, url_base=None, nexus_token=None):
         self.url_base = url_base
         self.nexus_token = nexus_token
-        self.is_mock = is_mock
 
     def _request(self, url, body_json=None):
         headers = {'Authorization': 'Bearer ' + self.nexus_token} if self.nexus_token else {}
@@ -93,17 +90,6 @@ class ApiClient():
         return _flatten_sources(sources, non_metadata_fields)
 
     def get_entity(self, uuid=None, hbm_id=None):
-        if self.is_mock:
-            return {
-                'created': '2020-01-01 00:00:00',
-                'modified': '2020-01-01 00:00:00',
-                'provenance_user_displayname': 'Chuck McCallum',
-                'provenance_user_email': 'mccalluc@example.com',
-                'provenance_group_name': 'Mock Group',
-                'hubmap_id': 'abcd-1234',
-                'description': 'Mock Entity'
-            }
-
         if uuid is not None and hbm_id is not None:
             raise Exception('Only UUID or HBM ID should be provided, not both')
         query = {'query':
@@ -138,8 +124,6 @@ class ApiClient():
 
         if 'files' not in entity or 'data_types' not in entity:
             return ConfCells(None, None)
-        if self.is_mock:
-            return ConfCells(self._get_mock_vitessce_conf(), None)
 
         # Otherwise, just try to visualize the data for the entity itself:
         try:
@@ -152,42 +136,6 @@ class ApiClient():
             current_app.logger.error(message)
 
             return ConfCells({'error': message}, None)
-
-    def _get_mock_vitessce_conf(self):
-        cellsData = json.dumps({'cell-id-1': {'mappings': {'t-SNE': [1, 1]}}})
-        cellsUri = DataURI.make(
-            'text/plain', charset='us-ascii', base64=True, data=cellsData
-        )
-        token = 'fake-token'
-        return {
-            'description': 'DEMO',
-            'layers': [
-                {
-                    'name': 'cells',
-                    'type': 'CELLS',
-                    'url': cellsUri,
-                    'requestInit': {
-                        'headers': {
-                            'Authorization': 'Bearer ' + token
-                        }
-                    }
-                },
-            ],
-            'name': 'Linnarsson',
-            'staticLayout': [
-                {
-                    'component': 'scatterplot',
-                    'props': {
-                        'mapping': 'UMAP',
-                        'view': {
-                            'zoom': 4,
-                            'target': [0, 0, 0]
-                        }
-                    },
-                    'x': 0, 'y': 0, 'w': 12, 'h': 2
-                },
-            ]
-        }
 
 
 def _flatten_sources(sources, non_metadata_fields):

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -221,8 +221,7 @@ def _flatten_sources(sources, non_metadata_fields):
                 for field in non_metadata_fields
             },
 
-            # This gets sample metadata.
-            # mapped_metadata not populated for samples... Can't recall why not.
+            # This gets sample and donor metadata.
             **source.get('metadata', {}),
 
             # This gets donor metadata, and concatenates nested lists.
@@ -234,15 +233,22 @@ def _flatten_sources(sources, non_metadata_fields):
         for source in sources
     ]
     for source in flat_sources:
-        # An alternative approach to removing individual keys
-        # would be to remove all values which are dicts.
+        if 'assay_type' in source.get('metadata', {}):
+            # For donors, this is the metadata in EAV form,
+            # for samples, this is a placeholder for dev-search,
+            # but for datasets, we want to move it up a level.
+            source.update(source['metadata'])
 
-        # For donors, this is the metadata in EAV form.
-        # For samples, this is a placeholder for dev-search.
-        source.pop('metadata', None)
-
-        source.pop('organ_donor_data', None)
-        source.pop('living_donor_data', None)
+        for field in [
+                'metadata',
+                # From datasets JSON:
+                'dag_provenance_list', 'extra_metadata', 'files_info_alt_path',
+                # Dataset TSV columns to hide:
+                'antibodies_path', 'contributors_path', 'version',
+                # From samples:
+                'organ_donor_data', 'living_donor_data'
+            ]:
+            source.pop(field, None)
     return flat_sources
 
 

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -234,7 +234,6 @@ def _flatten_sources(sources, non_metadata_fields):
     return flat_sources
 
 
-
 def _get_entity_from_hits(hits, has_token=None, uuid=None, hbm_id=None):
     '''
     >>> _get_entity_from_hits(['fake-hit-1', 'fake-hit-2'])

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -246,8 +246,7 @@ def _flatten_sources(sources, non_metadata_fields):
                 # Dataset TSV columns to hide:
                 'antibodies_path', 'contributors_path', 'version',
                 # From samples:
-                'organ_donor_data', 'living_donor_data'
-            ]:
+                'organ_donor_data', 'living_donor_data']:
             source.pop(field, None)
     return flat_sources
 

--- a/context/app/api/mock_client.py
+++ b/context/app/api/mock_client.py
@@ -1,0 +1,59 @@
+import json
+
+from datauri import DataURI
+
+from .vitessce_confs.base_confs import ConfCells
+from .client import ApiClient
+
+
+class MockApiClient(ApiClient):
+    def get_entity(self, uuid=None, hbm_id=None):
+        return {
+            'created': '2020-01-01 00:00:00',
+            'modified': '2020-01-01 00:00:00',
+            'provenance_user_displayname': 'Chuck McCallum',
+            'provenance_user_email': 'mccalluc@example.com',
+            'provenance_group_name': 'Mock Group',
+            'hubmap_id': 'abcd-1234',
+            'description': 'Mock Entity'
+        }
+
+    def get_vitessce_conf_cells(self, entity):
+        return ConfCells(_get_mock_vitessce_conf(), None)
+
+
+def _get_mock_vitessce_conf():
+    cellsData = json.dumps({'cell-id-1': {'mappings': {'t-SNE': [1, 1]}}})
+    cellsUri = DataURI.make(
+        'text/plain', charset='us-ascii', base64=True, data=cellsData
+    )
+    token = 'fake-token'
+    return {
+        'description': 'DEMO',
+        'layers': [
+            {
+                'name': 'cells',
+                'type': 'CELLS',
+                'url': cellsUri,
+                'requestInit': {
+                    'headers': {
+                        'Authorization': 'Bearer ' + token
+                    }
+                }
+            },
+        ],
+        'name': 'Linnarsson',
+        'staticLayout': [
+            {
+                'component': 'scatterplot',
+                'props': {
+                    'mapping': 'UMAP',
+                    'view': {
+                        'zoom': 4,
+                        'target': [0, 0, 0]
+                    }
+                },
+                'x': 0, 'y': 0, 'w': 12, 'h': 2
+            },
+        ]
+    }

--- a/context/app/api/vitessce_confs/assay_confs.py
+++ b/context/app/api/vitessce_confs/assay_confs.py
@@ -48,6 +48,7 @@ class SeqFISHViewConfBuilder(AbstractImagingViewConfBuilder):
     one per position, with the hybridization cycles
     grouped together per position in a single Vitessce configuration.
     """
+
     def get_conf_cells(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         full_seqfish_reqex = "/".join(
@@ -113,6 +114,7 @@ class TiledSPRMViewConfBuilder(ViewConfBuilder):
     non-stitched JSON-backed SPRM Vitessce configurations,
     one per tile per region, via SPRMJSONViewConfBuilder.
     """
+
     def get_conf_cells(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_tiles = get_matches(
@@ -145,6 +147,7 @@ class RNASeqViewConfBuilder(AbstractScatterplotViewConfBuilder):
     https://portal.hubmapconsortium.org/browse/dataset/c019a1cd35aab4d2b4a6ff221e92aaab
     from h5ad-to-arrow.cwl (August 2020 release).
     """
+
     def __init__(self, entity, nexus_token, is_mock=False):
         super().__init__(entity, nexus_token, is_mock)
         # All "file" Vitessce objects that do not have wrappers.
@@ -167,6 +170,7 @@ class ATACSeqViewConfBuilder(AbstractScatterplotViewConfBuilder):
     https://portal.hubmapconsortium.org/browse/dataset/d4493657cde29702c5ed73932da5317c
     from h5ad-to-arrow.cwl.
     """
+
     def __init__(self, entity, nexus_token, is_mock=False):
         super().__init__(entity, nexus_token, is_mock)
         # All "file" Vitessce objects that do not have wrappers.
@@ -192,6 +196,7 @@ class StitchedCytokitSPRMViewConfBuilder(ViewConfBuilder):
     used for datasets with multiple regions.
     These are from post-August 2020 Cytokit datasets (stitched).
     """
+
     def get_conf_cells(self):
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
         found_regions = get_matches(file_paths_found, STITCHED_REGEX)
@@ -227,6 +232,7 @@ class RNASeqAnnDataZarrViewConfBuilder(ViewConfBuilder):
     for "second generation" post-August 2020 RNA-seq data from anndata-to-ui.cwl like
     https://portal.hubmapconsortium.org/browse/dataset/e65175561b4b17da5352e3837aa0e497
     """
+
     def get_conf_cells(self):
         zarr_path = 'hubmap_ui/anndata-zarr/secondary_analysis.zarr'
         file_paths_found = [file["rel_path"] for file in self._entity["files"]]
@@ -275,6 +281,7 @@ class IMSViewConfBuilder(ImagePyramidViewConfBuilder):
     for IMS data that excludes the image pyramids
     of all the channels separated out.
     """
+
     def __init__(self, entity, nexus_token, is_mock=False):
         super().__init__(entity, nexus_token, is_mock)
         # Do not show the separated mass-spec images.

--- a/context/app/api/vitessce_confs/base_confs.py
+++ b/context/app/api/vitessce_confs/base_confs.py
@@ -198,6 +198,7 @@ class AbstractScatterplotViewConfBuilder(ViewConfBuilder):
     https://portal.hubmapconsortium.org/browse/dataset/d4493657cde29702c5ed73932da5317c
     from h5ad-to-arrow.cwl.
     """
+
     def get_conf_cells(self):
         file_paths_expected = [file["rel_path"] for file in self._files]
         file_paths_found = self._get_file_paths()
@@ -225,6 +226,7 @@ class SPRMViewConfBuilder(ImagePyramidViewConfBuilder):
     like SPRMJSONViewConfBuilder and SPRMAnnDataViewConfBuilder
     https://portal.hubmapconsortium.org/search?mapped_data_types[0]=CODEX%20%5BCytokit%20%2B%20SPRM%5D&entity_type[0]=Dataset
     """
+
     def _get_full_image_path(self):
         return f"{self._imaging_path_regex}/{self._image_name}.ome.tiff?"
 
@@ -260,6 +262,7 @@ class SPRMJSONViewConfBuilder(SPRMViewConfBuilder):
     SPRM Vitessce configurations, like
     https://portal.hubmapconsortium.org/browse/dataset/dc31a6d06daa964299224e9c8d6cafb3
     """
+
     def __init__(self, entity, nexus_token, is_mock=False, **kwargs):
         # All "file" Vitessce objects that do not have wrappers.
         super().__init__(entity, nexus_token, is_mock)
@@ -338,6 +341,7 @@ class SPRMAnnDataViewConfBuilder(SPRMViewConfBuilder):
     :param \\*\\*kwargs: { imaging_path: str, mask_path: str } for the paths
     of the image and mask relative to image_pyramid_regex
     """
+
     def __init__(self, entity, nexus_token, is_mock=False, **kwargs):
         super().__init__(entity, nexus_token, is_mock)
         self._base_name = kwargs["base_name"]

--- a/context/app/main.py
+++ b/context/app/main.py
@@ -1,7 +1,8 @@
 from flask import Flask, session, render_template
 
 from . import (
-    routes_main, routes_browse, routes_auth, routes_cells, routes_markdown,
+    routes_main, routes_browse, routes_api,
+    routes_auth, routes_cells, routes_markdown,
     default_config)
 from .flask_static_digest import FlaskStaticDigest
 flask_static_digest = FlaskStaticDigest()
@@ -55,6 +56,7 @@ def create_app(testing=False):
 
     app.register_blueprint(routes_main.blueprint)
     app.register_blueprint(routes_browse.blueprint)
+    app.register_blueprint(routes_api.blueprint)
     app.register_blueprint(routes_cells.blueprint)
     app.register_blueprint(routes_auth.blueprint)
     app.register_blueprint(routes_markdown.blueprint)

--- a/context/app/markdown/README.markdown
+++ b/context/app/markdown/README.markdown
@@ -1,0 +1,7 @@
+MD documents in this directory will be available at the top level on the site.
+For example, `CHANGELOG.md` is available at [`/CHANGELOG`](https://portal.hubmapconsortium.org/CHANGELOG).
+
+- This file is `README.markdown` instead of `README.md` so that it _won't_ be available at `/README`.
+- During development, this directory is read at startup; If you add a new file, you will need to restart.
+- If a file has the suffix `.redirect`, it will be read, and the server will give a redirect to the path it contains.
+

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -10,12 +10,13 @@ On a dataset page you can:
 - Download just the metadata as a key-value TSV by clicking the download button beside the "Metadata" section header.
 - Download the data files through Globus, via a link in the "Files" section.
 
-## Metadata for all donors
+## Metadata for all donors or samples
 
-For a TSV of donor metadata, visit [`/api/v0/donors.tsv`](/api/v0/donors.tsv).
-If you are logged in and have sufficient privs, this will include unpublished donors.
+For a TSV of donor or sample metadata, visit [`/api/v0/donors.tsv`](/api/v0/donors.tsv)
+or [`/api/v0/samples.tsv`](/api/v0/samples.tsv), respectively.
+If you are logged in and have sufficient privs, this will include unpublished data.
 
-This will be expanded to sample and dataset metadata soon.
+This will be expanded to dataset metadata soon.
 
 ## Query metadata
 

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -25,7 +25,8 @@ To more flexibly query metadata, an [Elasticsearch endpoint](https://smart-api.i
 
 ## Create datasets
 
-All API microservices developed by the IEC are documented at [SmartAPI](https://smart-api.info/registry?q=hubmap).
+[All API microservices](/docs/apis) developed by the IEC are documented at
+[SmartAPI](https://smart-api.info/registry?q=hubmap).
 These APIs support our internal UIs, and are unlikely to be useful to most external users.
 
 ## Query gene expression data

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -19,11 +19,12 @@ If you are logged in and have sufficient access privileges, these will include u
 
 ## Query metadata
 
-To more flexibly query metadata, an [Elasticsearch endpoint](https://smart-api.info/ui/7aaf02b838022d564da776b03f357158) is available.
+To more flexibly query metadata, the [HuBMAP Search API](https://smart-api.info/ui/7aaf02b838022d564da776b03f357158) is available.
+This web service is a thin wrapper around the [Elasticsearch `_search` method](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html).
 - Elasticsearch query syntax is non-trivial and only recommended for expert users.
 - The response structure is not documented, and we do not guarantee the stability of responses.
 
-## Create datasets
+## Edit HuBMAP datasets, samples, and donors
 
 [All API microservices](/docs/apis) developed by the IEC are documented at
 [SmartAPI](https://smart-api.info/registry?q=hubmap).

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -1,0 +1,36 @@
+# APIs and Data Downloads
+
+HuBMAP incorporates a wide range of data and metadata, developed by a number of separate teams,
+so unfortunately there is no single "HuBMAP API". Depending on your data needs, there are different places to begin.
+
+## Data or metadata for a single dataset
+
+On a dataset page you can:
+- Download the backing JSON by appending `.json` to the URL, or clicking the document icon in the upper right.
+- Download just the metadata as a key-value TSV by clicking the download button beside the "Metadata" section header.
+- Download the data files through Globus, via a link in the "Files" section.
+
+## Metadata for all donors
+
+For a TSV of donor metadata, visit [`/api/v0/donors.tsv`](/api/v0/donors.tsv).
+If you are logged in and have sufficient privs, this will include unpublished donors.
+
+This will be expanded to sample and dataset metadata soon.
+
+## Query metadata
+
+To more flexibly query metadata, an [Elasticsearch endpoint](https://smart-api.info/ui/7aaf02b838022d564da776b03f357158) is available.
+- If you haven't used it before, Elasticsearch query syntax is non-trivial.
+- The response structure is not documented, and we do not guarantee the stability of responses.
+
+## Create datasets
+
+All API microservices developed by the IEC are documented at [SmartAPI](https://smart-api.info/registry?q=hubmap).
+These APIs support our internal UIs, and are unlikely to be useful to most external users.
+
+## Query gene expression data
+
+It is possible to query gene expression data across datasets.
+The [API](https://github.com/hubmapconsortium/cross_modality_query#usage) is complex and not well documented,
+but there are [extensive examples](https://github.com/hubmapconsortium/hubmap-api-py-client#usage) for the Python client.
+

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -1,7 +1,7 @@
 # APIs and Data Downloads
 
 HuBMAP incorporates a wide range of data and metadata, developed by a number of separate teams,
-so unfortunately there is no single "HuBMAP API". Depending on your data needs, there are different places to begin.
+so unfortunately there is no single "HuBMAP API". Depending on your needs, there are different places to begin.
 
 ## Data or metadata for a single dataset
 
@@ -10,13 +10,12 @@ On a dataset page you can:
 - Download just the metadata as a key-value TSV by clicking the download button beside the "Metadata" section header.
 - Download the data files through Globus, via a link in the "Files" section.
 
-## Metadata for all donors or samples
+## Metadata for all donors, samples, or datasets
 
-For a TSV of donor or sample metadata, visit [`/api/v0/donors.tsv`](/api/v0/donors.tsv)
-or [`/api/v0/samples.tsv`](/api/v0/samples.tsv), respectively.
-If you are logged in and have sufficient privs, this will include unpublished data.
-
-This will be expanded to dataset metadata soon.
+For metadata in TSV form, visit [`/api/v0/donors.tsv`](/api/v0/donors.tsv),
+[`/api/v0/samples.tsv`](/api/v0/samples.tsv), or [`/api/v0/datasets.tsv`](/api/v0/datasets.tsv).
+The datasets TSV has a large number of columns, because different assay types have different metadata fields.
+If you are logged in and have sufficient privs, these will include unpublished data.
 
 ## Query metadata
 

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -26,9 +26,8 @@ This web service is a thin wrapper around the [Elasticsearch `_search` method](h
 
 ## Edit HuBMAP datasets, samples, and donors
 
-[All API microservices](/docs/apis) developed by the IEC are documented at
-[SmartAPI](https://smart-api.info/registry?q=hubmap).
-These APIs support our internal UIs, and are likely of limited value to most external users.
+The  [HuBMAP Entity API](https://smart-api.info/ui/0065e419668f3336a40d1f5ab89c6ba3) can be used to create, update and retrieve provenance entities which consist of three base types: donors, tissue samples, and datasets.
+Creation and modification of entities require internal access, but published entities can be programmatically retrieved by anyone.
 
 ## Query gene expression data
 

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -1,7 +1,7 @@
 # APIs and Data Downloads
 
 HuBMAP incorporates a wide range of data and metadata, developed by a number of separate teams,
-so unfortunately there is no single "HuBMAP API". Depending on your needs, there are different places to begin.
+and there is no single "HuBMAP API". Depending on your needs, there are different places to begin.
 
 ## Data or metadata for a single dataset
 
@@ -15,23 +15,23 @@ On a dataset page you can:
 For metadata in TSV form, visit [`/api/v0/donors.tsv`](/api/v0/donors.tsv),
 [`/api/v0/samples.tsv`](/api/v0/samples.tsv), or [`/api/v0/datasets.tsv`](/api/v0/datasets.tsv).
 The datasets TSV has a large number of columns, because different assay types have different metadata fields.
-If you are logged in and have sufficient privs, these will include unpublished data.
+If you are logged in and have sufficient access privileges, these will include unpublished data.
 
 ## Query metadata
 
 To more flexibly query metadata, an [Elasticsearch endpoint](https://smart-api.info/ui/7aaf02b838022d564da776b03f357158) is available.
-- If you haven't used it before, Elasticsearch query syntax is non-trivial.
+- Elasticsearch query syntax is non-trivial and only recommended for expert users.
 - The response structure is not documented, and we do not guarantee the stability of responses.
 
 ## Create datasets
 
 [All API microservices](/docs/apis) developed by the IEC are documented at
 [SmartAPI](https://smart-api.info/registry?q=hubmap).
-These APIs support our internal UIs, and are unlikely to be useful to most external users.
+These APIs support our internal UIs, and are likely of limited value to most external users.
 
 ## Query gene expression data
 
 It is possible to query gene expression data across datasets.
-The [API](https://github.com/hubmapconsortium/cross_modality_query#usage) is complex and not well documented,
+The [API](https://github.com/hubmapconsortium/cross_modality_query#usage) is complex,
 but there are [extensive examples](https://github.com/hubmapconsortium/hubmap-api-py-client#usage) for the Python client.
 

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -1,0 +1,57 @@
+from io import StringIO
+from csv import DictWriter
+
+from flask import Response
+
+from .utils import make_blueprint, get_client
+
+
+blueprint = make_blueprint(__name__)
+
+@blueprint.route('/api/v0/donors.tsv')
+def donors_tsv():
+    client = get_client()
+    first_fields = ['uuid', 'hubmap_id']
+    donors = client.get_all_donors(first_fields)
+    return _make_tsv_response(_dicts_to_tsv(donors, first_fields), 'donors.tsv')
+
+
+@blueprint.route('/api/v0/samples.tsv')
+def samples_tsv():
+    client = get_client()
+    first_fields = ['uuid', 'hubmap_id']
+    samples = client.get_all_samples(first_fields)
+    return _make_tsv_response(_dicts_to_tsv(samples, first_fields), 'samples.tsv')
+
+
+def _make_tsv_response(tsv_content, filename):
+    return Response(
+        response=tsv_content,
+        headers={'Content-Disposition': f"attachment; filename={filename}"},
+        mimetype='text/tab-separated-values'
+    )
+
+
+def _dicts_to_tsv(data_dicts, first_fields):
+    '''
+    >>> data_dicts = [
+    ...   {'title': 'Star Wars', 'subtitle': 'A New Hope', 'date': '1977'},
+    ...   {'title': 'The Empire Strikes Back', 'date': '1980'},
+    ...   {'title': 'The Return of the Jedi', 'date': '1983'}
+    ... ]
+    >>> from pprint import pp
+    >>> pp(dicts_to_tsv(data_dicts, ['title']))
+    ('title\\tdate\\tsubtitle\\r\\n'
+     'Star Wars\\t1977\\tA New Hope\\r\\n'
+     'The Empire Strikes Back\\t1980\\t\\r\\n'
+     'The Return of the Jedi\\t1983\\t\\r\\n')
+    '''
+    body_fields = sorted(
+        set().union(*[d.keys() for d in data_dicts])
+        - set(first_fields)
+    )
+    output = StringIO()
+    writer = DictWriter(output, first_fields + body_fields, delimiter='\t')
+    writer.writeheader()
+    writer.writerows(data_dicts)
+    return output.getvalue()

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -41,7 +41,7 @@ def _dicts_to_tsv(data_dicts, first_fields):
     ...   {'title': 'The Return of the Jedi', 'date': '1983'}
     ... ]
     >>> from pprint import pp
-    >>> pp(dicts_to_tsv(data_dicts, ['title']))
+    >>> pp(_dicts_to_tsv(data_dicts, ['title']))
     ('title\\tdate\\tsubtitle\\r\\n'
      'Star Wars\\t1977\\tA New Hope\\r\\n'
      'The Empire Strikes Back\\t1980\\t\\r\\n'

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -25,6 +25,14 @@ def samples_tsv():
     return _make_tsv_response(_dicts_to_tsv(samples, first_fields), 'samples.tsv')
 
 
+@blueprint.route('/api/v0/datasets.tsv')
+def datasets_tsv():
+    client = get_client()
+    first_fields = ['uuid', 'hubmap_id']
+    datasets = client.get_all_datasets(first_fields)
+    return _make_tsv_response(_dicts_to_tsv(datasets, first_fields), 'datasets.tsv')
+
+
 def _make_tsv_response(tsv_content, filename):
     return Response(
         response=tsv_content,

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -8,6 +8,7 @@ from .utils import make_blueprint, get_client
 
 blueprint = make_blueprint(__name__)
 
+
 @blueprint.route('/api/v0/donors.tsv')
 def donors_tsv():
     client = get_client()

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -1,32 +1,18 @@
 import json
 from urllib.parse import urlparse
 
-from flask import (current_app, session, render_template,
+from flask import (render_template,
                    abort, request, redirect, url_for, Response)
 
 import nbformat
 from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 
-from .api.client import ApiClient
-from .utils import get_default_flask_data, make_blueprint
+from .utils import get_default_flask_data, make_blueprint, get_client
 
 
 blueprint = make_blueprint(__name__)
 
 entity_types = ['donor', 'sample', 'dataset', 'support', 'collection']
-
-
-def _get_client():
-    try:
-        is_mock = current_app.config['IS_MOCK']
-    except KeyError:
-        is_mock = False
-    if is_mock:
-        return ApiClient(is_mock=is_mock)
-    return ApiClient(
-        current_app.config['ENTITY_API_BASE'],
-        session['nexus_token']
-    )
 
 
 def get_url_base_from_request():
@@ -38,7 +24,7 @@ def get_url_base_from_request():
 
 @blueprint.route('/browse/HBM<hbm_suffix>')
 def hbm_redirect(hbm_suffix):
-    client = _get_client()
+    client = get_client()
     entity = client.get_entity(hbm_id=f'HBM{hbm_suffix}')
     return redirect(
         url_for('routes_browse.details', type=entity['entity_type'].lower(), uuid=entity['uuid']))
@@ -56,7 +42,7 @@ def unknown_ext(type, uuid, unknown_ext):
 def details(type, uuid):
     if type not in entity_types:
         abort(404)
-    client = _get_client()
+    client = get_client()
     entity = client.get_entity(uuid)
     actual_type = entity['entity_type'].lower()
     if type != actual_type:
@@ -83,7 +69,7 @@ def details(type, uuid):
 def details_json(type, uuid):
     if type not in entity_types:
         abort(404)
-    client = _get_client()
+    client = get_client()
     entity = client.get_entity(uuid)
     return entity
 
@@ -92,7 +78,7 @@ def details_json(type, uuid):
 def details_notebook(type, uuid):
     if type not in entity_types:
         abort(404)
-    client = _get_client()
+    client = get_client()
     entity = client.get_entity(uuid)
     vitessce_conf = client.get_vitessce_conf_cells(entity)
     if (vitessce_conf is None
@@ -126,7 +112,7 @@ def details_rui_json(type, uuid):
     # so, to return a JSON object, and not just a string, we need to decode.
     if type not in entity_types:
         abort(404)
-    client = _get_client()
+    client = get_client()
     entity = client.get_entity(uuid)
     # For Samples...
     if 'rui_location' in entity:
@@ -144,7 +130,7 @@ def details_rui_json(type, uuid):
 
 @blueprint.route('/sitemap.txt')
 def sitemap_txt():
-    client = _get_client()
+    client = get_client()
     uuids = client.get_all_dataset_uuids()
     url_base = get_url_base_from_request()
     return Response(

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,6 +1,9 @@
 from os.path import dirname
 from urllib.parse import urlparse
 import json
+from io import StringIO
+from csv import DictWriter
+
 import nbformat
 from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 
@@ -345,9 +348,8 @@ def get_url_base_from_request():
     return f'{scheme}://{netloc}'
 
 
-# TODO: Move these, once the routes cleanup is merged: https://github.com/hubmapconsortium/portal-ui/pull/2052
-from io import StringIO
-from csv import DictWriter
+# TODO: Move these, once the routes cleanup is merged:
+# https://github.com/hubmapconsortium/portal-ui/pull/2052
 @blueprint.route('/api/v0/donors.tsv')
 def donors_tsv():
     client = _get_client()

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -345,7 +345,7 @@ def get_url_base_from_request():
     return f'{scheme}://{netloc}'
 
 
-# TODO: Move route, once the routes cleanup is merged: https://github.com/hubmapconsortium/portal-ui/pull/2052
+# TODO: Move these, once the routes cleanup is merged: https://github.com/hubmapconsortium/portal-ui/pull/2052
 from io import StringIO
 from csv import DictWriter
 @blueprint.route('/api/v0/donors.tsv')
@@ -360,6 +360,19 @@ def donors_tsv():
 
 
 def dicts_to_tsv(data_dicts, header_fields):
+    '''
+    >>> data_dicts = [
+    ...   {'title': 'Star Wars', 'subtitle': 'A New Hope', 'date': '1977'},
+    ...   {'title': 'The Empire Strikes Back', 'date': '1980'},
+    ...   {'title': 'The Return of the Jedi', 'date': '1983'}
+    ... ]
+    >>> from pprint import pp
+    >>> pp(dicts_to_tsv(data_dicts, ['title']))
+    ('title\\tdate\\tsubtitle\\r\\n'
+     'Star Wars\\t1977\\tA New Hope\\r\\n'
+     'The Empire Strikes Back\\t1980\\t\\r\\n'
+     'The Return of the Jedi\\t1983\\t\\r\\n')
+    '''
     body_fields = sorted(
         set().union(*[d.keys() for d in data_dicts])
         - set(header_fields)

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,6 +1,4 @@
 from os.path import dirname
-from io import StringIO
-from csv import DictWriter
 
 from flask import (render_template, current_app,
                    session, request)
@@ -167,54 +165,3 @@ def list_page(saved_list_uuid):
         title='Saved List',
         flask_data=flask_data
     )
-
-
-# TODO: Move these, once the routes cleanup is merged:
-# https://github.com/hubmapconsortium/portal-ui/pull/2052
-@blueprint.route('/api/v0/donors.tsv')
-def donors_tsv():
-    client = _get_client()
-    first_fields = ['uuid', 'hubmap_id']
-    donors = client.get_all_donors(first_fields)
-    return _make_tsv_response(_dicts_to_tsv(donors, first_fields), 'donors.tsv')
-
-
-@blueprint.route('/api/v0/samples.tsv')
-def samples_tsv():
-    client = _get_client()
-    first_fields = ['uuid', 'hubmap_id']
-    samples = client.get_all_samples(first_fields)
-    return _make_tsv_response(_dicts_to_tsv(samples, first_fields), 'samples.tsv')
-
-
-def _make_tsv_response(tsv_content, filename):
-    return Response(
-        response=tsv_content,
-        headers={'Content-Disposition': f"attachment; filename={filename}"},
-        mimetype='text/tab-separated-values'
-    )
-
-
-def _dicts_to_tsv(data_dicts, first_fields):
-    '''
-    >>> data_dicts = [
-    ...   {'title': 'Star Wars', 'subtitle': 'A New Hope', 'date': '1977'},
-    ...   {'title': 'The Empire Strikes Back', 'date': '1980'},
-    ...   {'title': 'The Return of the Jedi', 'date': '1983'}
-    ... ]
-    >>> from pprint import pp
-    >>> pp(dicts_to_tsv(data_dicts, ['title']))
-    ('title\\tdate\\tsubtitle\\r\\n'
-     'Star Wars\\t1977\\tA New Hope\\r\\n'
-     'The Empire Strikes Back\\t1980\\t\\r\\n'
-     'The Return of the Jedi\\t1983\\t\\r\\n')
-    '''
-    body_fields = sorted(
-        set().union(*[d.keys() for d in data_dicts])
-        - set(first_fields)
-    )
-    output = StringIO()
-    writer = DictWriter(output, first_fields + body_fields, delimiter='\t')
-    writer.writeheader()
-    writer.writerows(data_dicts)
-    return output.getvalue()

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -353,15 +353,16 @@ def get_url_base_from_request():
 @blueprint.route('/api/v0/donors.tsv')
 def donors_tsv():
     client = _get_client()
-    donors = client.get_all_donors()
+    first_fields = ['uuid', 'hubmap_id']
+    donors = client.get_all_donors(first_fields)
     return Response(
-        response=dicts_to_tsv(donors, ['uuid', 'hubmap_id']),
+        response=dicts_to_tsv(donors, first_fields),
         headers={'Content-Disposition': f"attachment; filename=donors.tsv"},
         mimetype='text/tab-separated-values'
     )
 
 
-def dicts_to_tsv(data_dicts, header_fields):
+def dicts_to_tsv(data_dicts, first_fields):
     '''
     >>> data_dicts = [
     ...   {'title': 'Star Wars', 'subtitle': 'A New Hope', 'date': '1977'},
@@ -377,10 +378,10 @@ def dicts_to_tsv(data_dicts, header_fields):
     '''
     body_fields = sorted(
         set().union(*[d.keys() for d in data_dicts])
-        - set(header_fields)
+        - set(first_fields)
     )
     output = StringIO()
-    writer = DictWriter(output, header_fields + body_fields, delimiter='\t')
+    writer = DictWriter(output, first_fields + body_fields, delimiter='\t')
     writer.writeheader()
     writer.writerows(data_dicts)
     return output.getvalue()

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -355,14 +355,26 @@ def donors_tsv():
     client = _get_client()
     first_fields = ['uuid', 'hubmap_id']
     donors = client.get_all_donors(first_fields)
+    return _make_tsv_response(_dicts_to_tsv(donors, first_fields), 'donors.tsv')
+
+
+@blueprint.route('/api/v0/samples.tsv')
+def samples_tsv():
+    client = _get_client()
+    first_fields = ['uuid', 'hubmap_id']
+    samples = client.get_all_samples(first_fields)
+    return _make_tsv_response(_dicts_to_tsv(samples, first_fields), 'samples.tsv')
+
+
+def _make_tsv_response(tsv_content, filename):
     return Response(
-        response=dicts_to_tsv(donors, first_fields),
-        headers={'Content-Disposition': f"attachment; filename=donors.tsv"},
+        response=tsv_content,
+        headers={'Content-Disposition': f"attachment; filename={filename}"},
         mimetype='text/tab-separated-values'
     )
 
 
-def dicts_to_tsv(data_dicts, first_fields):
+def _dicts_to_tsv(data_dicts, first_fields):
     '''
     >>> data_dicts = [
     ...   {'title': 'Star Wars', 'subtitle': 'A New Hope', 'date': '1977'},

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -35,9 +35,16 @@ function Footer(props) {
               <OutboundLink variant="body2" href="https://github.com/hubmapconsortium">
                 GitHub
               </OutboundLink>
-              <LightBlueLink variant="body2" href="/services">
-                Services
-              </LightBlueLink>
+              {!isMaintenancePage && (
+                <>
+                  <LightBlueLink variant="body2" href="/services">
+                    Services
+                  </LightBlueLink>
+                  <LightBlueLink variant="body2" href="/apis">
+                    APIs
+                  </LightBlueLink>
+                </>
+              )}
             </FlexColumn>
             <FlexColumn $mr={1}>
               <Typography variant="subtitle2">Policies</Typography>

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -1,15 +1,12 @@
 from flask import (current_app, session, Blueprint)
 
 from .api.client import ApiClient
+from .api.mock_client import MockApiClient
 
 
 def get_client():
-    try:
-        is_mock = current_app.config['IS_MOCK']
-    except KeyError:
-        is_mock = False
-    if is_mock:
-        return ApiClient(is_mock=is_mock)
+    if current_app.config.get('IS_MOCK'):
+        return MockApiClient()
     return ApiClient(
         current_app.config['ENTITY_API_BASE'],
         session['nexus_token']

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -1,4 +1,19 @@
-from flask import (current_app, Blueprint)
+from flask import (current_app, session, Blueprint)
+
+from .api.client import ApiClient
+
+
+def get_client():
+    try:
+        is_mock = current_app.config['IS_MOCK']
+    except KeyError:
+        is_mock = False
+    if is_mock:
+        return ApiClient(is_mock=is_mock)
+    return ApiClient(
+        current_app.config['ENTITY_API_BASE'],
+        session['nexus_token']
+    )
 
 
 def get_default_flask_data():


### PR DESCRIPTION
Fix #2039: Metadata TSVs. Add an `/apis` link in the footer to a new page that describes the different APIs and data download options we have. (The url is not `/docs/apis` because we've entirely handed that directory off to PK, but I'd like to just get this described here.)
- @shirey : I would like your buy-in on this description of the existing APIs.
- @ngehlenborg : Confirmation that this is what you want.
- @john-conroy : Code review.

Current headers of `donors.tsv`:
```
uuid
hubmap_id
age_unit
age_value
blood_type
body_mass_index_unit
body_mass_index_value
cause_of_death
death_event
height_unit
height_value
kidney_donor_profile_index_unit
kidney_donor_profile_index_value
mechanism_of_injury
medical_history
race
rh_factor
sex
social_history
weight_unit
weight_value
```

Current headers of `samples.tsv`:
```
uuid
hubmap_id
cold_ischemia_time_unit
cold_ischemia_time_value
health_status
organ_condition
pathologist_report
perfusion_solution
procedure_date
sample_id
specimen_preservation_temperature
specimen_quality_criteria
specimen_tumor_distance_unit
specimen_tumor_distance_value
vital_state
warm_ischemia_time_unit
warm_ischemia_time_value
```

`datasets.tsv` has a huge number of columns... perhaps add an optional query parameter so users could just get a particular assay type? But I'd like to be more clear about the real user story, and I don't think that should block this PR.