### PR TITLE
John conroy/copy viz submodule docker

### DIFF
--- a/CHANGELOG-copy-viz-submodule-docker.md
+++ b/CHANGELOG-copy-viz-submodule-docker.md
@@ -1,0 +1,1 @@
+- Copy portal-visualization submodule in dockerfile.

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -12,6 +12,7 @@ COPY .babelrc .babelrc
 COPY build-utils build-utils
 COPY app app
 COPY ingest-validation-tools ingest-validation-tools
+COPY portal-visualization portal-visualization
 
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build


### PR DESCRIPTION
`docker.sh` is working locally, but our deployed container is not. We need to copy the new submodule as a part of the dockerfile.