### PR TITLE
John conroy/fix fullscreen vitessce

### DIFF
--- a/CHANGELOG-fix-fullscreen-vitessce.md
+++ b/CHANGELOG-fix-fullscreen-vitessce.md
@@ -1,0 +1,2 @@
+- Fix overlap when viewing Vitessce in fullscreen.
+- Display subheader when Vitessce is fullscreen on any page.

--- a/context/app/static/js/components/Header/Header/Header.jsx
+++ b/context/app/static/js/components/Header/Header/Header.jsx
@@ -14,12 +14,14 @@ const visualizationSelector = (state) => ({
 function Header() {
   const anchorRef = useRef(null);
   const { summaryInView, summaryEntry } = useEntityStore(entityStoreSelector);
-  const displayEntityHeader =
-    summaryEntry &&
-    window.location.pathname.startsWith('/browse') &&
-    !window.location.pathname.startsWith('/browse/collection');
-
   const { vizIsFullscreen } = useVisualizationStore(visualizationSelector);
+
+  const displayEntityHeader =
+    (summaryEntry &&
+      window.location.pathname.startsWith('/browse') &&
+      !window.location.pathname.startsWith('/browse/collection')) ||
+    vizIsFullscreen;
+
 
   return (
     <>
@@ -30,7 +32,7 @@ function Header() {
       >
         <HeaderContent anchorRef={anchorRef} />
       </HeaderAppBar>
-      {(displayEntityHeader || vizIsFullscreen) && <EntityHeader />}
+      {displayEntityHeader && <EntityHeader />}
     </>
   );
 }

--- a/context/app/static/js/components/Header/Header/Header.jsx
+++ b/context/app/static/js/components/Header/Header/Header.jsx
@@ -30,7 +30,7 @@ function Header() {
       >
         <HeaderContent anchorRef={anchorRef} />
       </HeaderAppBar>
-      {displayEntityHeader && <EntityHeader />}
+      {(displayEntityHeader || vizIsFullscreen) && <EntityHeader />}
     </>
   );
 }

--- a/context/app/static/js/components/Header/Header/Header.jsx
+++ b/context/app/static/js/components/Header/Header/Header.jsx
@@ -22,7 +22,6 @@ function Header() {
       !window.location.pathname.startsWith('/browse/collection')) ||
     vizIsFullscreen;
 
-
   return (
     <>
       <HeaderAppBar

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
@@ -27,11 +27,15 @@ function EntityHeaderContent({ hubmap_id, entity_type, data, shouldDisplayHeader
     ({ item, key, props }) =>
       item && (
         <AnimatedFlexContainer style={props} key={key} maxWidth={vizIsFullscreen ? false : 'lg'}>
-          {iconMap[entity_type]}
-          <EntityHeaderItem text={hubmap_id} />
-          {Object.entries(data).map(([k, v]) => (
-            <EntityHeaderItem text={v.value || `undefined ${v.label}`} key={k} />
-          ))}
+          {entity_type && (
+            <>
+              {iconMap[entity_type]}
+              <EntityHeaderItem text={hubmap_id} />
+              {Object.entries(data).map(([k, v]) => (
+                <EntityHeaderItem text={v.value || `undefined ${v.label}`} key={k} />
+              ))}
+            </>
+          )}
           {vizIsFullscreen && (
             <RightDiv>
               <VisualizationShareButtonWrapper />

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -9,7 +9,6 @@ import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 import { Alert } from 'js/shared-styles/alerts';
 import DropdownListbox from 'js/shared-styles/dropdowns/DropdownListbox';
 import DropdownListboxOption from 'js/shared-styles/dropdowns/DropdownListboxOption';
-import { DetailPageSection } from 'js/components/detailPage/style';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import useVisualizationStore from 'js/stores/useVisualizationStore';
@@ -27,6 +26,7 @@ import {
   SelectionButton,
   StyledSectionHeader,
   Flex,
+  StyledDetailPageSection,
 } from './style';
 import { useVitessceConfig } from './hooks';
 import 'vitessce/dist/es/production/static/css/index.css';
@@ -115,7 +115,7 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader }) {
     vitessceConfig &&
     // Don't render multi-datasets unless they have a selection from the list of options in vitessceConfig.
     (!isMultiDataset || Number.isInteger(vitessceSelection)) && (
-      <DetailPageSection id="visualization">
+      <StyledDetailPageSection id="visualization" $vizIsFullscreen={vizIsFullscreen}>
         <SpacedSectionButtonRow
           leftText={shouldDisplayHeader ? <StyledSectionHeader>Visualization</StyledSectionHeader> : undefined}
           buttons={
@@ -192,7 +192,7 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader }) {
           <OutboundLink href="http://vitessce.io">Vitessce</OutboundLink>
         </StyledFooterText>
         <style type="text/css">{vizIsFullscreen && bodyExpandedCSS}</style>
-      </DetailPageSection>
+      </StyledDetailPageSection>
     )
   );
 }

--- a/context/app/static/js/components/detailPage/visualization/Visualization/style.js
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/style.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import Snackbar from '@material-ui/core/Snackbar';
@@ -7,6 +7,7 @@ import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
 import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 import { entityHeaderHeight } from 'js/components/detailPage/entityHeader/EntityHeader';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
+import { DetailPageSection } from 'js/components/detailPage/style';
 
 const totalHeightOffset = window.location.pathname.startsWith('/preview')
   ? headerHeight
@@ -73,7 +74,16 @@ const StyledFooterText = styled(Typography)`
   text-align: right;
 `;
 
-const bodyExpandedCSS = `
+const StyledDetailPageSection = styled(DetailPageSection)`
+  ${(props) =>
+    props.$vizIsFullscreen &&
+    css`
+      z-index: ${props.theme.zIndex.visualization};
+      position: relative;
+    `}
+`;
+
+const bodyExpandedCSS = css`
   body {
     overflow: hidden;
   }
@@ -91,4 +101,5 @@ export {
   ExpandableDiv,
   StyledFooterText,
   SelectionButton,
+  StyledDetailPageSection,
 };

--- a/context/app/static/js/theme.jsx
+++ b/context/app/static/js/theme.jsx
@@ -120,6 +120,7 @@ const theme = createMuiTheme({
     dropdownOffset: 1001,
     entityHeader: 1000,
     dropdown: 50,
+    visualization: 3,
     fileBrowserHeader: 1,
   },
 });


### PR DESCRIPTION
Fix #2400. Fix #2387.

#2400 was introduced by #2376. I've added back the necessary styles and made it more explicit that the `z-index` and `position:relative` is needed for fullscreen Vitessce only.

Since the header is no longer constrained to entity detail pages I believe a follow-up PR to rename the component to `Subheader` or similar and move it out of the `detail` directory. @mccalluc let me know if that makes sense to you.