### PR TITLE
Mccalluc/only offer start job if no active pending

### DIFF
--- a/CHANGELOG-only-offer-start-job-if-no-active-pending.md
+++ b/CHANGELOG-only-offer-start-job-if-no-active-pending.md
@@ -1,0 +1,1 @@
+- Only offer to start jupyter is there is nothing active or pending.

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -21,16 +21,18 @@ function JobDetails({ workspace, jobs }) {
       <div>
         <b>{workspace.name}</b>
       </div>
-      <button onClick={createHandleStart(workspace.id)} type="button">
-        Start Jupyter
-      </button>
+      {job.allowNew && (
+        <button onClick={createHandleStart(workspace.id)} type="button">
+          Start Jupyter
+        </button>
+      )}
       <JobDetailsDetails job={job} />
     </div>
   );
 }
 
 function JobDetailsDetails({ job }) {
-  if (!job) {
+  if (!job.status) {
     return null;
   }
   if (job.url) {

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -1,11 +1,35 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
+import { AppContext } from 'js/components/Providers';
 import { LightBlueLink } from 'js/shared-styles/Links';
-import { condenseJobs } from './utils';
+import { condenseJobs, startJob } from './utils';
 
-function JobDetails({ jobs }) {
+function JobDetails({ workspace, jobs }) {
+  const { workspacesEndpoint, workspacesToken } = useContext(AppContext);
+
+  function createHandleStart(workspaceId) {
+    async function handleStart() {
+      startJob({ workspaceId, workspacesEndpoint, workspacesToken });
+    }
+    return handleStart;
+  }
+
   const job = condenseJobs(jobs);
 
+  return (
+    <div>
+      <div>
+        <b>{workspace.name}</b>
+      </div>
+      <button onClick={createHandleStart(workspace.id)} type="button">
+        Start Jupyter
+      </button>
+      <JobDetailsDetails job={job} />
+    </div>
+  );
+}
+
+function JobDetailsDetails({ job }) {
   if (!job) {
     return null;
   }

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -8,7 +8,7 @@ import { DeleteIcon, AddIcon } from 'js/shared-styles/icons';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 import { PanelWrapper } from 'js/shared-styles/panels';
 
-import { createNotebookWorkspace, startJob } from './utils';
+import { createNotebookWorkspace } from './utils';
 import { useWorkspacesList } from './hooks';
 import { StyledButton } from './style';
 import JobDetails from './JobDetails';
@@ -40,13 +40,6 @@ function WorkspacesList() {
     // TODO: Update list on page
   }
 
-  function createHandleStart(workspaceId) {
-    async function handleStart() {
-      startJob({ workspaceId, workspacesEndpoint, workspacesToken });
-    }
-    return handleStart;
-  }
-
   return (
     <>
       <SpacedSectionButtonRow
@@ -73,15 +66,7 @@ function WorkspacesList() {
           workspacesList.map((workspace) => (
             /* TODO: Inbound links have fragments like "#workspace-123": Highlight? */
             <PanelWrapper key={workspace.id}>
-              <div>
-                <div>
-                  <b>{workspace.name}</b>
-                </div>
-                <button onClick={createHandleStart(workspace.id)} type="button">
-                  Start Jupyter
-                </button>
-                <JobDetails jobs={workspace.jobs} />
-              </div>
+              <JobDetails workspace={workspace} jobs={workspace.jobs} />
               <div>Created {workspace.datetime_created.slice(0, 10)}</div>
             </PanelWrapper>
           ))

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -78,10 +78,10 @@ function condenseJobs(jobs) {
     return `${url_domain}${url_path}`;
   }
 
-  const displayJobs = jobs.map((job) => ({ ...job, status: getDisplayStatus(job.status) }));
+  const displayStatusJobs = jobs.map((job) => ({ ...job, status: getDisplayStatus(job.status) }));
 
   const bestJob = [ACTIVE, ACTIVATING, INACTIVE]
-    .map((status) => displayJobs.find((job) => job.status === status))
+    .map((status) => displayStatusJobs.find((job) => job.status === status))
     .find((job) => job);
 
   const status = bestJob?.status;
@@ -93,6 +93,7 @@ function condenseJobs(jobs) {
     case INACTIVE:
       return { status, allowNew: true };
     default:
+      // No jobs of any status.
       return { status, allowNew: true };
   }
 }

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -78,11 +78,7 @@ function condenseJobs(jobs) {
     return `${url_domain}${url_path}`;
   }
 
-  const displayJobs = jobs.map((job) => {
-    const diplayJob = { ...job };
-    diplayJob.status = getDisplayStatus(job.status);
-    return diplayJob;
-  });
+  const displayJobs = jobs.map((job) => ({ ...job, status: getDisplayStatus(job.status) }));
 
   const bestJob = [ACTIVE, ACTIVATING, INACTIVE]
     .map((status) => displayJobs.find((job) => job.status === status))

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -84,17 +84,17 @@ function condenseJobs(jobs) {
     .map((status) => displayJobs.find((job) => job.status === status))
     .find((job) => job);
 
-  const justStatus = { status: bestJob?.status };
-  if (bestJob?.status === ACTIVE) {
-    return { ...justStatus, allowNew: false, url: getJobUrl(bestJob) };
+  const status = bestJob?.status;
+  switch (status) {
+    case ACTIVE:
+      return { status, allowNew: false, url: getJobUrl(bestJob) };
+    case ACTIVATING:
+      return { status, allowNew: false };
+    case INACTIVE:
+      return { status, allowNew: true };
+    default:
+      return { status, allowNew: true };
   }
-  if (bestJob?.status === ACTIVATING) {
-    return { ...justStatus, allowNew: false };
-  }
-  if (bestJob?.status === INACTIVE) {
-    return { ...justStatus, allowNew: true };
-  }
-  return { ...justStatus, allowNew: true };
 }
 
 export { createNotebookWorkspace, startJob, mergeJobsIntoWorkspaces, condenseJobs };

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -84,13 +84,17 @@ function condenseJobs(jobs) {
     .map((status) => displayJobs.find((job) => job.status === status))
     .find((job) => job);
 
-  if (!bestJob) {
-    return null;
+  const justStatus = { status: bestJob?.status };
+  if (bestJob?.status === ACTIVE) {
+    return { ...justStatus, allowNew: false, url: getJobUrl(bestJob) };
   }
-  if (bestJob.status === ACTIVE) {
-    return { status: ACTIVE, url: getJobUrl(bestJob) };
+  if (bestJob?.status === ACTIVATING) {
+    return { ...justStatus, allowNew: false };
   }
-  return { status: bestJob.status };
+  if (bestJob?.status === INACTIVE) {
+    return { ...justStatus, allowNew: true };
+  }
+  return { ...justStatus, allowNew: true };
 }
 
 export { createNotebookWorkspace, startJob, mergeJobsIntoWorkspaces, condenseJobs };

--- a/context/app/static/js/components/workspaces/utils.spec.js
+++ b/context/app/static/js/components/workspaces/utils.spec.js
@@ -41,7 +41,7 @@ test('it should pick one active job if available', () => {
     },
   ];
   const job = condenseJobs(jobs);
-  expect(job).toEqual({ status: 'Active', url: 'http://example.com/this' });
+  expect(job).toEqual({ allowNew: false, status: 'Active', url: 'http://example.com/this' });
 });
 
 test('it should pick an activating job if no active jobs are available', () => {
@@ -54,7 +54,7 @@ test('it should pick an activating job if no active jobs are available', () => {
     },
   ];
   const job = condenseJobs(jobs);
-  expect(job).toEqual({ status: 'Activating' });
+  expect(job).toEqual({ allowNew: false, status: 'Activating' });
 });
 
 test('it should map unknown status codes', () => {
@@ -64,11 +64,11 @@ test('it should map unknown status codes', () => {
     },
   ];
   const job = condenseJobs(jobs);
-  expect(job).toEqual({ status: 'Inactive' });
+  expect(job).toEqual({ allowNew: true, status: 'Inactive' });
 });
 
 test('it should return null for an empty list', () => {
   const jobs = [];
   const job = condenseJobs(jobs);
-  expect(job).toEqual(null);
+  expect(job).toEqual({ allowNew: true, status: undefined });
 });


### PR DESCRIPTION
@tsliaw -- I'm really just want to check in with you and make sure I'm handling the different job states correctly. The heart of it is this case statement:
```
    case ACTIVE:
      return { status, allowNew: false, url: getJobUrl(bestJob) };
      // ie: link to currently running, and no option to start new jupyter 
    case ACTIVATING:
      return { status, allowNew: false };
      // ie: no link, and no option to start new jupyter 
    case INACTIVE:
      return { status, allowNew: true };
      // ie: no link, but there is an option to start new jupyter 
    default:
      // No jobs of any status.
      return { status, allowNew: true };
      // ie: no status and no link, but there is an option to start new jupyter
```