### PR TITLE
publication warnings

### DIFF
--- a/CHANGELOG-publication-warnings.md
+++ b/CHANGELOG-publication-warnings.md
@@ -1,0 +1,1 @@
+- Fix react warnings on the publication page.

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -250,6 +250,7 @@ Routes.propTypes = {
     vis_lifted_uuid: PropTypes.string,
     organ: PropTypes.object,
     organs: PropTypes.object,
+    metadata: PropTypes.object,
   }),
 };
 

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -35,9 +35,9 @@ function Publication(props) {
         </Typography>
         <b>Corresponding Author:</b>{' '}
         {authors.corresponding.map((author) => (
-          <>
+          <span key={author.name}>
             {author.name} - <a href={`mailto:${author.email}`}>{author.email}</a>
-          </>
+          </span>
         ))}
       </StyledPaper>
       {Boolean(vitessce_conf) && <VisualizationWrapper vitData={vitessce_conf} />}


### PR DESCRIPTION
Fix a couple warnings on the publication page... If we actually had multiple corresponding authors the UI would need work, but not inclined to worry about that since the data seems to be very slow in coming.