### PR TITLE
Fix element nesting error on markdown pages

### DIFF
--- a/CHANGELOG-markdown-warning.md
+++ b/CHANGELOG-markdown-warning.md
@@ -1,0 +1,1 @@
+- Fix warning about invalid element nesting on markdown pages: `publication/*` and `docs/*`. 

--- a/context/app/static/js/components/Markdown/Markdown.jsx
+++ b/context/app/static/js/components/Markdown/Markdown.jsx
@@ -11,7 +11,8 @@ function Markdown(props) {
 
   return (
     <StyledPaper>
-      <Typography variant="body1">
+      <Typography variant="body1" component="div">
+        {/* Typography defaults to <p>, which causes invalid element nesting. */}
         {/* eslint-disable-next-line react/no-danger */}
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </Typography>


### PR DESCRIPTION
Fix #1146. (Previously closed as won't fix.)