### PR TITLE
update matomo host

### DIFF
--- a/CHANGELOG-update-matomo-id.md
+++ b/CHANGELOG-update-matomo-id.md
@@ -1,0 +1,1 @@
+- Update matomo init to reflect the new, paid, account.

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -8,7 +8,7 @@ function getSiteId(location) {
   // https://hubmap.matomo.cloud/index.php?module=SitesManager
 
   switch (host) {
-    case 'portal.hubmap.org':
+    case 'portal.hubmapconsortium.org':
       return 1;
     case 'localhost:5001':
       return 2;

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -5,10 +5,10 @@ function getSiteId(location) {
   const { host } = location;
 
   // siteIds should correspond to the list at:
-  // https://hubmapconsortium.matomo.cloud/index.php?module=SitesManager
+  // https://hubmap.matomo.cloud/index.php?module=SitesManager
 
   switch (host) {
-    case 'portal.hubmapconsortium.org':
+    case 'portal.hubmap.org':
       return 1;
     case 'localhost:5001':
       return 2;
@@ -18,12 +18,12 @@ function getSiteId(location) {
 }
 
 const tracker = new MatomoTracker({
-  urlBase: 'https://hubmapconsortium.matomo.cloud/',
+  urlBase: 'https://hubmap.matomo.cloud/',
   // eslint-disable-next-line no-restricted-globals
   siteId: getSiteId(location),
   // userId: 'UID76903202', // optional, default value: `undefined`.
-  // trackerUrl: 'https://LINK.TO.DOMAIN/tracking.php', // optional, default value: `${urlBase}matomo.php`
-  // srcUrl: 'https://LINK.TO.DOMAIN/tracking.js', // optional, default value: `${urlBase}matomo.js`
+  // trackerUrl: 'https://hubmap.matomo.cloud/tracking.php', // optional, default value: `${urlBase}matomo.php`
+  // srcUrl: 'https://hubmap.matomo.cloud/tracking.js', // optional, default value: `${urlBase}matomo.js`
   disabled: process.env.NODE_ENV === 'test', // Tracking calls should be no-ops during tests.
   // heartBeat: { // optional, enabled by default
   //   active: true, // optional, default value: true


### PR DESCRIPTION
Before merging this, we should confirm that it's logging events correctly. To do that, we need to add localhost to the list: I don't have privs. When setting up sites in the dashboard, Matomo only cares about the integer ID: The mapping from hostname to integer ID happens in our code.

- @ngehlenborg, please add websites `2` (localhost) and `3` (other) at https://hubmap.matomo.cloud/index.php?module=SitesManager.
- I think you'll also need to add John, Tiffany, and myself as users on each site. (Permissions go site by site.)
- @john-conroy, when that's done, checkout this branch, load http://localhost:5001 in one window, and look at https://hubmap.matomo.cloud/index.php in the other: You should see events being logged.