### PR TITLE
John conroy/use es for dataset collections

### DIFF
--- a/CHANGELOG-use-es-for-dataset-collections.md
+++ b/CHANGELOG-use-es-for-dataset-collections.md
@@ -1,0 +1,1 @@
+- Update dataset collections hook to better use es query to return collections which contain dataset.

--- a/context/app/static/js/hooks/useDatasetsCollections.js
+++ b/context/app/static/js/hooks/useDatasetsCollections.js
@@ -1,17 +1,21 @@
+import { useMemo } from 'react';
 import { useSearchHits } from 'js/hooks/useSearchData';
 import { getAllCollectionsQuery } from 'js/helpers/queries';
 
-function getCollectionsWhichContainDatasets(datasetsUUIDSet, collections) {
-  return collections.filter((collection) => {
-    // eslint-disable-next-line no-underscore-dangle
-    return collection._source?.datasets.some((dataset) => datasetsUUIDSet.has(dataset.uuid));
-  });
-}
-
 function useDatasetsCollections(datasetUUIDs) {
-  const { searchHits: collections } = useSearchHits(getAllCollectionsQuery);
-  const datasetUUIDSet = new Set(datasetUUIDs);
-  return getCollectionsWhichContainDatasets(datasetUUIDSet, collections);
+  const collectionsWithDatasetQuery = useMemo(() => {
+    return {
+      ...getAllCollectionsQuery,
+      query: {
+        terms: {
+          'datasets.uuid': datasetUUIDs,
+        },
+      },
+    };
+  }, [datasetUUIDs]);
+
+  const { searchHits: collections } = useSearchHits(collectionsWithDatasetQuery);
+  return collections;
 }
 
 export { useDatasetsCollections };


### PR DESCRIPTION
Fix #3084. Use es terms query to return collections which contain one of the given UUIDs in its datasets array.