### PR TITLE
Mccalluc/more version consistency

### DIFF
--- a/CHANGELOG-docker-dep-versioning.md
+++ b/CHANGELOG-docker-dep-versioning.md
@@ -1,0 +1,1 @@
+- Parameterize the docker build, so that it will also be in sync with the versions used in CI and in dev-start.sh.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -o errexit
+
+die() { set +v; echo "$*" 1>&2 ; exit 1; }
+
+IMAGE_NAME=$1
+[[ ! -z "$IMAGE_NAME" ]] || die "One argument, an image name, is required."
+
+NODE_V=$(cat .nvmrc | perl -pne 's/v//')
+PYTHON_MINOR_V=$(cat .python-version | perl -pne 's/\.\d+$//')
+echo "Building $IMAGE_NAME with Node $NODE_V and Python $PYTHON_MINOR_V..."
+
+# Docker BuildKit supports parallelizing multi-stage builds.
+# https://medium.com/@tonistiigi/advanced-multi-stage-build-patterns-6f741b852fae
+# https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds
+DOCKER_BUILDKIT=1 docker build \
+  --tag $IMAGE_NAME \
+  --build-arg NODE_V=$NODE_V \
+  --build-arg PYTHON_MINOR_V=$PYTHON_MINOR_V \
+  context

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,8 @@ die() { set +v; echo "$*" 1>&2 ; exit 1; }
 IMAGE_NAME=$1
 [[ ! -z "$IMAGE_NAME" ]] || die "One argument, an image name, is required."
 
-NODE_V=$(cat .nvmrc | perl -pne 's/v//')
-PYTHON_MINOR_V=$(cat .python-version | perl -pne 's/\.\d+$//')
+NODE_V=$(perl -pne 's/v//' .nvmrc )
+PYTHON_MINOR_V=$(perl -pne 's/\.\d+$//' .python-version)
 echo "Building $IMAGE_NAME with Node $NODE_V and Python $PYTHON_MINOR_V..."
 
 # Docker BuildKit supports parallelizing multi-stage builds.

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,4 +1,6 @@
 ARG NODE_V
+ARG PYTHON_MINOR_V
+
 FROM node:${NODE_V}-alpine as builder
 
 WORKDIR /work
@@ -19,7 +21,6 @@ COPY ingest-validation-tools ingest-validation-tools
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 
-ARG PYTHON_MINOR_V
 FROM tiangolo/uwsgi-nginx-flask:python${PYTHON_MINOR_V}
 
 COPY requirements.txt /app

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:12.16.3-alpine as builder
+ARG NODE_V
+FROM node:${NODE_V}-alpine as builder
+
 WORKDIR /work
 RUN apk add --no-cache python git
 
@@ -17,7 +19,8 @@ COPY ingest-validation-tools ingest-validation-tools
 ENV NODE_OPTIONS="--max-old-space-size=4096"
 RUN npm run build
 
-FROM tiangolo/uwsgi-nginx-flask:python3.9
+ARG PYTHON_MINOR_V
+FROM tiangolo/uwsgi-nginx-flask:python${PYTHON_MINOR_V}
 
 COPY requirements.txt /app
 RUN pip install -r /app/requirements.txt

--- a/docker.sh
+++ b/docker.sh
@@ -5,7 +5,6 @@ die() { set +v; echo "$*" 1>&2 ; exit 1; }
 
 IMAGE_NAME=hubmap/portal-ui
 CONTAINER_NAME=hubmap-portal-ui
-CONTEXT=context
 CONF_PATH=context/instance/app.conf
 PORT=$1
 
@@ -16,10 +15,7 @@ Copy example-app.conf and fill in blanks."
 
 docker rm -f $CONTAINER_NAME || echo "$CONTAINER_NAME is not yet running."
 
-# Docker BuildKit supports parallelizing multi-stage builds.
-# https://medium.com/@tonistiigi/advanced-multi-stage-build-patterns-6f741b852fae
-# https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds
-DOCKER_BUILDKIT=1 docker build --tag $IMAGE_NAME $CONTEXT
+./build.sh $IMAGE_NAME
 docker run -d \
   --name $CONTAINER_NAME \
   -p $PORT:80 \

--- a/push.sh
+++ b/push.sh
@@ -56,7 +56,7 @@ fi
 VERSION_IMAGE_NAME=hubmap/portal-ui:$VERSION
 LATEST_IMAGE_NAME=hubmap/portal-ui:latest
 
-docker build --tag $VERSION_IMAGE_NAME context
+./build.sh $VERSION_IMAGE_NAME
 docker tag $VERSION_IMAGE_NAME $LATEST_IMAGE_NAME
 docker push $VERSION_IMAGE_NAME
 docker push $LATEST_IMAGE_NAME


### PR DESCRIPTION
Extending the work begun in #2701
- Could probably use sed instead of perl... but perl regexes worked like I expected out of the box, and sed didn't.
- For just one or two parameters in bash, I think reading from `$1` or `$2` is fine, and the complexity of getopts isn't worth it
- `push.sh` wasn't using parallel builds, so you should get a small speedup from this.