### PR TITLE
version index for ccf

### DIFF
--- a/CHANGELOG-bump-ccf-path.md
+++ b/CHANGELOG-bump-ccf-path.md
@@ -1,0 +1,1 @@
+- The CCF uses a separate index, but it should also be bumped to v3.

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -22,7 +22,7 @@ class DefaultConfig(object):
 
     TYPE_SERVICE_PATH = f'/{version}'
     PORTAL_INDEX_PATH = f'/{version}/portal/search'
-    CCF_INDEX_PATH = '/entities/search'
+    CCF_INDEX_PATH = f'{version}/entities/search'
 
     # Everything else should be overridden in app.conf:
 


### PR DESCRIPTION
- Follow-up to #2924

For now, I assume it makes sense for all of these to be using the same version, even thought they are all accessing different resources under `v3`. This is mostly a FYI.