### PR TITLE
Mccalluc/two step ws deletion

### DIFF
--- a/CHANGELOG-two-step-ws-deletion.md
+++ b/CHANGELOG-two-step-ws-deletion.md
@@ -1,0 +1,1 @@
+- Make the UI reflect the underlying API more closely. UI should not be responsible for managing state.

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -73,7 +73,7 @@ function WorkspacesList() {
                 Created {workspace.datetime_created.slice(0, 10)}
                 <button
                   type="submit"
-                  disabled={workspace.jobs.length > 0 /* TODO: And/or check workspace status? */}
+                  disabled={workspace.jobs.length > 0 || workspace.status === 'deleting'}
                   onClick={() => {
                     handleDelete(workspace.id);
                   }}

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -71,7 +71,6 @@ function WorkspacesList() {
               <WorkspaceDetails workspace={workspace} />
               <div>
                 Created {workspace.datetime_created.slice(0, 10)}
-                {}
                 <button
                   type="submit"
                   disabled={workspace.jobs.length > 0 /* TODO: And/or check workspace status? */}
@@ -83,7 +82,7 @@ function WorkspacesList() {
                 </button>
                 <button
                   type="submit"
-                  disabled={workspace.jobs.length === 0 /* TODO: And/or check workspace status? */}
+                  disabled={workspace.jobs.length === 0}
                   onClick={() => {
                     handleStop(workspace.id);
                   }}

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -9,7 +9,7 @@ import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonR
 import { PanelWrapper } from 'js/shared-styles/panels';
 
 import WorkspaceDetails from 'js/components/workspaces/WorkspaceDetails';
-import { createEmptyWorkspace, deleteWorkspace } from './utils';
+import { createEmptyWorkspace, deleteWorkspace, stopJobs } from './utils';
 import { useWorkspacesList } from './hooks';
 import { StyledButton } from './style';
 
@@ -19,7 +19,11 @@ function WorkspacesList() {
 
   async function handleDelete(workspaceId) {
     deleteWorkspace({ workspaceId, workspacesEndpoint, workspacesToken });
-    // TODO: Handle failed deletion
+    // TODO: Update list of workspaces
+  }
+
+  async function handleStop(workspaceId) {
+    stopJobs({ workspaceId, workspacesEndpoint, workspacesToken });
     // TODO: Update list of workspaces
   }
 
@@ -67,14 +71,24 @@ function WorkspacesList() {
               <WorkspaceDetails workspace={workspace} />
               <div>
                 Created {workspace.datetime_created.slice(0, 10)}
+                {}
                 <button
                   type="submit"
+                  disabled={workspace.jobs.length > 0 /* TODO: And/or check workspace status? */}
                   onClick={() => {
                     handleDelete(workspace.id);
                   }}
                 >
-                  Delete
-                  {/* TODO: Checkbox instead of button. */}
+                  Delete Workspace
+                </button>
+                <button
+                  type="submit"
+                  disabled={workspace.jobs.length === 0 /* TODO: And/or check workspace status? */}
+                  onClick={() => {
+                    handleStop(workspace.id);
+                  }}
+                >
+                  Stop Jobs
                 </button>
               </div>
             </PanelWrapper>

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -76,7 +76,7 @@ function mergeJobsIntoWorkspaces(jobs, workspaces) {
   const wsIdToJobs = {};
   jobs.forEach((job) => {
     const { status, workspace_id } = job;
-    if (status === 'complete') {
+    if (['complete', 'failed'].includes(status)) {
       return;
     }
     if (!(workspace_id in wsIdToJobs)) {

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -21,33 +21,47 @@ async function createEmptyWorkspace({ workspacesEndpoint, workspacesToken, works
 }
 
 async function stopJob({ jobId, workspacesEndpoint, workspacesToken }) {
-  await fetch(`${workspacesEndpoint}/jobs/${jobId}/stop/`, {
+  const response = await fetch(`${workspacesEndpoint}/jobs/${jobId}/stop/`, {
     method: 'PUT',
     headers: getWorkspacesApiHeaders(workspacesToken),
   });
+  // When we understand when/why API failures occur, design approapriate UI.
+  if (response.ok) {
+    // eslint-disable-next-line no-alert
+    alert(`Job stop for ${jobId} will begin`);
+  } else {
+    // eslint-disable-next-line no-alert
+    alert(`Job stop for ${jobId} failed`);
+  }
 }
 
 async function deleteWorkspace({ workspaceId, workspacesEndpoint, workspacesToken }) {
   const headers = getWorkspacesApiHeaders(workspacesToken);
+  const response = await fetch(`${workspacesEndpoint}/workspaces/${workspaceId}/`, {
+    method: 'DELETE',
+    headers,
+  });
+  // When we understand when/why API failures occur, design approapriate UI.
+  if (response.ok) {
+    // eslint-disable-next-line no-alert
+    alert(`Workspace deletion for ${workspaceId} will begin`);
+  } else {
+    // eslint-disable-next-line no-alert
+    alert(`Workspace deletion for ${workspaceId} failed`);
+  }
+}
+
+async function stopJobs({ workspaceId, workspacesEndpoint, workspacesToken }) {
+  const headers = getWorkspacesApiHeaders(workspacesToken);
   const jobsResponse = await fetch(`${workspacesEndpoint}/jobs`, { headers });
   const jobsResults = await jobsResponse.json();
   const { jobs } = jobsResults.data;
+  // TODO: Filter down to only the jobs that are not already in the process of being stopped.
   jobs.forEach((job) => {
-    if (String(job.workspace_id) === workspaceId) {
+    if (String(job.workspace_id) === String(workspaceId)) {
       stopJob({ jobId: job.id, workspacesEndpoint, workspacesToken });
     }
   });
-  async function retryDelete() {
-    const deleteResponse = await fetch(`${workspacesEndpoint}/workspaces/${workspaceId}/`, {
-      method: 'DELETE',
-      headers,
-    });
-    // Delete will fail until all jobs are stopped, and this is simpler than checking all the jobs.
-    if (!deleteResponse.ok) {
-      setTimeout(retryDelete, 5000);
-    }
-  }
-  retryDelete();
 }
 
 async function startJob({ workspaceId, workspacesEndpoint, workspacesToken, setMessage, setDead }) {
@@ -72,7 +86,10 @@ function mergeJobsIntoWorkspaces(jobs, workspaces) {
 
   const wsIdToJobs = {};
   jobs.forEach((job) => {
-    const { workspace_id } = job;
+    const { status, workspace_id } = job;
+    if (status === 'complete') {
+      return;
+    }
     if (!(workspace_id in wsIdToJobs)) {
       wsIdToJobs[workspace_id] = [];
     }
@@ -164,4 +181,4 @@ async function locationIfJobRunning({ workspaceId, setMessage, setDead, workspac
   return null;
 }
 
-export { createEmptyWorkspace, deleteWorkspace, mergeJobsIntoWorkspaces, condenseJobs, locationIfJobRunning };
+export { createEmptyWorkspace, deleteWorkspace, stopJobs, mergeJobsIntoWorkspaces, condenseJobs, locationIfJobRunning };

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -46,7 +46,6 @@ async function stopJobs({ workspaceId, workspacesEndpoint, workspacesToken }) {
   const jobsResponse = await fetch(`${workspacesEndpoint}/jobs`, { headers });
   const jobsResults = await jobsResponse.json();
   const { jobs } = jobsResults.data;
-  // TODO: Filter down to only the jobs that are not already in the process of being stopped.
   jobs.forEach((job) => {
     if (String(job.workspace_id) === String(workspaceId)) {
       stopJob({ jobId: job.id, workspacesEndpoint, workspacesToken });

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -25,13 +25,8 @@ async function stopJob({ jobId, workspacesEndpoint, workspacesToken }) {
     method: 'PUT',
     headers: getWorkspacesApiHeaders(workspacesToken),
   });
-  // When we understand when/why API failures occur, design approapriate UI.
-  if (response.ok) {
-    // eslint-disable-next-line no-alert
-    alert(`Job stop for ${jobId} will begin`);
-  } else {
-    // eslint-disable-next-line no-alert
-    alert(`Job stop for ${jobId} failed`);
+  if (!response.ok) {
+    throw Error(`Job stop for job #${jobId} failed`);
   }
 }
 
@@ -41,13 +36,8 @@ async function deleteWorkspace({ workspaceId, workspacesEndpoint, workspacesToke
     method: 'DELETE',
     headers,
   });
-  // When we understand when/why API failures occur, design approapriate UI.
-  if (response.ok) {
-    // eslint-disable-next-line no-alert
-    alert(`Workspace deletion for ${workspaceId} will begin`);
-  } else {
-    // eslint-disable-next-line no-alert
-    alert(`Workspace deletion for ${workspaceId} failed`);
+  if (!response.ok) {
+    throw Error(`Workspace deletion for workspace #${workspaceId} failed`);
   }
 }
 


### PR DESCRIPTION
- Fix #2875

Deleting workspaces is a 2 step process at the API level:
- Stop running jobs
- Delete the workspace

(Obviously, things would be easier on my end if there were an `rm -rf`, but there's not, and Juan's made a good argument that these are separate concerns.)

Currently, the portal sends the stop job requests, and then tries to delete the workspace... and tries again until it works. Juan has said that it could take some time to stop running jobs. The problem with this is that the only the UI knows that we're in the middle of a deletion: If you leave the page, the retries stop, and the workspace will not be deleted.

This PR gives the user two separate buttons for the two steps in the process. I'm not proposing this as the final, polished UI, but just something that can work until a new design is available.

@ngehlenborg -- Approval indicates that you accept that the UI will need to change to accommodate the API. If you can not approve, then you need to negotiate with Phil and Juan to provide a richer API.

@jpuerto-psc -- I want to check with you that the in-between states are being handled appropriately. I'll post more questions line-by-line in the PR.

@john-conroy -- You've asked to be on UI PRs... but I think this is more about hashing out what the UI should be... For now, I'm happy with the plain buttons; Feel free to remove yourself from the reviewers list.

