### PR TITLE
John conroy/pin werkzeug

### DIFF
--- a/CHANGELOG-pin-werkzeug.md
+++ b/CHANGELOG-pin-werkzeug.md
@@ -1,0 +1,1 @@
+- Pin werkzeug version to fix ci.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -6,5 +6,5 @@ python-datauri==0.2.8
 python-frontmatter==0.5.0
 hubmap-api-py-client==0.0.9
 hubmap-commons==2.0.12
-Werkzeug==2.0.3
+Werkzeug==2.0.3  # TODO: This is just a transitive dependency. Remove when https://github.com/hubmapconsortium/portal-ui/issues/2547 is fixed.
 git+https://github.com/hubmapconsortium/portal-visualization.git@0.0.1#egg=portal-visualization

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -6,4 +6,5 @@ python-datauri==0.2.8
 python-frontmatter==0.5.0
 hubmap-api-py-client==0.0.9
 hubmap-commons==2.0.12
+Werkzeug==2.0.3
 git+https://github.com/hubmapconsortium/portal-visualization.git@0.0.1#egg=portal-visualization


### PR DESCRIPTION
Pin werkzeug version to 2.03 to fix CI errors seen in https://github.com/hubmapconsortium/portal-ui/runs/5738927912?check_suite_focus=true.

From: https://werkzeug.palletsprojects.com/en/2.1.x/test/#werkzeug.test.Client.open
> Changed in version 2.1: Removed the as_tuple parameter.
