### PR TITLE
handle missing `metadata`

### DIFF
--- a/CHANGELOG-missing-metadata.md
+++ b/CHANGELOG-missing-metadata.md
@@ -1,0 +1,1 @@
+- `metadata` will no longer be present on derived entities? Support either structure.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -124,7 +124,8 @@ class ApiClient():
             # TODO: Entity structure will change in the future to be consistent
             # about "files". Bill confirms that when the new structure comes in
             # there will be a period of backward compatibility to allow us to migrate.
-            derived_entity['files'] = derived_entity['metadata']['files']
+            if 'metadata' in derived_entity:
+                derived_entity['files'] = derived_entity['metadata']['files']
             vitessce_conf = \
                 self.get_vitessce_conf_cells_and_lifted_uuid(derived_entity).vitessce_conf
             return VitessceConfLiftedUUID(


### PR DESCRIPTION
@yuanzhou -- My guess is that the data on TEST is actually a regression, and this is not a tweak we should make... but I'm really not sure.

> Chuck McCallum  13 minutes ago
> so it might be a problem on the dataset itself, or the descendant.
> 
> Chuck McCallum  9 minutes ago
> so it looks like the derived_entity has files, but no metadata. Just deleting this line may be the fix. Zhou (Joe) Yuan — Is this an expected change in the document structure?
> 
> Zhou (Joe) Yuan  9 minutes ago
> I compared the json representations of the TEST and PROD, for TEST, the json.descendents.metadata is missing.
> 
> Chuck McCallum  8 minutes ago
> Is this an expected change? Do you know if this will be true for all datasets? (edited) 
> 
> Zhou (Joe) Yuan  6 minutes ago
> I don't remember we ever changed this. Let me find out
> 
> Chuck McCallum  4 minutes ago
> Thanks: I’ll start a PR — It’s not a hard thing to change, we just want to be sure this is actually intentional.
