### PR TITLE
Mccalluc/donor sample metadata

### DIFF
--- a/CHANGELOG-metadata.md
+++ b/CHANGELOG-metadata.md
@@ -1,0 +1,1 @@
+- Add donor and sample metadata.

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -74,8 +74,11 @@ function DatasetDetail(props) {
   } = assayMetadata;
   const isLatest = !('next_revision_uuid' in assayMetadata);
 
+  // source_sample seems to be an array, but that seems strange,
+  // and we don't have good constraints on document structure,
+  // so we'll be flexible.
+  const sampleMetadata = (source_sample?.[0] || source_sample)?.metadata || {};
   const donorMetadata = donor?.mapped_metadata || {};
-  const sampleMetadata = source_sample[0]?.metadata || {};
   const combinedMetadata = {
     ...metadata.metadata,
     ...Object.fromEntries(Object.entries(sampleMetadata).map(([key, value]) => [`sample.${key}`, value])),

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -54,6 +54,8 @@ function DatasetDetail(props) {
     protocol_url,
     metadata,
     files,
+    donor,
+    source_sample,
     uuid,
     data_types,
     mapped_data_types,
@@ -72,6 +74,14 @@ function DatasetDetail(props) {
   } = assayMetadata;
   const isLatest = !('next_revision_uuid' in assayMetadata);
 
+  const donorMetadata = donor?.mapped_metadata || {};
+  const sampleMetadata = source_sample[0]?.metadata || {};
+  const combinedMetadata = {
+    ...metadata.metadata,
+    ...Object.fromEntries(Object.entries(sampleMetadata).map(([key, value]) => [`sample.${key}`, value])),
+    ...Object.fromEntries(Object.entries(donorMetadata).map(([key, value]) => [`donor.${key}`, value])),
+  };
+
   const { elasticsearchEndpoint, nexusToken } = useContext(AppContext);
 
   const allCollections = useCollectionsData(elasticsearchEndpoint, nexusToken);
@@ -81,7 +91,7 @@ function DatasetDetail(props) {
     provenance: entity_type !== 'Support',
     visualization: Boolean(vitData),
     protocols: Boolean(protocol_url),
-    metadata: metadata && 'metadata' in metadata,
+    metadata: Boolean(Object.keys(combinedMetadata).length),
     files: true,
     collections: Boolean(collectionsData.length),
   };
@@ -137,7 +147,7 @@ function DatasetDetail(props) {
         )}
         {shouldDisplaySection.provenance && <ProvSection uuid={uuid} assayMetadata={assayMetadata} />}
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} />}
-        {shouldDisplaySection.metadata && <MetadataTable metadata={metadata.metadata} hubmap_id={hubmap_id} />}
+        {shouldDisplaySection.metadata && <MetadataTable metadata={combinedMetadata} hubmap_id={hubmap_id} />}
         <Files files={files} uuid={uuid} hubmap_id={hubmap_id} visLiftedUUID={visLiftedUUID} />
         {shouldDisplaySection.collections && <CollectionsSection collectionsData={collectionsData} />}
         <Attribution

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -22,6 +22,7 @@ function SampleDetail(props) {
   const { assayMetadata } = props;
   const {
     uuid,
+    donor,
     protocol_url,
     mapped_specimen_type,
     origin_sample: { mapped_organ },
@@ -40,10 +41,16 @@ function SampleDetail(props) {
 
   const { searchHits: derivedDatasets, isLoading: derivedDatsetsAreLoading } = useDerivedDatasetSearchHits(uuid);
 
+  const donorMetadata = donor?.mapped_metadata || {};
+  const combinedMetadata = {
+    ...(metadata || {}),
+    ...Object.fromEntries(Object.entries(donorMetadata).map(([key, value]) => [`donor.${key}`, value])),
+  };
+
   const shouldDisplaySection = {
     protocols: Boolean(protocol_url),
     tissue: true,
-    metadata: 'metadata' in assayMetadata,
+    metadata: Boolean(Object.keys(combinedMetadata).length),
     derived: Boolean(descendant_counts?.entity_type?.Dataset > 0),
   };
 
@@ -94,7 +101,7 @@ function SampleDetail(props) {
         />
         <ProvSection uuid={uuid} assayMetadata={assayMetadata} />
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} />}
-        {shouldDisplaySection.metadata && <MetadataTable metadata={metadata} hubmap_id={hubmap_id} />}
+        {shouldDisplaySection.metadata && <MetadataTable metadata={combinedMetadata} hubmap_id={hubmap_id} />}
         <Attribution
           group_name={group_name}
           created_by_user_displayname={created_by_user_displayname}


### PR DESCRIPTION
Fix #2163: 
- @tsliaw , This jumps the gun a little bit: Rather than waiting for a design, I suggest we just put it all in the sample table, and prefix with `donor.` or `sample.`. (The Donor and Sample metadata will be at the bottom of the list: Objects preserve order of keys, nowadays.). Acceptable?
- @john-conroy , Note the multiline comment. At one point, I thought about doing document validation at index time, but that didn't go anywhere, because of the number of failures. Does it make sense to try to make it robust against more edge cases, or take the time now to get a better handle on our document structure?