### PR TITLE
John conroy/track search bar

### DIFF
--- a/CHANGELOG-track-search-bar.md
+++ b/CHANGELOG-track-search-bar.md
@@ -1,0 +1,1 @@
+- Track free text searches on search pages.

--- a/context/app/static/js/components/Search/filters/AccordionFilter/AccordionFilter.jsx
+++ b/context/app/static/js/components/Search/filters/AccordionFilter/AccordionFilter.jsx
@@ -6,11 +6,11 @@ import FilterInnerAccordion from 'js/components/Search/filters/FilterInnerAccord
 import HierarchicalFilterItem from 'js/components/Search/filters/HierarchicalFilterItem';
 import CheckboxFilterItem from 'js/components/Search/filters/CheckboxFilterItem';
 
-export function withAnalyticsEvent(ItemComponent, title, pageTitle) {
+export function withAnalyticsEvent(ItemComponent, title, analyticsCategory) {
   return function UpdatedItemComponent({ onClick: originalOnClick, label, ...rest }) {
     function updatedOnClick() {
       ReactGA.event({
-        category: `${pageTitle} Search Page Interactions`,
+        category: analyticsCategory,
         action: 'Facet',
         label: `${title}: ${label}`,
       });

--- a/context/app/static/js/components/Search/filters/AccordionFilter/AccordionFilter.jsx
+++ b/context/app/static/js/components/Search/filters/AccordionFilter/AccordionFilter.jsx
@@ -35,9 +35,9 @@ export function getFilter(type) {
   }
 }
 
-function AccordionFilter({ type, title, pageTitle, ...rest }) {
+function AccordionFilter({ type, title, analyticsCategory, ...rest }) {
   const { Filter, itemComponent } = getFilter(type);
-  const item = itemComponent ? { itemComponent: withAnalyticsEvent(itemComponent, title, pageTitle) } : {};
+  const item = itemComponent ? { itemComponent: withAnalyticsEvent(itemComponent, title, analyticsCategory) } : {};
   return <Filter containerComponent={FilterInnerAccordion} title={title} {...rest} {...item} />;
 }
 

--- a/context/app/static/js/components/Search/filters/Filters/Filters.jsx
+++ b/context/app/static/js/components/Search/filters/Filters/Filters.jsx
@@ -4,10 +4,17 @@ import PropTypes from 'prop-types';
 import AccordionFilter from 'js/components/Search/filters/AccordionFilter';
 import FilterOuterAccordion from 'js/components/Search/filters/FilterOuterAccordion';
 
-function Filters({ filters, pageTitle }) {
+function Filters({ filters, analyticsCategory }) {
   return Object.entries(filters).map(([title, filterGroup], i) => {
     const innerAccordions = filterGroup.map((def) => {
-      return <AccordionFilter type={def.type} {...def.props} key={`title-${def.props.title}`} pageTitle={pageTitle} />;
+      return (
+        <AccordionFilter
+          type={def.type}
+          {...def.props}
+          key={`title-${def.props.title}`}
+          analyticsCategory={analyticsCategory}
+        />
+      );
     });
     if (!title) {
       // We leave the title blank for the group of facets

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -84,7 +84,14 @@ function DevSearch() {
 
   const allProps = { ...searchProps, apiUrl: elasticsearchEndpoint };
 
-  const wrappedSearch = <SearchWrapper {...allProps} resultsComponent={DevResults} isDevSearch pageTitle="Dev" />;
+  const wrappedSearch = (
+    <SearchWrapper
+      {...allProps}
+      resultsComponent={DevResults}
+      analyticsCategory="Dev Search Page Interactions"
+      isDevSearch
+    />
+  );
   return (
     <>
       <SearchHeader component="h1" variant="h2">

--- a/context/app/static/js/pages/search/Search.jsx
+++ b/context/app/static/js/pages/search/Search.jsx
@@ -92,7 +92,13 @@ function Search(props) {
     defaultQuery: getDefaultQuery(),
   };
 
-  const wrappedSearch = <SearchWrapper {...searchProps} resultsComponent={Results} pageTitle={title} />;
+  const wrappedSearch = (
+    <SearchWrapper
+      {...searchProps}
+      resultsComponent={Results}
+      analyticsCategory={`${title} Search Page Interactions`}
+    />
+  );
 
   return (
     <>


### PR DESCRIPTION
Towards #2217. Tracks free text searches. Only tracks new terms so searching the same terms n times in a row would only generate one event. Does not track undefined or empty searches. 

Here's the event there should be some example events on GA now.

```
ReactGA.event({
  category: analyticsCategory,
  action: 'Free Text Search',
  label: newQueryString,
});
```

Where `analyticsCategory` is `${pageTitle}: Search Interactions` e.g. 'Datasets Search Interactions'.