### PR TITLE
John conroy/handle sample category

### DIFF
--- a/CHANGELOG-handle-sample-category.md
+++ b/CHANGELOG-handle-sample-category.md
@@ -1,0 +1,1 @@
+- Handle change in elasticsearch document from specimen_type and mapped_specimen_type to sample_category.

--- a/README-deploy-qa.md
+++ b/README-deploy-qa.md
@@ -47,7 +47,7 @@ Thursday afternoon:
 
 ### Detail Pages
 
-Confirm the below for a variety of entities spread across assay types for datasets, specimen types for samples, and groups for donors.
+Confirm the below for a variety of entities spread across assay types for datasets, sample categories for samples, and groups for donors.
 
 *   Table of contents sidebar should reflect the sections on the page starting with ‘Summary’. Clicking a link should bring you to the appropriate section.
 *   Scrolling past the summary section should reveal a header below the primary app bar.

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -112,7 +112,7 @@ def _get_entities(entity_type, constraints={}, uuids=None):
     if entity_type in ['samples', 'datasets']:
         extra_fields += ['donor.hubmap_id', 'origin_sample.mapped_organ']
     if entity_type in ['samples']:
-        extra_fields += ['mapped_specimen_type']
+        extra_fields += ['sample_category']
     entities = client.get_entities(
         plural_lc_entity_type=entity_type, non_metadata_fields=extra_fields,
         constraints=constraints,

--- a/context/app/static/js/components/detailPage/SampleTissue/SampleTissue.jsx
+++ b/context/app/static/js/components/detailPage/SampleTissue/SampleTissue.jsx
@@ -8,7 +8,7 @@ import { DetailPageSection } from 'js/components/detailPage/style';
 import { FlexPaper } from './style';
 import SectionItem from '../SectionItem';
 
-function SampleTissue({ uuid, mapped_organ, mapped_specimen_type, hasRUI }) {
+function SampleTissue({ uuid, mapped_organ, sample_category, hasRUI }) {
   return (
     <DetailPageSection id="tissue">
       <SectionHeader>Tissue</SectionHeader>
@@ -18,8 +18,8 @@ function SampleTissue({ uuid, mapped_organ, mapped_specimen_type, hasRUI }) {
             {mapped_organ || 'Organ Type not defined'}
           </LightBlueLink>
         </SectionItem>
-        <SectionItem label="Specimen Type" ml={1} flexBasis="25%">
-          {mapped_specimen_type || 'Specimen Type not defined'}
+        <SectionItem label="Sample Category" ml={1} flexBasis="25%">
+          {sample_category || 'Sample Category not defined'}
         </SectionItem>
         {hasRUI && (
           <SectionItem label="Tissue Location" ml={1}>
@@ -41,7 +41,7 @@ function SampleTissue({ uuid, mapped_organ, mapped_specimen_type, hasRUI }) {
 SampleTissue.propTypes = {
   uuid: PropTypes.string.isRequired,
   mapped_organ: PropTypes.string.isRequired,
-  mapped_specimen_type: PropTypes.string.isRequired,
+  sample_category: PropTypes.string.isRequired,
   hasRUI: PropTypes.bool.isRequired,
 };
 

--- a/context/app/static/js/components/detailPage/SampleTissue/SampleTissue.spec.js
+++ b/context/app/static/js/components/detailPage/SampleTissue/SampleTissue.spec.js
@@ -5,17 +5,17 @@ import SampleTissue from './SampleTissue';
 
 function expectLabelsPresent() {
   expect(screen.getByText('Tissue')).toBeInTheDocument();
-  const labelsToTest = ['Organ Type', 'Specimen Type'];
+  const labelsToTest = ['Organ Type', 'Sample Category'];
   labelsToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 }
 
 test('text displays properly when all props provided', () => {
-  render(<SampleTissue mapped_organ="Fake Organ" mapped_specimen_type="Fake Specimen Type" hasRUI />);
+  render(<SampleTissue mapped_organ="Fake Organ" sample_category="Fake Sample Category" hasRUI />);
   expectLabelsPresent();
 
   expect(screen.getByText('Tissue Location')).toBeInTheDocument();
 
-  const valuesToTest = ['Fake Organ', 'Fake Specimen Type'];
+  const valuesToTest = ['Fake Organ', 'Fake Sample Category'];
   valuesToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 });
 
@@ -25,6 +25,6 @@ test('displays label not defined when values are undefined', () => {
 
   expect(screen.queryByText('Tissue Location')).not.toBeInTheDocument();
 
-  const valuesToTest = ['Organ Type not defined', 'Specimen Type not defined'];
+  const valuesToTest = ['Organ Type not defined', 'Sample Category not defined'];
   valuesToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 });

--- a/context/app/static/js/components/detailPage/derivedEntities/DerivedSamplesTable/DerivedSamplesTable.jsx
+++ b/context/app/static/js/components/detailPage/derivedEntities/DerivedSamplesTable/DerivedSamplesTable.jsx
@@ -12,7 +12,7 @@ function DerivedSamplesTable({ entities }) {
 
   const sampleColumns = [
     { id: 'origin_sample.mapped_organ', label: 'Organ' },
-    { id: 'mapped_specimen_type', label: 'Specimen' },
+    { id: 'sample_category', label: 'Sample Category' },
   ];
 
   const columns = [displayDOICol, ...sampleColumns, descendantCountsCol, lastModifiedTimestampCol];
@@ -24,7 +24,7 @@ function DerivedSamplesTable({ entities }) {
             uuid: entityUUID,
             hubmap_id,
             origin_sample,
-            mapped_specimen_type,
+            sample_category,
             descendant_counts,
             last_modified_timestamp,
           },
@@ -36,7 +36,7 @@ function DerivedSamplesTable({ entities }) {
               </LightBlueLink>
             </TableCell>
             <TableCell>{origin_sample?.mapped_organ}</TableCell>
-            <TableCell>{mapped_specimen_type}</TableCell>
+            <TableCell>{sample_category}</TableCell>
             <TableCell>{descendant_counts?.entity_type?.Dataset || 0}</TableCell>
             <TableCell>{format(last_modified_timestamp, 'yyyy-MM-dd')}</TableCell>
           </TableRow>

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeader/utils.js
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeader/utils.js
@@ -1,5 +1,5 @@
 function extractAndLabelMetadata(obj, keys) {
-  const labels = { mapped_organ: 'organ type', mapped_data_types: 'data type', mapped_specimen_type: 'specimen type' };
+  const labels = { mapped_organ: 'organ type', mapped_data_types: 'data type', sample_category: 'sample category' };
   const acc = {};
   keys.forEach((k) => {
     acc[k] = { value: k in obj ? obj[k] : undefined, label: k in labels ? labels[k] : k };
@@ -12,7 +12,7 @@ function extractHeaderMetadata(assayMetadata, entity_type) {
     return extractAndLabelMetadata(assayMetadata, ['mapped_organ', 'mapped_data_types']);
   }
   if (entity_type === 'Sample') {
-    return extractAndLabelMetadata(assayMetadata, ['mapped_organ', 'mapped_specimen_type']);
+    return extractAndLabelMetadata(assayMetadata, ['mapped_organ', 'sample_category']);
   }
   if (entity_type === 'Donor') {
     const donorMetadata = extractAndLabelMetadata(assayMetadata, ['sex']);

--- a/context/app/static/js/components/detailPage/provenance/ProvTable/ProvTable.jsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvTable/ProvTable.jsx
@@ -39,7 +39,7 @@ function ProvTable({ uuid, typesToSplit, ancestors, assayMetadata }) {
                         entity_type={item.entity_type}
                         isCurrentEntity={uuid === item.uuid}
                         isSampleSibling={
-                          j > 0 && item.entity_type === 'Sample' && type[j - 1].specimen_type === item.specimen_type
+                          j > 0 && item.entity_type === 'Sample' && type[j - 1].sample_category === item.sample_category
                         }
                         isFirstTile={j === 0}
                         isLastTile={j === type.length - 1}

--- a/context/app/static/js/components/detailPage/summary/Summary/Summary.stories.js
+++ b/context/app/static/js/components/detailPage/summary/Summary/Summary.stories.js
@@ -47,7 +47,7 @@ const SampleTemplate = (args) => (
   <Summary {...args}>
     <SummaryItem>Fake Organ Type</SummaryItem>
     <Typography variant="h6" component="p">
-      Fake Specimen Type
+      Fake Sample Category
     </Typography>
   </Summary>
 );

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.js
@@ -140,7 +140,7 @@ function buildDatasetFields() {
 function buildSampleFields() {
   const tileFields = {
     ...createSampleFacet({ fieldName: 'origin_sample.mapped_organ', label: 'Organ', type: 'string' }),
-    ...createSampleFacet({ fieldName: 'mapped_specimen_type', label: 'Specimen Type', type: 'string' }),
+    ...createSampleFacet({ fieldName: 'sample_category', label: 'Sample Category', type: 'string' }),
   };
 
   return { tableFields: tileFields, tileFields };

--- a/context/app/static/js/components/entity-tile/EntityTile/EntityTile.stories.js
+++ b/context/app/static/js/components/entity-tile/EntityTile/EntityTile.stories.js
@@ -37,7 +37,7 @@ Sample.args = {
   invertColors: false,
   entityData: {
     last_modified_timestamp: Date.now(),
-    mapped_specimen_type: 'Specimen Type',
+    sample_category: 'Sample Category',
     origin_sample: { mapped_organ: 'Organ Type' },
   },
   descendantCounts: { Sample: 1, Dataset: 2 },

--- a/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.jsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.jsx
@@ -14,7 +14,7 @@ function EntityTileBody({ entity_type, id, entityData, invertColors }) {
       <StyledDiv>
         <Tile.Title>{id}</Tile.Title>
         {'origin_sample' in entityData && <Tile.Text>{entityData.origin_sample.mapped_organ}</Tile.Text>}
-        {'mapped_specimen_type' in entityData && <Tile.Text>{entityData.mapped_specimen_type}</Tile.Text>}
+        {'sample_category' in entityData && <Tile.Text>{entityData.sample_category}</Tile.Text>}
         {'mapped_data_types' in entityData && <Tile.Text>{entityData.mapped_data_types.join(', ')}</Tile.Text>}
         {entity_type === 'Donor' && 'mapped_metadata' in entityData && (
           <>

--- a/context/app/static/js/components/home/FacetSearch/FacetSearch.jsx
+++ b/context/app/static/js/components/home/FacetSearch/FacetSearch.jsx
@@ -12,7 +12,7 @@ const baseLabels = {
   'mapped_metadata.sex': 'Sex',
   'mapped_metadata.race': 'Race',
   'origin_sample.mapped_organ': 'Organ',
-  mapped_specimen_type: 'Specimen Type',
+  sample_category: 'Sample Category',
   mapped_data_types: 'Data Type',
 };
 
@@ -20,13 +20,13 @@ const allLabels = {
   ...baseLabels,
   'donor.mapped_metadata.sex': baseLabels['mapped_metadata.sex'],
   'donor.mapped_metadata.race': baseLabels['mapped_metadata.race'],
-  'source_sample.mapped_specimen_type': baseLabels.mapped_specimen_type,
+  'source_sample.sample_category': baseLabels.sample_category,
 };
 
 const donorAggsQuery = getAggsQuery('donor', ['mapped_metadata.sex', 'mapped_metadata.race'], 100);
 const sampleAggsQuery = getAggsQuery(
   'sample',
-  ['donor.mapped_metadata.sex', 'donor.mapped_metadata.race', 'origin_sample.mapped_organ', 'mapped_specimen_type'],
+  ['donor.mapped_metadata.sex', 'donor.mapped_metadata.race', 'origin_sample.mapped_organ', 'sample_category'],
   100,
 );
 
@@ -36,7 +36,7 @@ const datasetAggsQuery = getAggsQuery(
     'donor.mapped_metadata.sex',
     'donor.mapped_metadata.race',
     'origin_sample.mapped_organ',
-    'source_sample.mapped_specimen_type',
+    'source_sample.sample_category',
     'mapped_data_types',
   ],
   100,

--- a/context/app/static/js/components/searchPage/config.js
+++ b/context/app/static/js/components/searchPage/config.js
@@ -58,7 +58,7 @@ const sampleConfig = {
   filters: {
     'Sample Metadata': [
       listFilter('origin_sample.mapped_organ', 'Organ'),
-      listFilter('mapped_specimen_type', 'Specimen Type'),
+      listFilter('sample_category', 'Sample Category'),
     ],
     'Donor Metadata': makeDonorMetadataFilters(false),
     Affiliation: affiliationFilters,
@@ -67,7 +67,7 @@ const sampleConfig = {
     table: [
       field('hubmap_id', 'HuBMAP ID'),
       field('group_name', 'Group'),
-      field('mapped_specimen_type', 'Specimen Type'),
+      field('sample_category', 'Sample Category'),
       field('origin_sample.mapped_organ', 'Organ'),
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],
@@ -81,7 +81,7 @@ const datasetConfig = {
     'Dataset Metadata': [
       listFilter('mapped_data_types', 'Data Type'),
       listFilter('origin_sample.mapped_organ', 'Organ'),
-      listFilter('source_sample.mapped_specimen_type', 'Specimen Type'),
+      listFilter('source_sample.sample_category', 'Sample Category'),
       hierarchicalFilter(['mapped_status', 'mapped_data_access_level'], 'Status'),
       listFilter('mapped_consortium', 'Consortium'),
     ],

--- a/context/app/static/js/components/tutorials/SearchDatasetTutorial/config.js
+++ b/context/app/static/js/components/tutorials/SearchDatasetTutorial/config.js
@@ -5,7 +5,7 @@ const defaultSteps = [
     target: '#Data-Type div.sk-item-list > label:nth-child(1)',
     disableBeacon: true,
     content:
-      'The Dataset Metadata menu on the left side allows filtering datasets by any combination of metadata categories: Data Type, Organ and Specimen Type. Search results update automatically as you edit the selection of filters.',
+      'The Dataset Metadata menu on the left side allows filtering datasets by any combination of metadata categories: Data Type, Organ and Sample Category. Search results update automatically as you edit the selection of filters.',
     title: 'Filter Your Browsing',
   },
   {

--- a/context/app/static/js/hooks/useDerivedEntitySearchHits.js
+++ b/context/app/static/js/hooks/useDerivedEntitySearchHits.js
@@ -42,7 +42,7 @@ function useDerivedSampleSearchHits(ancestorUUID) {
         'uuid',
         'hubmap_id',
         'origin_sample.mapped_organ',
-        'mapped_specimen_type',
+        'sample_category',
         'descendant_counts',
         'last_modified_timestamp',
       ],

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -26,7 +26,7 @@ function SampleDetail({ assayMetadata }) {
     uuid,
     donor,
     protocol_url,
-    mapped_specimen_type,
+    sample_category,
     origin_sample: { mapped_organ },
     group_name,
     created_by_user_displayname,
@@ -59,8 +59,8 @@ function SampleDetail({ assayMetadata }) {
 
   const setAssayMetadata = useEntityStore(entityStoreSelector);
   useEffect(() => {
-    setAssayMetadata({ hubmap_id, entity_type, mapped_organ, mapped_specimen_type });
-  }, [setAssayMetadata, hubmap_id, entity_type, mapped_organ, mapped_specimen_type]);
+    setAssayMetadata({ hubmap_id, entity_type, mapped_organ, sample_category });
+  }, [setAssayMetadata, hubmap_id, entity_type, mapped_organ, sample_category]);
 
   useSendUUIDEvent(entity_type, uuid);
 
@@ -84,7 +84,7 @@ function SampleDetail({ assayMetadata }) {
             </LightBlueLink>
           </SummaryItem>
           <Typography variant="h6" component="p">
-            {mapped_specimen_type}
+            {sample_category}
           </Typography>
         </Summary>
         {shouldDisplaySection.derived && (
@@ -95,12 +95,7 @@ function SampleDetail({ assayMetadata }) {
             sectionId="derived"
           />
         )}
-        <SampleTissue
-          uuid={uuid}
-          mapped_specimen_type={mapped_specimen_type}
-          mapped_organ={mapped_organ}
-          hasRUI={hasRUI}
-        />
+        <SampleTissue uuid={uuid} sample_category={sample_category} mapped_organ={mapped_organ} hasRUI={hasRUI} />
         <ProvSection uuid={uuid} assayMetadata={assayMetadata} />
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} />}
         {shouldDisplaySection.metadata && <MetadataTable metadata={combinedMetadata} hubmap_id={hubmap_id} />}

--- a/context/app/static/js/pages/entity-search/DatasetSearch/DatasetSearch.jsx
+++ b/context/app/static/js/pages/entity-search/DatasetSearch/DatasetSearch.jsx
@@ -8,7 +8,7 @@ const { tableFields } = buildDatasetFields();
 const facets = Object.assign(
   createDatasetFacet({ fieldName: 'mapped_data_types', label: 'Data Type', type: 'string' }),
   createDatasetFacet({ fieldName: 'origin_sample.mapped_organ', label: 'Organ', type: 'string' }),
-  createDatasetFacet({ fieldName: 'source_sample.mapped_specimen_type', label: 'Specimen Type', type: 'string' }),
+  createDatasetFacet({ fieldName: 'source_sample.sample_category', label: 'Sample Category', type: 'string' }),
   createDatasetFacet({ fieldName: 'mapped_consortium', label: 'Consortium', type: 'string' }),
   createDatasetFacet({ fieldName: 'mapped_status', label: 'Status', type: 'string' }),
   createDatasetFacet({ fieldName: 'mapped_data_access_level', label: 'Access Level', type: 'string' }),

--- a/context/app/static/js/pages/utils/entity-utils.spec.js
+++ b/context/app/static/js/pages/utils/entity-utils.spec.js
@@ -33,7 +33,7 @@ test('combines appropiately structured metadata', () => {
   };
   const origin_sample = {
     mapped_organ: 'Kidney (Right)',
-    mapped_specimen_type: 'Organ',
+    sample_category: 'Organ',
     // Currently, not seeing any metadata here, but that may change.
   };
   const source_sample = [


### PR DESCRIPTION
Replacing `mapped_specimen_type` and `specimen_type` with `sample_category`. There will be a follow-up in `search-api`'s `portal-translations` to capitalize the values and added grouped counts of `sample_category` values to `descendant_counts` and later here to use the new mapped field.