### PR TITLE
Two new filters on dev-search

### DIFF
--- a/CHANGELOG-dev-search-assay-filters.md
+++ b/CHANGELOG-dev-search-assay-filters.md
@@ -1,0 +1,1 @@
+- Add two hierarchical filters to dev-search; May help us represent assays better.

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -52,6 +52,8 @@ function DevSearch() {
         listFilter('mapped_data_types', 'mapped_data_types'),
         listFilter('metadata.metadata.assay_category', 'assay_category'),
         listFilter('metadata.metadata.assay_type', 'assay_type'),
+        hierarchicalFilter(['metadata.metadata.analyte_class', 'mapped_data_types'], 'By analyte'),
+        hierarchicalFilter(['metadata.metadata.assay_category', 'mapped_data_types'], 'By category'),
       ],
       'File Descriptions': [
         listFilter('files.description', 'Flat'),


### PR DESCRIPTION
- Follow-up to  https://github.com/hubmapconsortium/ingest-validation-tools/issues/1062
- Fix #2563

<img width="284" alt="Screen Shot 2022-04-11 at 3 39 13 PM" src="https://user-images.githubusercontent.com/730388/162817241-21652f2b-7615-4240-a947-f060a1846111.png">

There are some weird analyte values.... I think the original roadmap was to ask NIH if this would be useful. If it looks like it still could be useful, but we want to understand the data first, do you want to file an issue for that?