### PR TITLE
Fix `KeyError: 'files'`

### DIFF
--- a/CHANGELOG-keyerror-files.md
+++ b/CHANGELOG-keyerror-files.md
@@ -1,0 +1,1 @@
+- Instead of failing in python, vitessce load now fails... which is a little better.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -163,7 +163,7 @@ class ApiClient():
             # TODO: Entity structure will change in the future to be consistent
             # about "files". Bill confirms that when the new structure comes in
             # there will be a period of backward compatibility to allow us to migrate.
-            derived_entity['files'] = derived_entity['metadata']['files']
+            derived_entity['files'] = derived_entity['metadata'].get('files', [])
             vitessce_conf = self.get_vitessce_conf_cells_and_lifted_uuid(
                 derived_entity, marker=marker
             ).vitessce_conf


### PR DESCRIPTION
- Towards #2772

Instead of failing in python, vitessce load now fails... which is a little better.