### PR TITLE
Mccalluc/icon in link

### DIFF
--- a/CHANGELOG-button-icons.md
+++ b/CHANGELOG-button-icons.md
@@ -1,0 +1,1 @@
+- On the organs page, add Dataset and Sample icons in the respective buttons.

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -13,7 +13,7 @@ import SectionContainer from 'js/shared-styles/sections/SectionContainer';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 import useSearchData from 'js/hooks/useSearchData';
 
-import { Flex, StyledInfoIcon } from '../style';
+import { Flex, StyledInfoIcon, StyledDatasetIcon } from '../style';
 import { getSearchURL } from '../utils';
 
 function Assays(props) {
@@ -71,6 +71,7 @@ function Assays(props) {
         }
         buttons={
           <Button color="primary" variant="contained" component="a" href={searchUrl}>
+            <StyledDatasetIcon />
             View All Datasets
           </Button>
         }

--- a/context/app/static/js/components/organ/Samples/Samples.jsx
+++ b/context/app/static/js/components/organ/Samples/Samples.jsx
@@ -14,6 +14,7 @@ import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonR
 import { useSearchHits } from 'js/hooks/useSearchData';
 
 import { getSearchURL } from '../utils';
+import { StyledSampleIcon } from '../style';
 
 const columns = [
   { id: 'hubmap_id', label: 'Sample' },
@@ -61,6 +62,7 @@ function Samples(props) {
         leftText={<SectionHeader>Samples</SectionHeader>}
         buttons={
           <Button color="primary" variant="contained" component="a" href={searchUrl}>
+            <StyledSampleIcon />
             View All Samples
           </Button>
         }

--- a/context/app/static/js/components/organ/style.js
+++ b/context/app/static/js/components/organ/style.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { InfoIcon, DatasetIcon } from 'js/shared-styles/icons';
+import { InfoIcon, DatasetIcon, SampleIcon } from 'js/shared-styles/icons';
 
 const Flex = styled.div`
   display: flex;
@@ -20,4 +20,8 @@ const StyledDatasetIcon = styled(DatasetIcon)`
   ${marginRightStyle}
 `;
 
-export { Flex, StyledInfoIcon, StyledDatasetIcon };
+const StyledSampleIcon = styled(SampleIcon)`
+  ${marginRightStyle}
+`;
+
+export { Flex, StyledInfoIcon, StyledDatasetIcon, StyledSampleIcon };

--- a/context/app/static/js/components/organ/style.js
+++ b/context/app/static/js/components/organ/style.js
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
-import { InfoIcon } from 'js/shared-styles/icons';
+import styled, { css } from 'styled-components';
+import { InfoIcon, DatasetIcon } from 'js/shared-styles/icons';
 
 const Flex = styled.div`
   display: flex;
@@ -12,4 +12,12 @@ const StyledInfoIcon = styled(InfoIcon)`
   margin-bottom: ${(props) => props.theme.spacing(1)}px; // To match SectionHeader
 `;
 
-export { Flex, StyledInfoIcon };
+const marginRightStyle = css`
+  margin-right: ${(props) => props.theme.spacing(1)}px;
+`;
+
+const StyledDatasetIcon = styled(DatasetIcon)`
+  ${marginRightStyle}
+`;
+
+export { Flex, StyledInfoIcon, StyledDatasetIcon };


### PR DESCRIPTION
Fix #2247

- @john-conroy : code review.
- @tsliaw : design review. The handling of the sample section header has diverged from the [design](https://www.figma.com/file/OHx2hzPxER89yPFfWFWUCi/Organ%2FTissue-Pages?node-id=1%3A9) ... but I think this is ok?
<img width="397" alt="Screen Shot 2021-11-24 at 4 12 11 PM" src="https://user-images.githubusercontent.com/730388/143313404-4cdf341d-5708-464b-a7b2-0ca382a73227.png">


