### PR TITLE
John conroy/cells accordion

### DIFF
--- a/CHANGELOG-cells-accordion.md
+++ b/CHANGELOG-cells-accordion.md
@@ -1,0 +1,1 @@
+- Add accordions for cells query and results.

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -11,12 +11,18 @@ import { useSearchHits } from 'js/hooks/useSearchData';
 
 import { StyledDiv } from './style';
 
-function DatasetsSelectedByExpression({ setStepCompletedText, setResults }) {
-  const [geneNames, setGeneNames] = useState([]);
+function DatasetsSelectedByExpression({
+  setStepCompletedText,
+  setResults,
+  minExpressionLog,
+  setMinExpressionLog,
+  minCellPercentage,
+  setMinCellPercentage,
+  geneNames,
+  setGeneNames,
+}) {
   const [targetEntity, setTargetEntity] = useState('gene'); // eslint-disable-line no-unused-vars
   const [modality, setModality] = useState('rna'); // eslint-disable-line no-unused-vars
-  const [minExpressionLog, setMinExpressionLog] = useState(1);
-  const [minCellPercentage, setMinCellPercentage] = useState(10);
 
   const [cellsResults, setCellsResults] = useState([]);
   const [message, setMessage] = useState(null);

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useMemo, useEffect } from 'react';
 
-import Paper from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
 import Slider from '@material-ui/core/Slider';
 import FormLabel from '@material-ui/core/FormLabel';
@@ -9,6 +8,8 @@ import LogSliderWrapper from 'js/components/cells/LogSliderWrapper';
 import CellsService from 'js/components/cells/CellsService';
 import AutocompleteEntity from 'js/components/cells/AutocompleteEntity';
 import { useSearchHits } from 'js/hooks/useSearchData';
+
+import { StyledDiv } from './style';
 
 function DatasetsSelectedByExpression({ setStepCompletedText, setResults }) {
   const [geneNames, setGeneNames] = useState([]);
@@ -85,7 +86,7 @@ function DatasetsSelectedByExpression({ setStepCompletedText, setResults }) {
   }, [searchHits, setResults]);
 
   return (
-    <Paper>
+    <StyledDiv>
       <AutocompleteEntity targetEntity="genes" setter={setGeneNames} />
 
       <br />
@@ -113,7 +114,7 @@ function DatasetsSelectedByExpression({ setStepCompletedText, setResults }) {
       <Button onClick={handleSubmit}>Submit</Button>
       <br />
       {message}
-    </Paper>
+    </StyledDiv>
   );
 }
 

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useState, useMemo, useEffect } from 'react';
 
 import Paper from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
@@ -9,17 +9,15 @@ import LogSliderWrapper from 'js/components/cells/LogSliderWrapper';
 import CellsService from 'js/components/cells/CellsService';
 import AutocompleteEntity from 'js/components/cells/AutocompleteEntity';
 import { useSearchHits } from 'js/hooks/useSearchData';
-import DatasetsTable from 'js/components/cells/DatasetsTable';
 
-// eslint-disable-next-line no-unused-vars
-function DatasetsSelectedByExpression({ setStepCompletedText }) {
+function DatasetsSelectedByExpression({ setStepCompletedText, setResults }) {
   const [geneNames, setGeneNames] = useState([]);
   const [targetEntity, setTargetEntity] = useState('gene'); // eslint-disable-line no-unused-vars
   const [modality, setModality] = useState('rna'); // eslint-disable-line no-unused-vars
   const [minExpressionLog, setMinExpressionLog] = useState(1);
   const [minCellPercentage, setMinCellPercentage] = useState(10);
 
-  const [results, setResults] = useState([]);
+  const [cellsResults, setCellsResults] = useState([]);
   const [message, setMessage] = useState(null);
 
   async function handleSubmit() {
@@ -34,7 +32,7 @@ function DatasetsSelectedByExpression({ setStepCompletedText }) {
           minCellPercentage,
           modality,
         });
-        setResults(serviceResults);
+        setCellsResults(serviceResults);
       } else {
         throw Error(`Datasets by "${targetEntity}" unimplemented`);
       }
@@ -63,7 +61,7 @@ function DatasetsSelectedByExpression({ setStepCompletedText }) {
             },
             {
               terms: {
-                uuid: results.map((result) => result.uuid),
+                uuid: cellsResults.map((result) => result.uuid),
               },
             },
           ],
@@ -78,9 +76,13 @@ function DatasetsSelectedByExpression({ setStepCompletedText }) {
         'last_modified_timestamp',
       ],
     };
-  }, [results]);
+  }, [cellsResults]);
 
   const { searchHits } = useSearchHits(query);
+
+  useEffect(() => {
+    setResults(searchHits);
+  }, [searchHits, setResults]);
 
   return (
     <Paper>
@@ -111,9 +113,6 @@ function DatasetsSelectedByExpression({ setStepCompletedText }) {
       <Button onClick={handleSubmit}>Submit</Button>
       <br />
       {message}
-      {searchHits.length > 0 && (
-        <DatasetsTable datasets={searchHits} minGeneExpression={10 ** minExpressionLog} geneName={geneNames[0]} />
-      )}
     </Paper>
   );
 }

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -31,7 +31,10 @@ function DatasetsSelectedByExpression({
     try {
       if (targetEntity === 'gene') {
         setStepCompletedText(
-          `${geneNames.join(', ')} | Expression Level 10^${minExpressionLog} | ${minCellPercentage}% Cell Percentage`,
+          <>
+            {geneNames.join(', ')} | Expression Level 10<sup>{minExpressionLog}</sup> | {minCellPercentage}% Cell
+            Percentage
+          </>,
         );
         const serviceResults = await new CellsService().getDatasetsSelectedByGenes({
           geneNames,

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -12,7 +12,7 @@ import { useSearchHits } from 'js/hooks/useSearchData';
 import DatasetsTable from 'js/components/cells/DatasetsTable';
 
 // eslint-disable-next-line no-unused-vars
-function DatasetsSelectedByExpression(props) {
+function DatasetsSelectedByExpression({ setStepCompletedText }) {
   const [geneNames, setGeneNames] = useState([]);
   const [targetEntity, setTargetEntity] = useState('gene'); // eslint-disable-line no-unused-vars
   const [modality, setModality] = useState('rna'); // eslint-disable-line no-unused-vars
@@ -25,6 +25,9 @@ function DatasetsSelectedByExpression(props) {
   async function handleSubmit() {
     try {
       if (targetEntity === 'gene') {
+        setStepCompletedText(
+          `${geneNames.join(', ')} | Expression Level 10^${minExpressionLog} | ${minCellPercentage}% Cell Percentage`,
+        );
         const serviceResults = await new CellsService().getDatasetsSelectedByGenes({
           geneNames,
           minExpression: 10 ** minExpressionLog,

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/style.js
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/style.js
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+const StyledDiv = styled.div`
+  width: 100%;
+`;
+
+export { StyledDiv };

--- a/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
+++ b/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
@@ -19,7 +19,11 @@ const columns = [
   { id: 'expand', label: '' },
 ];
 
-function DatasetsTable({ datasets, minGeneExpression, geneName }) {
+function DatasetsTable({ datasets, minGeneExpression, geneName, setStepCompletedText }) {
+  useEffect(() => {
+    setStepCompletedText(`${datasets.length} Datasets Matching Query Parameters`);
+  });
+
   return (
     <Table stickyHeader>
       <TableHead>

--- a/context/app/static/js/pages/Cells/Cells.jsx
+++ b/context/app/static/js/pages/Cells/Cells.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { Alert } from 'js/shared-styles/alerts';
-
+import StepAccordion from 'js/shared-styles/accordions/StepAccordion';
 import DatasetsSelectedByExpression from 'js/components/cells/DatasetsSelectedByExpression';
 
 function About(props) {
@@ -29,7 +29,7 @@ function Cells() {
         given="a list of genes, a minimum expression level, and a minimum percentage of cells at that expression level"
         returns="a list of UUIDs for datasets which meet those minimums"
       />
-      <DatasetsSelectedByExpression />
+      <StepAccordion summaryHeading="Parameters" content={<DatasetsSelectedByExpression />} />
     </>
   );
 }

--- a/context/app/static/js/pages/Cells/Cells.jsx
+++ b/context/app/static/js/pages/Cells/Cells.jsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { Alert } from 'js/shared-styles/alerts';
 import StepAccordion from 'js/shared-styles/accordions/StepAccordion';
 import DatasetsSelectedByExpression from 'js/components/cells/DatasetsSelectedByExpression';
+import DatasetsTable from 'js/components/cells/DatasetsTable';
 
 function About(props) {
   const { title, given, returns } = props;
@@ -21,6 +22,7 @@ function About(props) {
 }
 
 function Cells() {
+  const [results, setResults] = useState([]);
   return (
     <>
       <Alert severity="warning">UI is still being designed, but we want to demonstrate that the API works.</Alert>
@@ -29,7 +31,13 @@ function Cells() {
         given="a list of genes, a minimum expression level, and a minimum percentage of cells at that expression level"
         returns="a list of UUIDs for datasets which meet those minimums"
       />
-      <StepAccordion summaryHeading="Parameters" content={<DatasetsSelectedByExpression />} />
+      <StepAccordion summaryHeading="Parameters" content={<DatasetsSelectedByExpression setResults={setResults} />} />
+      {results.length > 0 && (
+        <StepAccordion
+          summaryHeading="Results"
+          content={<DatasetsTable datasets={results} minGeneExpression={10 ** 1} geneName="VIM" />}
+        />
+      )}
     </>
   );
 }

--- a/context/app/static/js/pages/Cells/Cells.jsx
+++ b/context/app/static/js/pages/Cells/Cells.jsx
@@ -23,6 +23,10 @@ function About(props) {
 
 function Cells() {
   const [results, setResults] = useState([]);
+  const [minExpressionLog, setMinExpressionLog] = useState(1);
+  const [minCellPercentage, setMinCellPercentage] = useState(10);
+  const [geneNames, setGeneNames] = useState([]);
+
   return (
     <>
       <Alert severity="warning">UI is still being designed, but we want to demonstrate that the API works.</Alert>
@@ -31,13 +35,26 @@ function Cells() {
         given="a list of genes, a minimum expression level, and a minimum percentage of cells at that expression level"
         returns="a list of UUIDs for datasets which meet those minimums"
       />
-      <StepAccordion summaryHeading="Parameters" content={<DatasetsSelectedByExpression setResults={setResults} />} />
+      <StepAccordion
+        summaryHeading="Parameters"
+        content={
+          <DatasetsSelectedByExpression
+            setResults={setResults}
+            minExpressionLog={minExpressionLog}
+            setMinExpressionLog={setMinExpressionLog}
+            minCellPercentage={minCellPercentage}
+            setMinCellPercentage={setMinCellPercentage}
+            geneNames={geneNames}
+            setGeneNames={setGeneNames}
+          />
+        }
+      />
       <StepAccordion
         summaryHeading="Results"
         disabled={results.length === 0}
         content={
           results.length > 0 ? (
-            <DatasetsTable datasets={results} minGeneExpression={10 ** 1} geneName="VIM" />
+            <DatasetsTable datasets={results} minGeneExpression={10 ** minExpressionLog} geneName={geneNames[0]} />
           ) : undefined
         }
       />

--- a/context/app/static/js/pages/Cells/Cells.jsx
+++ b/context/app/static/js/pages/Cells/Cells.jsx
@@ -32,12 +32,15 @@ function Cells() {
         returns="a list of UUIDs for datasets which meet those minimums"
       />
       <StepAccordion summaryHeading="Parameters" content={<DatasetsSelectedByExpression setResults={setResults} />} />
-      {results.length > 0 && (
-        <StepAccordion
-          summaryHeading="Results"
-          content={<DatasetsTable datasets={results} minGeneExpression={10 ** 1} geneName="VIM" />}
-        />
-      )}
+      <StepAccordion
+        summaryHeading="Results"
+        disabled={results.length === 0}
+        content={
+          results.length > 0 ? (
+            <DatasetsTable datasets={results} minGeneExpression={10 ** 1} geneName="VIM" />
+          ) : undefined
+        }
+      />
     </>
   );
 }

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
@@ -2,12 +2,11 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Accordion from '@material-ui/core/ExpansionPanel';
 import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
-import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import { AccordionSummaryHeading, AccordionText, Flex, StyledAccordionSummary, SuccessIcon } from './style';
 
-function StepAccordion({ summaryHeading, content }) {
+function StepAccordion({ summaryHeading, content, disabled }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [stepCompletedText, setStepCompletedText] = useState(null);
 
@@ -15,7 +14,7 @@ function StepAccordion({ summaryHeading, content }) {
     setIsExpanded(expanded);
   }
   return (
-    <Accordion onChange={handleExpand}>
+    <Accordion onChange={handleExpand} disabled={disabled}>
       <StyledAccordionSummary expandIcon={<ExpandMoreIcon />} $isExpanded={isExpanded}>
         <AccordionSummaryHeading variant="subtitle2" $isExpanded={isExpanded}>
           {summaryHeading}
@@ -32,11 +31,10 @@ function StepAccordion({ summaryHeading, content }) {
         </Flex>
       </StyledAccordionSummary>
       <AccordionDetails>
-        <Typography>
-          {React.cloneElement(content, {
+        {content &&
+          React.cloneElement(content, {
             setStepCompletedText,
           })}
-        </Typography>
       </AccordionDetails>
     </Accordion>
   );
@@ -45,5 +43,11 @@ function StepAccordion({ summaryHeading, content }) {
 StepAccordion.propTypes = {
   summaryHeading: PropTypes.string.isRequired,
   content: PropTypes.element.isRequired,
+  disabled: PropTypes.element,
 };
+
+StepAccordion.defaultProps = {
+  disabled: false,
+};
+
 export default StepAccordion;

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
@@ -1,13 +1,15 @@
 import React, { useState } from 'react';
+import PropTypes from 'prop-types';
 import Accordion from '@material-ui/core/ExpansionPanel';
 import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
 import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
-import { AccordionSummaryHeading, AccordionSummaryText, StyledAccordionSummary } from './style';
+import { AccordionSummaryHeading, AccordionText, Flex, StyledAccordionSummary, SuccessIcon } from './style';
 
-function StepAccordion({ summaryHeading, summaryText, content }) {
+function StepAccordion({ summaryHeading, content }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [stepCompletedText, setStepCompletedText] = useState(null);
 
   function handleExpand(event, expanded) {
     setIsExpanded(expanded);
@@ -18,15 +20,30 @@ function StepAccordion({ summaryHeading, summaryText, content }) {
         <AccordionSummaryHeading variant="subtitle2" $isExpanded={isExpanded}>
           {summaryHeading}
         </AccordionSummaryHeading>
-        <AccordionSummaryText variant="body2" $isExpanded={isExpanded}>
-          {summaryText}
-        </AccordionSummaryText>
+        <Flex>
+          {stepCompletedText && (
+            <>
+              <AccordionText variant="body2" $isExpanded={isExpanded}>
+                {stepCompletedText}
+              </AccordionText>
+              <SuccessIcon />
+            </>
+          )}
+        </Flex>
       </StyledAccordionSummary>
       <AccordionDetails>
-        <Typography>{content}</Typography>
+        <Typography>
+          {React.cloneElement(content, {
+            setStepCompletedText,
+          })}
+        </Typography>
       </AccordionDetails>
     </Accordion>
   );
 }
 
+StepAccordion.propTypes = {
+  summaryHeading: PropTypes.string.isRequired,
+  content: PropTypes.element.isRequired,
+};
 export default StepAccordion;

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
@@ -25,28 +25,30 @@ function StepAccordion({ summaryHeading, content, disabled }) {
               <AccordionText variant="body2" $isExpanded={isExpanded}>
                 {stepCompletedText}
               </AccordionText>
-              <SuccessIcon />
+              <SuccessIcon data-testid="success-icon" />
             </>
           )}
         </Flex>
       </StyledAccordionSummary>
-      <AccordionDetails>
-        {content &&
-          React.cloneElement(content, {
+      {content && (
+        <AccordionDetails>
+          {React.cloneElement(content, {
             setStepCompletedText,
           })}
-      </AccordionDetails>
+        </AccordionDetails>
+      )}
     </Accordion>
   );
 }
 
 StepAccordion.propTypes = {
   summaryHeading: PropTypes.string.isRequired,
-  content: PropTypes.element.isRequired,
-  disabled: PropTypes.element,
+  content: PropTypes.element,
+  disabled: PropTypes.bool,
 };
 
 StepAccordion.defaultProps = {
+  content: undefined,
   disabled: false,
 };
 

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Accordion from '@material-ui/core/ExpansionPanel';
 import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
 
 import { AccordionSummaryHeading, AccordionText, Flex, StyledAccordionSummary, SuccessIcon } from './style';
 
@@ -15,7 +15,7 @@ function StepAccordion({ summaryHeading, content, disabled }) {
   }
   return (
     <Accordion onChange={handleExpand} disabled={disabled}>
-      <StyledAccordionSummary expandIcon={<ExpandMoreIcon />} $isExpanded={isExpanded}>
+      <StyledAccordionSummary expandIcon={<ArrowDropUpRoundedIcon />} $isExpanded={isExpanded}>
         <AccordionSummaryHeading variant="subtitle2" $isExpanded={isExpanded}>
           {summaryHeading}
         </AccordionSummaryHeading>

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import Accordion from '@material-ui/core/ExpansionPanel';
+import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
+import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+
+import { AccordionSummaryHeading, AccordionSummaryText, StyledAccordionSummary } from './style';
+
+function StepAccordion({ summaryHeading, summaryText, content }) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  function handleExpand(event, expanded) {
+    setIsExpanded(expanded);
+  }
+  return (
+    <Accordion onChange={handleExpand}>
+      <StyledAccordionSummary expandIcon={<ExpandMoreIcon />} $isExpanded={isExpanded}>
+        <AccordionSummaryHeading variant="subtitle2" $isExpanded={isExpanded}>
+          {summaryHeading}
+        </AccordionSummaryHeading>
+        <AccordionSummaryText variant="body2" $isExpanded={isExpanded}>
+          {summaryText}
+        </AccordionSummaryText>
+      </StyledAccordionSummary>
+      <AccordionDetails>
+        <Typography>{content}</Typography>
+      </AccordionDetails>
+    </Accordion>
+  );
+}
+
+export default StepAccordion;

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.spec.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.spec.js
@@ -1,0 +1,35 @@
+/* eslint-disable import/no-unresolved */
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import { render, screen } from 'test-utils/functions';
+import { fireEvent } from '@testing-library/react';
+
+import StepAccordion from './StepAccordion';
+
+const buttonText = 'Complete Step';
+const summaryText = 'Step 1 Completed';
+
+function ExampleContent({ setStepCompletedText }) {
+  return <Button onClick={() => setStepCompletedText(summaryText)}>{buttonText}</Button>;
+}
+
+test('should handle expanding the accordion and completing step', async () => {
+  const headingText = 'Step 1';
+  const iconTestId = 'success-icon';
+
+  render(<StepAccordion summaryHeading={headingText} content={<ExampleContent />} />);
+
+  expect(screen.getByText(headingText)).toBeInTheDocument();
+  expect(screen.queryByText(buttonText)).not.toBeVisible();
+  expect(screen.queryByText(summaryText)).not.toBeInTheDocument();
+  expect(screen.queryByTestId(iconTestId)).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByText(headingText)); // onClick applies to entire accordion summary it doesn't matter what is clicked
+
+  await screen.findByText(buttonText);
+
+  fireEvent.click(screen.getByText(buttonText));
+
+  await screen.findByText(summaryText);
+  expect(screen.getByTestId(iconTestId)).toBeInTheDocument();
+});

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.stories.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.stories.js
@@ -3,7 +3,7 @@ import Button from '@material-ui/core/Button';
 import StepAccordion from './StepAccordion';
 
 export default {
-  title: 'StepAccordion',
+  title: 'Accordions/StepAccordion',
   component: StepAccordion,
   argTypes: {
     content: {

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.stories.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import StepAccordion from './StepAccordion';
+
+export default {
+  title: 'StepAccordion',
+  component: StepAccordion,
+  argTypes: {
+    content: {
+      control: false,
+    },
+  },
+};
+
+function ExampleContent({ setStepCompletedText, stepNumber }) {
+  return (
+    <>
+      <Button onClick={() => setStepCompletedText(`Step ${stepNumber} Completed!`)}>Complete Step</Button>
+      <Button onClick={() => setStepCompletedText('')}>Reset</Button>
+    </>
+  );
+}
+
+export const Default = (args) => <StepAccordion {...args} content={<ExampleContent stepNumber={1} />} />;
+Default.args = {
+  summaryHeading: 'Step 1',
+};
+
+export const MultipleSteps = () =>
+  [1, 2, 3].map((stepNumber) => (
+    <StepAccordion summaryHeading={`Step ${stepNumber}`} content={<ExampleContent stepNumber={stepNumber} />} />
+  ));

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/index.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/index.js
@@ -1,0 +1,3 @@
+import StepAccordion from './StepAccordion';
+
+export default StepAccordion;

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import Typography from '@material-ui/core/Typography';
+import AccordionSummary from '@material-ui/core/ExpansionPanelSummary';
+
+const AccordionText = styled(Typography)`
+  color: ${(props) => (props.$isExpanded ? '#fff' : props.theme.palette.text.primary)};
+`;
+
+const AccordionSummaryHeading = styled(AccordionText)`
+  flex-grow: 1;
+  flex-shrink: 0;
+`;
+
+const AccordionSummaryText = styled(AccordionText)`
+  flex-grow: 3;
+`;
+
+const StyledAccordionSummary = styled(AccordionSummary)`
+  background-color: ${(props) => (props.$isExpanded ? props.theme.palette.secondary.main : '#E0E0E0')};
+`;
+
+export { AccordionSummaryHeading, AccordionSummaryText, StyledAccordionSummary };

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
@@ -3,6 +3,8 @@ import Typography from '@material-ui/core/Typography';
 import AccordionSummary from '@material-ui/core/ExpansionPanelSummary';
 import CheckCircleRoundedIcon from '@material-ui/icons/CheckCircleRounded';
 
+const iconHeight = '1.5rem';
+
 const AccordionText = styled(Typography)`
   color: ${(props) => (props.$isExpanded ? '#fff' : props.theme.palette.text.primary)};
 `;
@@ -14,6 +16,9 @@ const AccordionSummaryHeading = styled(AccordionText)`
 
 const StyledAccordionSummary = styled(AccordionSummary)`
   background-color: ${(props) => (props.$isExpanded ? props.theme.palette.secondary.main : '#E0E0E0')};
+  > div {
+    min-height: ${iconHeight};
+  }
   // only color the expand icon
   span > svg {
     color: ${(props) => (props.$isExpanded ? '#fff' : props.theme.palette.text.primary)};
@@ -22,6 +27,7 @@ const StyledAccordionSummary = styled(AccordionSummary)`
 
 const SuccessIcon = styled(CheckCircleRoundedIcon)`
   color: ${(props) => props.theme.palette.success.main};
+  font-size: ${iconHeight};
 `;
 
 const Flex = styled.div`

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
@@ -14,6 +14,9 @@ const AccordionSummaryHeading = styled(AccordionText)`
 
 const StyledAccordionSummary = styled(AccordionSummary)`
   background-color: ${(props) => (props.$isExpanded ? props.theme.palette.secondary.main : '#E0E0E0')};
+  svg {
+    color: ${(props) => (props.$isExpanded ? '#fff' : props.theme.palette.text.primary)};
+  }
 `;
 
 const SuccessIcon = styled(CheckCircleRoundedIcon)`

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import AccordionSummary from '@material-ui/core/ExpansionPanelSummary';
+import CheckCircleRoundedIcon from '@material-ui/icons/CheckCircleRounded';
 
 const AccordionText = styled(Typography)`
   color: ${(props) => (props.$isExpanded ? '#fff' : props.theme.palette.text.primary)};
@@ -11,12 +12,18 @@ const AccordionSummaryHeading = styled(AccordionText)`
   flex-shrink: 0;
 `;
 
-const AccordionSummaryText = styled(AccordionText)`
-  flex-grow: 3;
-`;
-
 const StyledAccordionSummary = styled(AccordionSummary)`
   background-color: ${(props) => (props.$isExpanded ? props.theme.palette.secondary.main : '#E0E0E0')};
 `;
 
-export { AccordionSummaryHeading, AccordionSummaryText, StyledAccordionSummary };
+const SuccessIcon = styled(CheckCircleRoundedIcon)`
+  color: ${(props) => props.theme.palette.success.main};
+`;
+
+const Flex = styled.div`
+  flex-grow: 4;
+  display: flex;
+  justify-content: space-between;
+`;
+
+export { AccordionSummaryHeading, AccordionText, StyledAccordionSummary, SuccessIcon, Flex };

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
@@ -8,7 +8,7 @@ const AccordionText = styled(Typography)`
 `;
 
 const AccordionSummaryHeading = styled(AccordionText)`
-  flex-grow: 1;
+  flex-basis: 20%;
   flex-shrink: 0;
 `;
 
@@ -25,7 +25,7 @@ const SuccessIcon = styled(CheckCircleRoundedIcon)`
 `;
 
 const Flex = styled.div`
-  flex-grow: 4;
+  flex-basis: 80%;
   display: flex;
   justify-content: space-between;
 `;

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
@@ -14,7 +14,8 @@ const AccordionSummaryHeading = styled(AccordionText)`
 
 const StyledAccordionSummary = styled(AccordionSummary)`
   background-color: ${(props) => (props.$isExpanded ? props.theme.palette.secondary.main : '#E0E0E0')};
-  svg {
+  // only color the expand icon
+  span > svg {
     color: ${(props) => (props.$isExpanded ? '#fff' : props.theme.palette.text.primary)};
   }
 `;


### PR DESCRIPTION
Towards #2142. Adds a reusable 'step' accordion component and separates the gene expression query and results each into an accordion. It still only handles single gene names, but should be expanded to multiple gene names and protein queries soon. Not worried about spacing here, it'll get fixed later down the road.

I don't think I need to worry about string overflow in the accordion summary, but if you feel like it's a risk, I could add styles to truncate the text with an ellipsis if needed.

I'd recommend checking this out locally and in the storybook.