### PR TITLE
"Creator" -> "Registered by"

### DIFF
--- a/CHANGELOG-registered-by.md
+++ b/CHANGELOG-registered-by.md
@@ -1,0 +1,1 @@
+- Change "Creator" to "Registered by".

--- a/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
+++ b/context/app/static/js/components/detailPage/Attribution/Attribution.jsx
@@ -15,7 +15,7 @@ function Attribution(props) {
       <SectionHeader>Attribution</SectionHeader>
       <FlexPaper>
         <SectionItem label="Group">{group_name}</SectionItem>
-        <SectionItem label="Creator" ml={1}>
+        <SectionItem label="Registered by" ml={1}>
           {created_by_user_displayname}
           <EmailIconLink email={encodeURI(created_by_user_email)} iconFontSize="1.1rem">
             {created_by_user_email}

--- a/context/app/static/js/components/detailPage/Attribution/Attribution.spec.js
+++ b/context/app/static/js/components/detailPage/Attribution/Attribution.spec.js
@@ -14,6 +14,6 @@ test('text displays properly', () => {
       created_by_user_email={created_by_user_email}
     />,
   );
-  const textToTest = ['Attribution', 'Group', 'Fake TMC', 'Creator', 'Fake Name', 'fake@fake.com'];
+  const textToTest = ['Attribution', 'Group', 'Fake TMC', 'Registered by', 'Fake Name', 'fake@fake.com'];
   textToTest.forEach((text) => expect(getByText(text)).toBeInTheDocument());
 });

--- a/context/app/static/js/components/searchPage/config.js
+++ b/context/app/static/js/components/searchPage/config.js
@@ -17,7 +17,10 @@ function makeDonorMetadataFilters(isDonor) {
   ];
 }
 
-const affiliationFilters = [listFilter('group_name', 'Group'), listFilter('created_by_user_displayname', 'Creator')];
+const affiliationFilters = [
+  listFilter('group_name', 'Group'),
+  listFilter('created_by_user_displayname', 'Registered by'),
+];
 
 const sharedTileFields = [
   field('last_modified_timestamp', 'Last Modified Unmapped'),


### PR DESCRIPTION
- Fix #2521 

This also changes the Preview pages... but I'd prefer not to add tons of special cases: My sense is that Bill plans to add the _actual_ creator to the ES documents, and at that point the label may change again.