### PR TITLE
users do not supply name when creating workspace

### DIFF
--- a/CHANGELOG-ws-no-name.md
+++ b/CHANGELOG-ws-no-name.md
@@ -1,0 +1,1 @@
+- Users will not supply a name when creating workspaces from datasets.

--- a/context/app/routes_notebooks.py
+++ b/context/app/routes_notebooks.py
@@ -76,13 +76,19 @@ def _get_workspace_name(request_args):
     return request_args.get('name')
 
 
-@blueprint.route('/browse/<type>/<uuid>.ipynb')
-def details_notebook(type, uuid):
+@blueprint.route(
+    '/browse/<type>/<uuid>.ipynb',
+    defaults={'create_workspace': False})
+@blueprint.route(
+    '/browse/<type>/<uuid>.ws.ipynb',
+    defaults={'create_workspace': True})
+# TODO: Change to a single route, and instead make behavior depend on HTTP method
+def details_notebook(type, uuid, create_workspace):
     if type not in entity_types:
         abort(404)
-    workspace_name = _get_workspace_name(request.args)
     client = get_client()
     entity = client.get_entity(uuid)
+    workspace_name = f"{entity['hubmap_id']} Workspace" if create_workspace else None
     vitessce_conf = client.get_vitessce_conf_cells_and_lifted_uuid(entity).vitessce_conf
     if (vitessce_conf is None
             or vitessce_conf.conf is None


### PR DESCRIPTION
RIght now, it looks for a query parameter with the name of the workspace ... but my understanding of the planned UI is that there will be no prompt for a name, and the workspaces will be assigned names like "HBM989.VVXT.224 Workspace". If that is correct, this is a small step in the right direction. 