### PR TITLE
Use alert as a stop-gap to report cells API errors

### DIFF
--- a/CHANGELOG-handle-4xx-from-cells-api.md
+++ b/CHANGELOG-handle-4xx-from-cells-api.md
@@ -1,0 +1,1 @@
+- Use `alert` as a stop-gap so we can understand how Cells API is working.

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -104,6 +104,12 @@ function DatasetsSelectedByExpression({
       setIsLoading(false);
     } catch (e) {
       setMessage(e.message);
+      // TODO: The message is displayed in this component...
+      // but after the user submits their data, the component collapses,
+      // so the message is hidden, and the user just sees the please wait.
+      // Not sure what the best long term solution is, but this unblocks Nils.
+      // eslint-disable-next-line no-alert
+      alert(e.message);
     }
   }
 


### PR DESCRIPTION
This is half-baked:
- We need to do work upstream in the SDK to distinguish expected and unexpected errors.
- We need to figure out how to report errors better... right now it appears after the button... but the whole div is closed by that point and the user is watching the spinner.
<img width="202" alt="Screen Shot 2022-05-24 at 6 16 00 PM" src="https://user-images.githubusercontent.com/730388/170141386-4b7a66c1-621b-488e-ae49-69f9686946a8.png">

- ... but we also just want to get something out the door, so @ngehlenborg can determine if the API is sufficiently reliable to move forward.

Perhaps filing a followup issue would be good? Or wait until the course forward is more clear? Or you might be able to make a quick improvement on this.
