### PR TITLE
Mccalluc/anndata notebook

### DIFF
--- a/CHANGELOG-fix-nb.md
+++ b/CHANGELOG-fix-nb.md
@@ -1,0 +1,1 @@
+- Notebook generation from the search page was broken. Fixed now.

--- a/context/app/api/client_utils.py
+++ b/context/app/api/client_utils.py
@@ -1,6 +1,6 @@
 def files_from_response(response_json):
     '''
-    >>> response_json = [
+    >>> response_json = {'hits': {'hits': [
     ...     {
     ...         '_id': '1234',
     ...         '_source': {
@@ -9,12 +9,13 @@ def files_from_response(response_json):
     ...             }]
     ...         }
     ...     }
-    ... ]
+    ... ]}}
     >>> files_from_response(response_json)
     {'1234': ['abc.txt']}
     '''
+    hits = response_json['hits']['hits']
     return {
         hit['_id']: [
-            file['rel_path'] for file in hit['_source']['files']
-        ] for hit in response_json
+            file['rel_path'] for file in hit['_source'].get('files', [])
+        ] for hit in hits
     }


### PR DESCRIPTION
I'm not sure how this was missed, and I'm not sure what should have been done differently: I don't think we'd want to add integration tests that depend on live APIs to CI... but maybe there should be some other place for that? 
- Fix #2618