### PR TITLE
Add source to publications request

### DIFF
--- a/CHANGELOG-source-in-publications-request.md
+++ b/CHANGELOG-source-in-publications-request.md
@@ -1,0 +1,1 @@
+- Decrease response size from search api request on publications landing page.

--- a/context/app/static/js/pages/Publications/hooks.js
+++ b/context/app/static/js/pages/Publications/hooks.js
@@ -6,6 +6,7 @@ import { buildPublicationPanelProps } from './utils';
 const getAllPublicationsQuery = {
   post_filter: { term: { 'entity_type.keyword': 'Publication' } },
   size: 10000,
+  _source: ['uuid', 'title', 'contributors', 'publication_status', 'publication_venue', 'publication_date'],
 };
 
 const publicationStatusMap = {


### PR DESCRIPTION
Decreases publications response size on landing page.