### PR TITLE
Organ pages good-enough and linked from Atlas menu

### DIFF
--- a/CHANGELOG-organ-pages.md
+++ b/CHANGELOG-organ-pages.md
@@ -1,0 +1,1 @@
+- Get the organ pages into an acceptable state and link from the Atlas menu.

--- a/context/app/routes_file_based.py
+++ b/context/app/routes_file_based.py
@@ -92,6 +92,6 @@ def organ_details_view(name):
     }
     return render_template(
         'pages/base_react.html',
-        title='Organ',
+        title=organ['name'],
         flask_data=flask_data
     )

--- a/context/app/static/js/components/Header/AtlasToolsLinks/AtlasToolsLinks.jsx
+++ b/context/app/static/js/components/Header/AtlasToolsLinks/AtlasToolsLinks.jsx
@@ -8,6 +8,10 @@ function AtlasToolsLinks(props) {
   const { isIndented } = props;
   return (
     <>
+      <DropdownLink href="/organ" isIndented={isIndented}>
+        Organs
+      </DropdownLink>
+      <StyledDivider />
       <DropdownLink href="https://hubmapconsortium.github.io/ccf/" isIndented={isIndented}>
         Common Coordinate Framework (CCF) Portal
       </DropdownLink>

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -4,6 +4,7 @@ import Button from '@material-ui/core/Button';
 import Slider from '@material-ui/core/Slider';
 import FormLabel from '@material-ui/core/FormLabel';
 
+import { getDefaultQuery } from 'js/helpers/functions';
 import LogSliderWrapper from 'js/components/cells/LogSliderWrapper';
 import CellsService from 'js/components/cells/CellsService';
 import AutocompleteEntity from 'js/components/cells/AutocompleteEntity';
@@ -51,15 +52,7 @@ function DatasetsSelectedByExpression({
   }
   const query = useMemo(() => {
     return {
-      query: {
-        bool: {
-          must_not: {
-            exists: {
-              field: 'next_revision_uuid',
-            },
-          },
-        },
-      },
+      query: getDefaultQuery(),
       post_filter: {
         bool: {
           must: [

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -6,12 +6,29 @@ import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import SectionContainer from 'js/shared-styles/sections/SectionContainer';
 import Button from '@material-ui/core/Button';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
+import useSearchData from 'js/hooks/useSearchData';
 
 import { getSearchURL } from '../utils';
 
 function Assays(props) {
   const { searchTerms } = props;
   const searchUrl = getSearchURL('Dataset', searchTerms);
+
+  const query = {
+    size: 0,
+    query: { bool: { must_not: { exists: { field: 'next_revision_uuid' } } } },
+    aggs: {
+      mapped_data_types: {
+        filter: { term: { 'entity_type.keyword': 'Dataset' } },
+        aggs: {
+          'mapped_data_types.keyword': { terms: { field: 'mapped_data_types.keyword', size: 100 } },
+          'mapped_data_types.keyword_count': { cardinality: { field: 'mapped_data_types.keyword' } },
+        },
+      },
+    },
+  };
+
+  const { searchData } = useSearchData(query);
 
   return (
     <SectionContainer>
@@ -24,8 +41,9 @@ function Assays(props) {
           </Button>
         }
       />
-      <Paper>TODO: Table listing assay types that have been used on {searchTerms}. (Not a list of datasets)</Paper>
-      TODO: Assay barchart
+      <Paper>
+        <pre>{JSON.stringify(searchData, null, 2)}</pre>
+      </Paper>
     </SectionContainer>
   );
 }

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -5,6 +5,7 @@ import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
 
+import { getDefaultQuery } from 'js/helpers/functions';
 import EntitiesTable from 'js/shared-styles/tables/EntitiesTable';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
@@ -20,7 +21,7 @@ function Assays(props) {
 
   const query = {
     size: 0,
-    query: { bool: { must_not: { exists: { field: 'next_revision_uuid' } } } },
+    query: getDefaultQuery(),
     aggs: {
       mapped_data_types: {
         filter: {

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -58,7 +58,7 @@ function Assays(props) {
   return (
     <SectionContainer>
       <SpacedSectionButtonRow
-        leftText={<SectionHeader>Datasets</SectionHeader>}
+        leftText={<SectionHeader>Assays</SectionHeader>}
         buttons={
           <Button color="primary" variant="contained" component="a" href={searchUrl}>
             View All Datasets

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -68,14 +68,17 @@ function Assays(props) {
       <Paper>
         <EntitiesTable
           columns={[
-            { id: 'a', label: 'Assays' },
-            { id: 'b', label: 'Dataset Count' },
+            { id: 'assays', label: 'Assays' },
+            { id: 'counts', label: 'Dataset Count' },
           ]}
         >
           {buckets.map((bucket) => (
             <TableRow key={bucket.key}>
               <TableCell>
-                <LightBlueLink href={`TODO${bucket.key}`} variant="body2">
+                <LightBlueLink
+                  href={`/search?entity_type[0]=Dataset&mapped_data_types[0]=${encodeURIComponent(bucket.key)}`}
+                  variant="body2"
+                >
                   {bucket.key}
                 </LightBlueLink>
               </TableCell>

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -56,12 +56,11 @@ function Assays(props) {
 
   return (
     <SectionContainer>
-      TODO: Assays Info popover
       <SpacedSectionButtonRow
         leftText={<SectionHeader>Datasets</SectionHeader>}
         buttons={
           <Button color="primary" variant="contained" component="a" href={searchUrl}>
-            View Data on Search Page
+            View All Datasets
           </Button>
         }
       />

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import TableCell from '@material-ui/core/TableCell';
 import TableRow from '@material-ui/core/TableRow';
@@ -19,36 +19,39 @@ function Assays(props) {
   const { searchTerms } = props;
   const searchUrl = getSearchURL('Dataset', searchTerms);
 
-  const query = {
-    size: 0,
-    query: getDefaultQuery(),
-    aggs: {
-      mapped_data_types: {
-        filter: {
-          bool: {
-            must: [
-              {
-                term: {
-                  'entity_type.keyword': 'Dataset',
+  const query = useMemo(
+    () => ({
+      size: 0,
+      query: getDefaultQuery(),
+      aggs: {
+        mapped_data_types: {
+          filter: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'entity_type.keyword': 'Dataset',
+                  },
                 },
-              },
-              {
-                bool: {
-                  should: searchTerms.map((searchTerm) => ({
-                    term: { 'origin_sample.mapped_organ.keyword': searchTerm },
-                  })),
+                {
+                  bool: {
+                    should: searchTerms.map((searchTerm) => ({
+                      term: { 'origin_sample.mapped_organ.keyword': searchTerm },
+                    })),
+                  },
                 },
-              },
-            ],
+              ],
+            },
+          },
+          aggs: {
+            'mapped_data_types.keyword': { terms: { field: 'mapped_data_types.keyword', size: 100 } },
+            'mapped_data_types.keyword_count': { cardinality: { field: 'mapped_data_types.keyword' } },
           },
         },
-        aggs: {
-          'mapped_data_types.keyword': { terms: { field: 'mapped_data_types.keyword', size: 100 } },
-          'mapped_data_types.keyword_count': { cardinality: { field: 'mapped_data_types.keyword' } },
-        },
       },
-    },
-  };
+    }),
+    [searchTerms],
+  );
 
   const { searchData } = useSearchData(query);
   const buckets = searchData.aggregations

--- a/context/app/static/js/components/organ/Azimuth/Azimuth.jsx
+++ b/context/app/static/js/components/organ/Azimuth/Azimuth.jsx
@@ -12,25 +12,25 @@ import { StyledPaper } from './style';
 
 function Azimuth(props) {
   const { config } = props;
-  const dataRefHtml = marked(config.dataref);
+  const dataRefHtml = marked.parseInline(config.dataref);
 
   return (
     <SectionContainer>
-      TODO: Add info popover.
       <SpacedSectionButtonRow
         leftText={<SectionHeader>Reference-Based Analysis</SectionHeader>}
         buttons={<OutboundLinkButton href={config.applink}>Open Azimuth App</OutboundLinkButton>}
       />
       <StyledPaper>
-        TODO: Fix formatting
         <LabelledSectionText label="Modalities">{config.modalities}</LabelledSectionText>
         <LabelledSectionText label="Nuclei in reference">{config.nunit}</LabelledSectionText>
         {/* eslint-disable react/no-danger */}
         <LabelledSectionText label="Reference dataset">
-          <div dangerouslySetInnerHTML={{ __html: dataRefHtml }} />
+          <span dangerouslySetInnerHTML={{ __html: dataRefHtml }} />
         </LabelledSectionText>
       </StyledPaper>
-      TODO: Refactor so that can get the spinner without the a title?
+
+      {/* Need to refactor so "Visualization" is not included. */}
+      <br />
       <VisualizationWrapper vitData={config.vitessce_conf} />
     </SectionContainer>
   );

--- a/context/app/static/js/components/organ/Azimuth/Azimuth.jsx
+++ b/context/app/static/js/components/organ/Azimuth/Azimuth.jsx
@@ -29,7 +29,8 @@ function Azimuth(props) {
         </LabelledSectionText>
       </StyledPaper>
 
-      {/* Need to refactor so "Visualization" is not included. */}
+      {/* TODO: Refactor so "Visualization" is not included... */}
+      {/* TODO: ... and then remove the <br> as well. */}
       <br />
       <VisualizationWrapper vitData={config.vitessce_conf} />
     </SectionContainer>

--- a/context/app/static/js/components/organ/Description/Description.jsx
+++ b/context/app/static/js/components/organ/Description/Description.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import SectionContainer from 'js/shared-styles/sections/SectionContainer';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 
@@ -11,7 +10,6 @@ function Description(props) {
 
   return (
     <SectionContainer>
-      <SectionHeader>Description</SectionHeader>
       <StyledPaper>
         <p>{children}</p>
         <p>

--- a/context/app/static/js/components/organ/OrganInfo/OrganInfo.jsx
+++ b/context/app/static/js/components/organ/OrganInfo/OrganInfo.jsx
@@ -10,7 +10,6 @@ function OrganInfo(props) {
 
   return (
     <SectionContainer>
-      TODO: Add Human Reference Atlas info popover
       <SectionHeader>Human Reference Atlas</SectionHeader>
       <Paper>
         <iframe

--- a/context/app/static/js/components/organ/Samples/Samples.jsx
+++ b/context/app/static/js/components/organ/Samples/Samples.jsx
@@ -1,17 +1,63 @@
 import React from 'react';
+import format from 'date-fns/format';
 
+import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
+import Button from '@material-ui/core/Button';
 
+import EntitiesTable from 'js/shared-styles/tables/EntitiesTable';
+import { LightBlueLink } from 'js/shared-styles/Links';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import SectionContainer from 'js/shared-styles/sections/SectionContainer';
-import Button from '@material-ui/core/Button';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
+import { useSearchHits } from 'js/hooks/useSearchData';
 
 import { getSearchURL } from '../utils';
 
 function Samples(props) {
   const { searchTerms } = props;
   const searchUrl = getSearchURL('Sample', searchTerms);
+
+  const columns = [
+    { id: 'hubmap_id', label: 'Sample' },
+    { id: 'donor.mapped_metadata.age_value', label: 'Donor Age' },
+    { id: 'donor.mapped_metadata.sex', label: 'Donor Sex' },
+    { id: 'donor.mapped_metadata.race', label: 'Donor Race' },
+    { id: 'descendant_counts.entity_type.Dataset', label: 'Derived Dataset Count' },
+    { id: 'last_modified_timestamp', label: 'Last Modified' },
+  ];
+
+  const query = {
+    query: {
+      bool: {
+        must_not: {
+          exists: {
+            field: 'next_revision_uuid',
+          },
+        },
+      },
+    },
+    post_filter: {
+      bool: {
+        must: [
+          {
+            term: {
+              'entity_type.keyword': 'Sample',
+            },
+          },
+          {
+            bool: {
+              should: searchTerms.map((searchTerm) => ({ term: { 'origin_sample.mapped_organ.keyword': searchTerm } })),
+            },
+          },
+        ],
+      },
+    },
+    _source: columns.map((column) => column.id),
+  };
+
+  const { searchHits } = useSearchHits(query);
 
   return (
     <SectionContainer>
@@ -24,7 +70,26 @@ function Samples(props) {
           </Button>
         }
       />
-      <Paper>TODO: table of samples matching {searchTerms}</Paper>
+      <Paper>
+        <EntitiesTable columns={columns}>
+          {searchHits.map(
+            ({ _id: uuid, _source: { hubmap_id, donor, descendant_counts, last_modified_timestamp } }) => (
+              <TableRow key={uuid}>
+                <TableCell>
+                  <LightBlueLink href={`/browse/sample/${uuid}`} variant="body2">
+                    {hubmap_id}
+                  </LightBlueLink>
+                </TableCell>
+                <TableCell>{donor.mapped_metadata.age_value}</TableCell>
+                <TableCell>{donor.mapped_metadata.sex}</TableCell>
+                <TableCell>{donor.mapped_metadata.race}</TableCell>
+                <TableCell>{descendant_counts?.entity_type?.Dataset || 0}</TableCell>
+                <TableCell>{format(last_modified_timestamp, 'yyyy-MM-dd')}</TableCell>
+              </TableRow>
+            ),
+          )}
+        </EntitiesTable>
+      </Paper>
     </SectionContainer>
   );
 }

--- a/context/app/static/js/components/organ/Samples/Samples.jsx
+++ b/context/app/static/js/components/organ/Samples/Samples.jsx
@@ -61,12 +61,11 @@ function Samples(props) {
 
   return (
     <SectionContainer>
-      TODO: &quot;Add to List&quot; button
       <SpacedSectionButtonRow
         leftText={<SectionHeader>Samples</SectionHeader>}
         buttons={
           <Button color="primary" variant="contained" component="a" href={searchUrl}>
-            View Data on Search Page
+            View All Samples
           </Button>
         }
       />

--- a/context/app/static/js/components/organ/Samples/Samples.jsx
+++ b/context/app/static/js/components/organ/Samples/Samples.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import format from 'date-fns/format';
 
 import TableCell from '@material-ui/core/TableCell';
@@ -29,26 +29,31 @@ function Samples(props) {
     { id: 'last_modified_timestamp', label: 'Last Modified' },
   ];
 
-  const query = {
-    query: getDefaultQuery(),
-    post_filter: {
-      bool: {
-        must: [
-          {
-            term: {
-              'entity_type.keyword': 'Sample',
+  const query = useMemo(
+    () => ({
+      query: getDefaultQuery(),
+      post_filter: {
+        bool: {
+          must: [
+            {
+              term: {
+                'entity_type.keyword': 'Sample',
+              },
             },
-          },
-          {
-            bool: {
-              should: searchTerms.map((searchTerm) => ({ term: { 'origin_sample.mapped_organ.keyword': searchTerm } })),
+            {
+              bool: {
+                should: searchTerms.map((searchTerm) => ({
+                  term: { 'origin_sample.mapped_organ.keyword': searchTerm },
+                })),
+              },
             },
-          },
-        ],
+          ],
+        },
       },
-    },
-    _source: columns.map((column) => column.id),
-  };
+      _source: columns.map((column) => column.id),
+    }),
+    [columns, searchTerms],
+  );
 
   const { searchHits } = useSearchHits(query);
 

--- a/context/app/static/js/components/organ/Samples/Samples.jsx
+++ b/context/app/static/js/components/organ/Samples/Samples.jsx
@@ -6,6 +6,7 @@ import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 import Button from '@material-ui/core/Button';
 
+import { getDefaultQuery } from 'js/helpers/functions';
 import EntitiesTable from 'js/shared-styles/tables/EntitiesTable';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
@@ -29,15 +30,7 @@ function Samples(props) {
   ];
 
   const query = {
-    query: {
-      bool: {
-        must_not: {
-          exists: {
-            field: 'next_revision_uuid',
-          },
-        },
-      },
-    },
+    query: getDefaultQuery(),
     post_filter: {
       bool: {
         must: [

--- a/context/app/static/js/components/organ/Samples/Samples.jsx
+++ b/context/app/static/js/components/organ/Samples/Samples.jsx
@@ -64,22 +64,30 @@ function Samples(props) {
       />
       <Paper>
         <EntitiesTable columns={columns}>
-          {searchHits.map(
-            ({ _id: uuid, _source: { hubmap_id, donor, descendant_counts, last_modified_timestamp } }) => (
+          {searchHits
+            .map((hit) => {
+              /* eslint-disable no-underscore-dangle */
+              if (!hit._source.donor) {
+                // eslint-disable-next-line no-param-reassign
+                hit._source.donor = {};
+              }
+              /* eslint-enable */
+              return hit;
+            })
+            .map(({ _id: uuid, _source: { hubmap_id, donor, descendant_counts, last_modified_timestamp } }) => (
               <TableRow key={uuid}>
                 <TableCell>
                   <LightBlueLink href={`/browse/sample/${uuid}`} variant="body2">
                     {hubmap_id}
                   </LightBlueLink>
                 </TableCell>
-                <TableCell>{donor.mapped_metadata.age_value}</TableCell>
-                <TableCell>{donor.mapped_metadata.sex}</TableCell>
-                <TableCell>{donor.mapped_metadata.race}</TableCell>
+                <TableCell>{donor?.mapped_metadata?.age_value}</TableCell>
+                <TableCell>{donor?.mapped_metadata?.sex}</TableCell>
+                <TableCell>{donor?.mapped_metadata?.race}</TableCell>
                 <TableCell>{descendant_counts?.entity_type?.Dataset || 0}</TableCell>
                 <TableCell>{format(last_modified_timestamp, 'yyyy-MM-dd')}</TableCell>
               </TableRow>
-            ),
-          )}
+            ))}
         </EntitiesTable>
       </Paper>
     </SectionContainer>

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -1,3 +1,5 @@
+import { BoolMustNot, ExistsQuery } from 'searchkit';
+
 export function isEmptyArrayOrObject(val) {
   if (val.constructor.name === 'Object') {
     return Object.keys(val).length === 0;
@@ -68,4 +70,8 @@ export function tableToDelimitedString(rows, colNames, d) {
 
 export function createDownloadUrl(fileStr, fileType) {
   return window.URL.createObjectURL(new Blob([fileStr], { type: fileType }));
+}
+
+export function getDefaultQuery() {
+  return BoolMustNot(ExistsQuery('next_revision_uuid'));
 }

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -1,5 +1,3 @@
-import { BoolMustNot, ExistsQuery } from 'searchkit';
-
 export function isEmptyArrayOrObject(val) {
   if (val.constructor.name === 'Object') {
     return Object.keys(val).length === 0;
@@ -73,5 +71,13 @@ export function createDownloadUrl(fileStr, fileType) {
 }
 
 export function getDefaultQuery() {
-  return BoolMustNot(ExistsQuery('next_revision_uuid'));
+  return {
+    bool: {
+      must_not: {
+        exists: {
+          field: 'next_revision_uuid',
+        },
+      },
+    },
+  };
 }

--- a/context/app/static/js/hooks/useSearchData.js
+++ b/context/app/static/js/hooks/useSearchData.js
@@ -34,7 +34,7 @@ function useSearchData(query) {
 
 function useSearchHits(query) {
   const { searchData, isLoading } = useSearchData(query);
-  const searchHits = searchData?.hits?.hits || {};
+  const searchHits = searchData?.hits?.hits || [];
   return { searchHits, isLoading };
 }
 

--- a/context/app/static/js/pages/Organ/Organ.jsx
+++ b/context/app/static/js/pages/Organ/Organ.jsx
@@ -12,7 +12,6 @@ function Organ(props) {
 
   return (
     <>
-      TODO: Add table of contents
       <SectionHeader variant="h1" component="h1">
         {organ.name}
       </SectionHeader>
@@ -29,7 +28,6 @@ function Organ(props) {
           <Samples searchTerms={organ.search} />
         </>
       )}
-      TODO: Confirm that we are not still planning to include the old IU component as well?
     </>
   );
 }

--- a/context/app/static/js/pages/search/CellsSearch.jsx
+++ b/context/app/static/js/pages/search/CellsSearch.jsx
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { BoolMustNot, ExistsQuery } from 'searchkit';
 
 import DatasetSearchPrompt from 'js/components/tutorials/DatasetSearchPrompt';
 import SearchDatasetTutorial from 'js/components/tutorials/SearchDatasetTutorial';
 import { AppContext } from 'js/components/Providers';
 import LookupEntity from 'js/helpers/LookupEntity';
-import { getAuthHeader } from 'js/helpers/functions';
+import { getAuthHeader, getDefaultQuery } from 'js/helpers/functions';
 import SearchWrapper from 'js/components/Search/SearchWrapper';
 import { donorConfig, sampleConfig, datasetConfig, fieldsToHighlight } from 'js/components/Search/config';
 import { listFilter } from 'js/components/Search/utils';
@@ -90,7 +89,7 @@ function Search(props) {
     queryFields: ['all_text', ...fieldsToHighlight],
     isLoggedIn: Boolean(nexusToken),
     apiUrl: elasticsearchEndpoint,
-    defaultQuery: BoolMustNot(ExistsQuery('next_revision_uuid')),
+    defaultQuery: getDefaultQuery(),
   };
 
   const wrappedSearch = <SearchWrapper {...searchProps} resultsComponent={Results} />;

--- a/context/app/static/js/pages/search/Search.jsx
+++ b/context/app/static/js/pages/search/Search.jsx
@@ -1,12 +1,11 @@
 import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
-import { BoolMustNot, ExistsQuery } from 'searchkit';
 
 import DatasetSearchPrompt from 'js/components/tutorials/DatasetSearchPrompt';
 import SearchDatasetTutorial from 'js/components/tutorials/SearchDatasetTutorial';
 import { AppContext } from 'js/components/Providers';
 import LookupEntity from 'js/helpers/LookupEntity';
-import { getAuthHeader } from 'js/helpers/functions';
+import { getAuthHeader, getDefaultQuery } from 'js/helpers/functions';
 import SearchWrapper from 'js/components/Search/SearchWrapper';
 import { donorConfig, sampleConfig, datasetConfig, fieldsToHighlight } from 'js/components/Search/config';
 import { listFilter } from 'js/components/Search/utils';
@@ -90,7 +89,7 @@ function Search(props) {
     queryFields: ['all_text', ...fieldsToHighlight],
     isLoggedIn: Boolean(nexusToken),
     apiUrl: elasticsearchEndpoint,
-    defaultQuery: BoolMustNot(ExistsQuery('next_revision_uuid')),
+    defaultQuery: getDefaultQuery(),
   };
 
   const wrappedSearch = <SearchWrapper {...searchProps} resultsComponent={Results} />;


### PR DESCRIPTION
cc @ngehlenborg / @tsliaw 

For the work I know still needs to be done, I've filed 
- #2182

Suggest that that be reviewed in conjunction with this, and if anything is absolutely essential, bring it forward.

Note that this also adds a util function that excludes entities that are not the latest version. We'll be adding a clause to this soon to also excludes retracted entities. 

Note that this adds "Organs" to the "Atlas & Tools" Menu. If we want to have this up on Friday, it needs to be in this release.

- Fix #2177 
- Fix #2126
- Fix #2092
- Fix #2090
- Fix #1824

