### PR TITLE
John conroy/images to cdn

### DIFF
--- a/CHANGELOG-images-to-cdn.md
+++ b/CHANGELOG-images-to-cdn.md
@@ -1,0 +1,1 @@
+- Move move images to a cloudfront cdn with s3 origin.

--- a/cloudformation-templates/portal-images.yml
+++ b/cloudformation-templates/portal-images.yml
@@ -1,0 +1,75 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Cloudfront/S3 Origin for Portal Images'
+
+Resources:
+  S3Bucket:
+    DeletionPolicy: 'Retain' # retain bucket if stack is deleted
+    Properties:
+      AccessControl: 'Private'
+      BucketName: !Sub '${AWS::StackName}-s3-origin'
+    Type: 'AWS::S3::Bucket'
+
+  S3BucketPolicy:
+    Properties:
+      Bucket: !Ref S3Bucket
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetObject'
+            Effect: 'Allow'
+            Principal:
+              CanonicalUser: !GetAtt CfOriginAccessIdentity.S3CanonicalUserId
+            Resource:
+              - !Sub 'arn:aws:s3:::${S3Bucket}/*'
+    Type: 'AWS::S3::BucketPolicy'
+
+  CloudFrontDistribution:
+    Properties:
+      DistributionConfig:
+        DefaultCacheBehavior:
+          AllowedMethods:
+            - 'HEAD'
+            - 'GET'
+          CachedMethods:
+            - 'HEAD'
+            - 'GET'
+          Compress: false
+          ForwardedValues:
+            Cookies:
+              Forward: 'none'
+            Headers:
+              - 'Origin'
+            QueryString: false
+          MinTTL: 86400
+          MaxTTL: 31536000
+          DefaultTTL: 86400
+          TargetOriginId: !Sub 's3-origin-${S3Bucket}'
+          ViewerProtocolPolicy: 'redirect-to-https'
+        Enabled: true
+        HttpVersion: 'http2'
+        IPV6Enabled: false
+        Origins:
+          - DomainName: !GetAtt S3Bucket.DomainName
+            Id: !Sub 's3-origin-${S3Bucket}'
+            OriginPath: ''
+            S3OriginConfig:
+              OriginAccessIdentity: !Sub 'origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}'
+        PriceClass: 'PriceClass_All'
+    Type: 'AWS::CloudFront::Distribution'
+
+  CloudFrontOriginAccessIdentity:
+    Properties:
+      CloudFrontOriginAccessIdentityConfig:
+        Comment: 'Access S3 bucket content only through CloudFront'
+    Type: 'AWS::CloudFront::CloudFrontOriginAccessIdentity'
+
+Outputs:
+  S3BucketName:
+    Description: 'S3 Bucket name'
+    Value: !Ref S3Bucket
+  CloudFrontDistributionID:
+    Description: 'CloudFront distribution ID'
+    Value: !Ref CloudFrontDistribution
+  CloudFrontDistributionDomainName:
+    Description: 'CloudFront distribution domain name'
+    Value: !GetAtt CloudFrontDistribution.DomainName


### PR DESCRIPTION
I haven't tried deploying the stack yet. TTL here refers to how long before CloudFront sends a new request to the s3 origin. To enforce browser caching we'd set the `Cache-Control: max-age=31536000` header when uploading the images to s3.

There is some followup work to automate the resizing and submission to s3 for images, but getting the images to s3/cloudfront is the priority.