### PR TITLE
John conroy/exclude lineup source maps

### DIFF
--- a/CHANGELOG-exclude-lineup-source-maps.md
+++ b/CHANGELOG-exclude-lineup-source-maps.md
@@ -1,0 +1,1 @@
+- Exclude source maps from lineupjs when bundling to prevent console warnings.

--- a/context/build-utils/webpack.common.js
+++ b/context/build-utils/webpack.common.js
@@ -31,6 +31,7 @@ const config = {
         test: /\.js$/,
         use: ['source-map-loader'],
         enforce: 'pre',
+        exclude: [/node_modules\/lineupjs[x]?/],
       },
       {
         test: /\.(js|jsx)$/,

--- a/context/build-utils/webpack.common.js
+++ b/context/build-utils/webpack.common.js
@@ -31,7 +31,7 @@ const config = {
         test: /\.js$/,
         use: ['source-map-loader'],
         enforce: 'pre',
-        exclude: [/node_modules\/lineupjs[x]?/],
+        exclude: [/node_modules\/lineupjsx?/],
       },
       {
         test: /\.(js|jsx)$/,


### PR DESCRIPTION
Fix #2145. This should handle `linupjs` and `lineupjsx`.