### PR TITLE
fewer warnings during tests

### DIFF
--- a/CHANGELOG-test-warnings.md
+++ b/CHANGELOG-test-warnings.md
@@ -1,0 +1,1 @@
+- Reduce the number of warnings during tests.

--- a/context/app/static/js/components/detailPage/Citation/Citation.jsx
+++ b/context/app/static/js/components/detailPage/Citation/Citation.jsx
@@ -23,9 +23,10 @@ function Citation({ contributors, citationTitle, created_timestamp, doi_url, doi
       className={className}
       bottomSpacing={1}
     >
-      <Typography variant="body1">
+      <Typography variant="body1" component="span">
         {citation} Available from: <OutboundIconLink href={doi_url}>{doi_url}</OutboundIconLink>
       </Typography>
+      <br />
       <OutboundIconLink href={`https://search.datacite.org/works/${doi}`}>View DataCite Page</OutboundIconLink>
     </LabelledSectionText>
   );

--- a/context/app/static/js/components/detailPage/SampleTissue/SampleTissue.spec.js
+++ b/context/app/static/js/components/detailPage/SampleTissue/SampleTissue.spec.js
@@ -10,7 +10,9 @@ function expectLabelsPresent() {
 }
 
 test('text displays properly when all props provided', () => {
-  render(<SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" hasRUI />);
+  render(
+    <SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" hasRUI uuid="placeholder" />,
+  );
   expectLabelsPresent();
 
   expect(screen.getByText('Tissue Location')).toBeInTheDocument();
@@ -20,6 +22,8 @@ test('text displays properly when all props provided', () => {
 });
 
 test('displays label not defined when values are undefined', () => {
+  // Supress proptype warnings:
+  jest.spyOn(global.console, 'error').mockImplementation(() => {});
   render(<SampleTissue />);
   expectLabelsPresent();
 

--- a/context/app/static/js/components/detailPage/files/GlobusLink/GlobusLink.spec.js
+++ b/context/app/static/js/components/detailPage/files/GlobusLink/GlobusLink.spec.js
@@ -38,6 +38,8 @@ test('displays info icon with 500 response', async () => {
     }),
   );
 
+  // error is expected: We don't want to see it in test logs.
+  jest.spyOn(global.console, 'error').mockImplementation(() => {});
   render(<GlobusLink uuid={uuid} hubmap_id={hubmap_id} />);
 
   await screen.findByTestId('error-icon');

--- a/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.spec.js
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.spec.js
@@ -26,14 +26,30 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 test('json button exists and has href', () => {
-  render(<SummaryData entity_type="Fake" uuid={testUUID} status="QA" mapped_data_access_level="Public" />);
+  render(
+    <SummaryData
+      entity_type="Fake"
+      uuid={testUUID}
+      status="QA"
+      mapped_data_access_level="Public"
+      hubmap_id="placeholder"
+    />,
+  );
 
   expect(screen.getByRole('link')).not.toBeEmptyDOMElement();
   expect(screen.getByRole('link')).toHaveAttribute('href', `/browse/fake/fakeuuid.json`);
 });
 
 test('dataset displays properly', async () => {
-  render(<SummaryData entity_type="Dataset" uuid={testUUID} status="QA" mapped_data_access_level="Public" />);
+  render(
+    <SummaryData
+      entity_type="Dataset"
+      uuid={testUUID}
+      status="QA"
+      mapped_data_access_level="Public"
+      hubmap_id="placeholder"
+    />,
+  );
   const textToTest = ['QA', 'Public Access'];
   textToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
   expect(screen.getByTestId('status-svg-icon')).toBeInTheDocument();
@@ -42,13 +58,27 @@ test('dataset displays properly', async () => {
 });
 
 test('non-dataset displays properly', () => {
-  render(<SummaryData entity_type="fake" uuid={testUUID} status="QA" mapped_data_access_level="Public" />);
+  render(
+    <SummaryData
+      entity_type="fake"
+      uuid={testUUID}
+      status="QA"
+      mapped_data_access_level="Public"
+      hubmap_id="placeholder"
+    />,
+  );
   expect(screen.queryByTestId('status-svg-icon')).toBeNull();
 });
 
 test('children display when provided', () => {
   render(
-    <SummaryData entity_type="fake" uuid={testUUID} status="QA" mapped_data_access_level="Public">
+    <SummaryData
+      entity_type="fake"
+      uuid={testUUID}
+      status="QA"
+      mapped_data_access_level="Public"
+      hubmap_id="placeholder"
+    >
       <div>child 1</div>
       <div>child 2</div>
     </SummaryData>,
@@ -61,6 +91,14 @@ test('children display when provided', () => {
 });
 
 test('children do not display when undefined', () => {
-  render(<SummaryData entity_type="fake" uuid={testUUID} status="QA" mapped_data_access_level="Public" />);
+  render(
+    <SummaryData
+      entity_type="fake"
+      uuid={testUUID}
+      status="QA"
+      mapped_data_access_level="Public"
+      hubmap_id="placeholder"
+    />,
+  );
   expect(screen.queryByTestId('summary-data-parent')).toBeNull();
 });

--- a/context/app/static/js/components/searchPage/TilesSortDropdown/TilesSortDropdown.spec.js
+++ b/context/app/static/js/components/searchPage/TilesSortDropdown/TilesSortDropdown.spec.js
@@ -16,7 +16,7 @@ const items = [
   {
     defaultOption: false,
     label: 'Fake',
-    field: 'Fake.keyword',
+    field: 'fake.keyword',
     order: 'asc',
     key: 'fake.keyword_asc',
   },

--- a/context/app/static/js/components/searchPage/filters/AccordionFilter/AccordionFilter.spec.js
+++ b/context/app/static/js/components/searchPage/filters/AccordionFilter/AccordionFilter.spec.js
@@ -32,7 +32,17 @@ test.each([
   ['AccordionCheckboxFilter'],
   ['AccordionHierarchicalMenuFilter'],
 ])('%s should render', (filterName) => {
-  render(<AccordionFilter type={filterName} />);
+  render(
+    <AccordionFilter
+      type={filterName}
+      title="placeholder"
+      fields={[]}
+      id="placeholder"
+      filter={{}}
+      label="placeholder"
+      field="placeholder"
+    />,
+  );
 });
 
 test('withAnalyticsEvent passes onClick with ga event and original onClick', () => {


### PR DESCRIPTION
This cuts the output from 1213 to 771 lines. I don't think it's really that important, but I think it's good to avoid warnings that we just get used to, though I'm not sure how best to get there, and this PR isn't consistent. Some options:
- Loosen prop-type checks.
- Fill in placeholders so prop-types pass.
- mock console.error so we don't see the warnings.
