### PR TITLE
Fix plurals in workspace section header.

### DIFF
--- a/CHANGELOG-workspace-header-plural.md
+++ b/CHANGELOG-workspace-header-plural.md
@@ -1,0 +1,1 @@
+- Fix plurals in workspace section header.

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -50,7 +50,7 @@ function WorkspacesList() {
       <SpacedSectionButtonRow
         leftText={
           <Typography variant="subtitle1">
-            {workspacesList.length} Workspace{workspacesList.length && 's'}
+            {workspacesList.length} Workspace{workspacesList.length !== 1 && 's'}
           </Typography>
         }
         buttons={


### PR DESCRIPTION
I think "0 Workspaces" (with the "s") sounds right?

Right now what I see in the header is
> 0 Workspace0