### PR TITLE
John conroy/fix loaders

### DIFF
--- a/context/app/static/js/components/cells/CellExpressionHistogram/CellExpressionHistogram.jsx
+++ b/context/app/static/js/components/cells/CellExpressionHistogram/CellExpressionHistogram.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Typography from '@material-ui/core/Typography';
 import { useTheme } from '@material-ui/core/styles';
 
@@ -6,10 +6,11 @@ import Histogram from 'js/shared-styles/charts/Histogram';
 import CellsService from 'js/components/cells/CellsService';
 import { StyledSkeleton } from 'js/components/cells/CellsCharts/style';
 
-function CellExpressionHistogram({ uuid, cellVariableName, isLoading, finishLoading, loadingKey }) {
+function CellExpressionHistogram({ uuid, cellVariableName, isLoading, finishLoading, loadingKey, isExpanded }) {
   const [expressionData, setExpressionData] = useState([]);
   const [diagnosticInfo, setDiagnosticInfo] = useState({});
   const theme = useTheme();
+  const loadedOnce = useRef(false);
 
   useEffect(() => {
     async function fetchCellExpression() {
@@ -26,8 +27,15 @@ function CellExpressionHistogram({ uuid, cellVariableName, isLoading, finishLoad
       setExpressionData(response.map((d) => d.values[cellVariableName]));
       finishLoading(loadingKey);
     }
-    fetchCellExpression();
-  }, [uuid, cellVariableName, finishLoading, loadingKey]);
+    if (loadedOnce.current) {
+      return;
+    }
+
+    if (isExpanded) {
+      fetchCellExpression();
+      loadedOnce.current = true;
+    }
+  }, [uuid, cellVariableName, finishLoading, loadingKey, isExpanded]);
 
   return Object.values(isLoading).every((val) => !val) ? (
     <>

--- a/context/app/static/js/components/cells/CellExpressionHistogram/CellExpressionHistogram.jsx
+++ b/context/app/static/js/components/cells/CellExpressionHistogram/CellExpressionHistogram.jsx
@@ -37,7 +37,11 @@ function CellExpressionHistogram({ uuid, cellVariableName, isLoading, finishLoad
     }
   }, [uuid, cellVariableName, finishLoading, loadingKey, isExpanded]);
 
-  return Object.values(isLoading).every((val) => !val) ? (
+  if (Object.values(isLoading).some((val) => val)) {
+    return <StyledSkeleton variant="rectangular" />;
+  }
+
+  return (
     <>
       <Typography>
         {diagnosticInfo.timeWaiting.toFixed(2)} seconds to receive an API response for {diagnosticInfo.numCells} cells.
@@ -53,8 +57,6 @@ function CellExpressionHistogram({ uuid, cellVariableName, isLoading, finishLoad
         barColor={theme.palette.success.main}
       />
     </>
-  ) : (
-    <StyledSkeleton variant="rectangular" />
   );
 }
 

--- a/context/app/static/js/components/cells/CellsCharts/CellsCharts.jsx
+++ b/context/app/static/js/components/cells/CellsCharts/CellsCharts.jsx
@@ -4,7 +4,7 @@ import CellExpressionHistogram from 'js/components/cells/CellExpressionHistogram
 
 import { Flex, ChartWrapper } from './style';
 
-function CellsCharts({ uuid, cellVariableName, minExpression, queryType }) {
+function CellsCharts({ uuid, cellVariableName, minExpression, queryType, heightRef, isExpanded }) {
   const histogramKey = 'cell-histogram';
   const clusterChartKey = 'cluster-bar';
   const [isLoading, setIsLoading] = useState({ [histogramKey]: true, [clusterChartKey]: true });
@@ -19,7 +19,7 @@ function CellsCharts({ uuid, cellVariableName, minExpression, queryType }) {
   }, []);
 
   return (
-    <Flex>
+    <Flex ref={heightRef}>
       <ChartWrapper>
         <CellExpressionHistogram
           uuid={uuid}
@@ -27,6 +27,7 @@ function CellsCharts({ uuid, cellVariableName, minExpression, queryType }) {
           isLoading={isLoading}
           finishLoading={finishLoading}
           loadingKey={histogramKey}
+          isExpanded={isExpanded}
         />
       </ChartWrapper>
       <ChartWrapper>
@@ -38,6 +39,7 @@ function CellsCharts({ uuid, cellVariableName, minExpression, queryType }) {
           isLoading={isLoading}
           finishLoading={finishLoading}
           loadingKey={clusterChartKey}
+          isExpanded={isExpanded}
         />
       </ChartWrapper>
     </Flex>

--- a/context/app/static/js/components/cells/DatasetClusterChart/DatasetClusterChart.jsx
+++ b/context/app/static/js/components/cells/DatasetClusterChart/DatasetClusterChart.jsx
@@ -99,7 +99,7 @@ function DatasetClusterChart({
           top: 50,
           right: 50,
           left: 50,
-          bottom: 50,
+          bottom: 60, // TODO: Fix height of chart and dropdown instead of compensating with extra bottom margin.
         }}
       />
     </>

--- a/context/app/static/js/components/cells/DatasetClusterChart/DatasetClusterChart.jsx
+++ b/context/app/static/js/components/cells/DatasetClusterChart/DatasetClusterChart.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { scaleLinear, scaleOrdinal, scaleBand } from '@visx/scale';
 import Button from '@material-ui/core/Button';
 import { useTheme } from '@material-ui/core/styles';
@@ -18,11 +18,13 @@ function DatasetClusterChart({
   isLoading,
   finishLoading,
   loadingKey,
+  isExpanded,
 }) {
   const [results, setResults] = useState({});
   const [scales, setScales] = useState({});
   const [selectedClusterTypeIndex, setSelectedClusterTypeIndex] = useState(0);
   const theme = useTheme();
+  const loadedOnce = useRef(false);
 
   useEffect(() => {
     if (Object.keys(results).length) {
@@ -61,8 +63,14 @@ function DatasetClusterChart({
       });
       setResults(response);
     }
-    fetchCellClusterMatches();
-  }, [cellVariableName, minExpression, queryType, uuid]);
+    if (loadedOnce.current) {
+      return;
+    }
+    if (isExpanded) {
+      fetchCellClusterMatches();
+      loadedOnce.current = true;
+    }
+  }, [cellVariableName, isExpanded, minExpression, queryType, uuid]);
 
   function handleSelectClusterType({ i }) {
     setSelectedClusterTypeIndex(i);

--- a/context/app/static/js/components/cells/DatasetClusterChart/DatasetClusterChart.jsx
+++ b/context/app/static/js/components/cells/DatasetClusterChart/DatasetClusterChart.jsx
@@ -76,7 +76,11 @@ function DatasetClusterChart({
     setSelectedClusterTypeIndex(i);
   }
 
-  return Object.values(isLoading).every((val) => !val) ? (
+  if (Object.values(isLoading).some((val) => val)) {
+    return <StyledSkeleton variant="rectangular" />;
+  }
+
+  return (
     <>
       <DropdownListbox
         id="bar-fill-dropdown"
@@ -103,9 +107,6 @@ function DatasetClusterChart({
         }}
       />
     </>
-  ) : (
-    <StyledSkeleton variant="rectangular" />
   );
 }
-
 export default DatasetClusterChart;

--- a/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
+++ b/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
@@ -4,11 +4,11 @@ import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
-import { useTransition, animated, config } from 'react-spring';
-import useResizeObserver from 'use-resize-observer/polyfilled';
+import { animated } from 'react-spring';
 
 import DatasetTableRow from 'js/components/cells/DatasetTableRow';
 import { initialHeight } from 'js/pages/Cells/style';
+import useExpandTransition from 'js/hooks/useExpandTransition';
 
 const columns = [
   { id: 'hubmap_id', label: 'HuBMAP ID' },
@@ -28,14 +28,7 @@ function DatasetsTable({ datasets, minExpression, cellVariableName, queryType, c
   }, [completeStep, datasets]);
   const heightRef = useRef(null);
 
-  const { height = 0 } = useResizeObserver({ ref: heightRef });
-
-  const transitions = useTransition(true, null, {
-    from: { opacity: 0, height: initialHeight },
-    enter: { opacity: 1, height },
-    config: config.slow,
-    update: { height },
-  });
+  const transitions = useExpandTransition(heightRef, initialHeight);
 
   return transitions.map(
     ({ item, key, props }) =>

--- a/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
+++ b/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
@@ -8,7 +8,7 @@ import { animated } from 'react-spring';
 
 import DatasetTableRow from 'js/components/cells/DatasetTableRow';
 import { initialHeight } from 'js/pages/Cells/style';
-import useExpandTransition from 'js/hooks/useExpandTransition';
+import { useExpandTransition } from 'js/hooks/useExpand';
 
 const columns = [
   { id: 'hubmap_id', label: 'HuBMAP ID' },

--- a/context/app/static/js/hooks/useExpand.js
+++ b/context/app/static/js/hooks/useExpand.js
@@ -21,5 +21,4 @@ function useExpandSpring(ref, initialElementHeight, toggle, optionalConfig) {
     config: optionalConfig || config.default,
   });
 }
-export { useExpandSpring };
-export default useExpandTransition;
+export { useExpandTransition, useExpandSpring };

--- a/context/app/static/js/hooks/useExpandTransition.js
+++ b/context/app/static/js/hooks/useExpandTransition.js
@@ -1,0 +1,25 @@
+import { useTransition, useSpring, config } from 'react-spring';
+import useResizeObserver from 'use-resize-observer/polyfilled';
+
+function useExpandTransition(ref, initialElementHeight, optionalConfig) {
+  const { height = 0 } = useResizeObserver({ ref });
+
+  return useTransition(true, null, {
+    from: { opacity: 0, height: initialElementHeight, overflowY: 'hidden' },
+    enter: { opacity: 1, height },
+    config: optionalConfig || config.default,
+    update: { height },
+  });
+}
+
+function useExpandSpring(ref, initialElementHeight, toggle, optionalConfig) {
+  const { height = 0 } = useResizeObserver({ ref });
+  return useSpring({
+    overflowY: 'hidden',
+    height: toggle ? height : initialElementHeight,
+    opacity: toggle ? 1 : 0,
+    config: optionalConfig || config.default,
+  });
+}
+export { useExpandSpring };
+export default useExpandTransition;

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.jsx
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.jsx
@@ -6,7 +6,7 @@ import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
 import { animated } from 'react-spring';
 
 import ExpandableRowCell from 'js/shared-styles/Table/ExpandableRowCell';
-import { useExpandSpring } from 'js/hooks/useExpandTransition';
+import { useExpandSpring } from 'js/hooks/useExpand';
 import { Provider, createStore, useStore } from './store';
 import { StyledTableCell } from './style';
 

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.jsx
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.jsx
@@ -1,15 +1,19 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import TableRow from '@material-ui/core/TableRow';
-import TableCell from '@material-ui/core/TableCell';
 import IconButton from '@material-ui/core/IconButton';
 import ArrowDropDownRoundedIcon from '@material-ui/icons/ArrowDropDownRounded';
 import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
+import { animated } from 'react-spring';
 
 import ExpandableRowCell from 'js/shared-styles/Table/ExpandableRowCell';
+import { useExpandSpring } from 'js/hooks/useExpandTransition';
 import { Provider, createStore, useStore } from './store';
+import { StyledTableCell } from './style';
 
 function ExpandableRowChild({ children, numCells, expandedContent }) {
   const { isExpanded, toggleIsExpanded } = useStore();
+  const heightRef = useRef(null);
+  const styles = useExpandSpring(heightRef, 0, isExpanded);
 
   return (
     <>
@@ -25,11 +29,16 @@ function ExpandableRowChild({ children, numCells, expandedContent }) {
           </IconButton>
         </ExpandableRowCell>
       </TableRow>
-      {isExpanded && (
-        <TableRow>
-          <TableCell colSpan={numCells}>{expandedContent}</TableCell>
-        </TableRow>
-      )}
+      <TableRow>
+        <StyledTableCell colSpan={numCells} $isExpanded={isExpanded}>
+          <animated.div style={styles}>
+            {React.cloneElement(expandedContent, {
+              heightRef,
+              isExpanded,
+            })}
+          </animated.div>
+        </StyledTableCell>
+      </TableRow>
     </>
   );
 }

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.jsx
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.jsx
@@ -8,7 +8,7 @@ import { animated } from 'react-spring';
 import ExpandableRowCell from 'js/shared-styles/Table/ExpandableRowCell';
 import { useExpandSpring } from 'js/hooks/useExpand';
 import { Provider, createStore, useStore } from './store';
-import { StyledTableCell } from './style';
+import { ExpandedRow, ExpandedCell } from './style';
 
 function ExpandableRowChild({ children, numCells, expandedContent }) {
   const { isExpanded, toggleIsExpanded } = useStore();
@@ -29,16 +29,16 @@ function ExpandableRowChild({ children, numCells, expandedContent }) {
           </IconButton>
         </ExpandableRowCell>
       </TableRow>
-      <TableRow>
-        <StyledTableCell colSpan={numCells} $isExpanded={isExpanded}>
+      <ExpandedRow $isExpanded={isExpanded}>
+        <ExpandedCell colSpan={numCells} $isExpanded={isExpanded}>
           <animated.div style={styles}>
             {React.cloneElement(expandedContent, {
               heightRef,
               isExpanded,
             })}
           </animated.div>
-        </StyledTableCell>
-      </TableRow>
+        </ExpandedCell>
+      </ExpandedRow>
     </>
   );
 }

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.spec.js
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.spec.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-unresolved */
 import React from 'react';
 import { render, screen } from 'test-utils/functions';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 
 import ExpandableRowCell from 'js/shared-styles/Table/ExpandableRowCell';
 import ExpandableRow from './ExpandableRow';
@@ -17,10 +17,13 @@ test('should handle user expanding row', async () => {
   );
   cellsText.forEach((cellText) => expect(screen.getByText(cellText)).not.toHaveStyle('border-bottom: none'));
   expect(screen.getByTestId('down-arrow-icon')).toBeInTheDocument();
+  expect(screen.getByText('123')).not.toBeVisible();
 
   fireEvent.click(screen.getByLabelText('expand row'));
 
-  await screen.findByText('123');
+  await waitFor(() => {
+    expect(screen.getByText('123')).toBeVisible();
+  });
 
   cellsText.forEach((cellText) => expect(screen.getByText(cellText)).toHaveStyle('border-bottom: none'));
   expect(screen.getByTestId('up-arrow-icon')).toBeInTheDocument();

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.stories.js
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/ExpandableRow.stories.js
@@ -15,9 +15,19 @@ export const ExpandableRow = (args) => (
     <ExpandableRowCell>C</ExpandableRowCell>
   </ExpandableRowComponent>
 );
+
+function Content({ heightRef }) {
+  return (
+    <div ref={heightRef}>
+      Mollit irure sit fugiat eiusmod ullamco laborum. Deserunt aliqua nulla occaecat reprehenderit est cupidatat ex
+      laborum. Occaecat ipsum anim dolore anim ut velit irure exercitation sunt. Incididunt pariatur dolore ut duis. Eu
+      nulla ut amet irure deserunt eiusmod aliqua fugiat labore.
+    </div>
+  );
+}
 ExpandableRow.args = {
   numCells: 4,
-  expandedContent: <div>123</div>,
+  expandedContent: <Content />,
 };
 
 ExpandableRow.storyName = 'ExpandableRow'; // needed for single story hoisting for multi word component names

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/style.js
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/style.js
@@ -1,9 +1,18 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import TableCell from '@material-ui/core/TableCell';
+import TableRow from '@material-ui/core/TableRow';
 
-const StyledTableCell = styled(TableCell)`
+const ExpandedRow = styled(TableRow)`
+  ${(props) =>
+    !props.$isExpanded &&
+    css`
+      visibility: hidden;
+    `};
+`;
+
+const ExpandedCell = styled(TableCell)`
   padding: ${(props) => (props.$isExpanded ? `${props.theme.spacing(2)}px` : 0)};
   border-bottom: ${(props) => (props.$isExpanded ? ' 1px solid rgba(224, 224, 224, 1)' : 'none')};
 `;
 
-export { StyledTableCell };
+export { ExpandedRow, ExpandedCell };

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/style.js
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/style.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import TableCell from '@material-ui/core/TableCell';
+
+const StyledTableCell = styled(TableCell)`
+  padding: ${(props) => (props.$isExpanded ? `${props.theme.spacing(2)}px` : 0)};
+  border-bottom: ${(props) => (props.$isExpanded ? ' 1px solid rgba(224, 224, 224, 1)' : 'none')};
+`;
+
+export { StyledTableCell };

--- a/context/app/static/js/shared-styles/Table/ExpandableRow/style.js
+++ b/context/app/static/js/shared-styles/Table/ExpandableRow/style.js
@@ -12,7 +12,8 @@ const ExpandedRow = styled(TableRow)`
 
 const ExpandedCell = styled(TableCell)`
   padding: ${(props) => (props.$isExpanded ? `${props.theme.spacing(2)}px` : 0)};
-  border-bottom: ${(props) => (props.$isExpanded ? ' 1px solid rgba(224, 224, 224, 1)' : 'none')};
+  border-bottom: ${(props) =>
+    props.$isExpanded ? ' 1px solid rgba(224, 224, 224, 1)' : 'none'}; // border color taken from MUI table cell
 `;
 
 export { ExpandedRow, ExpandedCell };


### PR DESCRIPTION
- Hides/reveals not conditionally renders `ExpandableRow` content.
- Adds spring to `ExpandableRow` expand.
- Pulls expand transition/spring into reusable hooks.

Nils wanted the charts in the table to be preserved when closed/re-opened. To do that I decided to hide the expanded content instead of not rendering it similar to what MUI does with its accordions. I also added some logic to the chart fetch hooks to make sure the hook is only run on the initial expand. Using a ref instead of state ensures the component is not updated when the value is changed. I attempted to move that logic into a reusable hook, but couldn't manage it quickly and cleanly.