### PR TITLE
Add email icons

### DIFF
--- a/CHANGELOG-email-icons.md
+++ b/CHANGELOG-email-icons.md
@@ -1,0 +1,1 @@
+- Add email icons on mailto links.

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -4,7 +4,7 @@ import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
-import { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background } from './style';
+import { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background, StyledEmailIcon } from './style';
 
 function Footer(props) {
   const { isMaintenancePage } = props;
@@ -32,7 +32,7 @@ function Footer(props) {
                 </>
               )}
               <LightBlueLink variant="body2" href="mailto:help@hubmapconsortium.org">
-                Submit Feedback
+                Submit Feedback <StyledEmailIcon />
               </LightBlueLink>
             </FlexColumn>
             <FlexColumn $mr={1}>

--- a/context/app/static/js/components/Footer/style.js
+++ b/context/app/static/js/components/Footer/style.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 import Container from '@material-ui/core/Container';
+
+import { EmailIcon } from 'js/shared-styles/icons';
 import { ReactComponent as Logo } from 'assets/svg/hubmap-logo.svg';
 
 const FlexContainer = styled(Container)`
@@ -38,4 +40,9 @@ const Background = styled.div`
   width: 100%;
 `;
 
-export { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background };
+const StyledEmailIcon = styled(EmailIcon)`
+  font-size: 1rem;
+  vertical-align: middle;
+`;
+
+export { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background, StyledEmailIcon };

--- a/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
+++ b/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
-import { FlexPaper } from './style';
+import { FlexPaper, StyledEmailIcon } from './style';
 import SectionItem from '../SectionItem';
 
 function Attribution(props) {
@@ -17,7 +17,9 @@ function Attribution(props) {
         <SectionItem label="Group">{group_name}</SectionItem>
         <SectionItem label="Creator" ml={1}>
           {created_by_user_displayname}
-          <LightBlueLink href={`mailto:${encodeURI(created_by_user_email)}`}>{created_by_user_email}</LightBlueLink>
+          <LightBlueLink href={`mailto:${encodeURI(created_by_user_email)}`}>
+            {created_by_user_email} <StyledEmailIcon />
+          </LightBlueLink>
         </SectionItem>
       </FlexPaper>
     </DetailPageSection>

--- a/context/app/static/js/components/detailPage/Attribution/style.js
+++ b/context/app/static/js/components/detailPage/Attribution/style.js
@@ -2,6 +2,8 @@ import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 
+import { EmailIcon } from 'js/shared-styles/icons';
+
 const StyledTypography = styled(Typography)`
   margin: 2px 0px 2px 0px;
 `;
@@ -11,4 +13,9 @@ const FlexPaper = styled(Paper)`
   padding: 30px 40px 30px 40px;
 `;
 
-export { StyledTypography, FlexPaper };
+const StyledEmailIcon = styled(EmailIcon)`
+  font-size: 1rem;
+  vertical-align: middle;
+`;
+
+export { StyledTypography, FlexPaper, StyledEmailIcon };

--- a/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -5,7 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import FilesContext from '../Files/context';
 import FilesConditionalLink from '../FilesConditionalLink';
-import { StyledExternalLinkIcon } from './style';
+import { StyledExternalLinkIcon, StyledEmailIcon } from './style';
 
 const messages = {
   401: 'Unauthorized access to the Globus Research Management System (bad or expired token). If you believe this to be an error, please contact',
@@ -44,7 +44,7 @@ function GlobusLinkMessage(props) {
       <Typography variant="body2">
         {`${messages[statusCode]} `}
         <LightBlueLink underline="none" variant="body2" href="mailto:help@hubmapconsortium.org">
-          help@hubmapconsortium.org
+          help@hubmapconsortium.org <StyledEmailIcon />
         </LightBlueLink>
         .
       </Typography>
@@ -55,7 +55,7 @@ function GlobusLinkMessage(props) {
     <Typography variant="body2">
       {`Unexpected error ${statusCode}. Report error to `}
       <LightBlueLink underline="none" variant="body2" href="mailto:help@hubmapconsortium.org">
-        help@hubmapconsortium.org
+        help@hubmapconsortium.org <StyledEmailIcon />
       </LightBlueLink>
       .
     </Typography>

--- a/context/app/static/js/components/detailPage/files/GlobusLinkMessage/style.js
+++ b/context/app/static/js/components/detailPage/files/GlobusLinkMessage/style.js
@@ -1,10 +1,15 @@
 import styled from 'styled-components';
 
-import { ExternalLinkIcon } from 'js/shared-styles/icons';
+import { ExternalLinkIcon, EmailIcon } from 'js/shared-styles/icons';
 
 const StyledExternalLinkIcon = styled(ExternalLinkIcon)`
   font-size: 1rem;
   vertical-align: top;
 `;
 
-export { StyledExternalLinkIcon };
+const StyledEmailIcon = styled(EmailIcon)`
+  font-size: 1rem;
+  vertical-align: middle;
+`;
+
+export { StyledExternalLinkIcon, StyledEmailIcon };

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+import { StyledEmailIcon } from './style';
 
 const LoginLink = () => <LightBlueLink href="/login">login</LightBlueLink>;
 const HelpEmailLink = () => (
-  <LightBlueLink href="mailto:help@hubmapconsortium.org">help@hubmapconsortium.org</LightBlueLink>
+  <LightBlueLink href="mailto:help@hubmapconsortium.org">
+    help@hubmapconsortium.org <StyledEmailIcon />
+  </LightBlueLink>
 );
 
 function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMaintenancePage }) {

--- a/context/app/static/js/components/error/ErrorBody/style.js
+++ b/context/app/static/js/components/error/ErrorBody/style.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+import { EmailIcon } from 'js/shared-styles/icons';
+
+const StyledEmailIcon = styled(EmailIcon)`
+  font-size: 1rem;
+  vertical-align: middle;
+`;
+
+export { StyledEmailIcon };

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
+import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+import { LightBlueLink } from 'js/shared-styles/Links';
 import Markdown from 'js/components/Markdown';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
-import { StyledPaper } from './style';
+import { StyledPaper, StyledEmailIcon } from './style';
 
 function Publication(props) {
   const { metadata, markdown } = props;
@@ -25,7 +27,7 @@ function Publication(props) {
         <Typography variant="h4" component="h2">
           Manuscript
         </Typography>
-        <b>{journal}</b>: <a href={url}>{url}</a>
+        <b>{journal}</b>: <OutboundLink href={url}>{url}</OutboundLink>
         <Typography variant="h4" component="h2">
           Authors
         </Typography>
@@ -36,7 +38,10 @@ function Publication(props) {
         <b>Corresponding Author:</b>{' '}
         {authors.corresponding.map((author) => (
           <span key={author.name}>
-            {author.name} - <a href={`mailto:${author.email}`}>{author.email}</a>
+            {author.name} -{' '}
+            <LightBlueLink href={`mailto:${author.email}`}>
+              {author.email} <StyledEmailIcon />
+            </LightBlueLink>
           </span>
         ))}
       </StyledPaper>

--- a/context/app/static/js/pages/Publication/style.js
+++ b/context/app/static/js/pages/Publication/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Paper from '@material-ui/core/Paper';
+import { EmailIcon } from 'js/shared-styles/icons';
 
 const StyledPaper = styled(Paper)`
   padding: 20px 40px 20px 40px;
@@ -10,4 +11,9 @@ const StyledPaper = styled(Paper)`
   }
 `;
 
-export { StyledPaper };
+const StyledEmailIcon = styled(EmailIcon)`
+  font-size: 1rem;
+  vertical-align: middle;
+`;
+
+export { StyledPaper, StyledEmailIcon };


### PR DESCRIPTION
- Fix #2016

... but I'm not really happy with all the style.js, but that seems to be the way things are done? Is there a reason not to update `js/shared-styles/icons` so the export is usable out of the box, without additional styling?

(Most of these I've confirmed the rendering, but I haven't for the globus error messages.)