### PR TITLE
Make datasets robust against missing contributors

### DIFF
--- a/CHANGELOG-missing-contributors.md
+++ b/CHANGELOG-missing-contributors.md
@@ -1,0 +1,1 @@
+- Make datasets robust against missing `contributors`.

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -86,6 +86,7 @@ function DatasetDetail(props) {
     metadata: Boolean(Object.keys(combinedMetadata).length),
     files: true,
     collections: Boolean(collectionsData.length),
+    contributors: contributors && Boolean(contributors.length),
   };
 
   const sectionOrder = getSectionOrder(
@@ -154,7 +155,7 @@ function DatasetDetail(props) {
         {shouldDisplaySection.metadata && <MetadataTable metadata={combinedMetadata} hubmap_id={hubmap_id} />}
         <Files files={files} uuid={uuid} hubmap_id={hubmap_id} visLiftedUUID={visLiftedUUID} />
         {shouldDisplaySection.collections && <CollectionsSection collectionsData={collectionsData} />}
-        <ContributorsTable contributors={contributors} title="Contributors" />
+        {shouldDisplaySection.contributors && <ContributorsTable contributors={contributors} title="Contributors" />}
         <Attribution
           group_name={group_name}
           created_by_user_displayname={created_by_user_displayname}


### PR DESCRIPTION
https://portal.test.hubmapconsortium.org/browse/dataset/550c5a19866fb79faf17ecb75ea6987f  is missing contributors. With this tweak, the page renders, but Vitessce still fails: I'm branch from this branch and make another PR for that.