### PR TITLE
Mccalluc/tsv and lineup

### DIFF
--- a/CHANGELOG-tsv-and-lineup.md
+++ b/CHANGELOG-tsv-and-lineup.md
@@ -1,0 +1,1 @@
+- Fix bugs in TSV download and Lineup.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -93,7 +93,10 @@ class ApiClient():
                 "term": {"entity_type.keyword": entity_type}
             },
             "query": _make_query(constraints, uuids),
-            "_source": [*non_metadata_fields, 'mapped_metadata', 'metadata']
+            "_source": {
+                "include": [*non_metadata_fields, 'mapped_metadata', 'metadata'],
+                "exclude": ['*.files']
+            }
         }
         response_json = self._request(
             current_app.config['ELASTICSEARCH_ENDPOINT']

--- a/context/app/static/js/pages/LineUpPage/LineUpPage.jsx
+++ b/context/app/static/js/pages/LineUpPage/LineUpPage.jsx
@@ -13,7 +13,7 @@ import metadataFieldTypes from 'metadata-field-types';
 
 function LineUpPage({ entities }) {
   const cleanEntities = entities.map((entity) =>
-    Object.fromEntries(Object.entries(entity).filter((pair) => pair[1] !== null)),
+    Object.fromEntries(Object.entries(entity).filter(([,v]) => v !== null)),
   );
   const firstRow = cleanEntities[0];
   const notEnumFields = new Set([

--- a/context/app/static/js/pages/LineUpPage/LineUpPage.jsx
+++ b/context/app/static/js/pages/LineUpPage/LineUpPage.jsx
@@ -13,7 +13,7 @@ import metadataFieldTypes from 'metadata-field-types';
 
 function LineUpPage({ entities }) {
   const cleanEntities = entities.map((entity) =>
-    Object.fromEntries(Object.entries(entity).filter(([,v]) => v !== null)),
+    Object.fromEntries(Object.entries(entity).filter(([, value]) => value !== null)),
   );
   const firstRow = cleanEntities[0];
   const notEnumFields = new Set([

--- a/context/app/static/js/pages/LineUpPage/LineUpPage.jsx
+++ b/context/app/static/js/pages/LineUpPage/LineUpPage.jsx
@@ -11,9 +11,11 @@ import Paper from '@material-ui/core/Paper';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import metadataFieldTypes from 'metadata-field-types';
 
-function LineUpPage(props) {
-  const { entities } = props;
-  const firstRow = entities[0];
+function LineUpPage({ entities }) {
+  const cleanEntities = entities.map((entity) =>
+    Object.fromEntries(Object.entries(entity).filter((pair) => pair[1] !== null)),
+  );
+  const firstRow = cleanEntities[0];
   const notEnumFields = new Set([
     'uuid',
     // Donors:
@@ -46,7 +48,7 @@ function LineUpPage(props) {
         LineUp
       </SectionHeader>
       <Paper>
-        <LineUp data={entities}>{columns}</LineUp>
+        <LineUp data={cleanEntities}>{columns}</LineUp>
       </Paper>
     </>
   );


### PR DESCRIPTION
- Fix #2871 
- Fix #2866

TSV: Excluding `files` because without this, the response size is too big, and even if we window the search results, we get a column with json blobs.

Lineup: I think lineup was blocked at both points, but I could be mistaken. Could file it upstream, but my general sense is that they're satisfied with the behavior.