### PR TITLE
Mccalluc/new docs

### DIFF
--- a/CHANGELOG-move-docs.md
+++ b/CHANGELOG-move-docs.md
@@ -1,0 +1,2 @@
+- Get rid of `docs/` links and replace with `https://software.docs.hubmapconsortium.org/about`.
+  (In a follow-up PR we'll remove the submodule, but holding off to avoid merge conflicts.)

--- a/context/app/markdown/docs.redirect
+++ b/context/app/markdown/docs.redirect
@@ -1,1 +1,1 @@
-/docs/technical
+https://software.docs.hubmapconsortium.org/technical

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -63,7 +63,7 @@ function Footer(props) {
                 Data Use Agreement
               </OutboundLink>
               {!isMaintenancePage && (
-                <LightBlueLink href="/docs/about#citation" variant="body2">
+                <LightBlueLink href="https://software.docs.hubmapconsortium.org/about#citation" variant="body2">
                   Citing HuBMAP
                 </LightBlueLink>
               )}

--- a/context/app/static/js/components/Header/DocumentationLinks/DocumentationLinks.jsx
+++ b/context/app/static/js/components/Header/DocumentationLinks/DocumentationLinks.jsx
@@ -7,13 +7,13 @@ function DocumentationLinks(props) {
   const { isIndented } = props;
   return (
     <>
-      <DropdownLink href="/docs/technical" isIndented={isIndented}>
+      <DropdownLink href="https://software.docs.hubmapconsortium.org/technical" isIndented={isIndented}>
         Technical
       </DropdownLink>
-      <DropdownLink href="/docs/faq" isIndented={isIndented}>
+      <DropdownLink href="https://software.docs.hubmapconsortium.org/faq" isIndented={isIndented}>
         FAQ
       </DropdownLink>
-      <DropdownLink href="/docs/about" isIndented={isIndented}>
+      <DropdownLink href="https://software.docs.hubmapconsortium.org/about" isIndented={isIndented}>
         About
       </DropdownLink>
     </>

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -30,7 +30,7 @@ function SummaryDataChildren(props) {
   return (
     <>
       <SummaryItem>
-        <LightBlueLink variant="h6" href="/docs/assays" underline="none">
+        <LightBlueLink variant="h6" href="https://software.docs.hubmapconsortium.org/assays" underline="none">
           {mapped_data_types}
         </LightBlueLink>
       </SummaryItem>

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -93,7 +93,7 @@ def mock_search_donor_post(path, **kwargs):
 @pytest.mark.parametrize(
     'path',
     ['/', '/browse/donor/fake-uuid', '/ccf-eui',
-     '/docs/technical', '/preview/multimodal-molecular-imaging-data']
+     '/preview/multimodal-molecular-imaging-data']
 )
 def test_200_html_page(client, path, mocker):
     mocker.patch('requests.get', side_effect=mock_prov_get)

--- a/end-to-end/artillery/skip-scenarios/portal-docs.yml
+++ b/end-to-end/artillery/skip-scenarios/portal-docs.yml
@@ -7,14 +7,6 @@ config:
 scenarios:
   - flow:
     - get:
-        url: "/docs/assays"
-        gzip: true
-        afterResponse: "printStatus"
-    - get:
-        url: "/docs/about"
-        gzip: true
-        afterResponse: "printStatus"
-    - get:
         url: "/CHANGELOG"
         gzip: true
         afterResponse: "printStatus"

--- a/end-to-end/cypress/integration/file-based-routes.spec.js
+++ b/end-to-end/cypress/integration/file-based-routes.spec.js
@@ -12,13 +12,10 @@ describe('file-based-routes', () => {
       // Vitessce loads, pulling data from the network.
       // Are incidental network requests ok, as long as tests don't depend on them?
     });
-    it('has working docs pages', () => {
+    it('has working markdown pages', () => {
       cy.visit('/');
-      cy.contains('Documentation').click();
-      cy.contains('FAQ');
-      cy.contains('About');
-      cy.contains('Technical').click();
-      cy.contains('HIVE Software Engineering Principles')
+      cy.contains('APIs').click();
+      cy.contains('APIs and Data Downloads');
     });
     it('has working publication pages', () => {
       // TODO: When we link to it from the menu, follow the link instead.


### PR DESCRIPTION
- Fix #2312.

Following the decision made this morning, the documentation will be hosted separately: This PR changes the links to point to the docs in their new home.
- I believe the documentation team has responsibility for moving the docs.
- Please do not approve until the documentation has been moved: You might want to check each URL.
- There is no reason this process should be drawn out. If there is a blocker, please identify it.
- If the old urls should redirect to the new ones, `*.md` can be replaced with `*.redirect`. I'll leave this to your judgement.