### PR TITLE
John conroy/replace to sorted

### DIFF
--- a/CHANGELOG-replace-to-sorted.md
+++ b/CHANGELOG-replace-to-sorted.md
@@ -1,0 +1,1 @@
+- Replace toSorted which firefox does not support.

--- a/context/app/static/js/hooks/useDatasetsCollections.js
+++ b/context/app/static/js/hooks/useDatasetsCollections.js
@@ -3,7 +3,7 @@ import { useSearchHits } from 'js/hooks/useSearchData';
 import { getAllCollectionsQuery } from 'js/helpers/queries';
 
 function useDatasetsCollections(datasetUUIDs) {
-  const datasetUUIDsString = JSON.stringify(datasetUUIDs.toSorted());
+  const datasetUUIDsString = JSON.stringify(datasetUUIDs.sort((a, b) => a - b));
   const collectionsWithDatasetQuery = useMemo(
     () => ({
       ...getAllCollectionsQuery,


### PR DESCRIPTION
`toSorted` isn't supported by Firefox. 

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/toSorted#browser_compatibility