### PR TITLE
John conroy/sort configure table

### DIFF
--- a/CHANGELOG-sort-configure-table.md
+++ b/CHANGELOG-sort-configure-table.md
@@ -1,0 +1,1 @@
+- Sort fields in configure search table.

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.js
@@ -14,7 +14,7 @@ function appendKeywordToFieldName({ fieldName, type }) {
 }
 
 // gets elasticsearch document path to metadata fields for related entities given an entity type
-function prependMetadataPathToFieldName({ fieldName, entityType }) {
+function prependMetadataPathToFieldName({ fieldName, pageEntityType }) {
   const donorMetadataPath = 'mapped_metadata';
   const sampleMetdataPath = 'metadata';
 
@@ -35,7 +35,7 @@ function prependMetadataPathToFieldName({ fieldName, entityType }) {
 
   // get entity type from ingest-validation-types document which maps fields to their entity type
   const fieldEntityType = metadataFieldtoEntityMap?.[fieldName];
-  const prefix = paths?.[entityType]?.[fieldEntityType];
+  const prefix = paths?.[pageEntityType]?.[fieldEntityType];
   if (prefix) {
     return `${prefix}.${fieldName}`;
   }

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.js
@@ -1,6 +1,8 @@
 import { RefinementSelectFacet } from '@searchkit/sdk';
+
 import metadataFieldtoTypeMap from 'metadata-field-types';
 import metadataFieldtoEntityMap from 'metadata-field-entities';
+import { capitalizeString } from 'js/helpers/functions';
 
 // appends '.keyword' to field name for elasticsearch string fields
 function appendKeywordToFieldName({ fieldName, type }) {
@@ -42,27 +44,50 @@ function prependMetadataPathToFieldName({ fieldName, entityType }) {
 }
 
 // prepends entity type to field name for fields that belong to other entities
-function prependEntityTypeToFieldName({ fieldName, entityType }) {
+function prependEntityTypeToFieldName({ fieldName, pageEntityType }) {
   const fieldEntityType = metadataFieldtoEntityMap[fieldName];
-  if (entityType !== fieldEntityType) return `${fieldEntityType}.${fieldName}`;
+  if (pageEntityType !== fieldEntityType) return `${fieldEntityType}.${fieldName}`;
 
   return fieldName;
 }
 
 // builds field config needed for searchkit
-function buildFieldConfig({ fieldName, label, type, ...rest }) {
+function buildFieldConfig({
+  fieldName,
+  label,
+  type,
+  facetGroup = 'Additional Facets',
+  configureGroup = 'General',
+  ...rest
+}) {
   const elasticsearchFieldName = appendKeywordToFieldName({ fieldName, type });
-  return { [fieldName]: { field: elasticsearchFieldName, identifier: fieldName, label, type, ...rest } };
+  return {
+    [fieldName]: {
+      field: elasticsearchFieldName,
+      identifier: fieldName,
+      label,
+      type,
+      facetGroup,
+      configureGroup,
+      ...rest,
+    },
+  };
 }
 
 // builds field config for metadata fields for searchkit
-function buildMetadataFieldConfig({ fieldName, entityType, ...rest }) {
+function buildMetadataFieldConfig({ fieldName, entityType: pageEntityType, ...rest }) {
   // get type from ingest-validation-types document which maps fields to their type
   const elasticsearchType = metadataFieldtoTypeMap[fieldName];
+  const fieldEntityType = metadataFieldtoEntityMap[fieldName];
+
+  const group = `${capitalizeString(fieldEntityType)} Metadata`;
+
   return buildFieldConfig({
-    fieldName: prependMetadataPathToFieldName({ fieldName, entityType }),
-    label: prependEntityTypeToFieldName({ fieldName, entityType }),
+    fieldName: prependMetadataPathToFieldName({ fieldName, pageEntityType }),
+    label: prependEntityTypeToFieldName({ fieldName, pageEntityType }),
     type: elasticsearchType,
+    facetGroup: group,
+    configureGroup: group,
     ...rest,
   });
 }
@@ -81,10 +106,6 @@ const withFacetGroup = (facetGroup) => (o) =>
     ...o,
     facetGroup,
   });
-
-function createFacet({ facetGroup = 'Additional Facets', ...rest }) {
-  return withFacetGroup(facetGroup)({ ...rest });
-}
 
 const createDonorFacet = withFacetGroup('Donor Metadata');
 const createDatasetFacet = withFacetGroup('Dataset Metadata');
@@ -132,7 +153,6 @@ export {
   createDatasetFacet,
   createAffiliationFacet,
   createSearchkitFacet,
-  createFacet,
   createField,
 };
 

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.spec.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.spec.js
@@ -4,7 +4,6 @@ import {
   buildFieldConfig,
   buildMetadataFieldConfig,
   createField,
-  createFacet,
   mergeObjects,
 } from './utils';
 
@@ -55,6 +54,8 @@ test('buildFieldConfig should build field config', () => {
       identifier: 'animal',
       label: 'Animal',
       type: 'string',
+      configureGroup: 'General',
+      facetGroup: 'Additional Facets',
     },
   });
 });
@@ -63,11 +64,13 @@ test('buildMetadataFieldConfig should build metadata field config', () => {
   expect(
     buildMetadataFieldConfig({ fieldName: 'assay_category', entityType: 'dataset', label: 'Assay Category' }),
   ).toEqual({
-    'metadata.metadata.assay_category': {
-      field: 'metadata.metadata.assay_category.keyword',
-      identifier: 'metadata.metadata.assay_category',
+    assay_category: {
+      field: 'assay_category.keyword',
+      identifier: 'assay_category',
       label: 'Assay Category',
       type: 'string',
+      configureGroup: 'Dataset Metadata',
+      facetGroup: 'Dataset Metadata',
     },
   });
 });
@@ -80,43 +83,21 @@ describe('createField', () => {
         identifier: 'animal',
         label: 'Animal',
         type: 'string',
+        configureGroup: 'General',
+        facetGroup: 'Additional Facets',
       },
     });
   });
 
   test('should create a metadata field config if the field exists in metadata field types', () => {
     expect(createField({ fieldName: 'assay_category', entityType: 'dataset', label: 'Assay Category' })).toEqual({
-      'metadata.metadata.assay_category': {
-        field: 'metadata.metadata.assay_category.keyword',
-        identifier: 'metadata.metadata.assay_category',
+      assay_category: {
+        field: 'assay_category.keyword',
+        identifier: 'assay_category',
         label: 'Assay Category',
         type: 'string',
-      },
-    });
-  });
-});
-
-describe('createFacet', () => {
-  test('should create a field with default "Additional Facets" facet group', () => {
-    expect(createFacet({ fieldName: 'animal', label: 'Animal', type: 'string' })).toEqual({
-      animal: {
-        field: 'animal.keyword',
-        identifier: 'animal',
-        label: 'Animal',
-        type: 'string',
-        facetGroup: 'Additional Facets',
-      },
-    });
-  });
-
-  test('should create a field with facet group if specified', () => {
-    expect(createFacet({ fieldName: 'animal', label: 'Animal', type: 'string', facetGroup: 'main' })).toEqual({
-      animal: {
-        field: 'animal.keyword',
-        identifier: 'animal',
-        label: 'Animal',
-        type: 'string',
-        facetGroup: 'main',
+        configureGroup: 'Dataset Metadata',
+        facetGroup: 'Dataset Metadata',
       },
     });
   });

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.spec.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.spec.js
@@ -23,25 +23,25 @@ describe('appendKeywordToFieldName', () => {
   });
 
   test('should return the correct path for donor metadata in samples', () => {
-    expect(prependMetadataPathToFieldName({ fieldName: 'age_value', entityType: 'sample' })).toBe(
+    expect(prependMetadataPathToFieldName({ fieldName: 'age_value', pageEntityType: 'sample' })).toBe(
       'donor.mapped_metadata.age_value',
     );
   });
 
   test('should return the correct path for donor metadata in datasets', () => {
-    expect(prependMetadataPathToFieldName({ fieldName: 'age_value', entityType: 'dataset' })).toBe(
+    expect(prependMetadataPathToFieldName({ fieldName: 'age_value', pageEntityType: 'dataset' })).toBe(
       'donor.mapped_metadata.age_value',
     );
   });
 
   test('should return the correct path for sample metadata in datasets', () => {
-    expect(prependMetadataPathToFieldName({ fieldName: 'health_status', entityType: 'dataset' })).toBe(
+    expect(prependMetadataPathToFieldName({ fieldName: 'health_status', pageEntityType: 'dataset' })).toBe(
       'source_sample.metadata.health_status',
     );
   });
 
   test('should return the correct path for dataset metadata in datasets', () => {
-    expect(prependMetadataPathToFieldName({ fieldName: 'assay_category', entityType: 'dataset' })).toBe(
+    expect(prependMetadataPathToFieldName({ fieldName: 'assay_category', pageEntityType: 'dataset' })).toBe(
       'metadata.metadata.assay_category',
     );
   });
@@ -64,9 +64,9 @@ test('buildMetadataFieldConfig should build metadata field config', () => {
   expect(
     buildMetadataFieldConfig({ fieldName: 'assay_category', entityType: 'dataset', label: 'Assay Category' }),
   ).toEqual({
-    assay_category: {
-      field: 'assay_category.keyword',
-      identifier: 'assay_category',
+    'metadata.metadata.assay_category': {
+      field: 'metadata.metadata.assay_category.keyword',
+      identifier: 'metadata.metadata.assay_category',
       label: 'Assay Category',
       type: 'string',
       configureGroup: 'Dataset Metadata',
@@ -91,9 +91,9 @@ describe('createField', () => {
 
   test('should create a metadata field config if the field exists in metadata field types', () => {
     expect(createField({ fieldName: 'assay_category', entityType: 'dataset', label: 'Assay Category' })).toEqual({
-      assay_category: {
-        field: 'assay_category.keyword',
-        identifier: 'assay_category',
+      'metadata.metadata.assay_category': {
+        field: 'metadata.metadata.assay_category.keyword',
+        identifier: 'metadata.metadata.assay_category',
         label: 'Assay Category',
         type: 'string',
         configureGroup: 'Dataset Metadata',

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/ConfigureSearchTable.jsx
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/ConfigureSearchTable.jsx
@@ -8,7 +8,7 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 
-import { sortFieldsByConfigureGroup } from './utils';
+import { getFieldEntriesSortedByConfigureGroup } from './utils';
 
 function ConfigureSearchTable({ selectedFields, handleToggleField, availableFields }) {
   return (
@@ -22,7 +22,7 @@ function ConfigureSearchTable({ selectedFields, handleToggleField, availableFiel
           </TableRow>
         </TableHead>
         <TableBody>
-          {sortFieldsByConfigureGroup(availableFields).map(([k, v]) => (
+          {getFieldEntriesSortedByConfigureGroup(availableFields).map(([k, v]) => (
             <TableRow key={k}>
               <TableCell>{v.label}</TableCell>
               <TableCell />

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/ConfigureSearchTable.jsx
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/ConfigureSearchTable.jsx
@@ -8,6 +8,8 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 
+import { sortFieldsByConfigureGroup } from './utils';
+
 function ConfigureSearchTable({ selectedFields, handleToggleField, availableFields }) {
   return (
     <TableContainer component={Paper}>
@@ -20,7 +22,7 @@ function ConfigureSearchTable({ selectedFields, handleToggleField, availableFiel
           </TableRow>
         </TableHead>
         <TableBody>
-          {Object.entries(availableFields).map(([k, v]) => (
+          {sortFieldsByConfigureGroup(availableFields).map(([k, v]) => (
             <TableRow key={k}>
               <TableCell>{v.label}</TableCell>
               <TableCell />

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/hooks.js
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/hooks.js
@@ -12,8 +12,8 @@ const relatedEntityTypesMap = {
 
 function useMetadataFieldConfigs(initialFieldConfigs) {
   const { entityType } = useStore();
-  return Object.keys(metadataFieldtoEntityMap).reduce(
-    (acc, { fieldName, fieldEntityType }) => {
+  return Object.entries(metadataFieldtoEntityMap).reduce(
+    (acc, [fieldName, fieldEntityType]) => {
       if (relatedEntityTypesMap[entityType].includes(fieldEntityType)) {
         return produce(acc, (draft) => {
           return {

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/hooks.js
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/hooks.js
@@ -2,9 +2,7 @@ import produce from 'immer';
 
 import metadataFieldtoEntityMap from 'metadata-field-entities';
 import { useStore } from 'js/components/entity-search/SearchWrapper/store';
-import { createFacet } from 'js/components/entity-search/SearchWrapper/utils';
-import { capitalizeString } from 'js/helpers/functions';
-import { getMetadataFieldsSortedByEntityTypeThenFieldName } from './utils';
+import { createField } from 'js/components/entity-search/SearchWrapper/utils';
 
 const relatedEntityTypesMap = {
   donor: ['donor'],
@@ -12,18 +10,15 @@ const relatedEntityTypesMap = {
   dataset: ['donor', 'sample'],
 };
 
-const sortedMetadataFields = getMetadataFieldsSortedByEntityTypeThenFieldName(metadataFieldtoEntityMap);
-
 function useMetadataFieldConfigs(initialFieldConfigs) {
   const { entityType } = useStore();
-  return sortedMetadataFields.reduce(
+  return Object.keys(metadataFieldtoEntityMap).reduce(
     (acc, { fieldName, fieldEntityType }) => {
       if (relatedEntityTypesMap[entityType].includes(fieldEntityType)) {
         return produce(acc, (draft) => {
-          const group = `${capitalizeString(fieldEntityType)} Metadata`;
           return {
             ...draft,
-            ...createFacet({ fieldName, entityType, facetGroup: group }),
+            ...createField({ fieldName, entityType }),
           };
         });
       }

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.js
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.js
@@ -6,4 +6,23 @@ function getMetadataFieldsSortedByEntityTypeThenFieldName(fields) {
     .map(([fieldName, fieldEntityType]) => ({ fieldName, fieldEntityType }));
 }
 
-export { getMetadataFieldsSortedByEntityTypeThenFieldName };
+function sortFieldsByConfigureGroup(fields) {
+  return Object.entries(fields).sort(
+    (
+      [, { configureGroup: configureGroupA, label: labelA }],
+      [, { configureGroup: configureGroupB, label: labelB }],
+    ) => {
+      // put 'General' configure group at top
+      if (configureGroupA === 'General' && configureGroupB !== 'General') {
+        return -1;
+      }
+      if (configureGroupA !== 'General' && configureGroupB === 'General') {
+        return 1;
+      }
+
+      return configureGroupA.localeCompare(configureGroupB) || labelA.localeCompare(labelB);
+    },
+  );
+}
+
+export { getMetadataFieldsSortedByEntityTypeThenFieldName, sortFieldsByConfigureGroup };

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.js
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.js
@@ -1,12 +1,4 @@
-function getMetadataFieldsSortedByEntityTypeThenFieldName(fields) {
-  return Object.entries(fields)
-    .sort(([fieldNameA, entityTypeA], [fieldNameB, entityTypeB]) => {
-      return entityTypeA.localeCompare(entityTypeB) || fieldNameA.localeCompare(fieldNameB);
-    })
-    .map(([fieldName, fieldEntityType]) => ({ fieldName, fieldEntityType }));
-}
-
-function sortFieldsByConfigureGroup(fields) {
+function getFieldEntriesSortedByConfigureGroup(fields) {
   return Object.entries(fields).sort(
     (
       [, { configureGroup: configureGroupA, label: labelA }],
@@ -25,4 +17,4 @@ function sortFieldsByConfigureGroup(fields) {
   );
 }
 
-export { getMetadataFieldsSortedByEntityTypeThenFieldName, sortFieldsByConfigureGroup };
+export { getFieldEntriesSortedByConfigureGroup };

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.js
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.js
@@ -4,7 +4,7 @@ function getFieldEntriesSortedByConfigureGroup(fields) {
       [, { configureGroup: configureGroupA, label: labelA }],
       [, { configureGroup: configureGroupB, label: labelB }],
     ) => {
-      // put 'General' configure group at top
+      // Sort 'General' configure group to top:
       if (configureGroupA === 'General' && configureGroupB !== 'General') {
         return -1;
       }

--- a/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.spec.js
+++ b/context/app/static/js/components/entity-search/sidebar/ConfigureSearchTable/utils.spec.js
@@ -1,19 +1,23 @@
-import { getMetadataFieldsSortedByEntityTypeThenFieldName } from './utils';
+import { getFieldEntriesSortedByConfigureGroup } from './utils';
 
-test('should sort by entity type then field name', () => {
+test('should sort by configure group with general on type then alphabetically then field name alphabetically', () => {
   const map = {
-    vital_state: 'sample',
-    assay_type: 'dataset',
-    sex: 'donor',
-    description: 'dataset',
-    blood_type: 'donor',
+    assay_type: { label: 'assay_type', configureGroup: 'Dataset Metadata' },
+    description: { label: 'description', configureGroup: 'Dataset Metadata' },
+    blood_type: { label: 'blood_type', configureGroup: 'Donor Metadata' },
+    date: { label: 'date', configureGroup: 'General' },
+    sex: { label: 'sex', configureGroup: 'Donor Metadata' },
+    vital_state: { label: 'vital_state', configureGroup: 'Sample Metadata' },
+    id: { label: 'id', configureGroup: 'General' },
   };
 
-  expect(getMetadataFieldsSortedByEntityTypeThenFieldName(map)).toEqual([
-    { fieldName: 'assay_type', fieldEntityType: 'dataset' },
-    { fieldName: 'description', fieldEntityType: 'dataset' },
-    { fieldName: 'blood_type', fieldEntityType: 'donor' },
-    { fieldName: 'sex', fieldEntityType: 'donor' },
-    { fieldName: 'vital_state', fieldEntityType: 'sample' },
+  expect(getFieldEntriesSortedByConfigureGroup(map)).toEqual([
+    ['date', { label: 'date', configureGroup: 'General' }],
+    ['id', { label: 'id', configureGroup: 'General' }],
+    ['assay_type', { label: 'assay_type', configureGroup: 'Dataset Metadata' }],
+    ['description', { label: 'description', configureGroup: 'Dataset Metadata' }],
+    ['blood_type', { label: 'blood_type', configureGroup: 'Donor Metadata' }],
+    ['sex', { label: 'sex', configureGroup: 'Donor Metadata' }],
+    ['vital_state', { label: 'vital_state', configureGroup: 'Sample Metadata' }],
   ]);
 });

--- a/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
+++ b/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
@@ -24,13 +24,17 @@ function selectedItemsReducer(state, { type, payload }) {
   }
 }
 
-function useGroupedMetadataFieldConfigs() {
+function useGroupedFieldConfigs() {
+  const { initialFields, initialFacets } = useStore();
   const metadataFieldConfigs = useMetadataFieldConfigs();
-  return Object.entries(metadataFieldConfigs).reduce((acc, [metadataFieldName, metadataFieldConfig]) => {
+
+  // Order matters. Field configs defined in initialFields/initialFacets will be overwritten
+  const allFieldConfigs = { ...initialFields, ...initialFacets, ...metadataFieldConfigs };
+  return Object.entries(allFieldConfigs).reduce((acc, [metadataFieldName, metadataFieldConfig]) => {
     return produce(acc, (draft) => {
       // eslint-disable-next-line no-param-reassign
-      draft[metadataFieldConfig.facetGroup] = {
-        ...draft[metadataFieldConfig.facetGroup],
+      draft[metadataFieldConfig.configureGroup] = {
+        ...draft[metadataFieldConfig.configureGroup],
         [metadataFieldName]: metadataFieldConfig,
       };
       return draft;
@@ -45,9 +49,7 @@ function getSelectedGroupsFieldConfigs(groups, selectedGroups) {
 }
 
 function useFieldGroups() {
-  const { initialFields, initialFacets } = useStore();
-  const groupedMetadataFieldConfigs = useGroupedMetadataFieldConfigs();
-  const groups = { General: { ...initialFields, ...initialFacets }, ...groupedMetadataFieldConfigs };
+  const groups = useGroupedFieldConfigs();
   const { selectedItems: selectedGroups, handleToggleItem: handleToggleGroup } = useSelectedItems(
     selectedItemsReducer,
     {},

--- a/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
+++ b/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
@@ -1,7 +1,7 @@
 import produce from 'immer';
 
 import { useSelectedItems } from 'js/components/entity-search/sidebar/ConfigureSearch/hooks';
-import { createDatasetFacet } from 'js/components/entity-search/SearchWrapper/utils';
+import { createField } from 'js/components/entity-search/SearchWrapper/utils';
 import fieldsToAssayMap from 'metadata-field-assays';
 import { useStore } from 'js/components/entity-search/SearchWrapper/store';
 import { invertKeyToArrayMap as createDataTypesToFieldsMap } from './utils';
@@ -58,13 +58,15 @@ function useFieldGroups() {
 }
 
 function buildFieldConfigs(fieldNames) {
-  return fieldNames.reduce(
-    (acc, fieldName) => ({
+  return fieldNames.reduce((acc, fieldName) => {
+    if (fieldName === 'version') {
+      return acc;
+    }
+    return {
       ...acc,
-      ...createDatasetFacet({ fieldName, entityType: 'dataset' }),
-    }),
-    {},
-  );
+      ...createField({ fieldName, entityType: 'dataset' }),
+    };
+  }, {});
 }
 
 function getDataTypesFields(selectedDataTypes) {

--- a/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
+++ b/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
@@ -62,7 +62,7 @@ function useFieldGroups() {
 function buildFieldConfigs(fieldNames) {
   return fieldNames.reduce((acc, fieldName) => {
     const excludedFieldNames = ['version'];
-    if (excludedFieldNames.includes(fieldName) {
+    if (excludedFieldNames.includes(fieldName)) {
       return acc;
     }
     return {

--- a/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
+++ b/context/app/static/js/components/entity-search/sidebar/DatasetConfigureSearchTable/hooks.js
@@ -28,7 +28,7 @@ function useGroupedFieldConfigs() {
   const { initialFields, initialFacets } = useStore();
   const metadataFieldConfigs = useMetadataFieldConfigs();
 
-  // Order matters. Field configs defined in initialFields/initialFacets will be overwritten
+  // Order matters. Field configs defined in initialFields/initialFacets will be overwritten.
   const allFieldConfigs = { ...initialFields, ...initialFacets, ...metadataFieldConfigs };
   return Object.entries(allFieldConfigs).reduce((acc, [metadataFieldName, metadataFieldConfig]) => {
     return produce(acc, (draft) => {
@@ -61,7 +61,8 @@ function useFieldGroups() {
 
 function buildFieldConfigs(fieldNames) {
   return fieldNames.reduce((acc, fieldName) => {
-    if (fieldName === 'version') {
+    const excludedFieldNames = ['version'];
+    if (excludedFieldNames.includes(fieldName) {
       return acc;
     }
     return {


### PR DESCRIPTION
Sorts the configure table by 'General' non-metadata fields then entity type primarily and alphabetically secondarily. 

@mccalluc I removed 'version' from the available fields, do you know of other fields that we might not want available? 

<img width="959" alt="Screen Shot 2022-05-05 at 10 20 54 AM" src="https://user-images.githubusercontent.com/62477388/166945338-4fe22e8b-8e58-4340-a8c1-92e696397444.png">
