### PR TITLE
Use index v3

### DIFF
--- a/CHANGELOG-move-to-index-v3.md
+++ b/CHANGELOG-move-to-index-v3.md
@@ -1,0 +1,1 @@
+- User v3 of the portal index.

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -12,7 +12,7 @@ class DefaultConfig(object):
     PERMANENT_SESSION_LIFETIME = timedelta(minutes=60)
     SESSION_COOKIE_SAMESITE = 'Lax'
 
-    PORTAL_INDEX_PATH = '/portal/v3'
+    PORTAL_INDEX_PATH = '/v3/portal/search'
     CCF_INDEX_PATH = '/entities/search'
 
     # Everything else should be overridden in app.conf:

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -12,7 +12,7 @@ class DefaultConfig(object):
     PERMANENT_SESSION_LIFETIME = timedelta(minutes=60)
     SESSION_COOKIE_SAMESITE = 'Lax'
 
-    PORTAL_INDEX_PATH = '/portal/search'
+    PORTAL_INDEX_PATH = '/portal/v3'
     CCF_INDEX_PATH = '/entities/search'
 
     # Everything else should be overridden in app.conf:


### PR DESCRIPTION
- Fix #2815
- I don't believe there are new errors in published datasets: See #2819
- Blocking on #2816... but I think these are unpublished?
- Question: Should the CCF also be using `v3`?