### PR TITLE
Mccalluc/fix devsearch sort

### DIFF
--- a/CHANGELOG-fix-devsearch-sort.md
+++ b/CHANGELOG-fix-devsearch-sort.md
@@ -1,0 +1,1 @@
+- Fix column sort on dev-search.

--- a/context/app/static/js/components/searchPage/DevResults/DevResults.jsx
+++ b/context/app/static/js/components/searchPage/DevResults/DevResults.jsx
@@ -8,7 +8,15 @@ import ResultsTable from '../ResultsTable';
 import ResultsCCF from '../ResultsCCF';
 
 function DevResults(props) {
-  const { sortOptions, hitsPerPage, tableResultFields, detailsUrlPrefix, idField, resultFieldIds } = props;
+  const {
+    sortOptions,
+    hitsPerPage,
+    tableResultFields,
+    detailsUrlPrefix,
+    idField,
+    resultFieldIds,
+    analyticsCategory,
+  } = props;
 
   return (
     <ViewSwitcherHits
@@ -23,7 +31,7 @@ function DevResults(props) {
               detailsUrlPrefix={detailsUrlPrefix}
               idField={idField}
               sortOptions={sortOptions}
-              analyticsCategory="dev-search"
+              analyticsCategory={analyticsCategory}
             />
           ),
           defaultOption: true,

--- a/context/app/static/js/components/searchPage/DevResults/DevResults.jsx
+++ b/context/app/static/js/components/searchPage/DevResults/DevResults.jsx
@@ -23,6 +23,7 @@ function DevResults(props) {
               detailsUrlPrefix={detailsUrlPrefix}
               idField={idField}
               sortOptions={sortOptions}
+              analyticsCategory="dev-search"
             />
           ),
           defaultOption: true,


### PR DESCRIPTION
- Fix #2781

I think we've actually been missing the `category` on dev-search events for a while, but the GA library is less fussy than Matomo, so we didn't get an error before. It was being passed in in `DevSearch.jsx`:

```
    <SearchWrapper
      {...allProps}
      resultsComponent={DevResults}
      analyticsCategory="Dev Search Page Interactions"
      isDevSearch
      elasticsearchEndpoint={elasticsearchEndpoint}
      groupsToken={groupsToken}
    />
```

... it just wasn't being used downstream.