### PR TITLE
Update typeservice to V3

### DIFF
--- a/CHANGELOG-v3-conf.md
+++ b/CHANGELOG-v3-conf.md
@@ -1,2 +1,1 @@
-- Add `v3` to search and types service URLs in example confs.
-  Configs in all environments will need to be updated as well.
+- Add `v3` to the types service, and at it to the Services page. No change to environment required.

--- a/CHANGELOG-v3-conf.md
+++ b/CHANGELOG-v3-conf.md
@@ -1,0 +1,2 @@
+- Add `v3` to search and types service URLs in example confs.
+  Configs in all environments will need to be updated as well.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -179,7 +179,9 @@ class ApiClient():
         else:
             try:
                 def get_assay(name):
-                    type_client = TypeClient(current_app.config["TYPE_SERVICE_ENDPOINT"])
+                    type_client = TypeClient(
+                        current_app.config["TYPE_SERVICE_ENDPOINT"]
+                        + '/' + current_app.config["SERVICE_VERSION"])
                     return type_client.getAssayType(name)
                 Builder = get_view_config_builder(entity=entity, get_assay=get_assay)
                 builder = Builder(entity, self.groups_token, current_app.config["ASSETS_ENDPOINT"])

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -181,7 +181,7 @@ class ApiClient():
                 def get_assay(name):
                     type_client = TypeClient(
                         current_app.config["TYPE_SERVICE_ENDPOINT"]
-                        + '/' + current_app.config["SERVICE_VERSION"])
+                        + current_app.config["TYPE_SERVICE_PATH"])
                     return type_client.getAssayType(name)
                 Builder = get_view_config_builder(entity=entity, get_assay=get_assay)
                 builder = Builder(entity, self.groups_token, current_app.config["ASSETS_ENDPOINT"])

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -19,7 +19,7 @@ class DefaultConfig(object):
 
     # These app-wide configurations do not vary between environments:
 
-    SERVICE_VERSION = version
+    TYPE_SERVICE_PATH = f'/{version}'
     PORTAL_INDEX_PATH = f'/{version}/portal/search'
     CCF_INDEX_PATH = '/entities/search'
 

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -32,6 +32,7 @@ class DefaultConfig(object):
 
     GATEWAY_ENDPOINT = 'should-be-overridden'
     ELASTICSEARCH_ENDPOINT = 'should-be-overridden'
+    TYPE_SERVICE_ENDPOINT = 'should-be-overridden'
     ASSETS_ENDPOINT = 'should-be-overridden'
     XMODALITY_ENDPOINT = 'should-be-overridden'
     WORKSPACES_ENDPOINT = 'should-be-overridden'

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -1,5 +1,10 @@
 from datetime import timedelta
 
+# By keeping this in code rather than configuration,
+# we can atomically release changes that uses new service features,
+# rather than requiring backward compatibility from new API versions
+# during the migration window.
+version = 'v3'
 
 class DefaultConfig(object):
     # This should be updated when app.conf is updated:
@@ -12,7 +17,10 @@ class DefaultConfig(object):
     PERMANENT_SESSION_LIFETIME = timedelta(minutes=60)
     SESSION_COOKIE_SAMESITE = 'Lax'
 
-    PORTAL_INDEX_PATH = '/v3/portal/search'
+    # These app-wide configurations do not vary between environments:
+
+    SERVICE_VERSION = version
+    PORTAL_INDEX_PATH = f'/{version}/portal/search'
     CCF_INDEX_PATH = '/entities/search'
 
     # Everything else should be overridden in app.conf:

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -1,9 +1,11 @@
 from datetime import timedelta
 
+
 # By keeping this in code rather than configuration,
 # we can atomically release changes that uses new service features,
 # rather than requiring backward compatibility from new API versions.
 version = 'v3'
+
 
 class DefaultConfig(object):
     # This should be updated when app.conf is updated:

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -2,8 +2,7 @@ from datetime import timedelta
 
 # By keeping this in code rather than configuration,
 # we can atomically release changes that uses new service features,
-# rather than requiring backward compatibility from new API versions
-# during the migration window.
+# rather than requiring backward compatibility from new API versions.
 version = 'v3'
 
 class DefaultConfig(object):

--- a/context/app/static/js/components/ServiceStatusTable/ServiceStatusTable.jsx
+++ b/context/app/static/js/components/ServiceStatusTable/ServiceStatusTable.jsx
@@ -38,6 +38,7 @@ function ServiceStatusTable({
   entityEndpoint,
   gatewayEndpoint,
   workspacesEndpoint,
+  typeServiceEndpoint,
 }) {
   const gatewayStatus = useGatewayStatus(`${gatewayEndpoint}/status.json`);
 
@@ -84,6 +85,13 @@ function ServiceStatusTable({
           endpointUrl: elasticsearchEndpoint,
           response: gatewayStatus.search_api,
           noteFunction: (api) => `ES: ${api.elasticsearch_connection}; ES Status: ${api.elasticsearch_status}`,
+        }),
+        buildServiceStatus({
+          apiName: 'type-api',
+          githubUrl: 'https://github.com/dbmi-pitt/search-adaptor',
+          endpointUrl: typeServiceEndpoint,
+          response: gatewayStatus.search_api,
+          noteFunction: () => 'Incorporated into the search-api machinery for historical reasons.',
         }),
         buildServiceStatus({
           apiName: 'uuid-api',

--- a/context/app/static/js/components/ServiceStatusTable/ServiceStatusTable.jsx
+++ b/context/app/static/js/components/ServiceStatusTable/ServiceStatusTable.jsx
@@ -91,7 +91,7 @@ function ServiceStatusTable({
           githubUrl: 'https://github.com/dbmi-pitt/search-adaptor',
           endpointUrl: typeServiceEndpoint,
           response: gatewayStatus.search_api,
-          noteFunction: () => 'Incorporated into the search-api machinery for historical reasons.',
+          noteFunction: () => 'Included in search-api for historical reasons.',
         }),
         buildServiceStatus({
           apiName: 'uuid-api',

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -31,6 +31,7 @@ def get_default_flask_data():
             'xmodalityEndpoint': current_app.config['XMODALITY_ENDPOINT'],
             'workspacesEndpoint': current_app.config['WORKSPACES_ENDPOINT'],
             'workspacesWsEndpoint': current_app.config['WORKSPACES_WS_ENDPOINT'],
+            'typeServiceEndpoint': current_app.config['TYPE_SERVICE_ENDPOINT'],
         },
         'globalAlertMd': current_app.config.get('GLOBAL_ALERT_MD')
     }

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -26,12 +26,13 @@ def get_default_flask_data():
             'gatewayEndpoint': current_app.config['GATEWAY_ENDPOINT'],
             'elasticsearchEndpoint': current_app.config['ELASTICSEARCH_ENDPOINT']
             + current_app.config['PORTAL_INDEX_PATH'],
+            'typeServiceEndpoint': current_app.config['TYPE_SERVICE_ENDPOINT']
+            + current_app.config['TYPE_SERVICE_PATH'],
             'assetsEndpoint': current_app.config['ASSETS_ENDPOINT'],
             'entityEndpoint': current_app.config['ENTITY_API_BASE'],
             'xmodalityEndpoint': current_app.config['XMODALITY_ENDPOINT'],
             'workspacesEndpoint': current_app.config['WORKSPACES_ENDPOINT'],
             'workspacesWsEndpoint': current_app.config['WORKSPACES_WS_ENDPOINT'],
-            'typeServiceEndpoint': current_app.config['TYPE_SERVICE_ENDPOINT'],
         },
         'globalAlertMd': current_app.config.get('GLOBAL_ALERT_MD')
     }


### PR DESCRIPTION
This change could have been made in env or in commons... but since we forgot to make the changes there before migration, it makes sense to make it here.

Going forward, if there's a "v4", there's one line that will need to be changed in `portal-ui` and no env change will be required.

On the service page, the new entry looks like:
> type-api	Up	https://search.api.hubmapconsortium.org/v3	search-adaptor 3.0.1	main:2e984ee	Included in search-api for historical reasons.


