### PR TITLE
Mccalluc/new route for view conf

### DIFF
--- a/CHANGELOG-request-vitessce-conf-from-client.md
+++ b/CHANGELOG-request-vitessce-conf-from-client.md
@@ -1,0 +1,1 @@
+- Request vitessce conf from client-side, rather than blocking page load.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -51,13 +51,9 @@ def details(type, uuid):
         return redirect(url_for('routes_browse.details', type=actual_type, uuid=uuid))
 
     template = 'pages/base_react.html'
-    conf_cells_and_lifted_uuid = client.get_vitessce_conf_cells_and_lifted_uuid(entity)
     flask_data = {
         **get_default_flask_data(),
         'entity': entity,
-        'vitessce_conf': conf_cells_and_lifted_uuid.vitessce_conf.conf,
-        'has_notebook': conf_cells_and_lifted_uuid.vitessce_conf.cells is not None,
-        'vis_lifted_uuid': conf_cells_and_lifted_uuid.vis_lifted_uuid
     }
     return render_template(
         template,
@@ -84,6 +80,7 @@ def details_vitessce(type, uuid):
     client = get_client()
     entity = client.get_entity(uuid)
     vitessce_conf = client.get_vitessce_conf_cells_and_lifted_uuid(entity).vitessce_conf
+    # TODO: Also return lifted_uuid
     # Returns a JSON null if there is no visualization.
     response = jsonify(vitessce_conf.conf)
     response.headers.add("Access-Control-Allow-Origin", "*")

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -38,7 +38,6 @@ function Routes(props) {
     markdown,
     errorCode,
     list_uuid,
-    has_notebook,
     vis_lifted_uuid,
     entities,
     organs,
@@ -74,12 +73,7 @@ function Routes(props) {
   if (urlPath.startsWith('/browse/dataset/') || urlPath.startsWith('/browse/support/')) {
     return (
       <Route>
-        <Dataset
-          assayMetadata={entity}
-          vitData={vitessce_conf}
-          hasNotebook={has_notebook}
-          visLiftedUUID={vis_lifted_uuid}
-        />
+        <Dataset assayMetadata={entity} visLiftedUUID={vis_lifted_uuid} />
       </Route>
     );
   }

--- a/context/app/static/js/hooks/useVitessceConfig.js
+++ b/context/app/static/js/hooks/useVitessceConfig.js
@@ -23,7 +23,7 @@ function useVitessceConfig(uuid, groupsToken) {
     getAndSetVitessceConfig();
   }, [uuid, groupsToken]);
 
-  return { vitessceConfig /* , isLoading */ };
+  return vitessceConfig /* , isLoading */;
 }
 
 export default useVitessceConfig;

--- a/context/app/static/js/hooks/useVitessceConfig.js
+++ b/context/app/static/js/hooks/useVitessceConfig.js
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { getAuthHeader } from 'js/helpers/functions';
+
+function useVitessceConfig(uuid, groupsToken) {
+  const [vitessceConfig, setVitessceConfig] = React.useState(undefined);
+
+  React.useEffect(() => {
+    async function getAndSetVitessceConfig() {
+      const headers = getAuthHeader(groupsToken);
+
+      const response = await fetch(`/browse/dataset/${uuid}.vitessce.json`, { headers });
+
+      if (!response.ok) {
+        console.error('Vitessce API failed', response);
+        // setIsLoading(false);
+        return;
+      }
+      const responseVitessceConfig = await response.json();
+      setVitessceConfig(responseVitessceConfig);
+      // setIsLoading(false);
+    }
+    getAndSetVitessceConfig();
+  }, [uuid, groupsToken]);
+
+  return { vitessceConfig /* , isLoading */ };
+}
+
+export default useVitessceConfig;

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -1,5 +1,6 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useContext } from 'react';
 
+import { AppContext } from 'js/components/Providers';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import Files from 'js/components/detailPage/files/Files';
 import ProvSection from 'js/components/detailPage/provenance/ProvSection';
@@ -17,6 +18,7 @@ import CollectionsSection from 'js/components/detailPage/CollectionsSection';
 import SupportAlert from 'js/components/detailPage/SupportAlert';
 import { DetailPageAlert } from 'js/components/detailPage/style';
 import { useSearchHits } from 'js/hooks/useSearchData';
+import useVitessceConfig from 'js/hooks/useVitessceConfig';
 import { getAllCollectionsQuery } from 'js/helpers/queries';
 
 // TODO use this context for components other than FileBrowser
@@ -51,7 +53,7 @@ function SummaryDataChildren({ mapped_data_types, origin_sample, doi_url, regist
 const entityStoreSelector = (state) => state.setAssayMetadata;
 
 function DatasetDetail(props) {
-  const { assayMetadata, vitData, hasNotebook, visLiftedUUID } = props;
+  const { assayMetadata, visLiftedUUID } = props;
   const {
     protocol_url,
     metadata,
@@ -88,6 +90,9 @@ function DatasetDetail(props) {
 
   const { searchHits: allCollections } = useSearchHits(getAllCollectionsQuery);
   const collectionsData = getCollectionsWhichContainDataset(uuid, allCollections);
+
+  const { groupsToken } = useContext(AppContext);
+  const vitData = useVitessceConfig(uuid, groupsToken);
 
   const shouldDisplaySection = {
     provenance: entity_type !== 'Support',
@@ -160,9 +165,7 @@ function DatasetDetail(props) {
             doi_url={doi_url}
           />
         </Summary>
-        {shouldDisplaySection.visualization && (
-          <VisualizationWrapper vitData={vitData} uuid={uuid} hasNotebook={hasNotebook} />
-        )}
+        {shouldDisplaySection.visualization && <VisualizationWrapper vitData={vitData} uuid={uuid} />}
         {shouldDisplaySection.provenance && <ProvSection uuid={uuid} assayMetadata={assayMetadata} />}
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} />}
         {shouldDisplaySection.metadata && <MetadataTable metadata={combinedMetadata} hubmap_id={hubmap_id} />}


### PR DESCRIPTION
- Towards #2434 (Turns out there was already a `.vitessce.json` endpoint: This just uses it.)

Filing as draft: Works for some visualizations... but I had forgotten that this code was also involved in vis-lifting. I think the solution is for the JSON endpoint to return a wrapper object, with the vitessce-conf, and the lifted UUID.... Or maybe there's a point in the vitessce object where we could put additional user data?

@john-conroy -- Could you give this a pre-review? I know that you've been concerned about layout shifts... but this is going to make it a lot worse: We just don't know if there is visualization section until the response comes back... and that could take a while... which is precisely why I think page render shouldn't block on it.

Backing up, maybe this is another reason to try again to move this to index-time, so all the information is there in the original JSON?