### PR TITLE
bump version number for portal-vis

### DIFF
--- a/CHANGELOG-bump-portal-vis.md
+++ b/CHANGELOG-bump-portal-vis.md
@@ -1,0 +1,1 @@
+- Bump portal-vis to fix a regression in handling of unstiched imagery.

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -10,7 +10,7 @@ hubmap-api-py-client>=0.0.9
 hubmap-commons>=2.0.12
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.6.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.7.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -638,8 +638,8 @@ platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
     --hash=sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227
     # via black
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.6.zip \
-    --hash=sha256:cac84bd484b926bba8fd6bea91f88fba89cb6e38bb0179215f22e7574a03335d
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.7.zip \
+    --hash=sha256:9cbc1c65383139efd70d840510b4c86e13b77476ddef87d40e16338019df328b
     # via -r context/requirements.in
 property==2.2 \
     --hash=sha256:d25e4da4e415408b9eb39b6521c088e4e2b8a9e2f9f96fb2d91680e97207ea19


### PR DESCRIPTION
- Fix #2949
- I was definitely the one who introduced the bug... but it worries me that this was published without anyone raising an alarm. (I'm also a little concerned that new unstitched datasets are still being published.)