### PR TITLE
Mccalluc/remove docs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "context/ingest-validation-tools"]
 	path = context/ingest-validation-tools
 	url = https://github.com/hubmapconsortium/ingest-validation-tools.git
-[submodule "context/app/markdown/docs"]
-	path = context/app/markdown/docs
-	url = https://github.com/hubmapconsortium/portal-docs.git
 [submodule "context/portal-visualization"]
 	path = context/portal-visualization
 	url = https://github.com/hubmapconsortium/portal-visualization.git

--- a/CHANGELOG-doc-redirect.md
+++ b/CHANGELOG-doc-redirect.md
@@ -1,0 +1,1 @@
+- Replace doc submodule with redirect files, so old URLs won't break.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The Data Portal depends, directly or indirectly, on many other HuBMAP repos:
 
 Issues with the Portal can be reported [via email](mailto:help@hubmapconsortium.org).
 More information on how issues are tracked across HuBMAP is available
-[here](https://portal.hubmapconsortium.org/docs/feedback).
+[here](https://software.docs.hubmapconsortium.org/feedback).
 
 ## Design
 

--- a/context/app/markdown/docs.redirect
+++ b/context/app/markdown/docs.redirect
@@ -1,1 +1,1 @@
-/docs/technical
+https://software.docs.hubmapconsortium.org/

--- a/context/app/markdown/docs/about.redirect
+++ b/context/app/markdown/docs/about.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/about

--- a/context/app/markdown/docs/apis.redirect
+++ b/context/app/markdown/docs/apis.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/apis

--- a/context/app/markdown/docs/assays.redirect
+++ b/context/app/markdown/docs/assays.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays

--- a/context/app/markdown/docs/assays/af.redirect
+++ b/context/app/markdown/docs/assays/af.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/af

--- a/context/app/markdown/docs/assays/atacseq.redirect
+++ b/context/app/markdown/docs/assays/atacseq.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/atacseq

--- a/context/app/markdown/docs/assays/celldive.redirect
+++ b/context/app/markdown/docs/assays/celldive.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/celldive

--- a/context/app/markdown/docs/assays/codex.redirect
+++ b/context/app/markdown/docs/assays/codex.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/codex

--- a/context/app/markdown/docs/assays/imc.redirect
+++ b/context/app/markdown/docs/assays/imc.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/imc

--- a/context/app/markdown/docs/assays/lcms.redirect
+++ b/context/app/markdown/docs/assays/lcms.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/lcms

--- a/context/app/markdown/docs/assays/lightsheet.redirect
+++ b/context/app/markdown/docs/assays/lightsheet.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/lightsheet

--- a/context/app/markdown/docs/assays/maldi-ims.redirect
+++ b/context/app/markdown/docs/assays/maldi-ims.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/maldi-ims

--- a/context/app/markdown/docs/assays/mxif.redirect
+++ b/context/app/markdown/docs/assays/mxif.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/mxif

--- a/context/app/markdown/docs/assays/nano.redirect
+++ b/context/app/markdown/docs/assays/nano.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/nano

--- a/context/app/markdown/docs/assays/pas.redirect
+++ b/context/app/markdown/docs/assays/pas.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/pas

--- a/context/app/markdown/docs/assays/rnaseq.redirect
+++ b/context/app/markdown/docs/assays/rnaseq.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/rnaseq

--- a/context/app/markdown/docs/assays/seqfish.redirect
+++ b/context/app/markdown/docs/assays/seqfish.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/seqfish

--- a/context/app/markdown/docs/assays/wgs.redirect
+++ b/context/app/markdown/docs/assays/wgs.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/assays/wgs

--- a/context/app/markdown/docs/consent.redirect
+++ b/context/app/markdown/docs/consent.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/consent

--- a/context/app/markdown/docs/data-states.redirect
+++ b/context/app/markdown/docs/data-states.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/data-states

--- a/context/app/markdown/docs/datasets.redirect
+++ b/context/app/markdown/docs/datasets.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/datasets

--- a/context/app/markdown/docs/donor.redirect
+++ b/context/app/markdown/docs/donor.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/donor

--- a/context/app/markdown/docs/faq.redirect
+++ b/context/app/markdown/docs/faq.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/faq

--- a/context/app/markdown/docs/feedback.redirect
+++ b/context/app/markdown/docs/feedback.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/feedback

--- a/context/app/markdown/docs/infrastructure.redirect
+++ b/context/app/markdown/docs/infrastructure.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/infrastructure

--- a/context/app/markdown/docs/metadata.redirect
+++ b/context/app/markdown/docs/metadata.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/metadata

--- a/context/app/markdown/docs/pipelines.redirect
+++ b/context/app/markdown/docs/pipelines.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/pipelines

--- a/context/app/markdown/docs/release-summer-2020.redirect
+++ b/context/app/markdown/docs/release-summer-2020.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/release-summer-2020

--- a/context/app/markdown/docs/software.redirect
+++ b/context/app/markdown/docs/software.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/software

--- a/context/app/markdown/docs/technical.redirect
+++ b/context/app/markdown/docs/technical.redirect
@@ -1,0 +1,1 @@
+https://software.docs.hubmapconsortium.org/technical

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -63,7 +63,7 @@ function Footer(props) {
                 Data Use Agreement
               </OutboundLink>
               {!isMaintenancePage && (
-                <LightBlueLink href="/docs/about#citation" variant="body2">
+                <LightBlueLink href="https://software.docs.hubmapconsortium.org/about#citation" variant="body2">
                   Citing HuBMAP
                 </LightBlueLink>
               )}

--- a/context/app/static/js/components/Header/ResourceLinks/ResourceLinks.jsx
+++ b/context/app/static/js/components/Header/ResourceLinks/ResourceLinks.jsx
@@ -7,13 +7,13 @@ function ResourceLinks(props) {
   const { isIndented } = props;
   return (
     <>
-      <DropdownLink href="/docs/technical" isIndented={isIndented}>
+      <DropdownLink href="https://software.docs.hubmapconsortium.org/technical" isIndented={isIndented}>
         Technical Documentation
       </DropdownLink>
-      <DropdownLink href="/docs/faq" isIndented={isIndented}>
+      <DropdownLink href="https://software.docs.hubmapconsortium.org/faq" isIndented={isIndented}>
         FAQ
       </DropdownLink>
-      <DropdownLink href="/docs/about" isIndented={isIndented}>
+      <DropdownLink href="https://software.docs.hubmapconsortium.org/about" isIndented={isIndented}>
         About
       </DropdownLink>
       <StyledDivider />

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -30,7 +30,7 @@ function SummaryDataChildren(props) {
   return (
     <>
       <SummaryItem>
-        <LightBlueLink variant="h6" href="/docs/assays" underline="none">
+        <LightBlueLink variant="h6" href="https://software.docs.hubmapconsortium.org/assays" underline="none">
           {mapped_data_types}
         </LightBlueLink>
       </SummaryItem>

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -95,7 +95,7 @@ def mock_search_donor_post(path, **kwargs):
 @pytest.mark.parametrize(
     'path',
     ['/', '/browse/donor/fake-uuid', '/ccf-eui',
-     '/docs/technical', '/preview/multimodal-molecular-imaging-data']
+     '/preview/multimodal-molecular-imaging-data']
 )
 def test_200_html_page(client, path, mocker):
     mocker.patch('requests.get', side_effect=mock_prov_get)
@@ -162,8 +162,7 @@ paths = ['/organ', '/publication', '/collections', '/cells']
     'path_status',
     [
         ('/', '200 OK'),
-        ('/docs', '302 FOUND', '/docs/technical'),
-        ('/docs/technical', '200 OK'),
+        ('/docs', '302 FOUND', 'https://software.docs.hubmapconsortium.org/'),
 
         *[(path, '200 OK') for path in paths],
         *[(path + '/', '302 FOUND', path) for path in paths],

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -2,7 +2,6 @@ import re
 import xml.etree.ElementTree as ET
 from xml.etree.ElementTree import ParseError
 import json
-from urllib.parse import urlparse
 
 
 import pytest

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -164,7 +164,7 @@ paths = ['/organ', '/publication', '/collections', '/cells']
         ('/docs', '302 FOUND', 'https://software.docs.hubmapconsortium.org/'),
 
         *[(path, '200 OK') for path in paths],
-        *[(path + '/', '302 FOUND', path) for path in paths],
+        *[(path + '/', '302 FOUND', f'http://localhost{path}') for path in paths],
     ],
     ids=lambda path_status: f'{path_status[0]} -> {path_status[1]} {"".join(path_status[2:])}'
 )

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -175,4 +175,4 @@ def test_truncate_and_redirect(client, path_status):
     response = client.get(path)
     assert response.status == status
     if response.status == '302 FOUND':
-        assert [urlparse(response.location).path] == location
+        assert [response.location] == location

--- a/end-to-end/artillery/skip-scenarios/portal-docs.yml
+++ b/end-to-end/artillery/skip-scenarios/portal-docs.yml
@@ -7,14 +7,6 @@ config:
 scenarios:
   - flow:
     - get:
-        url: "/docs/assays"
-        gzip: true
-        afterResponse: "printStatus"
-    - get:
-        url: "/docs/about"
-        gzip: true
-        afterResponse: "printStatus"
-    - get:
         url: "/CHANGELOG"
         gzip: true
         afterResponse: "printStatus"

--- a/end-to-end/cypress/integration/file-based-routes.spec.js
+++ b/end-to-end/cypress/integration/file-based-routes.spec.js
@@ -12,13 +12,12 @@ describe('file-based-routes', () => {
       // Vitessce loads, pulling data from the network.
       // Are incidental network requests ok, as long as tests don't depend on them?
     });
-    it('has working docs pages', () => {
+    it('has links to docs pages', () => {
       cy.visit('/');
       cy.contains('Resources').click();
       cy.contains('FAQ');
       cy.contains('About');
-      cy.contains('Technical').click();
-      cy.contains('HIVE Software Engineering Principles')
+      cy.contains('Technical');
     });
     it('has working publication pages', () => {
       // TODO: When we link to it from the menu, follow the link instead.


### PR DESCRIPTION
- Remove doc submodule
- Replace with redirect files
- Change links to documentation to point directly at software.docs
- Fix tests

After this is merged, I should un-archive portal-docs, move it to the graveyard, and re-archive it.

Draft until [technical.md is ported over](https://github.com/hubmapconsortium/software-docs/issues/33).