### PR TITLE
Bring the Workspaces closer to the design

### DIFF
--- a/CHANGELOG-ws-ui.md
+++ b/CHANGELOG-ws-ui.md
@@ -1,0 +1,1 @@
+- Bring the Workspaces UI closer to spec.

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -5,6 +5,20 @@ import { LightBlueLink } from 'js/shared-styles/Links';
 import { condenseJobs, startJob } from './utils';
 
 function JobDetails({ workspace, jobs }) {
+  const job = condenseJobs(jobs);
+
+  return (
+    <div>
+      <JobLink workspace={workspace} job={job}>
+        {workspace.name}
+      </JobLink>
+      {' | '}
+      <JobDetailsDetails job={job} />
+    </div>
+  );
+}
+
+function JobLink({ workspace, job, children }) {
   const { workspacesEndpoint, workspacesToken } = useContext(AppContext);
 
   function createHandleStart(workspaceId) {
@@ -14,29 +28,24 @@ function JobDetails({ workspace, jobs }) {
     return handleStart;
   }
 
-  const job = condenseJobs(jobs);
-
-  return (
-    <div>
-      <div>
-        <b>{workspace.name}</b>
-      </div>
-      {job.allowNew && (
-        <button onClick={createHandleStart(workspace.id)} type="button">
-          Start Jupyter
-        </button>
-      )}
-      <JobDetailsDetails job={job} />
-    </div>
-  );
+  if (job.allowNew) {
+    const handleStart = createHandleStart(workspace.id);
+    return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+      <span onClick={handleStart} onKeyPress={handleStart}>
+        {children}
+      </span>
+    );
+  }
+  if (job?.url) {
+    return <LightBlueLink href={job.url}>{children}</LightBlueLink>;
+  }
+  return children;
 }
 
 function JobDetailsDetails({ job }) {
   if (!job.status) {
     return null;
-  }
-  if (job.url) {
-    return <LightBlueLink href={job.url}>Status: {job.status}</LightBlueLink>;
   }
   return `Status: ${job.status}`;
 }

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -1,20 +1,20 @@
 import React, { useContext } from 'react';
 
 import { AppContext } from 'js/components/Providers';
-import { LightBlueLink } from 'js/shared-styles/Links';
+import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import { condenseJobs, startJob } from './utils';
 
 function JobDetails({ workspace, jobs }) {
   const job = condenseJobs(jobs);
 
   return (
-    <div>
+    <b>
       <JobLink workspace={workspace} job={job}>
         {workspace.name}
       </JobLink>
       {' | '}
       <JobDetailsDetails job={job} />
-    </div>
+    </b>
   );
 }
 
@@ -32,13 +32,13 @@ function JobLink({ workspace, job, children }) {
     const handleStart = createHandleStart(workspace.id);
     return (
       // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <span onClick={handleStart} onKeyPress={handleStart}>
+      <OutboundIconLink onClick={handleStart} onKeyPress={handleStart}>
         {children}
-      </span>
+      </OutboundIconLink>
     );
   }
   if (job?.url) {
-    return <LightBlueLink href={job.url}>{children}</LightBlueLink>;
+    return <OutboundIconLink href={job.url}>{children}</OutboundIconLink>;
   }
   return children;
 }

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -35,7 +35,7 @@ function JobLink({ workspace, job, children }) {
     const handleStart = createHandleStart(workspace.id);
     return (
       <OutboundIconLink>
-        <button onClick={handleStart} type="submit">
+        <button onClick={handleStart} type="submit" style={{ all: 'unset' }}>
           {children}
         </button>
       </OutboundIconLink>

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -24,13 +24,22 @@ function JobLink({ workspace, job, children }) {
   function createHandleStart(workspaceId) {
     async function handleStart() {
       startJob({ workspaceId, workspacesEndpoint, workspacesToken });
+      // TODO: Open new tab
+      // eslint-disable-next-line no-alert
+      alert('TODO: Open a new tab that will poll until the job is started.');
     }
     return handleStart;
   }
 
   if (job.allowNew) {
     const handleStart = createHandleStart(workspace.id);
-    return <OutboundIconLink onClick={handleStart}>{children}</OutboundIconLink>;
+    return (
+      <OutboundIconLink>
+        <button onClick={handleStart} type="submit">
+          {children}
+        </button>
+      </OutboundIconLink>
+    );
   }
   if (job?.url) {
     return <OutboundIconLink href={job.url}>{children}</OutboundIconLink>;

--- a/context/app/static/js/components/workspaces/JobDetails.jsx
+++ b/context/app/static/js/components/workspaces/JobDetails.jsx
@@ -30,12 +30,7 @@ function JobLink({ workspace, job, children }) {
 
   if (job.allowNew) {
     const handleStart = createHandleStart(workspace.id);
-    return (
-      // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-      <OutboundIconLink onClick={handleStart} onKeyPress={handleStart}>
-        {children}
-      </OutboundIconLink>
-    );
+    return <OutboundIconLink onClick={handleStart}>{children}</OutboundIconLink>;
   }
   if (job?.url) {
     return <OutboundIconLink href={job.url}>{children}</OutboundIconLink>;

--- a/context/app/static/js/components/workspaces/JobLink.jsx
+++ b/context/app/static/js/components/workspaces/JobLink.jsx
@@ -21,7 +21,7 @@ function JobLink({ workspace, job, children }) {
     const handleStart = createHandleStart(workspace.id);
     return (
       <OutboundIconLink>
-        <button onClick={handleStart} type="submit" style={{ all: 'unset' }}>
+        <button onClick={handleStart} type="submit" style={{ all: 'unset', cursor: 'pointer' }}>
           {children}
         </button>
       </OutboundIconLink>

--- a/context/app/static/js/components/workspaces/JobLink.jsx
+++ b/context/app/static/js/components/workspaces/JobLink.jsx
@@ -1,0 +1,36 @@
+import React, { useContext } from 'react';
+
+import { AppContext } from 'js/components/Providers';
+import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+import { startJob } from './utils';
+
+function JobLink({ workspace, job, children }) {
+  const { workspacesEndpoint, workspacesToken } = useContext(AppContext);
+
+  function createHandleStart(workspaceId) {
+    async function handleStart() {
+      startJob({ workspaceId, workspacesEndpoint, workspacesToken });
+      // TODO: Open new tab
+      // eslint-disable-next-line no-alert
+      alert('TODO: Open a new tab that will poll until the job is started.');
+    }
+    return handleStart;
+  }
+
+  if (job.allowNew) {
+    const handleStart = createHandleStart(workspace.id);
+    return (
+      <OutboundIconLink>
+        <button onClick={handleStart} type="submit" style={{ all: 'unset' }}>
+          {children}
+        </button>
+      </OutboundIconLink>
+    );
+  }
+  if (job?.url) {
+    return <OutboundIconLink href={job.url}>{children}</OutboundIconLink>;
+  }
+  return children;
+}
+
+export default JobLink;

--- a/context/app/static/js/components/workspaces/JobLink.jsx
+++ b/context/app/static/js/components/workspaces/JobLink.jsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import { AppContext } from 'js/components/Providers';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import { startJob } from './utils';
+import { LinkButton } from './style';
 
 function JobLink({ workspace, job, children }) {
   const { workspacesEndpoint, workspacesToken } = useContext(AppContext);
@@ -21,9 +22,7 @@ function JobLink({ workspace, job, children }) {
     const handleStart = createHandleStart(workspace.id);
     return (
       <OutboundIconLink>
-        <button onClick={handleStart} type="submit" style={{ all: 'unset', cursor: 'pointer' }}>
-          {children}
-        </button>
+        <LinkButton onClick={handleStart}>{children}</LinkButton>
       </OutboundIconLink>
     );
   }

--- a/context/app/static/js/components/workspaces/JobLink.jsx
+++ b/context/app/static/js/components/workspaces/JobLink.jsx
@@ -19,10 +19,9 @@ function JobLink({ workspace, job, children }) {
   }
 
   if (job.allowNew) {
-    const handleStart = createHandleStart(workspace.id);
     return (
       <OutboundIconLink>
-        <LinkButton onClick={handleStart}>{children}</LinkButton>
+        <LinkButton onClick={createHandleStart(workspace.id)}>{children}</LinkButton>
       </OutboundIconLink>
     );
   }

--- a/context/app/static/js/components/workspaces/JobStatus.jsx
+++ b/context/app/static/js/components/workspaces/JobStatus.jsx
@@ -1,0 +1,8 @@
+function JobStatus({ job }) {
+  if (!job.status) {
+    return null;
+  }
+  return `Status: ${job.status}`;
+}
+
+export default JobStatus;

--- a/context/app/static/js/components/workspaces/JobStatus.jsx
+++ b/context/app/static/js/components/workspaces/JobStatus.jsx
@@ -1,8 +1,5 @@
 function JobStatus({ job }) {
-  if (!job.status) {
-    return null;
-  }
-  return `Status: ${job.status}`;
+  return `Status: ${job.status || 'No Jobs'}`;
 }
 
 export default JobStatus;

--- a/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
@@ -3,18 +3,19 @@ import React from 'react';
 import { condenseJobs } from './utils';
 import JobLink from './JobLink';
 import JobStatus from './JobStatus';
+import { Bold } from './style';
 
 function WorkspaceDetails({ workspace }) {
   const job = condenseJobs(workspace.jobs);
 
   return (
-    <b>
+    <Bold>
       <JobLink workspace={workspace} job={job}>
         {workspace.name}
       </JobLink>
       {' | '}
       <JobStatus job={job} />
-    </b>
+    </Bold>
   );
 }
 

--- a/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
@@ -4,8 +4,8 @@ import { AppContext } from 'js/components/Providers';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import { condenseJobs, startJob } from './utils';
 
-function JobDetails({ workspace, jobs }) {
-  const job = condenseJobs(jobs);
+function WorkspaceDetails({ workspace }) {
+  const job = condenseJobs(workspace.jobs);
 
   return (
     <b>
@@ -54,4 +54,4 @@ function JobDetailsDetails({ job }) {
   return `Status: ${job.status}`;
 }
 
-export default JobDetails;
+export default WorkspaceDetails;

--- a/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { condenseJobs } from './utils';
 import JobLink from './JobLink';
+import JobStatus from './JobStatus';
 
 function WorkspaceDetails({ workspace }) {
   const job = condenseJobs(workspace.jobs);
@@ -15,13 +16,6 @@ function WorkspaceDetails({ workspace }) {
       <JobStatus job={job} />
     </b>
   );
-}
-
-function JobStatus({ job }) {
-  if (!job.status) {
-    return null;
-  }
-  return `Status: ${job.status}`;
 }
 
 export default WorkspaceDetails;

--- a/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails.jsx
@@ -1,8 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
-import { AppContext } from 'js/components/Providers';
-import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
-import { condenseJobs, startJob } from './utils';
+import { condenseJobs } from './utils';
+import JobLink from './JobLink';
 
 function WorkspaceDetails({ workspace }) {
   const job = condenseJobs(workspace.jobs);
@@ -13,41 +12,12 @@ function WorkspaceDetails({ workspace }) {
         {workspace.name}
       </JobLink>
       {' | '}
-      <JobDetailsDetails job={job} />
+      <JobStatus job={job} />
     </b>
   );
 }
 
-function JobLink({ workspace, job, children }) {
-  const { workspacesEndpoint, workspacesToken } = useContext(AppContext);
-
-  function createHandleStart(workspaceId) {
-    async function handleStart() {
-      startJob({ workspaceId, workspacesEndpoint, workspacesToken });
-      // TODO: Open new tab
-      // eslint-disable-next-line no-alert
-      alert('TODO: Open a new tab that will poll until the job is started.');
-    }
-    return handleStart;
-  }
-
-  if (job.allowNew) {
-    const handleStart = createHandleStart(workspace.id);
-    return (
-      <OutboundIconLink>
-        <button onClick={handleStart} type="submit" style={{ all: 'unset' }}>
-          {children}
-        </button>
-      </OutboundIconLink>
-    );
-  }
-  if (job?.url) {
-    return <OutboundIconLink href={job.url}>{children}</OutboundIconLink>;
-  }
-  return children;
-}
-
-function JobDetailsDetails({ job }) {
+function JobStatus({ job }) {
   if (!job.status) {
     return null;
   }

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -11,7 +11,7 @@ import { PanelWrapper } from 'js/shared-styles/panels';
 import { createNotebookWorkspace } from './utils';
 import { useWorkspacesList } from './hooks';
 import { StyledButton } from './style';
-import JobDetails from './JobDetails';
+import WorkspaceDetails from './WorkspaceDetails';
 
 function WorkspacesList() {
   const { workspacesEndpoint, workspacesToken } = useContext(AppContext);
@@ -66,7 +66,7 @@ function WorkspacesList() {
           workspacesList.map((workspace) => (
             /* TODO: Inbound links have fragments like "#workspace-123": Highlight? */
             <PanelWrapper key={workspace.id}>
-              <JobDetails workspace={workspace} jobs={workspace.jobs} />
+              <WorkspaceDetails workspace={workspace} />
               <div>Created {workspace.datetime_created.slice(0, 10)}</div>
             </PanelWrapper>
           ))

--- a/context/app/static/js/components/workspaces/style.js
+++ b/context/app/static/js/components/workspaces/style.js
@@ -8,4 +8,9 @@ const StyledButton = styled(WhiteBackgroundIconButton)`
   height: 36px;
 `;
 
-export { StyledButton };
+const LinkButton = styled.button`
+  all: unset;
+  cursor: pointer;
+`;
+
+export { StyledButton, LinkButton };

--- a/context/app/static/js/components/workspaces/style.js
+++ b/context/app/static/js/components/workspaces/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import Typography from '@material-ui/core/Typography';
 
 import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
 // Copy-and-paste from js/components/savedLists/SavedListScrollbox/style.js
@@ -13,4 +14,8 @@ const LinkButton = styled.button`
   cursor: pointer;
 `;
 
-export { StyledButton, LinkButton };
+const Bold = styled(Typography)`
+  font-weight: bold;
+`;
+
+export { StyledButton, LinkButton, Bold };

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -74,8 +74,12 @@ function condenseJobs(jobs) {
   }
 
   function getJobUrl(job) {
-    const { url_domain, url_path } = job.job_details.current_job_details.connection_details;
-    return `${url_domain}${url_path}`;
+    const details = job.job_details.current_job_details;
+    if (details.connection_details) {
+      const { url_domain, url_path } = details.connection_details;
+      return `${url_domain}${url_path}`;
+    }
+    return `/poll-job-${job.id}-until-ready`;
   }
 
   const displayStatusJobs = jobs.map((job) => ({ ...job, status: getDisplayStatus(job.status) }));

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -79,6 +79,7 @@ function condenseJobs(jobs) {
       const { url_domain, url_path } = details.connection_details;
       return `${url_domain}${url_path}`;
     }
+    // TODO
     return `/poll-job-${job.id}-until-ready`;
   }
 

--- a/context/app/static/js/shared-styles/Links/index.js
+++ b/context/app/static/js/shared-styles/Links/index.js
@@ -6,7 +6,6 @@ const LinkWithoutUnderline = (props) => <Link {...props} underline="none" />;
 
 const LightBlueLink = styled(LinkWithoutUnderline)`
   color: ${(props) => props.theme.palette.info.main};
-  cursor: pointer;
 `;
 
 export { LightBlueLink };

--- a/context/app/static/js/shared-styles/Links/index.js
+++ b/context/app/static/js/shared-styles/Links/index.js
@@ -6,6 +6,7 @@ const LinkWithoutUnderline = (props) => <Link {...props} underline="none" />;
 
 const LightBlueLink = styled(LinkWithoutUnderline)`
   color: ${(props) => props.theme.palette.info.main};
+  cursor: pointer;
 `;
 
 export { LightBlueLink };


### PR DESCRIPTION
Present a uniform UI for workspaces, regardless of whether Jupyter is already running, or if it needs to be started from scratch. We're getting into territory where we're disguising how the system works behind the scenes, and that worries me a little.

@tsliaw :
- Is this acceptable, as far as it goes?
- How should we handle workspaces with no active jobs?
- This reminded me what #2746 was for. I'll branch from this and implement a stop-gap.
<img width="251" alt="Screen Shot 2022-08-09 at 4 18 48 PM" src="https://user-images.githubusercontent.com/730388/183752830-d9abfc85-e12a-4e3e-bf72-007483eff949.png">

