### PR TITLE
change to "marker"... or "Select gene to query"

### DIFF
--- a/CHANGELOG-not-substring.md
+++ b/CHANGELOG-not-substring.md
@@ -1,0 +1,1 @@
+- In Cells UI, change from "substring" to something domain specific.

--- a/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
+++ b/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
@@ -57,7 +57,7 @@ function AutocompleteEntity(props) {
       }}
       renderInput={(params) => (
         <TextField
-          label="marker"
+          label={`Select ${targetEntity} to query`}
           value={substring}
           name="substring"
           variant="outlined"

--- a/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
+++ b/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
@@ -57,7 +57,7 @@ function AutocompleteEntity(props) {
       }}
       renderInput={(params) => (
         <TextField
-          label="substring"
+          label="marker"
           value={substring}
           name="substring"
           variant="outlined"


### PR DESCRIPTION
- Fix #2766

I'm not confident this is the right choice... would it be better to say `gene or protein` or either `gene` or `protein` depending on the context?

(Whatever the name is here, I think keeping the same name internally makes sense: Devs are just going to think of it as a substring.)

<img width="189" alt="Screen Shot 2022-07-22 at 5 24 57 PM" src="https://user-images.githubusercontent.com/730388/180570767-fdf6e341-ad2f-4744-a5d7-e1b51cef04e8.png">
