### PR TITLE
John conroy/pass job types id on start

### DIFF
--- a/CHANGELOG-pass-job-types-id-on-start.md
+++ b/CHANGELOG-pass-job-types-id-on-start.md
@@ -1,0 +1,1 @@
+- Pass job_types_id to workspace job start request.

--- a/context/app/static/js/components/workspaces/utils.js
+++ b/context/app/static/js/components/workspaces/utils.js
@@ -58,20 +58,21 @@ async function stopJobs({ workspaceId, workspacesEndpoint, workspacesToken }) {
 }
 
 async function startJob({ workspaceId, workspacesEndpoint, workspacesToken, setMessage, setDead }) {
-  const startResponse = await fetch(`${workspacesEndpoint}/workspaces/${workspaceId}/start`, {
-    method: 'PUT',
-    headers: getWorkspacesApiHeaders(workspacesToken),
-    body: JSON.stringify({
-      job_type: 'JupyterLabJob',
-      job_details: {},
-    }),
-  });
-
-  if (!startResponse.ok) {
-    setDead(true);
-  }
-  const start = await startResponse.json();
-  setMessage(start.message);
+  fetch(`${workspacesEndpoint}/job_types`)
+    .then((response) => response.json())
+    .then(({ data: { job_types } }) =>
+      fetch(`${workspacesEndpoint}/workspaces/${workspaceId}/start`, {
+        method: 'PUT',
+        headers: getWorkspacesApiHeaders(workspacesToken),
+        body: JSON.stringify({
+          job_type: job_types.jupyter_lab.id,
+          job_details: {},
+        }),
+      }),
+    )
+    .then((response) => response.json())
+    .then(({ start }) => setMessage(start.message))
+    .catch(() => setDead(true));
 }
 
 function getNotebookPath(workspace) {


### PR DESCRIPTION
Handle newly required `job_types_id` on PUT to start workspace job.