### PR TITLE
Mccalluc/hide retracted

### DIFF
--- a/CHANGELOG-hide-retracted.md
+++ b/CHANGELOG-hide-retracted.md
@@ -1,0 +1,1 @@
+- Add retracted datasets to the list of things that are hidden from the default search.

--- a/context/app/static/js/helpers/__tests__/addRestrictionsToQuery.spec.js
+++ b/context/app/static/js/helpers/__tests__/addRestrictionsToQuery.spec.js
@@ -21,11 +21,18 @@ test('it should return the correct query', () => {
           },
           {
             bool: {
-              must_not: {
-                exists: {
-                  field: 'next_revision_uuid',
+              must_not: [
+                {
+                  exists: {
+                    field: 'next_revision_uuid',
+                  },
                 },
-              },
+                {
+                  exists: {
+                    field: 'sub_status',
+                  },
+                },
+              ],
             },
           },
         ],
@@ -49,11 +56,18 @@ test('it should return the correct query when no inner query is provided', () =>
         must: [
           {
             bool: {
-              must_not: {
-                exists: {
-                  field: 'next_revision_uuid',
+              must_not: [
+                {
+                  exists: {
+                    field: 'next_revision_uuid',
+                  },
                 },
-              },
+                {
+                  exists: {
+                    field: 'sub_status',
+                  },
+                },
+              ],
             },
           },
         ],

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -73,11 +73,18 @@ export function createDownloadUrl(fileStr, fileType) {
 export function getDefaultQuery() {
   return {
     bool: {
-      must_not: {
-        exists: {
-          field: 'next_revision_uuid',
+      must_not: [
+        {
+          exists: {
+            field: 'next_revision_uuid',
+          },
         },
-      },
+        {
+          exists: {
+            field: 'sub_status',
+          },
+        },
+      ],
     },
   };
 }

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -73,18 +73,11 @@ export function createDownloadUrl(fileStr, fileType) {
 export function getDefaultQuery() {
   return {
     bool: {
-      must_not: [
-        {
-          exists: {
-            field: 'next_revision_uuid',
-          },
+      must_not: ['next_revision_uuid', 'sub_status'].map((field) => ({
+        exists: {
+          field,
         },
-        {
-          exists: {
-            field: 'sub_status',
-          },
-        },
-      ],
+      })),
     },
   };
 }


### PR DESCRIPTION
- fix #2167, I think

@tsliaw -- The linked issue doesn't refer to a design... Will just this in the header be enough on the detail page, or do we need more messaging? 

<img width="178" alt="Screen Shot 2021-12-15 at 1 28 34 PM" src="https://user-images.githubusercontent.com/730388/146244424-0069b2a4-68ab-405f-a224-9f137d0a1196.png">

@john-conroy -- code review

@ngehlenborg -- Filing as draft for now: I see that you made the comment below... I'll add a check-box facet for this on the public search, like we already have on dev-search... not sure that's the best call, but I don't feel strongly.

> It should be possible to find retracted datasets through the search interface but by default they should be excluded. Could this be handled as a facet with value is_retracted that would be set to false for all queries unless explicitly requested?