### PR TITLE
Mccalluc/donor sample field descriptions

### DIFF
--- a/CHANGELOG-donor-sample-field-descriptions.md
+++ b/CHANGELOG-donor-sample-field-descriptions.md
@@ -1,0 +1,1 @@
+- Add descriptions to `donor.*` and `sample.*` metadata fields.

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
@@ -126,4 +126,4 @@ MetadataTable.propTypes = {
 };
 
 export default MetadataTable;
-export { tableDataToRows };
+export { tableDataToRows, getDescription };

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
@@ -21,6 +21,24 @@ import {
   StyledInfoIcon,
 } from './style';
 
+function getDescription(field) {
+  const [prefix, stem] = field.split('.');
+  if (!stem) {
+    return metadataFieldDescriptions[field];
+  }
+  const description = metadataFieldDescriptions[stem];
+  if (!description) {
+    return undefined;
+  }
+  if (prefix === 'donor') {
+    return `For the original donor: ${metadataFieldDescriptions[stem]}`;
+  }
+  if (prefix === 'sample') {
+    return `For the original sample: ${metadataFieldDescriptions[stem]}`;
+  }
+  throw new Error(`Unrecognized metadata field prefix: ${prefix}`);
+}
+
 function tableDataToRows(tableData) {
   return (
     Object.entries(tableData)
@@ -32,7 +50,7 @@ function tableDataToRows(tableData) {
       .map((entry) => ({
         key: entry[0],
         value: Array.isArray(entry[1]) ? entry[1].join(', ') : entry[1].toString(),
-        description: metadataFieldDescriptions[entry[0]],
+        description: getDescription(entry[0]),
       }))
   );
 }

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.spec.js
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.spec.js
@@ -1,6 +1,28 @@
 /* eslint-disable import/no-unresolved */
 
-import { tableDataToRows } from './MetadataTable';
+import { tableDataToRows, getDescription } from './MetadataTable';
+
+test('should handle plain fields', () => {
+  // Wouldn't actually expect to see age_value anywhere except for donor,
+  // but shouldn't make a difference... and if it does, we want to know.
+  expect(getDescription('age_value')).toEqual('The time elapsed since birth.');
+});
+
+test('should handle donor fields', () => {
+  expect(getDescription('donor.age_value')).toEqual('For the original donor: The time elapsed since birth.');
+});
+
+test('should handle sample fields', () => {
+  expect(getDescription('sample.age_value')).toEqual('For the original sample: The time elapsed since birth.');
+});
+
+test('should return undefined if there is not a definition', () => {
+  expect(getDescription('sample.no_such_stem')).toEqual(undefined);
+});
+
+test('should error if stem is known, but prefix is not', () => {
+  expect(() => getDescription('no_such_prefix.age_value')).toThrow();
+});
 
 test('should look up field descriptions', () => {
   expect(


### PR DESCRIPTION
Fix #2251.

@tsliaw , does the wording ("For the original donor: ...", "For the original sample: ...") seem good to you?