### PR TITLE
Mccalluc/better vitessce errors

### DIFF
--- a/CHANGELOG-vitessce-error.md
+++ b/CHANGELOG-vitessce-error.md
@@ -1,0 +1,1 @@
+- If there is an error during vitessce conf generation, generate a valid conf that just has an error message.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -161,8 +161,8 @@ class ApiClient():
                 builder = Builder(entity, self.groups_token)
                 vitessce_conf = builder.get_conf_cells()
             except Exception:
-                message = f'Building vitessce conf threw error: {traceback.format_exc()}'
-                current_app.logger.error(message)
+                current_app.logger.error(
+                    f'Building vitessce conf threw error: {traceback.format_exc()}')
                 vitessce_conf = ConfCells({
                     'name': 'Error',
                     'version': '1.0.4',

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -163,7 +163,19 @@ class ApiClient():
             except Exception:
                 message = f'Building vitessce conf threw error: {traceback.format_exc()}'
                 current_app.logger.error(message)
-                vitessce_conf = ConfCells({'error': message}, None)
+                vitessce_conf = ConfCells({
+                    'name': 'Error',
+                    'version': '1.0.4',
+                    'datasets': [],
+                    'initStrategy': 'none',
+                    'layout': [{
+                        'component': 'description',
+                        "props": {
+                            "description": 'Error while generating the Vitessce configuration'
+                        },
+                        'x': 0, 'y': 0, 'w': 12, 'h': 1
+                    }],
+                }, None)
 
         return VitessceConfLiftedUUID(
             vitessce_conf=vitessce_conf,


### PR DESCRIPTION
- Fix #2325: Instead of giving a JSON schema error about a missing version number, give an error message in the UI
- but: this PR surfaces https://github.com/vitessce/vitessce/issues/1131: The please-wait spinner never goes away.

I don't the new vitessce bug should block this PR: The error message is readable, and the spinner that doesn't go away doesn't seem horribly out of line, particularly since it is an error message.