### PR TITLE
Mccalluc/vis qa to es

### DIFF
--- a/CHANGELOG-better-vis-scan.md
+++ b/CHANGELOG-better-vis-scan.md
@@ -1,0 +1,1 @@
+- Add another parameter to the vis-scan script, so we can target other indices.

--- a/CHANGELOG-find-git-root.md
+++ b/CHANGELOG-find-git-root.md
@@ -1,0 +1,1 @@
+- Use Trevor's idiom for finding the git root.

--- a/scripts/qa/find-vis-bugs.py
+++ b/scripts/qa/find-vis-bugs.py
@@ -10,6 +10,7 @@ from flask import Flask
 # Run from anywhere:
 sys.path.append(str(Path(__file__).parent.parent.parent))
 from context.app.api.client import ApiClient  # noqa: E402
+from context.app.default_config import DefaultConfig  # noqa: E402
 
 
 def get_context(args):
@@ -22,7 +23,7 @@ def get_context(args):
         'TYPE_SERVICE_ENDPOINT': types_url,
         'ASSETS_ENDPOINT': assets_url,
         'ELASTICSEARCH_ENDPOINT': search_url,
-        'PORTAL_INDEX_PATH': '/portal/search'  # TODO: pull from default_config.py
+        'PORTAL_INDEX_PATH': DefaultConfig.PORTAL_INDEX_PATH
     })
 
     return app.app_context()
@@ -41,12 +42,15 @@ def get_errors():
         warn(f'{i}/{len(uuids)} ({len(errors)} errors): Checking {uuid} ...')
         try:
             before_conf = perf_counter()
-            client.get_vitessce_conf_cells_and_lifted_uuid(dataset, wrap_error=False)
+            conf_uuid = client.get_vitessce_conf_cells_and_lifted_uuid(dataset, wrap_error=False)
+            warn(
+                f'\tVis: {conf_uuid.vitessce_conf.conf is not None}; '
+                f'Lifted: {conf_uuid.vis_lifted_uuid} ')
             waiting_for_conf += perf_counter() - before_conf
         except Exception as e:
             warn(f'ERROR: {e}')
             errors[uuid] = e
-        warn(f'JSON: {waiting_for_json:.2f}s; Vitessce: {waiting_for_conf:.2f}s')
+        warn(f'\tJSON: {waiting_for_json:.2f}s; Vitessce: {waiting_for_conf:.2f}s')
     return errors
 
 

--- a/scripts/qa/find-vis-bugs.py
+++ b/scripts/qa/find-vis-bugs.py
@@ -13,6 +13,29 @@ from context.app.api.client import ApiClient  # noqa: E402
 from context.app.default_config import DefaultConfig  # noqa: E402
 
 
+def get_parser():
+    parser = argparse.ArgumentParser(
+        description='Scan all datasets for visualization bugs. Exits with status 0 if no errors.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--search_url',
+        default='https://search.api.hubmapconsortium.org',
+        help='Search API endpoint')
+    parser.add_argument(
+        '--portal_index_path',
+        default=DefaultConfig.PORTAL_INDEX_PATH,
+        help='Under the Search API endpoint, the particular index to use')
+    parser.add_argument(
+        '--types_url',
+        default='https://search.api.hubmapconsortium.org',
+        help='Type Service endpoint')
+    parser.add_argument(
+        '--assets_url',
+        default='https://assets.hubmapconsortium.org',
+        help='Assets endpoint')
+    return parser
+
+
 def get_context(args):
     search_url = args.search_url
     types_url = args.types_url
@@ -55,20 +78,7 @@ def get_errors():
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description='Scan all datasets for visualization bugs. Exits with status 0 if no errors.')
-    parser.add_argument(
-        '--search_url',
-        default='https://search.api.hubmapconsortium.org',
-        help='Search API endpoint')
-    parser.add_argument(
-        '--types_url',
-        default='https://search.api.hubmapconsortium.org',
-        help='Type Service endpoint')
-    parser.add_argument(
-        '--assets_url',
-        default='https://assets.hubmapconsortium.org',
-        help='Assets endpoint')
+    parser = get_parser()
 
     with get_context(parser.parse_args()):
         errors = get_errors()

--- a/scripts/qa/find-vis-bugs.py
+++ b/scripts/qa/find-vis-bugs.py
@@ -40,13 +40,14 @@ def get_context(args):
     search_url = args.search_url
     types_url = args.types_url
     assets_url = args.assets_url
+    portal_index_path = args.portal_index_path
 
     app = Flask(__name__)
     app.config.from_mapping({
         'TYPE_SERVICE_ENDPOINT': types_url,
         'ASSETS_ENDPOINT': assets_url,
         'ELASTICSEARCH_ENDPOINT': search_url,
-        'PORTAL_INDEX_PATH': DefaultConfig.PORTAL_INDEX_PATH
+        'PORTAL_INDEX_PATH': portal_index_path
     })
 
     return app.app_context()

--- a/scripts/qa/find-vis-bugs.py
+++ b/scripts/qa/find-vis-bugs.py
@@ -3,9 +3,6 @@
 from pathlib import Path
 import sys
 import argparse
-import requests
-from csv import DictReader, excel_tab
-from io import StringIO
 from time import perf_counter
 
 from flask import Flask
@@ -15,16 +12,13 @@ sys.path.append(str(Path(__file__).parent.parent.parent))
 from context.app.api.client import ApiClient  # noqa: E402
 
 
-client = ApiClient()
-
-
 def main():
     parser = argparse.ArgumentParser(
         description='Scan all datasets for visualization bugs. Exits with status 0 if no errors.')
     parser.add_argument(
-        '--portal_url',
-        default='https://portal.hubmapconsortium.org',
-        help='Portal instance to download TSV and JSON from')
+        '--entity_url',
+        default='https://search.api.hubmapconsortium.org/portal/search',
+        help='Entity API')
     parser.add_argument(
         '--types_url',
         default='https://search.api.hubmapconsortium.org',
@@ -35,39 +29,38 @@ def main():
         help='Assets endpoint')
     args = parser.parse_args()
 
-    portal_url = args.portal_url
+    entity_url = args.entity_url
     types_url = args.types_url
     assets_url = args.assets_url
+
+    client = ApiClient(entity_url)
 
     app = Flask(__name__)
     app.config.from_mapping({
         'TYPE_SERVICE_ENDPOINT': types_url,
-        'ASSETS_ENDPOINT': assets_url
+        'ASSETS_ENDPOINT': assets_url,
+        'ELASTICSEARCH_ENDPOINT': 'https://search.api.hubmapconsortium.org',
+        'PORTAL_INDEX_PATH': '/portal/search'  # TODO: pull from default_config.py
     })
 
-    tsv_url = f'{portal_url}/metadata/v0/datasets.tsv'
-    tsv = requests.get(tsv_url).text
-    datasets = list(DictReader(StringIO(tsv), dialect=excel_tab))[1:]
-    uuids = [dataset['uuid'] for dataset in datasets]
-    errors = {}
-    waiting_for_json = 0
-    waiting_for_conf = 0
-    for (i, uuid) in enumerate(uuids):
-        dataset_url = f'{portal_url}/browse/dataset/{uuid}'
-        dataset_json_url = f'{dataset_url}.json'
-        before_json = perf_counter()
-        dataset = requests.get(dataset_json_url).json()
-        waiting_for_json += perf_counter() - before_json
-        warn(f'{i}/{len(uuids)} ({len(errors)} errors): Checking {dataset_url} ...')
-        try:
-            before_conf = perf_counter()
-            with app.app_context():
+    with app.app_context():
+        uuids = client.get_all_dataset_uuids()
+        errors = {}
+        waiting_for_json = 0
+        waiting_for_conf = 0
+        for (i, uuid) in enumerate(uuids):
+            before_json = perf_counter()
+            dataset = client.get_entity(uuid=uuid)
+            waiting_for_json += perf_counter() - before_json
+            warn(f'{i}/{len(uuids)} ({len(errors)} errors): Checking {uuid} ...')
+            try:
+                before_conf = perf_counter()
                 client.get_vitessce_conf_cells_and_lifted_uuid(dataset, wrap_error=False)
-            waiting_for_conf += perf_counter() - before_conf
-        except Exception as e:
-            warn(f'ERROR: {e}')
-            errors[dataset_url] = e
-        warn(f'JSON: {waiting_for_json:.2f}s; Vitessce: {waiting_for_conf:.2f}s')
+                waiting_for_conf += perf_counter() - before_conf
+            except Exception as e:
+                warn(f'ERROR: {e}')
+                errors[uuid] = e
+            warn(f'JSON: {waiting_for_json:.2f}s; Vitessce: {waiting_for_conf:.2f}s')
 
     if not errors:
         print('No errors')

--- a/scripts/qa/find-vis-bugs.py
+++ b/scripts/qa/find-vis-bugs.py
@@ -8,7 +8,10 @@ from time import perf_counter
 from flask import Flask
 
 # Run from anywhere:
-sys.path.append(str(Path(__file__).parent.parent.parent))
+for path in Path(__file__).parents:
+    if (path / '.git').is_dir():
+        sys.path.append(str(path))
+        break
 from context.app.api.client import ApiClient  # noqa: E402
 from context.app.default_config import DefaultConfig  # noqa: E402
 

--- a/scripts/qa/find-vis-bugs.py
+++ b/scripts/qa/find-vis-bugs.py
@@ -12,13 +12,51 @@ sys.path.append(str(Path(__file__).parent.parent.parent))
 from context.app.api.client import ApiClient  # noqa: E402
 
 
+def get_context(args):
+    search_url = args.search_url
+    types_url = args.types_url
+    assets_url = args.assets_url
+
+    app = Flask(__name__)
+    app.config.from_mapping({
+        'TYPE_SERVICE_ENDPOINT': types_url,
+        'ASSETS_ENDPOINT': assets_url,
+        'ELASTICSEARCH_ENDPOINT': search_url,
+        'PORTAL_INDEX_PATH': '/portal/search'  # TODO: pull from default_config.py
+    })
+
+    return app.app_context()
+
+
+def get_errors():
+    errors = {}
+    client = ApiClient()
+    uuids = client.get_all_dataset_uuids()
+    waiting_for_json = 0
+    waiting_for_conf = 0
+    for (i, uuid) in enumerate(uuids):
+        before_json = perf_counter()
+        dataset = client.get_entity(uuid=uuid)
+        waiting_for_json += perf_counter() - before_json
+        warn(f'{i}/{len(uuids)} ({len(errors)} errors): Checking {uuid} ...')
+        try:
+            before_conf = perf_counter()
+            client.get_vitessce_conf_cells_and_lifted_uuid(dataset, wrap_error=False)
+            waiting_for_conf += perf_counter() - before_conf
+        except Exception as e:
+            warn(f'ERROR: {e}')
+            errors[uuid] = e
+        warn(f'JSON: {waiting_for_json:.2f}s; Vitessce: {waiting_for_conf:.2f}s')
+    return errors
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Scan all datasets for visualization bugs. Exits with status 0 if no errors.')
     parser.add_argument(
-        '--entity_url',
-        default='https://search.api.hubmapconsortium.org/portal/search',
-        help='Entity API')
+        '--search_url',
+        default='https://search.api.hubmapconsortium.org',
+        help='Search API endpoint')
     parser.add_argument(
         '--types_url',
         default='https://search.api.hubmapconsortium.org',
@@ -27,40 +65,9 @@ def main():
         '--assets_url',
         default='https://assets.hubmapconsortium.org',
         help='Assets endpoint')
-    args = parser.parse_args()
 
-    entity_url = args.entity_url
-    types_url = args.types_url
-    assets_url = args.assets_url
-
-    client = ApiClient(entity_url)
-
-    app = Flask(__name__)
-    app.config.from_mapping({
-        'TYPE_SERVICE_ENDPOINT': types_url,
-        'ASSETS_ENDPOINT': assets_url,
-        'ELASTICSEARCH_ENDPOINT': 'https://search.api.hubmapconsortium.org',
-        'PORTAL_INDEX_PATH': '/portal/search'  # TODO: pull from default_config.py
-    })
-
-    with app.app_context():
-        uuids = client.get_all_dataset_uuids()
-        errors = {}
-        waiting_for_json = 0
-        waiting_for_conf = 0
-        for (i, uuid) in enumerate(uuids):
-            before_json = perf_counter()
-            dataset = client.get_entity(uuid=uuid)
-            waiting_for_json += perf_counter() - before_json
-            warn(f'{i}/{len(uuids)} ({len(errors)} errors): Checking {uuid} ...')
-            try:
-                before_conf = perf_counter()
-                client.get_vitessce_conf_cells_and_lifted_uuid(dataset, wrap_error=False)
-                waiting_for_conf += perf_counter() - before_conf
-            except Exception as e:
-                warn(f'ERROR: {e}')
-                errors[uuid] = e
-            warn(f'JSON: {waiting_for_json:.2f}s; Vitessce: {waiting_for_conf:.2f}s')
+    with get_context(parser.parse_args()):
+        errors = get_errors()
 
     if not errors:
         print('No errors')


### PR DESCRIPTION
- Add `--portal_index_path` argument
- Break code into functions
- Use the portal's internal client, rather than straight HTTP.
- Clean up output.
- Fix #2817

... except, from 
-  #2816 
> Right, but check https://portal.test.hubmapconsortium.org/browse/dataset/906ce8025bd07f04fe6a33d1a4daf400, which is connected to the new, v3 version of the indices.

I was expecting to see an error on that UUID, and I don't:
```
$ scripts/qa/find-vis-bugs.py --portal_index_path /portal/v3
...
d55e751748bd094ff5b0b55befb08d41	Image pyramid assay with uuid 0f3894d45b772804de43137fa8c353ed has no matching files
c6a254b2dc2ed46b002500ade163a7cc	seqFish assay with uuid 9db61adfc017670a196ea9b3ca1852a0 has no matching files
eaad5ed4b3aa2186bd87e05ff28b593e	seqFish assay with uuid b5707bbde0050121ca7291e30054d548 has no matching files
d3e05111d84be552b98f5fe2b18e3054	Image pyramid assay with uuid 3af85031cea5b0c772212855550cc3b1 has no matching files
```

(Same errors as on the default.)

Filing as draft: Will add arg to run a single UUID.