### PR TITLE
John conroy/responsive detail summary

### DIFF
--- a/CHANGELOG-responsive-detail-summary.md
+++ b/CHANGELOG-responsive-detail-summary.md
@@ -1,0 +1,1 @@
+- Enable detail summary to wrap when needed.

--- a/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.stories.js
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import Typography from '@material-ui/core/Typography';
 import { rest } from 'msw';
+import SummaryItem from 'js/components/detailPage/summary/SummaryItem';
+import { getArrayRange } from 'js/helpers/functions';
 import SummaryData from './SummaryData';
 
 export default {
@@ -40,24 +41,12 @@ Dataset.args = {
 
 export const WithChildren = (args) => (
   <SummaryData {...args}>
-    <Typography>Child</Typography>
+    {getArrayRange(8).map((n) => (
+      <SummaryItem>Child {n}</SummaryItem>
+    ))}{' '}
   </SummaryData>
 );
 WithChildren.args = {
-  ...sharedArgs,
-  entity_type: 'Dataset',
-};
-
-export const WithChildrenOverflow = (args) => (
-  <SummaryData {...args}>
-    <Typography>Child 1</Typography>
-    <Typography>Child 2</Typography>
-    <Typography>Child 3</Typography>
-    <Typography>Child 4</Typography>
-    <Typography>Child 5</Typography>
-  </SummaryData>
-);
-WithChildrenOverflow.args = {
   ...sharedArgs,
   entity_type: 'Dataset',
 };

--- a/context/app/static/js/components/detailPage/summary/SummaryData/style.js
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/style.js
@@ -5,6 +5,7 @@ import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
 
 const FlexEnd = styled.div`
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-end;
 `;
 

--- a/context/app/static/js/shared-styles/sections/SectionButtonRow/style.js
+++ b/context/app/static/js/shared-styles/sections/SectionButtonRow/style.js
@@ -4,6 +4,7 @@ const Flex = styled.div`
   display: flex;
   align-items: flex-end;
   justify-content: space-between;
+  flex-wrap: wrap;
 `;
 
 export { Flex };


### PR DESCRIPTION
The right hand text/buttons will wrap when needed as shown below, but otherwise will look as it has.

<img width="664" alt="Screen Shot 2022-03-09 at 3 22 59 PM" src="https://user-images.githubusercontent.com/62477388/157696858-eef7f643-3ce5-4bbd-9f2c-d7b93d881e75.png">
