### PR TITLE
Bound Vitessce

### DIFF
--- a/CHANGELOG-bound-vitessce.md
+++ b/CHANGELOG-bound-vitessce.md
@@ -1,0 +1,1 @@
+- Use new Vitessce functionality so components can't be dragged off the bottom.

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -184,6 +184,7 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader }) {
               onConfigChange={handleVitessceConfigDebounced}
               height={vizIsFullscreen ? null : vitessceFixedHeight}
               onWarn={addError}
+              isBounded
             />
           </ExpandableDiv>
         </Paper>

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -69,7 +69,7 @@
         "uuid": "^8.3.2",
         "vega": "^5.17.3",
         "vega-lite": "^4.13.1",
-        "vitessce": "^1.1.21",
+        "vitessce": "^1.2.1",
         "web-vitals": "^1.1.0",
         "whatwg-fetch": "^3.0.0",
         "zustand": "^3.5.9"
@@ -50519,9 +50519,9 @@
       }
     },
     "node_modules/vitessce": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.21.tgz",
-      "integrity": "sha512-bOPemOSKc3Z9hreNq21/pE7zkndnvIAcSlzJOsq6w/kdff5GSY3C5Wbg2utUAdFwPDZ3eGxu5s8ep3qAbXvUNg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.2.1.tgz",
+      "integrity": "sha512-jdAvHgMgRvIGOvZot+wZYXbk/kLY5kLhhodJ8+H4kO6qHum/1CxvLph7YVF163fCtsv3dvMVsfBaeVz2L8U5cQ==",
       "dependencies": {
         "@babel/runtime": "7.8.7",
         "@hms-dbmi/viv": "~0.12.6",
@@ -50568,7 +50568,7 @@
         "rc-tooltip": "^4.0.3",
         "rc-tree": "2.1.0",
         "react-color": "^2.18.0",
-        "react-grid-layout": "^1.1.1",
+        "react-grid-layout": "^1.3.4",
         "react-vega": "^7.4.4",
         "react-virtualized": "^9.22.2",
         "short-number": "^1.0.6",
@@ -92396,9 +92396,9 @@
       }
     },
     "vitessce": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.1.21.tgz",
-      "integrity": "sha512-bOPemOSKc3Z9hreNq21/pE7zkndnvIAcSlzJOsq6w/kdff5GSY3C5Wbg2utUAdFwPDZ3eGxu5s8ep3qAbXvUNg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-1.2.1.tgz",
+      "integrity": "sha512-jdAvHgMgRvIGOvZot+wZYXbk/kLY5kLhhodJ8+H4kO6qHum/1CxvLph7YVF163fCtsv3dvMVsfBaeVz2L8U5cQ==",
       "requires": {
         "@babel/runtime": "7.8.7",
         "@hms-dbmi/viv": "~0.12.6",
@@ -92445,7 +92445,7 @@
         "rc-tooltip": "^4.0.3",
         "rc-tree": "2.1.0",
         "react-color": "^2.18.0",
-        "react-grid-layout": "^1.1.1",
+        "react-grid-layout": "^1.3.4",
         "react-vega": "^7.4.4",
         "react-virtualized": "^9.22.2",
         "short-number": "^1.0.6",

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -69,7 +69,7 @@
         "uuid": "^8.3.2",
         "vega": "^5.17.3",
         "vega-lite": "^4.13.1",
-        "vitessce": "^1.1.20",
+        "vitessce": "^1.1.21",
         "web-vitals": "^1.1.0",
         "whatwg-fetch": "^3.0.0",
         "zustand": "^3.5.9"

--- a/context/package.json
+++ b/context/package.json
@@ -62,7 +62,7 @@
     "uuid": "^8.3.2",
     "vega": "^5.17.3",
     "vega-lite": "^4.13.1",
-    "vitessce": "^1.1.20",
+    "vitessce": "^1.1.21",
     "web-vitals": "^1.1.0",
     "whatwg-fetch": "^3.0.0",
     "zustand": "^3.5.9"

--- a/context/package.json
+++ b/context/package.json
@@ -62,7 +62,7 @@
     "uuid": "^8.3.2",
     "vega": "^5.17.3",
     "vega-lite": "^4.13.1",
-    "vitessce": "^1.1.21",
+    "vitessce": "^1.2.1",
     "web-vitals": "^1.1.0",
     "whatwg-fetch": "^3.0.0",
     "zustand": "^3.5.9"


### PR DESCRIPTION
- Fix #2409

Use new vitessce functionality to prevent components being dragged off the bottom... well, it doesn't prevent dragging off the bottom, it just reverts the drag if it's off the bottom, but during the drag, we can still have issues:
<img width="1497" alt="Screen Shot 2022-09-06 at 11 43 16 AM" src="https://user-images.githubusercontent.com/730388/188679087-7b62bb23-69e0-4dfe-a5b5-649c18a2bfbd.png">

I took a couple minutes to explore whether wrapping it in 
```
<div style={{ maxHeight: vitessceFixedHeight, overflow: 'hidden' }}>
```
would change anything, but it doesn't... and that's probably a bad idea regardless.

I'd suggest merging this, unless you have a better idea, and leaving a note on the agenda to explain the limitations... but hoping not to do more work in this area.
