### PR TITLE
John conroy/fix collections hook deps

### DIFF
--- a/CHANGELOG-fix-collection-hook-deps.md
+++ b/CHANGELOG-fix-collection-hook-deps.md
@@ -1,0 +1,1 @@
+- Change dependencies in useDatasetsCollections hooks to fix infinite loop.

--- a/context/app/static/js/hooks/useDatasetsCollections.js
+++ b/context/app/static/js/hooks/useDatasetsCollections.js
@@ -3,16 +3,18 @@ import { useSearchHits } from 'js/hooks/useSearchData';
 import { getAllCollectionsQuery } from 'js/helpers/queries';
 
 function useDatasetsCollections(datasetUUIDs) {
-  const collectionsWithDatasetQuery = useMemo(() => {
-    return {
+  const datasetUUIDsString = JSON.stringify(datasetUUIDs.toSorted());
+  const collectionsWithDatasetQuery = useMemo(
+    () => ({
       ...getAllCollectionsQuery,
       query: {
         terms: {
-          'datasets.uuid': datasetUUIDs,
+          'datasets.uuid': JSON.parse(datasetUUIDsString),
         },
       },
-    };
-  }, [datasetUUIDs]);
+    }),
+    [datasetUUIDsString],
+  );
 
   const { searchHits: collections } = useSearchHits(collectionsWithDatasetQuery);
   return collections;


### PR DESCRIPTION
Fix bug introduced in #3085. Filed an issue in jira to introduce https://swr.vercel.app/ for our fetch hooks. One benefit of the library is that the `useSWR` hook performs deep compares for its dependencies and we wouldn't have to memoize arrays or objects.