### PR TITLE
Mccalluc/big workspace icon

### DIFF
--- a/CHANGELOG-workspace-header-icon.md
+++ b/CHANGELOG-workspace-header-icon.md
@@ -1,0 +1,1 @@
+- Add an icon in the header title.

--- a/context/app/static/js/components/style.js
+++ b/context/app/static/js/components/style.js
@@ -6,7 +6,7 @@ import { Alert } from 'js/shared-styles/alerts';
 const StyledAlert = styled(Alert)`
   width: ${(props) => props.theme.breakpoints.values.lg}px;
   margin-top: ${(props) => props.theme.spacing(3)}px;
-  z-index: 0; // Does not disaply on preview pages without this; Not sure sure why not.
+  z-index: 0; // Does not display on preview pages without this; Not sure sure why not.
 `;
 
 const FlexContainer = styled(Container)`

--- a/context/app/static/js/pages/Workspaces/Workspaces.jsx
+++ b/context/app/static/js/pages/Workspaces/Workspaces.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
-import SvgIcon from '@material-ui/core/SvgIcon';
 
+import HeaderIcon from 'js/shared-styles/icons/HeaderIcon';
 import { ReactComponent as WorkspacesIcon } from 'assets/svg/workspaces.svg';
 import { AppContext } from 'js/components/Providers';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
@@ -13,7 +13,7 @@ function Workspaces() {
   return (
     <>
       <SectionHeader variant="h1" component="h1">
-        <SvgIcon component={WorkspacesIcon} /> My Workspaces
+        <HeaderIcon component={WorkspacesIcon} /> My Workspaces
       </SectionHeader>
       {!isAuthenticated ? (
         <Description padding="20px">

--- a/context/app/static/js/pages/Workspaces/Workspaces.jsx
+++ b/context/app/static/js/pages/Workspaces/Workspaces.jsx
@@ -1,5 +1,7 @@
 import React, { useContext } from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
 
+import { ReactComponent as WorkspacesIcon } from 'assets/svg/workspaces.svg';
 import { AppContext } from 'js/components/Providers';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import Description from 'js/shared-styles/sections/Description';
@@ -11,7 +13,7 @@ function Workspaces() {
   return (
     <>
       <SectionHeader variant="h1" component="h1">
-        My Workspaces
+        <SvgIcon component={WorkspacesIcon} /> My Workspaces
       </SectionHeader>
       {!isAuthenticated ? (
         <Description padding="20px">

--- a/context/app/static/js/pages/Workspaces/Workspaces.jsx
+++ b/context/app/static/js/pages/Workspaces/Workspaces.jsx
@@ -8,12 +8,16 @@ import Description from 'js/shared-styles/sections/Description';
 import { LightBlueLink } from 'js/shared-styles/Links';
 import WorkspacesAuthenticated from 'js/components/workspaces/WorkspacesAuthenticated';
 
+import { FlexContainer } from './style';
+
 function Workspaces() {
   const { isAuthenticated } = useContext(AppContext);
   return (
     <>
       <SectionHeader variant="h1" component="h1">
-        <HeaderIcon component={WorkspacesIcon} /> My Workspaces
+        <FlexContainer>
+          <HeaderIcon component={WorkspacesIcon} /> My Workspaces
+        </FlexContainer>
       </SectionHeader>
       {!isAuthenticated ? (
         <Description padding="20px">

--- a/context/app/static/js/pages/Workspaces/style.js
+++ b/context/app/static/js/pages/Workspaces/style.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+// js/components/style.js is a Container, and adds unwanted left and right padding.
+const FlexContainer = styled.div`
+  display: flex;
+  height: 100%;
+  align-items: center;
+`;
+
+export { FlexContainer };

--- a/context/app/static/js/shared-styles/icons/HeaderIcon.jsx
+++ b/context/app/static/js/shared-styles/icons/HeaderIcon.jsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+const HeaderIcon = styled(SvgIcon)`
+  vertical-align: -12%;
+  font-size: 2.4rem;
+`;
+
+export default HeaderIcon;


### PR DESCRIPTION
- The height is based on the height for h1 headers... Maybe I should take this from the theme?
- The vertical-align just makes it look more like the mock-up, but I'm not sure how well it would work for other icons.

<img width="317" alt="Screen Shot 2022-08-23 at 12 30 25 PM" src="https://user-images.githubusercontent.com/730388/186212550-903317c4-b83d-4786-b22a-96533a53a7b5.png">
