### PR TITLE
Use mermaid for the readme diagram

### DIFF
--- a/CHANGELOG-diagram.md
+++ b/CHANGELOG-diagram.md
@@ -1,0 +1,1 @@
+- Use mermaid for the README repo diagram.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,29 @@ It is deployed at [portal.hubmapconsortium.org](https://portal.hubmapconsortium.
 
 The Data Portal depends, directly or indirectly, on many other HuBMAP repos:
 
-[![Repo diagram](https://docs.google.com/drawings/d/e/2PACX-1vThwGinlSgVkqf782swQGHL8RAxPJ1JJfVRc4CrXmFJ0LY-ysFXY1yCGaYebWxTlc5ct0hwRlKIWt_D/pub?w=500)](https://docs.google.com/drawings/d/1IWjIlPytwHe5PAQCEwoTQI5mIhIK4EZ4USI6MVGFGNY/edit)
+```mermaid
+graph TD
+    gateway
+
+    top[portal-ui] --> commons
+    top --> ccf-ui
+    top --> vitessce --> viv
+    top --> valid[ingest-validation-tools]
+    top --> hubmap-api-py-client --> cells-api
+    top --> entity-api --> pipe[ingest-pipeline]
+    top --> assets-api --> pipe
+    top --> search-api --> pipe
+
+    pipe --> valid
+    pipe --> portal-containers
+
+    subgraph apis
+        entity-api
+        assets-api
+        search-api
+        cells-api
+    end
+```
 
 ## Feedback
 


### PR DESCRIPTION
Thought you both might be interested in an example. It's pretty opinionated, and is really designed to just support a few key types of diagrams. There are other tools in this space that try to translate arbitrary ascii-art-diagrams, and that's not what this does.

I worked on it in the [live editor](https://mermaid-js.github.io/mermaid-live-editor/edit/#pako:eNpdkU2OwyAMha8SsS4XyGJWnRPM7JouXOImlvgTmFZR1bsPlGRQ4pXf5wc25iWUG1H0Ygrg5-73PNguxwSMT1gGWyU7f_EuMGiZ6NpJ-dUpZ4yz8b9eobpnw549iDFGhat4HKqgabyQnTCy_Ahgclayczpe99453Qx4CZ6kX6TShJZrW9Q6Fr735zLxUvhHevK4dSq5JouHDhAjctyd2BsiQlDzwVAtJW9POrB1ecpZhtw2xO1UTLe6-XzluswSbfTG2nCNtXkaO2wD7ShOwmAwQGP-6FfBg-AZDQ6iz-mId0iaBzHYd7Ymn_8Av0diF0TPIeFJQGL3s1i16eo5E-ThTYXvP1rXvF4) and then pasted it here.