### PR TITLE
use publication date, if available

### DIFF
--- a/CHANGELOG-create-publish.md
+++ b/CHANGELOG-create-publish.md
@@ -1,0 +1,1 @@
+- If a publication date is available, use it in preference to the creation date.

--- a/context/app/static/js/components/detailPage/Summary/Summary.jsx
+++ b/context/app/static/js/components/detailPage/Summary/Summary.jsx
@@ -10,6 +10,7 @@ function Summary(props) {
     hubmap_id,
     entity_type,
     created_timestamp,
+    published_timestamp,
     last_modified_timestamp,
     uuid,
     description,
@@ -43,6 +44,7 @@ function Summary(props) {
         citationTitle={citationTitle}
         last_modified_timestamp={last_modified_timestamp}
         created_timestamp={created_timestamp}
+        published_timestamp={published_timestamp}
         doi_url={doi_url}
         doi={doi}
         collectionName={collectionName}

--- a/context/app/static/js/components/detailPage/Summary/Summary.spec.js
+++ b/context/app/static/js/components/detailPage/Summary/Summary.spec.js
@@ -26,6 +26,24 @@ test('timestamps display when defined', () => {
   expect(screen.queryAllByText('Undefined')).toHaveLength(0);
 });
 
+test('publication prefered to creation, if available', () => {
+  render(
+    <Summary
+      hubmap_id="fakedoi"
+      entity_type="Fakeentity"
+      uuid="fakeuuid"
+      created_timestamp={1596724856094}
+      published_timestamp={1596724856094}
+      last_modified_timestamp={1596724856094}
+    />,
+  );
+  const textToTest = ['Publication Date', 'Modification Date'];
+  textToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
+
+  expect(screen.getAllByText('2020-08-06')).toHaveLength(2);
+  expect(screen.queryAllByText('Undefined')).toHaveLength(0);
+});
+
 test('timestamps do not display when undefined', () => {
   render(<Summary hubmap_id="fakedoi" entity_type="Fakeentity" uuid="fakeuuid" />);
 

--- a/context/app/static/js/components/detailPage/SummaryBody/SummaryBody.jsx
+++ b/context/app/static/js/components/detailPage/SummaryBody/SummaryBody.jsx
@@ -10,6 +10,7 @@ function SummaryBody({
   description,
   collectionName,
   created_timestamp,
+  published_timestamp,
   last_modified_timestamp,
   contributors,
   citationTitle,
@@ -38,7 +39,11 @@ function SummaryBody({
         />
       )}
       <Flex>
-        <StyledCreationDate label="Creation Date" timestamp={created_timestamp} />
+        {published_timestamp ? (
+          <StyledCreationDate label="Publication Date" timestamp={published_timestamp} />
+        ) : (
+          <StyledCreationDate label="Creation Date" timestamp={created_timestamp} />
+        )}
         <StyledModificationDate label="Modification Date" timestamp={last_modified_timestamp} />
       </Flex>
     </SummaryPaper>

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -70,6 +70,7 @@ function DatasetDetail(props) {
     entity_type,
     created_timestamp,
     last_modified_timestamp,
+    published_timestamp,
     description,
     status,
     sub_status,
@@ -145,6 +146,7 @@ function DatasetDetail(props) {
           hubmap_id={hubmap_id}
           created_timestamp={created_timestamp}
           last_modified_timestamp={last_modified_timestamp}
+          published_timestamp={published_timestamp}
           description={description}
           status={combinedStatus}
           mapped_data_access_level={mapped_data_access_level}


### PR DESCRIPTION
- Fix #1754

@tsliaw , does this seem ok? If a Dataset is unpublished, giving the creation date is probably more useful than just showing "Undefined". Mostly, I want to avoid having a separate component for Datasets that isn't shared with Samples and Donors.