### PR TITLE
John conroy/fix facet alignment

### DIFF
--- a/CHANGELOG-fix-facet-alignment.md
+++ b/CHANGELOG-fix-facet-alignment.md
@@ -1,0 +1,1 @@
+- Fix checkbox facet alignment on search pages.

--- a/context/app/static/js/components/Search/filters/CheckboxFilterItem/style.js
+++ b/context/app/static/js/components/Search/filters/CheckboxFilterItem/style.js
@@ -26,6 +26,7 @@ const StyledFormControlLabel = styled(FormControlLabel)`
   span:nth-child(2) {
     flex-grow: 1;
   }
+  align-items: start;
 `;
 
 export { StyledCheckBoxBlankIcon, StyledCheckBoxIcon, StyledCheckbox, StyledFormControlLabel };


### PR DESCRIPTION
Fix checkbox facet alignment on search pages to match what it was before recent changes.

<img width="1792" alt="Screen Shot 2021-11-04 at 2 59 49 PM" src="https://user-images.githubusercontent.com/62477388/140403256-d862ae81-fcc2-4731-b2b9-93d428f859bd.png">
