### PR TITLE
cells title is just "Cells | HuBMAP" now

### DIFF
--- a/CHANGELOG-cells-title.md
+++ b/CHANGELOG-cells-title.md
@@ -1,0 +1,1 @@
+- Page title had been 'Cells API Demo' ... but we're moving into production, so shorten it to 'Cells'.

--- a/context/app/routes_cells.py
+++ b/context/app/routes_cells.py
@@ -21,7 +21,7 @@ blueprint = make_blueprint(__name__)
 def cells_ui():
     return render_template(
         'base-pages/react-content.html',
-        title='Cells API Demo',
+        title='Cells',
         flask_data={**get_default_flask_data()}
     )
 


### PR DESCRIPTION
@ngehlenborg -- There was some question as to whether this was all you wanted, or if you were thinking something else is needed. This string is concatenated with ` | HuBMAP` for the html title. The on-page title is still just "Cells".

Fix #2770.