### PR TITLE
Mccalluc/parameterize vitessce conf tests

### DIFF
--- a/CHANGELOG-vitessce-conf-tests.md
+++ b/CHANGELOG-vitessce-conf-tests.md
@@ -1,0 +1,1 @@
+- Refactor the vitessce conf tests for readability.

--- a/context/app/api/vitessce_confs/test_confs.py
+++ b/context/app/api/vitessce_confs/test_confs.py
@@ -24,7 +24,7 @@ FIXTURES_EXPECTED_OUTPUT_DIR = "fixtures/output_expected"
 
 BASE_NAME_FOR_SPRM = "BASE_NAME"
 
-AssayConfClasses = {
+builders = {
     "cytokit_json": TiledSPRMViewConfBuilder,
     "rna": RNASeqViewConfBuilder,
     "atac": ATACSeqViewConfBuilder,
@@ -54,7 +54,7 @@ def test_assays(entity_file):
         entity_file.name,
     )[1]
     entity = json.loads(entity_file.read_text())
-    AssayViewConfClass = AssayConfClasses[assay]
+    AssayViewConfClass = builders[assay]
     if assay in ["sprm", "sprm_anndata"]:
         vc = AssayViewConfClass(
             entity=entity,
@@ -80,7 +80,7 @@ def test_assays(entity_file):
     malformed_entity = json.loads(
         Path(str(entity_file).replace(assay, f"malformed_{assay}")).read_text()
     )
-    AssayViewConfClass = AssayConfClasses[assay]
+    AssayViewConfClass = builders[assay]
     if assay in ["sprm", "sprm_anndata"]:
         vc = AssayViewConfClass(
             entity=malformed_entity,

--- a/context/app/api/vitessce_confs/test_confs.py
+++ b/context/app/api/vitessce_confs/test_confs.py
@@ -51,9 +51,9 @@ non_malformed_entities = set(fixtures_dir.glob("*_entity.json")) - set(
 def test_assays(entity_file):
     assay = re.search(
         r'([^/]+)_entity.json',
-        str(entity_file),
+        entity_file.name,
     )[1]
-    entity = json.loads(Path(entity_file).read_text())
+    entity = json.loads(entity_file.read_text())
     AssayViewConfClass = AssayConfClasses[assay]
     if assay in ["sprm", "sprm_anndata"]:
         vc = AssayViewConfClass(

--- a/context/app/api/vitessce_confs/test_confs.py
+++ b/context/app/api/vitessce_confs/test_confs.py
@@ -50,7 +50,7 @@ non_malformed_entities = set(fixtures_dir.glob("*_entity.json")) - set(
 @pytest.mark.parametrize("entity_file", non_malformed_entities)
 def test_assays(entity_file):
     assay = re.search(
-        str(parent_dir / f"{str(re.escape(FIXTURES_INPUT_DIR))}/(.*)_entity.json"),
+        r'([^/]+)_entity.json',
         str(entity_file),
     )[1]
     entity = json.loads(Path(entity_file).read_text())

--- a/context/app/api/vitessce_confs/test_confs.py
+++ b/context/app/api/vitessce_confs/test_confs.py
@@ -54,9 +54,9 @@ def test_assays(entity_file):
         entity_file.name,
     )[1]
     entity = json.loads(entity_file.read_text())
-    AssayViewConfClass = builders[assay]
+    Builder = builders[assay]
     if assay in ["sprm", "sprm_anndata"]:
-        vc = AssayViewConfClass(
+        builder = Builder(
             entity=entity,
             groups_token=MOCK_GROUPS_TOKEN,
             is_mock=True,
@@ -67,10 +67,10 @@ def test_assays(entity_file):
             mask_path="imaging_path"
         )
     else:
-        vc = AssayViewConfClass(
+        builder = Builder(
             entity=entity, groups_token=MOCK_GROUPS_TOKEN, is_mock=True
         )
-    conf = vc.get_conf_cells().conf
+    conf = builder.get_conf_cells().conf
     conf_expected = json.loads(
         (
             parent_dir / f"{FIXTURES_EXPECTED_OUTPUT_DIR}/{assay}_conf.json"
@@ -80,9 +80,9 @@ def test_assays(entity_file):
     malformed_entity = json.loads(
         Path(str(entity_file).replace(assay, f"malformed_{assay}")).read_text()
     )
-    AssayViewConfClass = builders[assay]
+    Builder = builders[assay]
     if assay in ["sprm", "sprm_anndata"]:
-        vc = AssayViewConfClass(
+        builder = Builder(
             entity=malformed_entity,
             groups_token=MOCK_GROUPS_TOKEN,
             is_mock=True,
@@ -93,8 +93,8 @@ def test_assays(entity_file):
             mask_path="imaging_path"
         )
     else:
-        vc = AssayViewConfClass(
+        builder = Builder(
             entity=malformed_entity, groups_token=MOCK_GROUPS_TOKEN, is_mock=True
         )
     with pytest.raises(FileNotFoundError):
-        vc.get_conf_cells().conf
+        builder.get_conf_cells().conf

--- a/context/app/api/vitessce_confs/test_confs.py
+++ b/context/app/api/vitessce_confs/test_confs.py
@@ -42,12 +42,12 @@ AssayConfClasses = {
 
 parent_dir = Path(__file__).parent
 fixtures_dir = parent_dir / FIXTURES_INPUT_DIR
-non_malformed_entities = set(fixtures_dir.glob("*_entity.json")) - set(
+entity_paths = set(fixtures_dir.glob("*_entity.json")) - set(
     fixtures_dir.glob("malformed_*_entity.json")
 )
 
 
-@pytest.mark.parametrize("entity_file", non_malformed_entities)
+@pytest.mark.parametrize("entity_file", entity_paths)
 def test_assays(entity_file):
     assay = re.search(
         r'([^/]+)_entity.json',


### PR DESCRIPTION
I've set the diffs to ignore whitespace to make it easier to read. Using test parameterization is nice because it will capture all failures, not just the first one, and it will show you the parameters of the run that failed, instead of requiring you to infer that from context. Also some renaming to distinguish the configuration from the configuration builder, etc.

- see also #2308