### PR TITLE
Mccalluc/fix home prop types

### DIFF
--- a/CHANGELOG-fix-prop-types.md
+++ b/CHANGELOG-fix-prop-types.md
@@ -1,0 +1,1 @@
+- Fix proptype warnings.

--- a/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
+++ b/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
@@ -13,7 +13,7 @@ function UserLinks({ isAuthenticated, userEmail }) {
   return (
     <Dropdown title={<TruncatedSpan>{isAuthenticated ? userEmail || 'User' : 'User Profile'}</TruncatedSpan>}>
       <DropdownLink href="/my-lists">My Lists</DropdownLink>
-      {workspacesUsers.includes(userEmail) && <DropdownLink href="/workspaces">My Workspaces</DropdownLink>}
+      {workspacesUsers.includes(userEmail) ? <DropdownLink href="/workspaces">My Workspaces</DropdownLink> : null}
       <StyledDivider />
       {isAuthenticated ? (
         <WarningDropdownLink href="/logout">Log Out</WarningDropdownLink>

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -297,6 +297,7 @@ Routes.propTypes = {
     organ: PropTypes.object,
     organs: PropTypes.object,
     metadata: PropTypes.object,
+    organs_count: PropTypes.number,
   }),
 };
 


### PR DESCRIPTION
`false` as a child was failing the check, but `null` is fine... Is this ok, or would it be better to change the proptype?