### PR TITLE
John conroy/fix source sample access

### DIFF
--- a/CHANGELOG-fix-source-sample-access.md
+++ b/CHANGELOG-fix-source-sample-access.md
@@ -1,0 +1,1 @@
+- Fix how the search results accesses sample metadata from elasticsearch.

--- a/context/app/static/js/components/entity-search/ResultsTable/ResultsTable.jsx
+++ b/context/app/static/js/components/entity-search/ResultsTable/ResultsTable.jsx
@@ -1,6 +1,5 @@
 /* eslint-disable no-underscore-dangle */
 import React from 'react';
-import get from 'lodash/get';
 import Table from '@material-ui/core/Table';
 import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
@@ -13,6 +12,7 @@ import { useStore } from 'js/components/entity-search/SearchWrapper/store';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import SortingHeaderCell from 'js/components/entity-search/results/SortingHeaderCell';
 import { StyledTableRow } from './style';
+import { getFieldFromHitFields } from './utils';
 
 function ResultsTable({ hits }) {
   const { fields } = useStore();
@@ -37,7 +37,7 @@ function ResultsTable({ hits }) {
                   {identifier === 'hubmap_id' ? (
                     <LightBlueLink href={`/browse/dataset/${hit.id}`}>{hit.fields[identifier]}</LightBlueLink>
                   ) : (
-                    get(hit.fields, identifier)
+                    getFieldFromHitFields(hit.fields, identifier)
                   )}
                 </TableCell>
               ))}

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.js
@@ -1,0 +1,15 @@
+import get from 'lodash/get';
+
+import { paths } from 'js/components/entity-search/SearchWrapper/metadataDocumentPaths';
+
+function getFieldFromHitFields(hitFields, identifier) {
+  const datasetSamplePath = paths.dataset.sample;
+  if (identifier.startsWith(datasetSamplePath)) {
+    // Unlike origin_sample, source_sample is an array and cannot be accessed with lodash/get
+    return hitFields?.source_sample?.[0].metadata[identifier.replace(`${datasetSamplePath}.`, '')];
+  }
+
+  return get(hitFields, identifier);
+}
+
+export { getFieldFromHitFields };

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.js
@@ -5,7 +5,7 @@ import { paths } from 'js/components/entity-search/SearchWrapper/metadataDocumen
 function getFieldFromHitFields(hitFields, identifier) {
   const datasetSamplePath = paths.dataset.sample;
   if (identifier.startsWith(datasetSamplePath)) {
-    // Unlike origin_sample, source_sample is an array and cannot be accessed with lodash/get
+    // Unlike origin_sample, source_sample is an array and cannot be accessed with lodash/get.
     return hitFields?.source_sample?.[0].metadata?.[identifier.replace(`${datasetSamplePath}.`, '')];
   }
 

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.js
@@ -6,7 +6,7 @@ function getFieldFromHitFields(hitFields, identifier) {
   const datasetSamplePath = paths.dataset.sample;
   if (identifier.startsWith(datasetSamplePath)) {
     // Unlike origin_sample, source_sample is an array and cannot be accessed with lodash/get
-    return hitFields?.source_sample?.[0].metadata[identifier.replace(`${datasetSamplePath}.`, '')];
+    return hitFields?.source_sample?.[0].metadata?.[identifier.replace(`${datasetSamplePath}.`, '')];
   }
 
   return get(hitFields, identifier);

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.spec.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.spec.js
@@ -1,0 +1,34 @@
+import { paths } from 'js/components/entity-search/SearchWrapper/metadataDocumentPaths';
+import { getFieldFromHitFields } from './utils';
+
+const datasetSamplePath = paths.dataset.sample;
+
+test('returns nested non source_sample fields', () => {
+  const hitFields = {
+    a: { b: 'c' },
+  };
+  expect(getFieldFromHitFields(hitFields, 'a.b')).toBe('c');
+});
+
+test('returns metadata field from source_sample', () => {
+  const hitFields = {
+    a: { b: 'c' },
+    source_sample: [{ metadata: { animal: 'cat' } }],
+  };
+  expect(getFieldFromHitFields(hitFields, `${datasetSamplePath}.animal`)).toBe('cat');
+});
+
+test('returns undefined if source_sample does not exist', () => {
+  const hitFields = {
+    a: { b: 'c' },
+  };
+  expect(getFieldFromHitFields(hitFields, `${datasetSamplePath}.fruit`)).toBeUndefined();
+});
+
+test('returns undefined if source_sample exists, but the field does not', () => {
+  const hitFields = {
+    a: { b: 'c' },
+    source_sample: [{ metadata: { animal: 'cat' } }],
+  };
+  expect(getFieldFromHitFields(hitFields, `${datasetSamplePath}.fruit`)).toBeUndefined();
+});

--- a/context/app/static/js/components/entity-search/SearchWrapper/metadataDocumentPaths.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/metadataDocumentPaths.js
@@ -1,0 +1,19 @@
+const donorMetadataPath = 'mapped_metadata';
+const sampleMetdataPath = 'metadata';
+
+const paths = {
+  donor: {
+    donor: donorMetadataPath,
+  },
+  sample: {
+    sample: sampleMetdataPath,
+    donor: `donor.${donorMetadataPath}`,
+  },
+  dataset: {
+    donor: `donor.${donorMetadataPath}`,
+    sample: `source_sample.${sampleMetdataPath}`,
+    dataset: 'metadata.metadata',
+  },
+};
+
+export { paths };

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.js
@@ -3,6 +3,7 @@ import { RefinementSelectFacet } from '@searchkit/sdk';
 import metadataFieldtoTypeMap from 'metadata-field-types';
 import metadataFieldtoEntityMap from 'metadata-field-entities';
 import { capitalizeString } from 'js/helpers/functions';
+import { paths } from 'js/components/entity-search/SearchWrapper/metadataDocumentPaths';
 
 // appends '.keyword' to field name for elasticsearch string fields
 function appendKeywordToFieldName({ fieldName, type }) {
@@ -15,24 +16,6 @@ function appendKeywordToFieldName({ fieldName, type }) {
 
 // gets elasticsearch document path to metadata fields for related entities given an entity type
 function prependMetadataPathToFieldName({ fieldName, pageEntityType }) {
-  const donorMetadataPath = 'mapped_metadata';
-  const sampleMetdataPath = 'metadata';
-
-  const paths = {
-    donor: {
-      donor: donorMetadataPath,
-    },
-    sample: {
-      sample: sampleMetdataPath,
-      donor: `donor.${donorMetadataPath}`,
-    },
-    dataset: {
-      donor: `donor.${donorMetadataPath}`,
-      sample: `source_sample.${sampleMetdataPath}`,
-      dataset: 'metadata.metadata',
-    },
-  };
-
   // get entity type from ingest-validation-types document which maps fields to their entity type
   const fieldEntityType = metadataFieldtoEntityMap?.[fieldName];
   const prefix = paths?.[pageEntityType]?.[fieldEntityType];


### PR DESCRIPTION
As we discussed, `source_sample` inside dataset es documents are arrays and must be handled differently.