### PR TITLE
Mccalluc/show workspace api in service list

### DIFF
--- a/CHANGELOG-ws-service.md
+++ b/CHANGELOG-ws-service.md
@@ -1,0 +1,1 @@
+- Provide what information we have on workspaces on the services page.

--- a/context/app/static/js/components/ServiceStatusTable/ServiceStatusTable.jsx
+++ b/context/app/static/js/components/ServiceStatusTable/ServiceStatusTable.jsx
@@ -15,9 +15,9 @@ import StatusIcon from './StatusIcon';
 import { useGatewayStatus } from './hooks';
 
 function buildServiceStatus(args) {
-  const { apiName, endpointUrl, githubUrl, response, noteFunction } = args;
+  const { apiName, endpointUrl, githubUrl, response = {}, noteFunction } = args;
   const { build, version: apiVersion, api_auth } = response;
-  const isUp = api_auth || apiName === 'gateway';
+  const isUp = apiName === 'gateway' || api_auth;
   // The gateway is implicit: If it's not up, you wouldn't get anything at all,
   // (and you wouldn't be able to get to the portal in the first place.)
   return {
@@ -32,7 +32,15 @@ function buildServiceStatus(args) {
 }
 
 function ServiceStatusTable(props) {
-  const { elasticsearchEndpoint, assetsEndpoint, xmodalityEndpoint, entityEndpoint, gatewayEndpoint } = props;
+  const {
+    elasticsearchEndpoint,
+    assetsEndpoint,
+    xmodalityEndpoint,
+    entityEndpoint,
+    gatewayEndpoint,
+    workspacesEndpoint,
+    workspacesWsEndpoint,
+  } = props;
   const gatewayStatus = useGatewayStatus(`${gatewayEndpoint}/status.json`);
 
   const apiStatuses = gatewayStatus
@@ -84,6 +92,18 @@ function ServiceStatusTable(props) {
           apiName: 'uuid-api',
           response: gatewayStatus.uuid_api,
           noteFunction: (api) => `MySQL: ${api.mysql_connection}`,
+        }),
+        buildServiceStatus({
+          apiName: 'workspaces-api',
+          endpointUrl: workspacesEndpoint,
+          githubUrl: 'https://github.com/hubmapconsortium/user_workspaces_server',
+          noteFunction: () => 'TODO: Waiting for gateway to provide info',
+        }),
+        buildServiceStatus({
+          apiName: 'workspaces-ws-api',
+          endpointUrl: workspacesWsEndpoint,
+          githubUrl: 'https://github.com/hubmapconsortium/user_workspaces_server',
+          noteFunction: () => 'TODO: Waiting for gateway to provide info',
         }),
       ]
     : [];


### PR DESCRIPTION
On https://portal.hubmapconsortium.org/services adds:
<img width="970" alt="Screen Shot 2022-06-27 at 1 47 01 PM" src="https://user-images.githubusercontent.com/730388/176003733-904c4d30-418c-48d2-8cd6-2a2813dfa808.png">


- @jpuerto-psc : Mostly want to confirm that https://github.com/hubmapconsortium/user_workspaces_server/issues/28 and https://github.com/hubmapconsortium/user_workspaces_server/issues/34 are on your radar. I don't think this PR needs to wait on them... but when that information is available, this is where it will be used.
- @john-conroy : normal review.