### PR TITLE
Mccalluc/only show one status

### DIFF
--- a/CHANGELOG-clean-status.md
+++ b/CHANGELOG-clean-status.md
@@ -1,0 +1,1 @@
+- Change the display of workspace status to match Tiffany's spec.

--- a/CHANGELOG-only-offer-start-job-if-no-active-pending.md
+++ b/CHANGELOG-only-offer-start-job-if-no-active-pending.md
@@ -1,0 +1,1 @@
+- Only offer to start jupyter is there is nothing active or pending.

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -3,24 +3,44 @@ import React from 'react';
 import { LightBlueLink } from 'js/shared-styles/Links';
 
 const ACTIVE = 'Active';
+const ACTIVATING = 'Activating';
+const INACTIVE = 'Inactive';
 
-function mapStatus(status) {
+function getDisplayStatus(status) {
   return (
     {
-      pending: 'Activating',
+      pending: ACTIVATING,
       running: ACTIVE,
-    }[status] || 'Inactive'
+    }[status] || INACTIVE
   );
 }
 
-function JobDetails({ job }) {
-  const status = mapStatus(job.status);
+function getJobUrl(job) {
   const { url_domain, url_path } = job.job_details.current_job_details.connection_details;
+  return `${url_domain}${url_path}`;
+}
 
-  if (status !== ACTIVE) {
-    return `Status: ${status}`;
+function JobDetails({ jobs }) {
+  const displayJobs = jobs.map((job) => {
+    const diplayJob = { ...job };
+    diplayJob.status = getDisplayStatus(job.status);
+    return diplayJob;
+  });
+
+  const firstActiveJob = displayJobs.filter((job) => job.status === ACTIVE)[0];
+  const firstActivatingJob = displayJobs.filter((job) => job.status === ACTIVATING)[0];
+  const firstInactiveJob = displayJobs.filter((job) => job.status === INACTIVE)[0];
+
+  if (firstActiveJob) {
+    return <LightBlueLink href={getJobUrl(firstActiveJob)}>Status: {firstActiveJob.status}</LightBlueLink>;
   }
-  return <LightBlueLink href={`${url_domain}${url_path}`}>Status: {status}</LightBlueLink>;
+  if (firstActivatingJob) {
+    return `Status: ${firstActivatingJob.status}`;
+  }
+  if (firstInactiveJob) {
+    return `Status: ${firstInactiveJob.status}`;
+  }
+  return '';
 }
 
 export default JobDetails;

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -12,16 +12,14 @@ function mapStatus(status) {
 }
 
 function JobDetails({ job }) {
-  const { status, datetime_created } = job;
+  const { status } = job;
   const details = job.job_details.current_job_details.connection_details;
   // I would destructure details...
   // except that in some cases connection_details has been missing.
   return (
     <div>
       {details ? (
-        <LightBlueLink href={`${details.url_domain}${details.url_path}`}>
-          Jupyter ({mapStatus(status)}, {datetime_created})
-        </LightBlueLink>
+        <LightBlueLink href={`${details.url_domain}${details.url_path}`}>Jupyter ({mapStatus(status)})</LightBlueLink>
       ) : (
         'Jupyter not available'
       )}

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -1,12 +1,38 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
+import { AppContext } from 'js/components/Providers';
 import { LightBlueLink } from 'js/shared-styles/Links';
-import { condenseJobs } from './utils';
+import { condenseJobs, startJob } from './utils';
 
-function JobDetails({ jobs }) {
+function JobDetails({ workspace, jobs }) {
+  const { workspacesEndpoint, workspacesToken } = useContext(AppContext);
+
+  function createHandleStart(workspaceId) {
+    async function handleStart() {
+      startJob({ workspaceId, workspacesEndpoint, workspacesToken });
+    }
+    return handleStart;
+  }
+
   const job = condenseJobs(jobs);
 
-  if (!job) {
+  return (
+    <div>
+      <div>
+        <b>{workspace.name}</b>
+      </div>
+      {job.allowNew && (
+        <button onClick={createHandleStart(workspace.id)} type="button">
+          Start Jupyter
+        </button>
+      )}
+      <JobDetailsDetails job={job} />
+    </div>
+  );
+}
+
+function JobDetailsDetails({ job }) {
+  if (!job.status) {
     return null;
   }
   if (job.url) {

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -1,43 +1,18 @@
 import React from 'react';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
-
-const ACTIVE = 'Active';
-const ACTIVATING = 'Activating';
-const INACTIVE = 'Inactive';
-
-function getDisplayStatus(status) {
-  return (
-    {
-      pending: ACTIVATING,
-      running: ACTIVE,
-    }[status] || INACTIVE
-  );
-}
-
-function getJobUrl(job) {
-  const { url_domain, url_path } = job.job_details.current_job_details.connection_details;
-  return `${url_domain}${url_path}`;
-}
+import { condenseJobs } from './utils';
 
 function JobDetails({ jobs }) {
-  const displayJobs = jobs.map((job) => {
-    const diplayJob = { ...job };
-    diplayJob.status = getDisplayStatus(job.status);
-    return diplayJob;
-  });
+  const job = condenseJobs(jobs);
 
-  const bestJob = [ACTIVE, ACTIVATING, INACTIVE]
-    .map((status) => displayJobs.find((job) => job.status === status))
-    .find((job) => job);
-
-  if (!bestJob) {
+  if (!job) {
     return null;
   }
-  if (bestJob.status === ACTIVE) {
-    return <LightBlueLink href={getJobUrl(bestJob)}>Status: {ACTIVE}</LightBlueLink>;
+  if (job.url) {
+    return <LightBlueLink href={job.url}>Status: {job.status}</LightBlueLink>;
   }
-  return `Status: ${bestJob.status}`;
+  return `Status: ${job.status}`;
 }
 
 export default JobDetails;

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -2,6 +2,15 @@ import React from 'react';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 
+function mapStatus(status) {
+  return (
+    {
+      pending: 'Activating',
+      running: 'Active',
+    }[status] || 'Inactive'
+  );
+}
+
 function JobDetails({ job }) {
   const { status, datetime_created } = job;
   const details = job.job_details.current_job_details.connection_details;
@@ -11,7 +20,7 @@ function JobDetails({ job }) {
     <div>
       {details ? (
         <LightBlueLink href={`${details.url_domain}${details.url_path}`}>
-          Jupyter ({status}, {datetime_created})
+          Jupyter ({mapStatus(status)}, {datetime_created})
         </LightBlueLink>
       ) : (
         'Jupyter not available'

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
 
+const ACTIVE = 'Active';
+
 function mapStatus(status) {
   return (
     {
       pending: 'Activating',
-      running: 'Active',
+      running: ACTIVE,
     }[status] || 'Inactive'
   );
 }
@@ -15,6 +17,9 @@ function JobDetails({ job }) {
   const status = mapStatus(job.status);
   const { url_domain, url_path } = job.job_details.current_job_details.connection_details;
 
+  if (status !== ACTIVE) {
+    return `Status: ${status}`;
+  }
   return <LightBlueLink href={`${url_domain}${url_path}`}>Status: {status}</LightBlueLink>;
 }
 

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -12,19 +12,10 @@ function mapStatus(status) {
 }
 
 function JobDetails({ job }) {
-  const { status } = job;
-  const details = job.job_details.current_job_details.connection_details;
-  // I would destructure details...
-  // except that in some cases connection_details has been missing.
-  return (
-    <div>
-      {details ? (
-        <LightBlueLink href={`${details.url_domain}${details.url_path}`}>Jupyter ({mapStatus(status)})</LightBlueLink>
-      ) : (
-        'Jupyter not available'
-      )}
-    </div>
-  );
+  const status = mapStatus(job.status);
+  const { url_domain, url_path } = job.job_details.current_job_details.connection_details;
+
+  return <LightBlueLink href={`${url_domain}${url_path}`}>Status: {status}</LightBlueLink>;
 }
 
 export default JobDetails;

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -27,21 +27,17 @@ function JobDetails({ jobs }) {
     return diplayJob;
   });
 
-  const firstActiveJob = displayJobs.find((job) => job.status === ACTIVE);
-  if (firstActiveJob) {
-    return <LightBlueLink href={getJobUrl(firstActiveJob)}>Status: {firstActiveJob.status}</LightBlueLink>;
-  }
+  const bestJob = [ACTIVE, ACTIVATING, INACTIVE]
+    .map((status) => displayJobs.find((job) => job.status === status))
+    .find((job) => job);
 
-  const firstActivatingJob = displayJobs.find((job) => job.status === ACTIVATING);
-  if (firstActivatingJob) {
-    return `Status: ${firstActivatingJob.status}`;
+  if (!bestJob) {
+    return null;
   }
-
-  const firstInactiveJob = displayJobs.find((job) => job.status === INACTIVE);
-  if (firstInactiveJob) {
-    return `Status: ${firstInactiveJob.status}`;
+  if (bestJob.status === ACTIVE) {
+    return <LightBlueLink href={getJobUrl(bestJob)}>Status: {ACTIVE}</LightBlueLink>;
   }
-  return '';
+  return `Status: ${bestJob.status}`;
 }
 
 export default JobDetails;

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -27,16 +27,17 @@ function JobDetails({ jobs }) {
     return diplayJob;
   });
 
-  const firstActiveJob = displayJobs.filter((job) => job.status === ACTIVE)[0];
-  const firstActivatingJob = displayJobs.filter((job) => job.status === ACTIVATING)[0];
-  const firstInactiveJob = displayJobs.filter((job) => job.status === INACTIVE)[0];
-
+  const firstActiveJob = displayJobs.find((job) => job.status === ACTIVE);
   if (firstActiveJob) {
     return <LightBlueLink href={getJobUrl(firstActiveJob)}>Status: {firstActiveJob.status}</LightBlueLink>;
   }
+
+  const firstActivatingJob = displayJobs.find((job) => job.status === ACTIVATING);
   if (firstActivatingJob) {
     return `Status: ${firstActivatingJob.status}`;
   }
+
+  const firstInactiveJob = displayJobs.find((job) => job.status === INACTIVE);
   if (firstInactiveJob) {
     return `Status: ${firstInactiveJob.status}`;
   }

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -8,7 +8,7 @@ import { DeleteIcon, AddIcon } from 'js/shared-styles/icons';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 import { PanelWrapper } from 'js/shared-styles/panels';
 
-import { createNotebookWorkspace, startJob } from './utils';
+import { createNotebookWorkspace } from './utils';
 import { useWorkspacesList } from './hooks';
 import { StyledButton } from './style';
 import JobDetails from './JobDetails';
@@ -40,13 +40,6 @@ function WorkspacesList() {
     // TODO: Update list on page
   }
 
-  function createHandleStart(workspaceId) {
-    async function handleStart() {
-      startJob({ workspaceId, workspacesEndpoint, workspacesToken });
-    }
-    return handleStart;
-  }
-
   return (
     <>
       <SpacedSectionButtonRow
@@ -73,15 +66,7 @@ function WorkspacesList() {
           workspacesList.map((workspace) => (
             /* TODO: Inbound links have fragments like "#workspace-123": Highlight? */
             <PanelWrapper key={workspace.id}>
-              <div>
-                <div>
-                  <b>{workspace.name}</b>
-                </div>
-                <button onClick={createHandleStart(workspace.id)} type="button">
-                  Start Jupyter
-                </button>
-                <JobDetails jobs={workspace.jobs} />
-              </div>
+              <JobDetails workspace={workspace} jobs={workspace.jobs} />
               <div>Created {workspace.datetime_created.slice(0, 10)}</div>
             </PanelWrapper>
           ))

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -80,9 +80,7 @@ function WorkspacesList() {
                 <button onClick={createHandleStart(workspace.id)} type="button">
                   Start Jupyter
                 </button>
-                {workspace.jobs.map((job) => (
-                  <JobDetails job={job} key={job.id} />
-                ))}
+                <JobDetails jobs={workspace.jobs} />
               </div>
               <div>Created {workspace.datetime_created.slice(0, 10)}</div>
             </PanelWrapper>

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -59,4 +59,42 @@ function mergeJobsIntoWorkspaces(jobs, workspaces) {
   return workspaces;
 }
 
-export { createNotebookWorkspace, startJob, mergeJobsIntoWorkspaces };
+function condenseJobs(jobs) {
+  const ACTIVE = 'Active';
+  const ACTIVATING = 'Activating';
+  const INACTIVE = 'Inactive';
+
+  function getDisplayStatus(status) {
+    return (
+      {
+        pending: ACTIVATING,
+        running: ACTIVE,
+      }[status] || INACTIVE
+    );
+  }
+
+  function getJobUrl(job) {
+    const { url_domain, url_path } = job.job_details.current_job_details.connection_details;
+    return `${url_domain}${url_path}`;
+  }
+
+  const displayJobs = jobs.map((job) => {
+    const diplayJob = { ...job };
+    diplayJob.status = getDisplayStatus(job.status);
+    return diplayJob;
+  });
+
+  const bestJob = [ACTIVE, ACTIVATING, INACTIVE]
+    .map((status) => displayJobs.find((job) => job.status === status))
+    .find((job) => job);
+
+  if (!bestJob) {
+    return null;
+  }
+  if (bestJob.status === ACTIVE) {
+    return { status: ACTIVE, url: getJobUrl(bestJob) };
+  }
+  return { status: bestJob.status };
+}
+
+export { createNotebookWorkspace, startJob, mergeJobsIntoWorkspaces, condenseJobs };

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -78,23 +78,24 @@ function condenseJobs(jobs) {
     return `${url_domain}${url_path}`;
   }
 
-  const displayJobs = jobs.map((job) => {
-    const diplayJob = { ...job };
-    diplayJob.status = getDisplayStatus(job.status);
-    return diplayJob;
-  });
+  const displayStatusJobs = jobs.map((job) => ({ ...job, status: getDisplayStatus(job.status) }));
 
   const bestJob = [ACTIVE, ACTIVATING, INACTIVE]
-    .map((status) => displayJobs.find((job) => job.status === status))
+    .map((status) => displayStatusJobs.find((job) => job.status === status))
     .find((job) => job);
 
-  if (!bestJob) {
-    return null;
+  const status = bestJob?.status;
+  switch (status) {
+    case ACTIVE:
+      return { status, allowNew: false, url: getJobUrl(bestJob) };
+    case ACTIVATING:
+      return { status, allowNew: false };
+    case INACTIVE:
+      return { status, allowNew: true };
+    default:
+      // No jobs of any status.
+      return { status, allowNew: true };
   }
-  if (bestJob.status === ACTIVE) {
-    return { status: ACTIVE, url: getJobUrl(bestJob) };
-  }
-  return { status: bestJob.status };
 }
 
 export { createNotebookWorkspace, startJob, mergeJobsIntoWorkspaces, condenseJobs };

--- a/context/app/static/js/components/workspaces/utils.spec.js
+++ b/context/app/static/js/components/workspaces/utils.spec.js
@@ -1,4 +1,4 @@
-import { mergeJobsIntoWorkspaces } from './utils';
+import { mergeJobsIntoWorkspaces, condenseJobs } from './utils';
 
 test('it should merge jobs into workspaces', () => {
   const workspaces = [{ id: 1, other_ws_info: true }];
@@ -17,4 +17,58 @@ test('it should merge jobs into workspaces', () => {
       ],
     },
   ]);
+});
+
+test('it should pick one active job if available', () => {
+  const jobs = [
+    {
+      status: 'pending',
+    },
+    {
+      status: 'running',
+      job_details: {
+        current_job_details: { connection_details: { url_domain: 'http://example.com/', url_path: 'this' } },
+      },
+    },
+    {
+      status: 'running',
+      job_details: {
+        current_job_details: { connection_details: { url_domain: 'http://example.com/', url_path: 'not-this' } },
+      },
+    },
+    {
+      status: 'other',
+    },
+  ];
+  const job = condenseJobs(jobs);
+  expect(job).toEqual({ status: 'Active', url: 'http://example.com/this' });
+});
+
+test('it should pick an activating job if no active jobs are available', () => {
+  const jobs = [
+    {
+      status: 'other',
+    },
+    {
+      status: 'pending',
+    },
+  ];
+  const job = condenseJobs(jobs);
+  expect(job).toEqual({ status: 'Activating' });
+});
+
+test('it should map unknown status codes', () => {
+  const jobs = [
+    {
+      status: 'other',
+    },
+  ];
+  const job = condenseJobs(jobs);
+  expect(job).toEqual({ status: 'Inactive' });
+});
+
+test('it should return null for an empty list', () => {
+  const jobs = [];
+  const job = condenseJobs(jobs);
+  expect(job).toEqual(null);
 });

--- a/context/app/static/js/components/workspaces/utils.spec.js
+++ b/context/app/static/js/components/workspaces/utils.spec.js
@@ -41,7 +41,7 @@ test('it should pick one active job if available', () => {
     },
   ];
   const job = condenseJobs(jobs);
-  expect(job).toEqual({ status: 'Active', url: 'http://example.com/this' });
+  expect(job).toEqual({ allowNew: false, status: 'Active', url: 'http://example.com/this' });
 });
 
 test('it should pick an activating job if no active jobs are available', () => {
@@ -54,7 +54,7 @@ test('it should pick an activating job if no active jobs are available', () => {
     },
   ];
   const job = condenseJobs(jobs);
-  expect(job).toEqual({ status: 'Activating' });
+  expect(job).toEqual({ allowNew: false, status: 'Activating' });
 });
 
 test('it should map unknown status codes', () => {
@@ -64,11 +64,11 @@ test('it should map unknown status codes', () => {
     },
   ];
   const job = condenseJobs(jobs);
-  expect(job).toEqual({ status: 'Inactive' });
+  expect(job).toEqual({ allowNew: true, status: 'Inactive' });
 });
 
 test('it should return null for an empty list', () => {
   const jobs = [];
   const job = condenseJobs(jobs);
-  expect(job).toEqual(null);
+  expect(job).toEqual({ allowNew: true, status: undefined });
 });


### PR DESCRIPTION
The modelling of jobs in the API is rather different from the design from Tiffany envisions. UIs exist to simplify things, so this isn't necessarily a problem... but I wanted to to get buy-in from @jpuerto-psc , so we're not trying to sort this out a month from now, when more has been built on top.

Notable differences:

- **This fixes #2801** 

The design uses a different set of terms from what the API returns: some don't correspond to states the API provides (ie, there is no "Deleting" state from the API) and other distinctions the API makes don't matter in the UI, so we're just left with 'Active', 'Activating', and 'Inactive'.

- **This fixes #2802**

A workspace can have multiple jobs... but the UI design just tells the user about a single job. To implement that, I scan the jobs, and just display the highest status I can find.

- **We don't display any job metadata**

Only if the job is "Active" do I show a link. Otherwise, the UI just has "Status: Activating" or "Status: Inactive", and nothing else.

@jpuerto-psc , if this is fine with you, (and @pdblood), great: Just approve. If it's not, I'd suggest:
- Review this, and request changes.
- Get in touch with Tiffany, and explain your usecase, and see if the UI design can change.
- If you can't get on the same page, no worries: Just document what the differences are, and we elevate to Nils and Phil.

Thanks!