### PR TITLE
John conroy/fix log script

### DIFF
--- a/CHANGELOG-fix-log-script.md
+++ b/CHANGELOG-fix-log-script.md
@@ -1,0 +1,1 @@
+- Fix output dir path in query-portal-logs.py

--- a/etc/qa/query-portal-logs.py
+++ b/etc/qa/query-portal-logs.py
@@ -4,7 +4,6 @@ import boto3
 import time
 from datetime import date, datetime, timedelta
 from csv import DictWriter
-
 import sys
 from pathlib import Path
 

--- a/etc/qa/query-portal-logs.py
+++ b/etc/qa/query-portal-logs.py
@@ -4,8 +4,14 @@ import boto3
 import time
 from datetime import date, datetime, timedelta
 from csv import DictWriter
+
+import sys
 from pathlib import Path
 
+for path in Path(__file__).parents:
+    if (path / '.git').is_dir():
+        sys.path.append(str(path))
+        break
 
 if __name__ == "__main__":
     client = boto3.Session(profile_name='harvarddev').client('logs')
@@ -33,7 +39,7 @@ if __name__ == "__main__":
         )
 
     if response['status'] == "Complete":
-        with open(f"{ Path(__file__).parent}/portal-logs-errors/errors-{date.today()}.csv",
+        with open(f"portal-logs-errors/errors-{date.today()}.csv",
                   'w', newline='') as csvfile:
             writer = DictWriter(csvfile, fieldnames=[
                                 '@timestamp', '@logStream', '@message', '@ptr'])


### PR DESCRIPTION
Same approach as #2821. You may have an idea for moving the `sys.path.append` code block to a utils file (or whatever the Python convention is...) for reuse between scripts. Alternatively, I could move the  `portal-logs-errors` output dir down to `etc/qa`.