### PR TITLE
increase timeout

### DIFF
--- a/CHANGELOG-nginx-timeout.md
+++ b/CHANGELOG-nginx-timeout.md
@@ -1,0 +1,1 @@
+- In the NGINX conf, bump the timeout up to 600s, so that requests to the cells API won't time out.

--- a/context/portal.nginx.conf
+++ b/context/portal.nginx.conf
@@ -4,6 +4,8 @@ gzip_disable "msie6";
 gzip_vary on;
 gzip_proxied any;
 
+uwsgi_read_timeout 600s;
+
 server {
     # "~": Case-sensitive regex matching
     # http://nginx.org/en/docs/http/ngx_http_core_module.html#location


### PR DESCRIPTION
Running the docker container locally, this prevented timeout errors. [Notes.](https://github.com/hubmapconsortium/portal-ui/blob/mccalluc/debug-cells/cells-lab-notebook.md)

John will do some work in the UI to prevent a single user from expanding multiple cells rows at the same time. 

- Issue: #2320

This is not a zero-risk change, but Nils is on board. Keeping as draft until Bill or Zhao can comment on whether we may also hit timeout errors from the gateway.