### PR TITLE
John conroy/preserve cells order

### DIFF
--- a/CHANGELOG-preserve-cells-order.md
+++ b/CHANGELOG-preserve-cells-order.md
@@ -1,0 +1,1 @@
+- Use order of datasets provided by cells service in cells ui.

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/hooks.js
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/hooks.js
@@ -37,6 +37,14 @@ function getSearchQuery(cellsResults) {
   };
 }
 
+function buildHitsMap(hits) {
+  return hits.reduce((acc, hit) => {
+    // eslint-disable-next-line no-underscore-dangle
+    acc[hit._id] = hit;
+    return acc;
+  }, {});
+}
+
 function useDatasetsSelectedByExpression({
   completeStep,
   setResults,
@@ -77,7 +85,9 @@ function useDatasetsSelectedByExpression({
       );
       const serviceResults = await new CellsService().getDatasets(queryParams);
       const searchResults = await fetchSearchData(getSearchQuery(serviceResults), elasticsearchEndpoint, groupsToken);
-      setResults(searchResults.hits.hits);
+
+      const hitsMap = buildHitsMap(searchResults.hits.hits);
+      setResults(serviceResults.map(({ uuid }) => hitsMap[uuid]));
       setIsLoading(false);
     } catch (e) {
       setMessage(e.message);
@@ -93,4 +103,4 @@ function useDatasetsSelectedByExpression({
   return { genomicModality, handleSelectModality, handleSubmit, message };
 }
 
-export { useDatasetsSelectedByExpression };
+export { buildHitsMap, useDatasetsSelectedByExpression };

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/hooks.spec.js
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/hooks.spec.js
@@ -1,0 +1,8 @@
+import { buildHitsMap } from './hooks';
+
+test('should first', () => {
+  expect(buildHitsMap([{ _id: 'a' }, { _id: 'b' }])).toEqual({
+    a: { _id: 'a' },
+    b: { _id: 'b' },
+  });
+});


### PR DESCRIPTION
Previously order was determined by `search-api`, this will preserve order from cells service.

Ideally we could use elasticsearch's `_mget` endpoint which allows us to fetch the documents given `_id`s which will retain the order of the `_id`s included in the request body. I'll reach out to Bill to see if this is feasible.