### PR TITLE
Add explicit target in SVG

### DIFF
--- a/CHANGELOG-svg-link-target.md
+++ b/CHANGELOG-svg-link-target.md
@@ -1,0 +1,1 @@
+- Add explicit `target` in SVG that is used in iframe.

--- a/context/app/static/js/components/home/AssayTypeBarChart/AssayTypeBarChart.jsx
+++ b/context/app/static/js/components/home/AssayTypeBarChart/AssayTypeBarChart.jsx
@@ -83,7 +83,9 @@ function AssayTypeBarChart({
                           bar.bar.data.mapped_data_type,
                         )}&${selectedColorFacetName}[0]=${encodeURIComponent(bar.key)}`}
                         key={`barstack-horizontal-${barStack.index}-${bar.index}`}
+                        target="_parent"
                       >
+                        {/* Make target explicit because html base target doesn't apply inside SVG. */}
                         <rect
                           x={bar.x}
                           y={bar.y}


### PR DESCRIPTION
- Fix #2152 

@shirey -- Can you confirm that this is actually only a problem with the barchart iframe? Using `iframe-demo.html` I can confirm that on Chrome the links there open up inside the iframe, instead of on the top level... but the links in the entity-counts iframe seem to be working fine.

@john-conroy -- Code review. There definitely seems to be a difference between FF and Chrome here, but I haven't found anything which describes exactly this issue, so I think we should just try to accommodate both.