### PR TITLE
Mccalluc/normalize slashes

### DIFF
--- a/CHANGELOG-truncate-path.md
+++ b/CHANGELOG-truncate-path.md
@@ -1,0 +1,1 @@
+- Remove trailing '/' and 's' from path and redirect.

--- a/context/app/main.py
+++ b/context/app/main.py
@@ -85,10 +85,6 @@ def create_app(testing=False):
         path = request.path
         if path.endswith('/') and path != '/':
             return redirect(path[:-1])
-        # This is a little sketchy, but it's another common typo:
-        # egrep 'route\(.*s['"'"'"]' context/app/routes_*
-        if path.endswith('s') and path not in ['/cells', '/services', '/collections', '/my-lists']:
-            return redirect(path[:-1])
 
     @app.context_processor
     def inject_template_globals():

--- a/context/app/main.py
+++ b/context/app/main.py
@@ -1,4 +1,4 @@
-from flask import Flask, session, render_template
+from flask import Flask, session, render_template, redirect, request
 
 from . import (
     routes_main, routes_browse, routes_api, routes_file_based,
@@ -76,6 +76,19 @@ def create_app(testing=False):
     app.register_error_handler(404, not_found)
     app.register_error_handler(504, gateway_timeout)
     app.register_error_handler(500, any_other_error)
+
+    # Credit to https://stackoverflow.com/a/40365514
+    # for this way to redirect from slash-ending urls to plain.
+    app.url_map.strict_slashes = False
+    @app.before_request
+    def clear_trailing():
+        path = request.path
+        if path.endswith('/') and path != '/':
+            return redirect(path[:-1])
+        # This is a little sketchy, but it's another common typo:
+        # egrep 'route\(.*s['"'"'"]' context/app/routes_*
+        if path.endswith('s') and path not in ['/cells', '/services', '/collections', '/my-lists']:
+            return redirect(path[:-1])
 
     @app.context_processor
     def inject_template_globals():

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -155,25 +155,18 @@ def test_robots_txt_allow(client):
     assert 'Disallow: /search' in response.data.decode('utf8')
 
 
-singular_paths = ['/organ', '/publication']
-plural_paths = ['/cells', '/services', '/collections', '/my-lists']
+paths = ['/organ', '/publication', '/collections', '/cells']
 
 
 @pytest.mark.parametrize(
     'path_status',
     [
         ('/', '200 OK'),
+        ('/docs', '302 FOUND', '/docs/technical'),
+        ('/docs/technical', '200 OK'),
 
-        # Redirect for paths which should be singular:
-        *[(path, '200 OK') for path in singular_paths],
-        *[(path + '/', '302 FOUND', path) for path in singular_paths],
-        *[(path + 's', '302 FOUND', path) for path in singular_paths],
-        *[(path + 's/', '302 FOUND', path + 's') for path in singular_paths],
-
-        # Exceptions: Routes that do end in "s" and should not be redirected:
-        *[(path, '200 OK') for path in plural_paths],
-        *[(path + '/', '302 FOUND', path) for path in plural_paths],
-        *[(path[:-1], '404 NOT FOUND') for path in plural_paths]
+        *[(path, '200 OK') for path in paths],
+        *[(path + '/', '302 FOUND', path) for path in paths],
     ],
     ids=lambda path_status: f'{path_status[0]} -> {path_status[1]} {"".join(path_status[2:])}'
 )

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -157,6 +157,8 @@ def test_robots_txt_allow(client):
 
 singular_paths = ['/organ', '/publication']
 plural_paths = ['/cells', '/services', '/collections', '/my-lists']
+
+
 @pytest.mark.parametrize(
     'path_status',
     [

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -151,3 +151,14 @@ def test_robots_txt_disallow(client):
 def test_robots_txt_allow(client):
     response = client.get('/robots.txt', headers={'Host': 'portal.hubmapconsortium.org'})
     assert 'Disallow: /search' in response.data.decode('utf8')
+
+
+@pytest.mark.parametrize(
+    'path_status',
+    [('/cells/', '302 FOUND')],
+    ids=lambda path_status: f'{path_status[0]} -> {path_status[1]}'
+)
+def test_truncate_and_redirect(client, path_status):
+    (path, status) = path_status
+    response = client.get(path)
+    assert response.status == status


### PR DESCRIPTION
- Fix #2351
- Also handle cases like `/organs` when you mean `/organ`

Output of test is probably easier to read than the test itself... maybe too much parameterization?

<details>

```
test_truncate_and_redirect[/ -> 200 OK ] PASSED
test_truncate_and_redirect[/organ -> 200 OK ] PASSED
test_truncate_and_redirect[/publication -> 200 OK ] PASSED
test_truncate_and_redirect[/organ/ -> 302 FOUND /organ] PASSED
test_truncate_and_redirect[/publication/ -> 302 FOUND /publication] PASSED
test_truncate_and_redirect[/organs -> 302 FOUND /organ] PASSED
test_truncate_and_redirect[/publications -> 302 FOUND /publication] PASSED
test_truncate_and_redirect[/organs/ -> 302 FOUND /organs] PASSED
test_truncate_and_redirect[/publications/ -> 302 FOUND /publications] PASSED
test_truncate_and_redirect[/cells -> 200 OK ] PASSED
test_truncate_and_redirect[/services -> 200 OK ] PASSED
test_truncate_and_redirect[/collections -> 200 OK ] PASSED
test_truncate_and_redirect[/my-lists -> 200 OK ] PASSED
test_truncate_and_redirect[/cells/ -> 302 FOUND /cells] PASSED
test_truncate_and_redirect[/services/ -> 302 FOUND /services] PASSED
test_truncate_and_redirect[/collections/ -> 302 FOUND /collections] PASSED
test_truncate_and_redirect[/my-lists/ -> 302 FOUND /my-lists] PASSED
test_truncate_and_redirect[/cell -> 404 NOT FOUND ] PASSED
test_truncate_and_redirect[/service -> 404 NOT FOUND ] PASSED
test_truncate_and_redirect[/collection -> 404 NOT FOUND ] PASSED
test_truncate_and_redirect[/my-list -> 404 NOT FOUND ] PASSED
```

</details>