### PR TITLE
Mccalluc/sticky cookie

### DIFF
--- a/CHANGELOG-sticky-cookie.md
+++ b/CHANGELOG-sticky-cookie.md
@@ -1,0 +1,1 @@
+- When a user logs in, add a cookie, and check it during logging, to distinguish internal and external traffic.

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -142,6 +142,7 @@ def login():
     previous_url = unquote(request.cookies.get('urlBeforeLogin'))
     response = make_response(
         redirect(previous_url))
+    # Cookie read in trackers.js:
     response.set_cookie(
         key='last_login',
         value=datetime.now().isoformat(),

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -1,4 +1,5 @@
 from urllib.parse import urlencode, unquote
+from datetime import datetime
 
 from flask import (
     make_response, current_app, url_for,
@@ -141,6 +142,10 @@ def login():
     previous_url = unquote(request.cookies.get('urlBeforeLogin'))
     response = make_response(
         redirect(previous_url))
+    response.set_cookie(
+        key='last_login',
+        value=datetime.now().isoformat(),
+        expires=2**31 - 1)
     log('7: redirect previous_url')
     return response
 

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -1,5 +1,6 @@
 import MatomoTracker from '@datapunt/matomo-tracker-js';
 import ReactGA from 'react-ga';
+import { readCookie } from 'js/helpers/functions';
 
 function getSiteId(location) {
   const { host } = location;
@@ -15,6 +16,11 @@ function getSiteId(location) {
     default:
       return 3;
   }
+}
+
+function isHubmapUser() {
+  // Set in routes_auth.py:
+  return Boolean(readCookie('last_login'));
 }
 
 const tracker = new MatomoTracker({
@@ -37,6 +43,7 @@ const tracker = new MatomoTracker({
   //   setRequestMethod: 'POST'
   // }
 });
+tracker.setCustomDimension(1, isHubmapUser() ? 'internal' : 'external');
 
 ReactGA.initialize('UA-133341631-3', { testMode: process.env.NODE_ENV === 'test' });
 

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -18,9 +18,9 @@ function getSiteId(location) {
   }
 }
 
-function isHubmapUser() {
+function getUserType() {
   // Set in routes_auth.py:
-  return Boolean(readCookie('last_login'));
+  return readCookie('last_login') ? 'internal' : 'external';
 }
 
 const tracker = new MatomoTracker({
@@ -42,8 +42,8 @@ const tracker = new MatomoTracker({
   //   setSecureCookie: true,
   //   setRequestMethod: 'POST'
   // }
+  configurations: { setCustomDimension: [1 /* user_type */, getUserType()] },
 });
-tracker.setCustomDimension(1, isHubmapUser() ? 'internal' : 'external');
 
 ReactGA.initialize('UA-133341631-3', { testMode: process.env.NODE_ENV === 'test' });
 


### PR DESCRIPTION
- Fix #2859 
- I started to use a "custom variable", but it looks like "custom dimension" is preferred now.
- Dimensions need to be pre-registered in the matomo UI, and then referenced by ID in the API.
- I added this dimension for each of our three sites (local, prod, other).
- Docs confused me: [this](https://developer.matomo.org/api-reference/tracking-javascript) made me think it was a method on the tracker object, but that didn't work, and [this](https://github.com/jonkoops/matomo-tracker/pull/585/files#diff-bcd475bc7ec4b99349047ee03e3358d7e713e576ac0c4b710b88abdeca9cd266R13) does.
- Or at least it doesn't error? I haven't seen data show up in the dash board, but maybe the non-real-time options take time to aggregate?