### PR TITLE
surface ws api problems

### DIFF
--- a/context/app/static/js/components/workspaces/hooks.js
+++ b/context/app/static/js/components/workspaces/hooks.js
@@ -2,7 +2,7 @@ import { useContext, useState, useEffect } from 'react';
 
 import { AppContext } from 'js/components/Providers';
 
-import { mergeJobsIntoWorkspaces } from './utils';
+import { mergeJobsIntoWorkspaces, getWorkspacesApiHeaders } from './utils';
 
 function useWorkspacesList() {
   const [workspacesList, setWorkspacesList] = useState([]);
@@ -15,10 +15,7 @@ function useWorkspacesList() {
     async function getAndSetWorkspacesList() {
       const fetchOpts = {
         method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'UWS-Authorization': `Token ${workspacesToken}`,
-        },
+        headers: getWorkspacesApiHeaders(workspacesToken),
       };
       const [workspacesResponse, jobsResponse] = await Promise.all([
         fetch(`${workspacesEndpoint}/workspaces`, fetchOpts),

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -1,6 +1,9 @@
 import { jobStatuses, validateJobStatus, workspaceStatuses, validateWorkspaceStatus } from './statusCodes';
 
 function getWorkspacesApiHeaders(workspacesToken) {
+  if (!workspacesToken) {
+    throw Error('token missing; login again');
+  }
   return {
     'Content-Type': 'application/json',
     'UWS-Authorization': `Token ${workspacesToken}`,
@@ -129,7 +132,17 @@ function condenseJobs(jobs) {
     const details = job.job_details.current_job_details;
     if (details.connection_details) {
       const { url_domain, url_path } = details.connection_details;
-      return `${url_domain}${url_path}`;
+      /*
+      API is returning URLs that end with "/lab", but these redirect to "/lab/tree"
+      and then produce an error message:
+      
+      The path:
+        /passthrough/l002.hive.psc.edu/421/lab/tree
+      was not found. JupyterLab redirected to:
+        /passthrough/l002.hive.psc.edu/421/
+      */
+      const clean_url_path = url_path.replace(/\/lab\?/, '?');
+      return `${url_domain}${clean_url_path}`;
     }
     return null;
   }
@@ -188,4 +201,12 @@ async function locationIfJobRunning({ workspaceId, setMessage, setDead, workspac
   return null;
 }
 
-export { createEmptyWorkspace, deleteWorkspace, stopJobs, mergeJobsIntoWorkspaces, condenseJobs, locationIfJobRunning };
+export {
+  getWorkspacesApiHeaders,
+  createEmptyWorkspace,
+  deleteWorkspace,
+  stopJobs,
+  mergeJobsIntoWorkspaces,
+  condenseJobs,
+  locationIfJobRunning,
+};

--- a/context/app/static/js/pages/WorkspacePleaseWait/WorkspacePleaseWait.jsx
+++ b/context/app/static/js/pages/WorkspacePleaseWait/WorkspacePleaseWait.jsx
@@ -22,7 +22,8 @@ function WorkspacePleaseWait({ workspaceId }) {
     if (jobLocation) {
       const [urlBase, urlQuery] = jobLocation.split('?');
       const workspacePath = document.location.hash.slice(1);
-      const jupyterUrl = `${urlBase}/tree/${workspacePath}?${urlQuery}`;
+      const path = workspacePath ? `/tree/${workspacePath}` : '';
+      const jupyterUrl = `${urlBase}${path}?${urlQuery}`;
       document.location = jupyterUrl;
     } else {
       setTimeout(setLocationOrRetry, 5000);


### PR DESCRIPTION
Further work here is blocked until the problems described on slack are resolved:

> Different topic: The API responses look like:
> "proxy_details": {"path": "/passthrough/l002.hive.psc.edu/15/lab?token=8d480506c...
> Are you sure the lab should be there? and has it always been there? These urls don’t work for me: It seems to redirect to /lab/tree, and then I get an error like:
> The path: /passthrough/l002.hive.psc.edu/421/lab/tree was not found. JupyterLab redirected to: /passthrough/l002.hive.psc.edu/421/
> For now, I’ll just truncate the lab on my side to get past the error.
> 
> … Ok, there’s also a problem just in JupyterLab. If I load:
> https://workspaces-pt.hubmapconsortium.org/passthrough/l002.hive.psc.edu/421/
> It updates the location to
> https://workspaces-pt.hubmapconsortium.org/passthrough/l002.hive.psc.edu/421/lab/workspaces/auto-t?reset
> and then there’s an error message:
> Path Not Found
> The path: /passthrough/l002.hive.psc.edu/421/lab/tree was not found. JupyterLab redirected to: /passthrough/l002.hive.psc.edu/421/
> and then it updates the location again, back to
> https://workspaces-pt.hubmapconsortium.org/passthrough/l002.hive.psc.edu/421/
> [4:13](https://hubmapconsortium.slack.com/archives/C02UPEGH7PA/p1664223186423789)
> All of this is in JupyterLab — portal-ui code isn’t involved — and I’m pretty sure it’s a regression.