### PR TITLE
add workspaces link to menu

### DIFF
--- a/CHANGELOG-workspaces-link.md
+++ b/CHANGELOG-workspaces-link.md
@@ -1,0 +1,1 @@
+- For beta users, and link to workspaces in menu.

--- a/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
+++ b/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
@@ -14,9 +14,7 @@ function UserLinks(props) {
   return (
     <Dropdown title={<TruncatedSpan>{isAuthenticated ? userEmail || 'User' : 'User Profile'}</TruncatedSpan>}>
       <DropdownLink href="/my-lists">My Lists</DropdownLink>
-      {isAuthenticated && workspacesUsers.includes(userEmail) && (
-        <DropdownLink href="/workspaces">My Workspaces</DropdownLink>
-      )}
+      {workspacesUsers.includes(userEmail) && <DropdownLink href="/workspaces">My Workspaces</DropdownLink>}
       <StyledDivider />
       {isAuthenticated ? (
         <WarningDropdownLink href="/logout">Log Out</WarningDropdownLink>

--- a/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
+++ b/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
+import { AppContext } from 'js/components/Providers';
 import Dropdown from '../Dropdown';
 import DropdownLink from '../DropdownLink';
 import { StyledDivider } from '../HeaderContent/style';
@@ -8,10 +9,14 @@ import { TruncatedSpan, WarningDropdownLink } from './style';
 
 function UserLinks(props) {
   const { isAuthenticated, userEmail } = props;
+  const { workspacesUsers } = useContext(AppContext);
 
   return (
     <Dropdown title={<TruncatedSpan>{isAuthenticated ? userEmail || 'User' : 'User Profile'}</TruncatedSpan>}>
       <DropdownLink href="/my-lists">My Lists</DropdownLink>
+      {isAuthenticated && workspacesUsers.includes(userEmail) && (
+        <DropdownLink href="/workspaces">My Workspaces</DropdownLink>
+      )}
       <StyledDivider />
       {isAuthenticated ? (
         <WarningDropdownLink href="/logout">Log Out</WarningDropdownLink>


### PR DESCRIPTION
- Should `userEmail` also be pulled from context, since it's there? Or is there an argument for passing things explicitly, sometimes?
- I think the plan for the future would be for this not to be conditional: If they aren't logged in, the workspaces page doesn't do much, but we'd still link to it?