### PR TITLE
Mccalluc/fix maintenance load message

### DIFF
--- a/CHANGELOG-maintenance.md
+++ b/CHANGELOG-maintenance.md
@@ -1,0 +1,1 @@
+- Get the maintenance page build working again, and add a cypress test.

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -14,7 +14,7 @@ function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMainten
 
   useEffect(() => {
     async function fetchMessage() {
-      setMessage((await import('./message.json')).default);
+      setMessage((await import(/* webpackChunkName: "message" */ './message.json')).default);
     }
     fetchMessage();
   }, []);

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+import message from './message.json';
 
 const LoginLink = () => <LightBlueLink href="/login">login</LightBlueLink>;
 const HelpEmailLink = () => (
@@ -13,7 +14,7 @@ function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMainten
   if (isMaintenancePage) {
     return (
       <>
-        While the portal is under maintenance, visit the{' '}
+        {message} While the portal is under maintenance, visit the{' '}
         <OutboundLink href="https://hubmapconsortium.org/">HuBMAP Consortium</OutboundLink> website.
       </>
     );

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -1,9 +1,8 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
-import message from './message.json';
 
 const LoginLink = () => <LightBlueLink href="/login">login</LightBlueLink>;
 const HelpEmailLink = () => (
@@ -11,6 +10,15 @@ const HelpEmailLink = () => (
 );
 
 function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMaintenancePage }) {
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    async function fetchMessage() {
+      setMessage((await import('./message.json')).default);
+    }
+    fetchMessage();
+  }, []);
+
   if (isMaintenancePage) {
     return (
       <>

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
+import marked from 'marked';
+
 import { LightBlueLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 
@@ -10,22 +12,18 @@ const HelpEmailLink = () => (
 );
 
 function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMaintenancePage }) {
-  const [message, setMessage] = useState('');
+  const [messageMarkdown, setMessageMarkdown] = useState('');
 
   useEffect(() => {
     async function fetchMessage() {
-      setMessage((await import(/* webpackChunkName: "message" */ './message.json')).default);
+      setMessageMarkdown((await import(/* webpackChunkName: "message" */ './message.md.yaml')).default);
     }
     fetchMessage();
   }, []);
 
   if (isMaintenancePage) {
-    return (
-      <>
-        {message} While the portal is under maintenance, visit the{' '}
-        <OutboundLink href="https://hubmapconsortium.org/">HuBMAP Consortium</OutboundLink> website.
-      </>
-    );
+    // eslint-disable-next-line react/no-danger
+    return <span dangerouslySetInnerHTML={{ __html: marked(messageMarkdown) }} />;
   }
 
   if (errorCode === 401 && isGlobus401) {

--- a/context/app/static/js/components/error/ErrorBody/message.json
+++ b/context/app/static/js/components/error/ErrorBody/message.json
@@ -1,1 +1,0 @@
-"Portal unavailable for scheduled maintenance."

--- a/context/app/static/js/components/error/ErrorBody/message.json
+++ b/context/app/static/js/components/error/ErrorBody/message.json
@@ -1,0 +1,1 @@
+"Portal unavailable for scheduled maintenance."

--- a/context/app/static/js/components/error/ErrorBody/message.md.yaml
+++ b/context/app/static/js/components/error/ErrorBody/message.md.yaml
@@ -1,0 +1,2 @@
+Portal unavailable for scheduled maintenance.
+While the portal is under maintenance, visit the [HuBMAP Consortium website](https://hubmapconsortium.org/).

--- a/context/app/static/js/pages/Error/Error.spec.js
+++ b/context/app/static/js/pages/Error/Error.spec.js
@@ -21,7 +21,6 @@ test.each([
 test('should display maintenance titles', () => {
   render(<Error isMaintenancePage />);
   expect(screen.getByText('Portal Maintenance')).toBeInTheDocument();
-  expect(screen.getByText('Portal unavailable for scheduled maintenance.')).toBeInTheDocument();
 });
 
 test('should display titles for unexpected error codes', () => {

--- a/context/app/static/js/pages/Error/utils.js
+++ b/context/app/static/js/pages/Error/utils.js
@@ -9,7 +9,7 @@ export function getErrorTitleAndSubtitle(errorCode, isMaintenancePage, isErrorBo
   };
 
   if (isMaintenancePage) {
-    return { title: 'Portal Maintenance', subtitle: 'Portal unavailable for scheduled maintenance.' };
+    return { title: 'Portal Maintenance' };
   }
 
   if (isErrorBoundary) {

--- a/context/build-utils/webpack.dev.maintenance.js
+++ b/context/build-utils/webpack.dev.maintenance.js
@@ -9,7 +9,7 @@ const envConfig = {
   devServer: {
     contentBase: join(__dirname, '../app/static/js/maintenance/public/'),
     publicPath: '/',
-    port: 5001,
+    port: 5002,
     compress: true,
     stats: 'minimal',
   },

--- a/context/build-utils/webpack.maintenance.js
+++ b/context/build-utils/webpack.maintenance.js
@@ -52,7 +52,7 @@ const config = {
       },
       {
         test: /\.svg$/,
-        use: { loader: '@svgr/webpack' },
+        use: ['@svgr/webpack', 'url-loader'],
       },
       {
         test: /\.(png|jpg|gif)$/,

--- a/end-to-end/cypress/integration/maintenance.spec.js
+++ b/end-to-end/cypress/integration/maintenance.spec.js
@@ -2,5 +2,6 @@ describe('portal-ui-maintenance', () => {
     it('has expected text', () => {
       cy.visit('http://localhost:8000');
       cy.contains('Portal Maintenance');
+      cy.contains('Portal unavailable for scheduled maintenance.');
   });
 });

--- a/end-to-end/cypress/integration/maintenance.spec.js
+++ b/end-to-end/cypress/integration/maintenance.spec.js
@@ -1,0 +1,6 @@
+describe('portal-ui-maintenance', () => {
+    it('has expected text', () => {
+      cy.visit('http://localhost:8000');
+      cy.contains('Portal Maintenance');
+  });
+});

--- a/test.sh
+++ b/test.sh
@@ -97,11 +97,18 @@ start npm-test
 npm run test
 end npm-test
 
-cd -
 
-start docker
+start cypress
+
+npm run build:maintain
+( cd app/static/js/maintenance/public/ ; python -m http.server 8000 & )
+
+cd -
 ./docker.sh 5001  # Needs to match port in cypress.json.
 server_up 5001  # Without this, Cypress gets an undefined content-type and immediately fails.
 end-to-end/test.sh
 docker kill hubmap-portal-ui
-end docker
+
+end cypress
+
+


### PR DESCRIPTION
- Towards #2397 ... wait to close till the bundle has been delivered.

Use `import()` to split the code, so there's a standalone file with just the message:
```
$ cat app/static/js/maintenance/public/message.bundle.js
(window.webpackJsonp=window.webpackJsonp||[]).push([[1],{62:function(e){e.exports=JSON.parse('"Portal unavailable for scheduled maintenance. While the portal is under maintenance, visit the [HuBMAP Consortium website](https://hubmapconsortium.org/)."')}}]);
```
@yuanzhou , will you be able to work with this file?

Changed the display a little bit, moving the subtitle into the message.


There might be a better way to work around webpack, but this is what I came up with. 