### PR TITLE
Mccalluc/tsv download button

### DIFF
--- a/CHANGELOG-tsv-download-button.md
+++ b/CHANGELOG-tsv-download-button.md
@@ -1,0 +1,1 @@
+- On search, a button to download the TSV.

--- a/context/app/markdown/apis.md
+++ b/context/app/markdown/apis.md
@@ -12,10 +12,10 @@ On a dataset page you can:
 
 ## Metadata for all donors, samples, or datasets
 
-For metadata in TSV form, visit [`/api/v0/donors.tsv`](/api/v0/donors.tsv),
-[`/api/v0/samples.tsv`](/api/v0/samples.tsv), or [`/api/v0/datasets.tsv`](/api/v0/datasets.tsv).
+For metadata in TSV form, visit [`/metadata/v0/donors.tsv`](/metadata/v0/donors.tsv),
+[`/metadata/v0/samples.tsv`](/metadata/v0/samples.tsv), or [`/metadata/v0/datasets.tsv`](/metadata/v0/datasets.tsv).
 Without constraints, the datasets TSV has a large number of columns, because different assay types have different metadata fields.
-Add parameters to limit to a particular assay, for example [`datasets.tsv?assay_type=CODEX`](/api/v0/datasets.tsv?assay_type=CODEX).
+Add parameters to limit to a particular assay, for example [`datasets.tsv?assay_type=CODEX`](/metadata/v0/datasets.tsv?assay_type=CODEX).
 If you are logged in and have sufficient access privileges, these will include unpublished data.
 
 ## Query metadata

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -9,7 +9,7 @@ from .utils import make_blueprint, get_client, get_default_flask_data
 blueprint = make_blueprint(__name__)
 
 
-@blueprint.route('/api/v0/<entity_type>.tsv')
+@blueprint.route('/metadata/v0/<entity_type>.tsv')
 def entities_tsv(entity_type):
     entities = _get_entities(entity_type)
     return _make_tsv_response(_dicts_to_tsv(entities, _first_fields), f'{entity_type}.tsv')

--- a/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
+++ b/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
@@ -1,15 +1,20 @@
 import React from 'react';
+import ReactGA from 'react-ga';
 
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 
 import { StyledButton } from './style';
+
+function sendTsvEvent(event) {
+  ReactGA.pageview(event.currentTarget.href);
+}
 
 function DownloadButton(props) {
   const { type } = props;
   const lcPluralType = `${type.toLowerCase()}s`;
   return (
     <SecondaryBackgroundTooltip title="Download a TSV of the table metadata. This will not take into account any filtering done on the search page.">
-      <StyledButton href={`/api/v0/${lcPluralType}.tsv`} target="_blank" component="a">
+      <StyledButton href={`/api/v0/${lcPluralType}.tsv`} target="_blank" component="a" onClick={sendTsvEvent}>
         Download Metadata
       </StyledButton>
     </SecondaryBackgroundTooltip>

--- a/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
+++ b/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
@@ -2,8 +2,14 @@ import React from 'react';
 
 import { StyledButton } from './style';
 
-function DownloadButton() {
-  return <StyledButton>Download Metadata</StyledButton>;
+function DownloadButton(props) {
+  const { type } = props;
+  const lcPluralType = `${type.toLowerCase()}s`;
+  return (
+    <StyledButton href={`/api/v0/${lcPluralType}.tsv`} target="_blank" component="a">
+      Download Metadata
+    </StyledButton>
+  );
 }
 
 export default DownloadButton;

--- a/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
+++ b/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
@@ -14,7 +14,14 @@ function DownloadButton(props) {
   const lcPluralType = `${type.toLowerCase()}s`;
   return (
     <SecondaryBackgroundTooltip title="Download a TSV of the table metadata. This will not take into account any filtering done on the search page.">
-      <StyledButton href={`/api/v0/${lcPluralType}.tsv`} target="_blank" component="a" onClick={sendTsvEvent}>
+      <StyledButton
+        href={`/api/v0/${lcPluralType}.tsv`}
+        target="_blank"
+        component="a"
+        onClick={sendTsvEvent}
+        variant="outlined"
+        color="primary"
+      >
         Download Metadata
       </StyledButton>
     </SecondaryBackgroundTooltip>

--- a/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
+++ b/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+import { StyledButton } from './style';
+
+function DownloadButton() {
+  return <StyledButton>Download Metadata</StyledButton>;
+}
+
+export default DownloadButton;

--- a/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
+++ b/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
@@ -15,7 +15,7 @@ function DownloadButton(props) {
   return (
     <SecondaryBackgroundTooltip title="Download a TSV of the table metadata. This will not take into account any filtering done on the search page.">
       <StyledButton
-        href={`/api/v0/${lcPluralType}.tsv`}
+        href={`/metadata/v0/${lcPluralType}.tsv`}
         target="_blank"
         component="a"
         onClick={sendTsvEvent}

--- a/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
+++ b/context/app/static/js/components/Search/DownloadButton/DownloadButton.jsx
@@ -1,14 +1,18 @@
 import React from 'react';
 
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+
 import { StyledButton } from './style';
 
 function DownloadButton(props) {
   const { type } = props;
   const lcPluralType = `${type.toLowerCase()}s`;
   return (
-    <StyledButton href={`/api/v0/${lcPluralType}.tsv`} target="_blank" component="a">
-      Download Metadata
-    </StyledButton>
+    <SecondaryBackgroundTooltip title="Download a TSV of the table metadata. This will not take into account any filtering done on the search page.">
+      <StyledButton href={`/api/v0/${lcPluralType}.tsv`} target="_blank" component="a">
+        Download Metadata
+      </StyledButton>
+    </SecondaryBackgroundTooltip>
   );
 }
 

--- a/context/app/static/js/components/Search/DownloadButton/index.js
+++ b/context/app/static/js/components/Search/DownloadButton/index.js
@@ -1,0 +1,3 @@
+import DownloadButton from './DownloadButton';
+
+export default DownloadButton;

--- a/context/app/static/js/components/Search/DownloadButton/style.js
+++ b/context/app/static/js/components/Search/DownloadButton/style.js
@@ -2,12 +2,8 @@ import styled from 'styled-components';
 import Button from '@material-ui/core/Button';
 
 const StyledButton = styled(Button)`
-  margin-left: ${(props) => props.theme.spacing(1)}px;
-  background-color: white;
+  margin: 0 ${(props) => props.theme.spacing(1)}px;
   height: 40px;
-  margin-right: ${(props) => props.theme.spacing(1)}px;
-  border-radius: 3px;
-  border: 1px solid ${(props) => props.theme.palette.secondary.main};
 `;
 
 export { StyledButton };

--- a/context/app/static/js/components/Search/DownloadButton/style.js
+++ b/context/app/static/js/components/Search/DownloadButton/style.js
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+import Button from '@material-ui/core/Button';
+
+const StyledButton = styled(Button)`
+  margin-left: ${(props) => props.theme.spacing(1)}px;
+  background-color: white;
+  height: 40px;
+  margin-right: ${(props) => props.theme.spacing(1)}px;
+  border-radius: 3px;
+  border: 1px solid ${(props) => props.theme.palette.secondary.main};
+`;
+
+export { StyledButton };

--- a/context/app/static/js/components/Search/Search.scss
+++ b/context/app/static/js/components/Search/Search.scss
@@ -103,7 +103,6 @@ $text-primary: rgba(0, 0, 0, 0.87);
 
 .sk-search-box {
     background-color: white;
-    max-width: 925px;
 }
 
 .sk-search-box__icon{

--- a/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
+++ b/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { SearchBox, SelectedFilters, SortingSelector, ViewSwitcherToggle } from 'searchkit';
 
 import SearchViewSwitch, { DevSearchViewSwitch } from './SearchViewSwitch';
+import DownloadButton from '../DownloadButton';
 import TilesSortDropdown from '../TilesSortDropdown';
 import SelectedFilter from '../SelectedFilter';
 import { Flex, CenteredDiv } from './style';
@@ -15,6 +16,7 @@ function SearchBarLayout(props) {
         <SearchBox autofocus queryFields={queryFields} />
         <CenteredDiv>
           <SortingSelector options={sortOptions} listComponent={TilesSortDropdown} />
+          <DownloadButton />
           <ViewSwitcherToggle listComponent={isDevSearch ? DevSearchViewSwitch : SearchViewSwitch} />
         </CenteredDiv>
       </Flex>

--- a/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
+++ b/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
@@ -16,7 +16,7 @@ function SearchBarLayout(props) {
         <SearchBox autofocus queryFields={queryFields} />
         <CenteredDiv>
           <SortingSelector options={sortOptions} listComponent={TilesSortDropdown} />
-          <DownloadButton type={type} />
+          {!isDevSearch && <DownloadButton type={type} />}
           <ViewSwitcherToggle listComponent={isDevSearch ? DevSearchViewSwitch : SearchViewSwitch} />
         </CenteredDiv>
       </Flex>

--- a/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
+++ b/context/app/static/js/components/Search/SearchBarLayout/SearchBarLayout.jsx
@@ -9,14 +9,14 @@ import SelectedFilter from '../SelectedFilter';
 import { Flex, CenteredDiv } from './style';
 
 function SearchBarLayout(props) {
-  const { queryFields, sortOptions, isDevSearch } = props;
+  const { type, queryFields, sortOptions, isDevSearch } = props;
   return (
     <>
       <Flex>
         <SearchBox autofocus queryFields={queryFields} />
         <CenteredDiv>
           <SortingSelector options={sortOptions} listComponent={TilesSortDropdown} />
-          <DownloadButton />
+          <DownloadButton type={type} />
           <ViewSwitcherToggle listComponent={isDevSearch ? DevSearchViewSwitch : SearchViewSwitch} />
         </CenteredDiv>
       </Flex>

--- a/context/app/static/js/components/Search/SearchWrapper.jsx
+++ b/context/app/static/js/components/Search/SearchWrapper.jsx
@@ -52,7 +52,7 @@ function SearchWrapper(props) {
   return (
     <SearchkitProvider searchkit={searchkit}>
       <>
-        <SearchBarLayout queryFields={queryFields} sortOptions={sortOptions} isDevSearch={isDevSearch} />
+        <SearchBarLayout type={type} queryFields={queryFields} sortOptions={sortOptions} isDevSearch={isDevSearch} />
         <LayoutBody>
           <StyledSideBar>
             <Accordions filters={filters} />


### PR DESCRIPTION
Towards #2129: Pull down for Dataset assay types not yet implemented, but I think this is a fine intermediate state.

- @john-conroy -- Basing this off of `TileSortDropDown`... I think they are different enough that trying to factor out a common Button not worth it, but could be wrong.
- @tsliaw : as we add more buttons here, I'm not sure that we want to continue reserving space for the tiles sort control -- Would it work for the search box just to use what space there is?
- @ngehlenborg : This is blocked on the resolution of #2099 -- We should get that sorted out before linking to the TSVs more publicly.