### PR TITLE
restore mocks

### DIFF
--- a/CHANGELOG-clear-mocks.md
+++ b/CHANGELOG-clear-mocks.md
@@ -1,0 +1,1 @@
+- Clear mocks after every Jest test: We want to avoid a mock on one test having side effects on another.

--- a/context/jest.config.js
+++ b/context/jest.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  clearMocks: true,
+  restoreMocks: true,
   testPathIgnorePatterns: ['jest.config.js', '/node_modules/', '/cypress/'],
   setupFilesAfterEnv: ['<rootDir>/test-utils/setupTests.js'],
   moduleNameMapper: {

--- a/context/jest.config.js
+++ b/context/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  clearMocks: true,
   testPathIgnorePatterns: ['jest.config.js', '/node_modules/', '/cypress/'],
   setupFilesAfterEnv: ['<rootDir>/test-utils/setupTests.js'],
   moduleNameMapper: {


### PR DESCRIPTION
I'm going to be mocking the console to silence warnings, but it seems good to restore mocks for each test to avoid side-effects. I'm surprised it's not the default.

I think [`restoreMocks`](https://jestjs.io/docs/configuration#restoremocks-boolean) ("This will lead to any mocks having their fake implementations removed and restores their initial implementation") is better here than `clearMocks` ("This does not remove any mock implementation that may have been provided.") or `resetMocks` ("This will lead to any mocks having their fake implementations removed but does not restore their initial implementation.")