### PR TITLE
Stop auto-incrementing submodules

### DIFF
--- a/CHANGELOG-no-more-auto-increment-submodules.md
+++ b/CHANGELOG-no-more-auto-increment-submodules.md
@@ -1,0 +1,2 @@
+- Submodules are no longer auto-incremented on deploy. This was begun so that documentation updates could be
+  published with the minimum hassle, but with the commitment to move to the github pages, it is no longer needed.

--- a/push.sh
+++ b/push.sh
@@ -7,16 +7,6 @@ git diff --quiet || die 'Uncommitted changes: Stash or commit'
 git checkout main
 git pull
 
-git submodule foreach '
-  echo "was:" `git rev-parse HEAD`
-  git checkout main
-  git pull
-  echo "now:" `git rev-parse HEAD`
-'
-organ-utils/make_organ_dir.py
-git add .
-git commit -m 'Update submodules and organs' || echo 'Nothing to commit; Continue to git push...'
-
 get_minor_version() {
   REF_MINOR=$1
   REF_DATE=$2


### PR DESCRIPTION
I have archived https://github.com/hubmapconsortium/portal-docs, and when https://github.com/hubmapconsortium/software-docs/pull/25 is merged, portal-docs can be moved to the graveyard.

I don't believe the wait to merge the PR (now a month) should block other changes that follow from the decision in December to move documentation to that repo.