### PR TITLE
Mccalluc/bump vis for codex highlight

### DIFF
--- a/CHANGELOG-codex-sprm-vis.md
+++ b/CHANGELOG-codex-sprm-vis.md
@@ -1,0 +1,2 @@
+- Support marker selection in CODEX (Cytokit + SPRM) via URL parameter.
+

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "portal-ui",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.4",

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -10,7 +10,7 @@ hubmap-api-py-client>=0.0.9
 hubmap-commons>=2.0.12
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.5.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.6.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -638,8 +638,8 @@ platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
     --hash=sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227
     # via black
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.5.zip \
-    --hash=sha256:d79b6793b6146ec6847fc86e67e2483e2f25d68c47fa55b7b7736e10e1b70fbc
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.6.zip \
+    --hash=sha256:cac84bd484b926bba8fd6bea91f88fba89cb6e38bb0179215f22e7574a03335d
     # via -r context/requirements.in
 property==2.2 \
     --hash=sha256:d25e4da4e415408b9eb39b6521c088e4e2b8a9e2f9f96fb2d91680e97207ea19


### PR DESCRIPTION
Filing as draft. I thought I had tested it with vis-preview.py... but doesn't seem to work, or at least

- http://localhost:5001/browse/dataset/43213991a54ce196d406707ffe2e86bd?marker=FoxP3

doesn't work. (Reached from cells doing a protein query for `FoxP3 | Expression Level 10<sup>-3</sup> | 1% Cell Percentage`.)

- Fix #2764

