### PR TITLE
Mccalluc/pick nb to open

### DIFF
--- a/CHANGELOG-open-notebook-in-lab.md
+++ b/CHANGELOG-open-notebook-in-lab.md
@@ -1,0 +1,1 @@
+- When a workspace is openned, if it contains a single notebook, open it by default.

--- a/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
@@ -14,7 +14,7 @@ function WorkspaceDetails({ workspace }) {
 
   return (
     <Flex>
-      <OutboundIconLink href={`/workspaces/${workspace.id}`} variant={typographyVariant}>
+      <OutboundIconLink href={`/workspaces/${workspace.id}#${workspace.path}`} variant={typographyVariant}>
         {workspace.name}
       </OutboundIconLink>
       <Typography variant={typographyVariant}>

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -70,11 +70,7 @@ async function startJob({ workspaceId, workspacesEndpoint, workspacesToken, setM
 function getNotebookPath(workspace) {
   // TODO: Replace with current_workspace_details, when available.
   const { files } = workspace.workspace_details.request_workspace_details;
-  const nbFiles = files.filter(({ name }) => name.endsWith('.ipynb'));
-  if (nbFiles.length !== 1) {
-    return '';
-  }
-  return nbFiles[0].name;
+ const files.find({name} => name.endsWith('.ipynb'))?.name || '';
 }
 
 function mergeJobsIntoWorkspaces(jobs, workspaces) {

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -67,6 +67,16 @@ async function startJob({ workspaceId, workspacesEndpoint, workspacesToken, setM
   setMessage(start.message);
 }
 
+function getNotebookPath(workspace) {
+  // TODO: Replace with current_workspace_details, when available.
+  const { files } = workspace.workspace_details.request_workspace_details;
+  const nbFiles = files.filter(({ name }) => name.endsWith('.ipynb'));
+  if (nbFiles.length !== 1) {
+    return '';
+  }
+  return nbFiles[0].name;
+}
+
 function mergeJobsIntoWorkspaces(jobs, workspaces) {
   const activeWorkspaces = workspaces.filter(({ status }) => ['active', 'idle'].includes(status));
 
@@ -82,6 +92,8 @@ function mergeJobsIntoWorkspaces(jobs, workspaces) {
   activeWorkspaces.forEach((workspace) => {
     // eslint-disable-next-line no-param-reassign
     workspace.jobs = wsIdToJobs?.[workspace.id] || [];
+    // eslint-disable-next-line no-param-reassign
+    workspace.path = getNotebookPath(workspace);
   });
 
   return activeWorkspaces;

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -70,7 +70,7 @@ async function startJob({ workspaceId, workspacesEndpoint, workspacesToken, setM
 function getNotebookPath(workspace) {
   // TODO: Replace with current_workspace_details, when available.
   const { files } = workspace.workspace_details.request_workspace_details;
- const files.find({name} => name.endsWith('.ipynb'))?.name || '';
+  return files.find(({ name }) => name.endsWith('.ipynb'))?.name || '';
 }
 
 function mergeJobsIntoWorkspaces(jobs, workspaces) {

--- a/context/app/static/js/components/workspaces/utils.spec.js
+++ b/context/app/static/js/components/workspaces/utils.spec.js
@@ -52,7 +52,7 @@ test('it should only provide a path if there is exactly one notebook', () => {
       status: 'active',
       workspace_details: {
         request_workspace_details: {
-          files: [{ name: 'workspace1.ipynb' }, { name: 'workspace2.ipynb' }], // too many
+          files: [{ name: 'workspace1.ipynb' }, { name: 'workspace2.ipynb' }], // too many... take first
         },
       },
     },
@@ -64,7 +64,7 @@ test('it should only provide a path if there is exactly one notebook', () => {
   ];
   const jobs = [];
   const mergedWorkspaces = mergeJobsIntoWorkspaces(jobs, workspaces);
-  expect(mergedWorkspaces.map((ws) => ws.path)).toEqual(['', '', 'workspace.ipynb']);
+  expect(mergedWorkspaces.map((ws) => ws.path)).toEqual(['', 'workspace1.ipynb', 'workspace.ipynb']);
 });
 
 test('it should pick one active job if available', () => {

--- a/context/app/static/js/components/workspaces/utils.spec.js
+++ b/context/app/static/js/components/workspaces/utils.spec.js
@@ -36,6 +36,37 @@ test('it should filter out workspaces that are not "active" or "idle"', () => {
   ]);
 });
 
+test('it should only provide a path if there is exactly one notebook', () => {
+  const workspaces = [
+    {
+      id: 0,
+      status: 'active',
+      workspace_details: {
+        request_workspace_details: {
+          files: [], // too few
+        },
+      },
+    },
+    {
+      id: 2,
+      status: 'active',
+      workspace_details: {
+        request_workspace_details: {
+          files: [{ name: 'workspace1.ipynb' }, { name: 'workspace2.ipynb' }], // too many
+        },
+      },
+    },
+    {
+      id: 1,
+      status: 'active',
+      workspace_details, // just right!
+    },
+  ];
+  const jobs = [];
+  const mergedWorkspaces = mergeJobsIntoWorkspaces(jobs, workspaces);
+  expect(mergedWorkspaces.map((ws) => ws.path)).toEqual(['', '', 'workspace.ipynb']);
+});
+
 test('it should pick one active job if available', () => {
   const jobs = [
     {

--- a/context/app/static/js/components/workspaces/utils.spec.js
+++ b/context/app/static/js/components/workspaces/utils.spec.js
@@ -1,7 +1,13 @@
 import { mergeJobsIntoWorkspaces, condenseJobs } from './utils';
 
+const workspace_details = {
+  request_workspace_details: {
+    files: [{ name: 'workspace.ipynb' }],
+  },
+};
+
 test('it should merge jobs into workspaces', () => {
-  const workspaces = [{ id: 1, other_ws_info: true, status: 'active' }];
+  const workspaces = [{ id: 1, other_ws_info: true, status: 'active', workspace_details }];
   const jobs = [{ id: 42, workspace_id: 1, other_job_info: true }];
   const mergedWorkspaces = mergeJobsIntoWorkspaces(jobs, workspaces);
   expect(mergedWorkspaces).toEqual([
@@ -9,28 +15,24 @@ test('it should merge jobs into workspaces', () => {
       id: 1,
       other_ws_info: true,
       status: 'active',
-      jobs: [
-        {
-          id: 42,
-          workspace_id: 1,
-          other_job_info: true,
-        },
-      ],
+      path: 'workspace.ipynb',
+      jobs,
+      workspace_details,
     },
   ]);
 });
 
 test('it should filter out workspaces that are not "active" or "idle"', () => {
   const workspaces = [
-    { id: 1, status: 'active' },
-    { id: 2, status: 'idle' },
-    { id: 3, status: 'other' },
+    { id: 1, status: 'active', workspace_details },
+    { id: 2, status: 'idle', workspace_details },
+    { id: 3, status: 'other', workspace_details },
   ];
   const jobs = [];
   const mergedWorkspaces = mergeJobsIntoWorkspaces(jobs, workspaces);
   expect(mergedWorkspaces).toEqual([
-    { id: 1, status: 'active', jobs: [] },
-    { id: 2, status: 'idle', jobs: [] },
+    { id: 1, status: 'active', jobs: [], path: 'workspace.ipynb', workspace_details },
+    { id: 2, status: 'idle', jobs: [], path: 'workspace.ipynb', workspace_details },
   ]);
 });
 

--- a/context/app/static/js/pages/WorkspacePleaseWait/WorkspacePleaseWait.jsx
+++ b/context/app/static/js/pages/WorkspacePleaseWait/WorkspacePleaseWait.jsx
@@ -20,7 +20,10 @@ function WorkspacePleaseWait({ workspaceId }) {
       workspacesToken,
     });
     if (jobLocation) {
-      document.location = jobLocation;
+      const [urlBase, urlQuery] = jobLocation.split('?');
+      const workspacePath = document.location.hash.slice(1);
+      const jupyterUrl = `${urlBase}/tree/${workspacePath}?${urlQuery}`;
+      document.location = jupyterUrl;
     } else {
       setTimeout(setLocationOrRetry, 5000);
     }


### PR DESCRIPTION
- Fix #2869

When generating the list of workspaces, try to find a notebook to open for the workspace, and append it as the hash of the please-wait page's URL.

When Jupyter is available, take the notebook path from the URL hash and insert it into the Jupyter URL.

- @jpuerto-psc : The API response includes a `current_workspace_details`... but it's empty. Would it be possible to populate it? and when done, nudge me.
- @ngehlenborg : Given the caveat that this might not be the _current_ state of the workspace, is this good enough for now?

(`request_workspace_details` includes the full content of the original creation call... I'm a little concerned about this size of this response. Obviously, the file names are useful, but I'm not sure that the file content needs to be in this API response.)