### PR TITLE
Default link icon size

### DIFF
--- a/CHANGELOG-default-icon-size.md
+++ b/CHANGELOG-default-icon-size.md
@@ -1,0 +1,1 @@
+- Link icons default to `1rem` if unspecified.

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -34,7 +34,7 @@ function Footer(props) {
                   </LightBlueLink>
                 </>
               )}
-              <EmailIconLink variant="body2" email="help@hubmapconsortium.org" iconFontSize="1rem">
+              <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
                 Submit Feedback
               </EmailIconLink>
             </FlexColumn>
@@ -73,7 +73,7 @@ function Footer(props) {
             </FlexColumn>
             <FlexColumn>
               <Typography variant="subtitle2">Funding</Typography>
-              <OutboundIconLink href="https://commonfund.nih.gov/hubmap" variant="body2" iconFontSize="1rem">
+              <OutboundIconLink href="https://commonfund.nih.gov/hubmap" variant="body2">
                 NIH Common Fund
               </OutboundIconLink>
             </FlexColumn>

--- a/context/app/static/js/components/detailPage/Citation/Citation.jsx
+++ b/context/app/static/js/components/detailPage/Citation/Citation.jsx
@@ -24,14 +24,9 @@ function Citation({ contributors, citationTitle, created_timestamp, doi_url, doi
       bottomSpacing={1}
     >
       <Typography variant="body1">
-        {citation} Available from:{' '}
-        <OutboundIconLink href={doi_url} iconFontSize="1rem">
-          {doi_url}
-        </OutboundIconLink>
+        {citation} Available from: <OutboundIconLink href={doi_url}>{doi_url}</OutboundIconLink>
       </Typography>
-      <OutboundIconLink href={`https://search.datacite.org/works/${doi}`} iconFontSize="1rem">
-        View DataCite Page
-      </OutboundIconLink>
+      <OutboundIconLink href={`https://search.datacite.org/works/${doi}`}>View DataCite Page</OutboundIconLink>
     </LabelledSectionText>
   );
 }

--- a/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.jsx
+++ b/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.jsx
@@ -50,7 +50,7 @@ function ContributorsTable(props) {
                   <TableCell>{row.name}</TableCell>
                   <TableCell>{row.affiliation}</TableCell>
                   <TableCell>
-                    <OutboundIconLink href={`https://orcid.org/${row.orcid_id}`} variant="body2" iconFontSize="1rem">
+                    <OutboundIconLink href={`https://orcid.org/${row.orcid_id}`} variant="body2">
                       {row.orcid_id}
                     </OutboundIconLink>
                   </TableCell>

--- a/context/app/static/js/components/detailPage/Protocol/Protocol.jsx
+++ b/context/app/static/js/components/detailPage/Protocol/Protocol.jsx
@@ -14,9 +14,7 @@ function ProtocolLink(props) {
   return (
     <SectionItem label={title}>
       {resolverHostnameAndDOI ? (
-        <OutboundIconLink href={`https://${resolverHostnameAndDOI}`} iconFontSize="1rem">
-          {resolverHostnameAndDOI}
-        </OutboundIconLink>
+        <OutboundIconLink href={`https://${resolverHostnameAndDOI}`}>{resolverHostnameAndDOI}</OutboundIconLink>
       ) : (
         'Please wait...'
       )}

--- a/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
+++ b/context/app/static/js/components/detailPage/files/GlobusLinkMessage/GlobusLinkMessage.jsx
@@ -43,7 +43,7 @@ function GlobusLinkMessage(props) {
     return (
       <Typography variant="body2">
         {`${messages[statusCode]} `}
-        <EmailIconLink variant="body2" email="help@hubmapconsortium.org" iconFontSize="1rem">
+        <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
           help@hubmapconsortium.org
         </EmailIconLink>
         .
@@ -54,7 +54,7 @@ function GlobusLinkMessage(props) {
   return (
     <Typography variant="body2">
       {`Unexpected error ${statusCode}. Report error to `}
-      <EmailIconLink variant="body2" email="help@hubmapconsortium.org" iconFontSize="1rem">
+      <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
         help@hubmapconsortium.org
       </EmailIconLink>
       .

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -189,9 +189,7 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader }) {
         </Paper>
         <StyledFooterText variant="body2">
           Powered by&nbsp;
-          <OutboundIconLink href="http://vitessce.io" iconFontSize="1rem">
-            Vitessce
-          </OutboundIconLink>
+          <OutboundIconLink href="http://vitessce.io">Vitessce</OutboundIconLink>
         </StyledFooterText>
         <style type="text/css">{vizIsFullscreen && bodyExpandedCSS}</style>
       </StyledDetailPageSection>

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -7,11 +7,7 @@ import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink'
 import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 
 const LoginLink = () => <LightBlueLink href="/login">login</LightBlueLink>;
-const HelpEmailLink = () => (
-  <EmailIconLink email="help@hubmapconsortium.org" iconFontSize="1rem">
-    help@hubmapconsortium.org
-  </EmailIconLink>
-);
+const HelpEmailLink = () => <EmailIconLink email="help@hubmapconsortium.org">help@hubmapconsortium.org</EmailIconLink>;
 
 function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMaintenancePage }) {
   if (isMaintenancePage) {
@@ -36,10 +32,7 @@ function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMainten
       <>
         Could not confirm your Globus credentials. You may not have been added to the HuBMAP Group on Globus. Request
         access at <HelpEmailLink />. Or, you may be logged into a different Globus account from the one in the HuBMAP
-        Group. Check{' '}
-        <OutboundIconLink href="http://app.globus.org/" iconFontSize="1rem">
-          http://app.globus.org/
-        </OutboundIconLink>{' '}
+        Group. Check <OutboundIconLink href="http://app.globus.org/">http://app.globus.org/</OutboundIconLink> details
         details on account.
       </>
     );

--- a/context/app/static/js/components/organ/Description/Description.jsx
+++ b/context/app/static/js/components/organ/Description/Description.jsx
@@ -11,10 +11,7 @@ function Description(props) {
     <StyledPaper>
       <p>{children}</p>
       <p>
-        Uberon:{' '}
-        <OutboundIconLink href={uberonIri} iconFontSize="1rem">
-          {uberonShort}
-        </OutboundIconLink>
+        Uberon: <OutboundIconLink href={uberonIri}>{uberonShort}</OutboundIconLink>
       </p>
     </StyledPaper>
   );

--- a/context/app/static/js/pages/Collection/Collection.jsx
+++ b/context/app/static/js/pages/Collection/Collection.jsx
@@ -46,7 +46,7 @@ function Collection(props) {
             doi={doi}
           >
             {doi_url && (
-              <OutboundIconLink href={doi_url} variant="body1" iconFontSize="1rem">
+              <OutboundIconLink href={doi_url} variant="body1">
                 doi:{doi}
               </OutboundIconLink>
             )}

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -39,10 +39,7 @@ function Publication(props) {
         <b>Corresponding Author:</b>{' '}
         {authors.corresponding.map((author) => (
           <span key={author.name}>
-            {author.name} -{' '}
-            <EmailIconLink email={`${author.email}`} iconFontSize="1rem">
-              {author.email}
-            </EmailIconLink>
+            {author.name} - <EmailIconLink email={`${author.email}`}>{author.email}</EmailIconLink>
           </span>
         ))}
       </StyledPaper>

--- a/context/app/static/js/shared-styles/icons/index.js
+++ b/context/app/static/js/shared-styles/icons/index.js
@@ -19,7 +19,7 @@ import ArrowDropDownRoundedIcon from '@material-ui/icons/ArrowDropDownRounded';
 import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
 
 const fontSizeStyle = css`
-  font-size: ${(props) => props.$fontSize};
+  font-size: ${(props) => props.$fontSize || '1rem'};
 `;
 
 const CenterIcon = styled(AccountBalanceIcon)`


### PR DESCRIPTION
- Fix #2504
- Only real change is removing the prop: Larger diff because line wrapping isn't needed any longer.
- I verified that everything still looked good only for the first few that I changed.
- Three instances of `iconFontSize="1.1rem"` remain: `Attribution.jsx`, `DataUseGuidelines.jsx`, `Dataset.jsx`... Maybe they should change too?