### PR TITLE
John conroy/email link icons

### DIFF
--- a/CHANGELOG-email-link-icons.md
+++ b/CHANGELOG-email-link-icons.md
@@ -1,0 +1,1 @@
+- Add icons to email links.

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -4,6 +4,7 @@ import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background } from './style';
 
 function Footer(props) {
@@ -31,9 +32,9 @@ function Footer(props) {
                   </LightBlueLink>
                 </>
               )}
-              <LightBlueLink variant="body2" href="mailto:help@hubmapconsortium.org">
+              <EmailIconLink variant="body2" href="help@hubmapconsortium.org" iconFontSize="1rem">
                 Submit Feedback
-              </LightBlueLink>
+              </EmailIconLink>
             </FlexColumn>
             <FlexColumn $mr={1}>
               <Typography variant="subtitle2">Software</Typography>

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -32,7 +32,7 @@ function Footer(props) {
                   </LightBlueLink>
                 </>
               )}
-              <EmailIconLink variant="body2" href="help@hubmapconsortium.org" iconFontSize="1rem">
+              <EmailIconLink variant="body2" email="help@hubmapconsortium.org" iconFontSize="1rem">
                 Submit Feedback
               </EmailIconLink>
             </FlexColumn>

--- a/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
+++ b/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
@@ -17,7 +17,7 @@ function Attribution(props) {
         <SectionItem label="Group">{group_name}</SectionItem>
         <SectionItem label="Creator" ml={1}>
           {created_by_user_displayname}
-          <EmailIconLink href={`mailto:${encodeURI(created_by_user_email)}`} iconFontSize="1rem">
+          <EmailIconLink href={`mailto:${encodeURI(created_by_user_email)}`} iconFontSize="1.1rem">
             {created_by_user_email}
           </EmailIconLink>
         </SectionItem>

--- a/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
+++ b/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
@@ -17,7 +17,7 @@ function Attribution(props) {
         <SectionItem label="Group">{group_name}</SectionItem>
         <SectionItem label="Creator" ml={1}>
           {created_by_user_displayname}
-          <EmailIconLink href={`mailto:${encodeURI(created_by_user_email)}`} iconFontSize="1.1rem">
+          <EmailIconLink email={`mailto:${encodeURI(created_by_user_email)}`} iconFontSize="1.1rem">
             {created_by_user_email}
           </EmailIconLink>
         </SectionItem>

--- a/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
+++ b/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { LightBlueLink } from 'js/shared-styles/Links';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
+import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import { FlexPaper } from './style';
 import SectionItem from '../SectionItem';
 
@@ -17,7 +17,9 @@ function Attribution(props) {
         <SectionItem label="Group">{group_name}</SectionItem>
         <SectionItem label="Creator" ml={1}>
           {created_by_user_displayname}
-          <LightBlueLink href={`mailto:${encodeURI(created_by_user_email)}`}>{created_by_user_email}</LightBlueLink>
+          <EmailIconLink href={`mailto:${encodeURI(created_by_user_email)}`} iconFontSize="1rem">
+            {created_by_user_email}
+          </EmailIconLink>
         </SectionItem>
       </FlexPaper>
     </DetailPageSection>

--- a/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 
-import { LightBlueLink } from 'js/shared-styles/Links';
+import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import FilesContext from '../Files/context';
 import FilesConditionalLink from '../FilesConditionalLink';
 import { StyledExternalLinkIcon } from './style';
@@ -43,9 +43,9 @@ function GlobusLinkMessage(props) {
     return (
       <Typography variant="body2">
         {`${messages[statusCode]} `}
-        <LightBlueLink underline="none" variant="body2" href="mailto:help@hubmapconsortium.org">
+        <EmailIconLink variant="body2" href="help@hubmapconsortium.org" iconFontSize="1rem">
           help@hubmapconsortium.org
-        </LightBlueLink>
+        </EmailIconLink>
         .
       </Typography>
     );
@@ -54,9 +54,9 @@ function GlobusLinkMessage(props) {
   return (
     <Typography variant="body2">
       {`Unexpected error ${statusCode}. Report error to `}
-      <LightBlueLink underline="none" variant="body2" href="mailto:help@hubmapconsortium.org">
+      <EmailIconLink variant="body2" href="help@hubmapconsortium.org" iconFontSize="1rem">
         help@hubmapconsortium.org
-      </LightBlueLink>
+      </EmailIconLink>
       .
     </Typography>
   );

--- a/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -43,7 +43,7 @@ function GlobusLinkMessage(props) {
     return (
       <Typography variant="body2">
         {`${messages[statusCode]} `}
-        <EmailIconLink variant="body2" href="help@hubmapconsortium.org" iconFontSize="1rem">
+        <EmailIconLink variant="body2" email="help@hubmapconsortium.org" iconFontSize="1rem">
           help@hubmapconsortium.org
         </EmailIconLink>
         .
@@ -54,7 +54,7 @@ function GlobusLinkMessage(props) {
   return (
     <Typography variant="body2">
       {`Unexpected error ${statusCode}. Report error to `}
-      <EmailIconLink variant="body2" href="help@hubmapconsortium.org" iconFontSize="1rem">
+      <EmailIconLink variant="body2" email="help@hubmapconsortium.org" iconFontSize="1rem">
         help@hubmapconsortium.org
       </EmailIconLink>
       .

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -7,7 +7,7 @@ import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 
 const LoginLink = () => <LightBlueLink href="/login">login</LightBlueLink>;
 const HelpEmailLink = () => (
-  <EmailIconLink href="help@hubmapconsortium.org" iconFontSize="1rem">
+  <EmailIconLink email="help@hubmapconsortium.org" iconFontSize="1rem">
     help@hubmapconsortium.org
   </EmailIconLink>
 );

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -3,10 +3,13 @@ import PropTypes from 'prop-types';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 
 const LoginLink = () => <LightBlueLink href="/login">login</LightBlueLink>;
 const HelpEmailLink = () => (
-  <LightBlueLink href="mailto:help@hubmapconsortium.org">help@hubmapconsortium.org</LightBlueLink>
+  <EmailIconLink href="help@hubmapconsortium.org" iconFontSize="1rem">
+    help@hubmapconsortium.org
+  </EmailIconLink>
 );
 
 function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMaintenancePage }) {

--- a/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
+++ b/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
-import { StyledPaper, MainText, StyledEmailIcon } from './style';
+import { StyledPaper, MainText } from './style';
 
 function DataUseGuidelines() {
   return (
@@ -16,7 +16,7 @@ function DataUseGuidelines() {
       <MainText mt={2} variant="body1">
         Please direct any questions to{' '}
         <EmailIconLink href="help@hubmapconsortium.org" iconFontSize="1.1rem">
-          help@hubmapconsortium.org <StyledEmailIcon />
+          help@hubmapconsortium.org
         </EmailIconLink>
       </MainText>
     </StyledPaper>

--- a/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
+++ b/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
@@ -15,7 +15,7 @@ function DataUseGuidelines() {
       </MainText>
       <MainText mt={2} variant="body1">
         Please direct any questions to{' '}
-        <EmailIconLink href="help@hubmapconsortium.org" iconFontSize="1.1rem">
+        <EmailIconLink email="help@hubmapconsortium.org" iconFontSize="1.1rem">
           help@hubmapconsortium.org
         </EmailIconLink>
       </MainText>

--- a/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
+++ b/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
@@ -15,7 +15,7 @@ function DataUseGuidelines() {
       </MainText>
       <MainText mt={2} variant="body1">
         Please direct any questions to{' '}
-        <EmailIconLink href="help@hubmapconsortium.org" iconFontSize="1rem">
+        <EmailIconLink href="help@hubmapconsortium.org" iconFontSize="1.1rem">
           help@hubmapconsortium.org <StyledEmailIcon />
         </EmailIconLink>
       </MainText>

--- a/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
+++ b/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LightBlueLink } from 'js/shared-styles/Links';
+import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import { StyledPaper, MainText, StyledEmailIcon } from './style';
 
 function DataUseGuidelines() {
@@ -15,9 +15,9 @@ function DataUseGuidelines() {
       </MainText>
       <MainText mt={2} variant="body1">
         Please direct any questions to{' '}
-        <LightBlueLink href="mailto:help@hubmapconsortium.org">
+        <EmailIconLink href="help@hubmapconsortium.org" iconFontSize="1rem">
           help@hubmapconsortium.org <StyledEmailIcon />
-        </LightBlueLink>
+        </EmailIconLink>
       </MainText>
     </StyledPaper>
   );

--- a/context/app/static/js/components/home/DataUseGuidelines/style.js
+++ b/context/app/static/js/components/home/DataUseGuidelines/style.js
@@ -2,8 +2,6 @@ import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 
-import { EmailIcon } from 'js/shared-styles/icons';
-
 const StyledPaper = styled(Paper)`
   padding: ${(props) => props.theme.spacing(2)}px;
 `;
@@ -12,9 +10,4 @@ const MainText = styled(Typography)`
   margin-top: ${(props) => props.theme.spacing(props.mt)}px;
 `;
 
-const StyledEmailIcon = styled(EmailIcon)`
-  font-size: 1rem;
-  vertical-align: middle;
-`;
-
-export { StyledPaper, MainText, StyledEmailIcon };
+export { StyledPaper, MainText };

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -4,6 +4,9 @@ import Typography from '@material-ui/core/Typography';
 import Markdown from 'js/components/Markdown';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
+import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
+import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+
 import { StyledPaper } from './style';
 
 function Publication(props) {
@@ -25,7 +28,7 @@ function Publication(props) {
         <Typography variant="h4" component="h2">
           Manuscript
         </Typography>
-        <b>{journal}</b>: <a href={url}>{url}</a>
+        <b>{journal}</b>: <OutboundLink href={url}>{url}</OutboundLink>
         <Typography variant="h4" component="h2">
           Authors
         </Typography>
@@ -36,7 +39,10 @@ function Publication(props) {
         <b>Corresponding Author:</b>{' '}
         {authors.corresponding.map((author) => (
           <span key={author.name}>
-            {author.name} - <a href={`mailto:${author.email}`}>{author.email}</a>
+            {author.name} -{' '}
+            <EmailIconLink href={`${author.email}`} iconFontSize="1rem">
+              {author.email}
+            </EmailIconLink>
           </span>
         ))}
       </StyledPaper>

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -40,7 +40,7 @@ function Publication(props) {
         {authors.corresponding.map((author) => (
           <span key={author.name}>
             {author.name} -{' '}
-            <EmailIconLink href={`${author.email}`} iconFontSize="1rem">
+            <EmailIconLink email={`${author.email}`} iconFontSize="1rem">
               {author.email}
             </EmailIconLink>
           </span>

--- a/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/EmailIconLink.jsx
+++ b/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/EmailIconLink.jsx
@@ -12,10 +12,10 @@ function sendEmailEvent(event) {
   });
 }
 
-function EmailIconLink({ iconFontSize, href, ...rest }) {
+function EmailIconLink({ iconFontSize, email, ...rest }) {
   return (
     <IconLink
-      href={`mailto:${href}`}
+      href={`mailto:${email}`}
       onCLick={sendEmailEvent}
       icon={<EmailIcon $fontSize={iconFontSize} />}
       {...rest}

--- a/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/EmailIconLink.jsx
+++ b/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/EmailIconLink.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import IconLink from 'js/shared-styles/Links/iconLinks/IconLink';
+import { EmailIcon } from 'js/shared-styles/icons';
+import ReactGA from 'react-ga';
+
+function sendEmailEvent(event) {
+  ReactGA.event({
+    category: 'Email Link',
+    action: 'Clicked',
+    label: event.target.href,
+    nonInteraction: false,
+  });
+}
+
+function EmailIconLink({ iconFontSize, href, ...rest }) {
+  return (
+    <IconLink href={`mailto:${href}`} onCLick={sendEmailEvent} icon={<EmailIcon fontSize={iconFontSize} />} {...rest} />
+  );
+}
+
+export default EmailIconLink;

--- a/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/EmailIconLink.jsx
+++ b/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/EmailIconLink.jsx
@@ -14,7 +14,12 @@ function sendEmailEvent(event) {
 
 function EmailIconLink({ iconFontSize, href, ...rest }) {
   return (
-    <IconLink href={`mailto:${href}`} onCLick={sendEmailEvent} icon={<EmailIcon fontSize={iconFontSize} />} {...rest} />
+    <IconLink
+      href={`mailto:${href}`}
+      onCLick={sendEmailEvent}
+      icon={<EmailIcon $fontSize={iconFontSize} />}
+      {...rest}
+    />
   );
 }
 

--- a/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/index.js
+++ b/context/app/static/js/shared-styles/Links/iconLinks/EmailIconLink/index.js
@@ -1,0 +1,3 @@
+import EmailIconLink from './EmailIconLink';
+
+export default EmailIconLink;


### PR DESCRIPTION
Fix #2016.

I opted to add `mailto:` inside the `EmailLinkIcon` component. Should I use a proper name other than `href` to make this more clear?

<img width="1791" alt="Screen Shot 2022-03-01 at 11 38 31 AM" src="https://user-images.githubusercontent.com/62477388/156210340-6f01696a-a097-4973-93ff-ba2a4cd5ecd5.png">

