### PR TITLE
John conroy/add more default filters

### DIFF
--- a/CHANGELOG-add-more-default-filters.md
+++ b/CHANGELOG-add-more-default-filters.md
@@ -1,0 +1,1 @@
+- Add default filters used in the existing search page to the search revision.

--- a/context/app/static/js/components/entity-search/SearchWrapper/SearchWrapper.jsx
+++ b/context/app/static/js/components/entity-search/SearchWrapper/SearchWrapper.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { SearchkitClient, SearchkitProvider } from '@searchkit/client';
 
 import Search from 'js/components/entity-search/Search';
+import { getDefaultFilters } from 'js/components/entity-search/searchkit-modifications/getDefaultFilters';
 import {
   mergeObjects,
   getDonorMetadataFields,
@@ -31,7 +32,7 @@ function SearchWrapper({ uniqueFacets, uniqueFields, entityType }) {
     createField({ fieldName: 'mapped_last_modified_timestamp', label: 'Last Modified', type: 'string' }),
   ]);
 
-  const defaultFilters = getEntityTypeFilter(entityType);
+  const defaultFilters = mergeObjects([getEntityTypeFilter(entityType), getDefaultFilters()]);
 
   const numericFacetsProps = useNumericFacetsProps(entityType);
 

--- a/context/app/static/js/components/entity-search/searchkit-modifications/getDefaultFilters.js
+++ b/context/app/static/js/components/entity-search/searchkit-modifications/getDefaultFilters.js
@@ -1,0 +1,37 @@
+// Copied from https://www.searchkit.co/docs/core/customisations/customisations-filters
+// Modified to handle our default filters
+
+import { getDefaultQuery } from 'js/helpers/functions';
+
+const filterIdentifier = 'defaultQueryFilters';
+class DefaultFilters {
+  // We cannot make getIdentifier and getFilters static methods because they are consumed by searchkit.
+
+  // eslint-disable-next-line class-methods-use-this
+  getIdentifier() {
+    return filterIdentifier;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  getFilters() {
+    return getDefaultQuery();
+  }
+
+  getSelectedFilter() {
+    return {
+      id: this.getIdentifier(),
+      identifier: this.getIdentifier(),
+    };
+  }
+}
+
+function getDefaultFilters() {
+  return {
+    [filterIdentifier]: {
+      definition: new DefaultFilters(),
+      value: { identifier: filterIdentifier },
+    },
+  };
+}
+
+export { getDefaultFilters };


### PR DESCRIPTION
Adds default filters to remove entities with `sub_status` and `next_revision_uuid`. The results should now match the existing search page.