### PR TITLE
Render react error page for all errors

### DIFF
--- a/CHANGELOG-pretty-500.md
+++ b/CHANGELOG-pretty-500.md
@@ -1,0 +1,1 @@
+- Render the react error page for all errors even if there is not an explict handler.

--- a/context/app/main.py
+++ b/context/app/main.py
@@ -43,6 +43,14 @@ def gateway_timeout(e):
     return render_react_error(504, 'Gateway Timeout')
 
 
+def any_other_error(e):
+    '''
+    In debug mode, we will still fall back to the interactive debugger.
+    https://flask.palletsprojects.com/en/2.0.x/errorhandling/#unhandled-exceptions
+    '''
+    return render_react_error(500, 'Internal Server Error')
+
+
 def create_app(testing=False):
     app = Flask(__name__, instance_relative_config=True)
     app.config.from_object(default_config.DefaultConfig)
@@ -67,6 +75,7 @@ def create_app(testing=False):
     app.register_error_handler(403, forbidden)
     app.register_error_handler(404, not_found)
     app.register_error_handler(504, gateway_timeout)
+    app.register_error_handler(500, any_other_error)
 
     @app.context_processor
     def inject_template_globals():


### PR DESCRIPTION
Presently, if an error that we don't otherwise handle falls through, we'll get this:
<img width="1000" alt="Screen Shot 2021-12-07 at 11 06 21 AM" src="https://user-images.githubusercontent.com/730388/145236849-97a4aa40-455c-44b5-b791-a7951f253e79.png">

(Screen shot from an error on the TEST the other day: When I pointed my local instance at TEST with the same path, I was dropped into the debug view.)

- This change makes no difference when `FLASK_ENV=development`: I've confirmed that we still get the flask debugger.
- In production, instead of the white error screen above, you'll get the pretty react error page: I've confirmed by removing `FLASK_ENV=development` from `dev-start.sh`; you still get a stack trace in the log.
- Going forward, if someone does get an unstyled error page we can say with high confidence that the error happened outside of our flask: either the NGINX in our container, or at the gateway.
- ... if we do get a 500, the root cause may still be in the APIs that we rely on.

