### PR TITLE
dev-search is 404 away from localhost

### DIFF
--- a/CHANGELOG-devsearch-is-for-devs.md
+++ b/CHANGELOG-devsearch-is-for-devs.md
@@ -1,0 +1,1 @@
+- To avoid confusion, /dev-search is now 404 if host is anything other than localhost.

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 from flask import (render_template, current_app, abort,
                    session, request)
 
@@ -76,6 +78,8 @@ def test_search(type):
 
 @blueprint.route('/dev-search')
 def dev_search():
+    if urlparse(request.base_url).hostname != 'localhost':
+        abort(404)
     title = 'Dev Search'
     flask_data = {
         **get_default_flask_data(),


### PR DESCRIPTION
- Fix #2903

This is partly a policy question, but dev-search has been a place to demonstrate that sometimes fields value _do not_ line up with their labels, and it's been very useful in that regard. If endusers start using it, then we need to ask what they think they're doing, and make the needed changes to support that usecase.

But, with this PR, it will just return 404 for any user not on localhost. (Devs can see the new behavior by looking at http://127.0.0.1:5001/dev-search.)