### PR TITLE
Mccalluc/error log filter

### DIFF
--- a/CHANGELOG-log-filter.md
+++ b/CHANGELOG-log-filter.md
@@ -1,0 +1,1 @@
+- Add a somewhat gratuitous filter on the error-log report.

--- a/filter-portal-logs.py
+++ b/filter-portal-logs.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+from sys import argv
+from pathlib import Path
+from re import subn, MULTILINE
+
+class Filterer:
+    def __init__(self, logs):
+        self.logs = logs
+        self.report = {}
+    def _filter_one(self, pattern):
+        (logs, num_matches) = subn(pattern, '', self.logs, flags=MULTILINE)
+        self.report[pattern] = num_matches
+        self.logs = logs
+    def filter_all(self):
+        self._filter_one('^.*ERROR in client: Expected only one descendant on.*$\n')
+
+
+if __name__ == "__main__":
+    logs = Path(argv[1]).read_text()
+    filterer = Filterer(logs)
+    filterer.filter_all()
+    print('Old errors:')
+    print(filterer.report)
+    print('\nNew errors:')
+    print(filterer.logs)

--- a/filter-portal-logs.py
+++ b/filter-portal-logs.py
@@ -6,10 +6,12 @@ from re import subn, MULTILINE
 
 from yaml import dump
 
+
 class Filterer:
     def __init__(self, logs):
         self.logs = logs
         self.report = {}
+
     def _filter_one(self, pattern, issue):
         (logs, count) = subn(rf'^.*{pattern}.*$\n', '', self.logs, flags=MULTILINE)
         self.report[pattern] = {
@@ -17,6 +19,7 @@ class Filterer:
             'issue': issue
         }
         self.logs = logs
+
     def filter_all(self):
         self._filter_one(
             r'Expected only one descendant on',


### PR DESCRIPTION
@john-conroy : Does this seem useful to you? I know that I tend to add ad-hoc tweaks that may be individually useful, but aren't really sustainable over the long run. In this case, it identified one new class of error:
- #2556

and apart from the four classes identified in the script, in the last report we have just two errors that are entirely new:
```
[2022-03-29 03:35:59,613] ERROR in app: Exception on /browse/dataset/8122e6bbb32d0561eade1136d320a561 [GET]
    rv = self.handle_user_exception(e)
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://search.api.hubmapconsortium.org/portal/search
[2022-03-29 03:35:59,612] ERROR in client: {"message": "Internal server error"}
```
```
[2022-03-28 03:05:07,993] ERROR in app: Exception on /login [GET]
    rv = self.handle_user_exception(e)
    raise self.error_class(r)
globus_sdk.exc.AuthAPIError: (400, 'Error', 'invalid_grant')
```
each happened only once, and seem pretty clearly to depend on an upstream API, so I don't think we need to focus on them right now.