### PR TITLE
john-conroy/start workspaces on workspace page HMP-7

### DIFF
--- a/CHANGELOG-start-workspace-on-workspaces-page.md
+++ b/CHANGELOG-start-workspace-on-workspaces-page.md
@@ -1,0 +1,1 @@
+- Start workspace jobs on workspaces page not loading page.

--- a/context/app/routes_notebooks.py
+++ b/context/app/routes_notebooks.py
@@ -141,14 +141,7 @@ def blank_notebook():
     body = request.get_json()
     workspace_name = body.get('workspace_name')
 
-    cells = [
-        {
-            "cell_type": "markdown",
-            "metadata": {},
-            "source": [
-                f"## {workspace_name}"
-            ]
-        }]
+    cells = [new_markdown_cell(f"## {workspace_name}")]
     return _nb_response_from_dicts('notebook', cells, workspace_name=workspace_name)
 
 

--- a/context/app/static/js/components/entity-search/MetadataMenu/hooks.js
+++ b/context/app/static/js/components/entity-search/MetadataMenu/hooks.js
@@ -2,11 +2,13 @@ import { useCallback } from 'react';
 
 import { useStore as useDropdownMenuStore } from 'js/shared-styles/dropdowns/DropdownMenuProvider/store';
 import { useStore as useSelectedTableStore } from 'js/shared-styles/tables/SelectableTableProvider/store';
-import { createAndLaunchWorkspace } from 'js/components/workspaces/utils';
+import { useCreateAndLaunchWorkspace } from 'js/components/workspaces/hooks';
 
 function useMetadataMenu(lcPluralType) {
   const { selectedRows: selectedHits } = useSelectedTableStore();
   const { closeMenu } = useDropdownMenuStore();
+
+  const createAndLaunchWorkspace = useCreateAndLaunchWorkspace();
 
   const createNotebook = useCallback(
     async ({ workspaceName }) => {
@@ -16,7 +18,7 @@ function useMetadataMenu(lcPluralType) {
       });
       closeMenu();
     },
-    [closeMenu, lcPluralType, selectedHits],
+    [closeMenu, createAndLaunchWorkspace, lcPluralType, selectedHits],
   );
   return { createNotebook, selectedHits, closeMenu };
 }

--- a/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
 
-import { condenseJobs } from 'js/components/workspaces/utils';
 import JobStatus from 'js/components/workspaces/JobStatus';
-
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+import { condenseJobs } from 'js/components/workspaces/utils';
 import { Flex } from './style';
 
 const typographyVariant = 'subtitle1';
 
-function WorkspaceDetails({ workspace }) {
+function WorkspaceDetails({ workspace, handleStartWorkspace }) {
   const job = condenseJobs(workspace.jobs);
 
   return (
@@ -17,6 +16,7 @@ function WorkspaceDetails({ workspace }) {
       <OutboundIconLink
         href={`/workspaces/${workspace.id}?notebook_path=${encodeURIComponent(workspace.path)}`}
         variant={typographyVariant}
+        onClick={() => handleStartWorkspace(workspace.id)}
       >
         {workspace.name}
       </OutboundIconLink>

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -18,6 +18,7 @@ function WorkspacesList() {
     handleDeleteWorkspace: handleDelete,
     handleCreateWorkspace,
     handleStopWorkspace: handleStop,
+    handleStartWorkspace,
   } = useWorkspacesList();
 
   return (
@@ -49,7 +50,7 @@ function WorkspacesList() {
           workspacesList.map((workspace) => (
             /* TODO: Inbound links have fragments like "#workspace-123": Highlight? */
             <PanelWrapper key={workspace.id}>
-              <WorkspaceDetails workspace={workspace} />
+              <WorkspaceDetails workspace={workspace} handleStartWorkspace={handleStartWorkspace} />
               <div>
                 Created {workspace.datetime_created.slice(0, 10)}
                 <button

--- a/context/app/static/js/components/workspaces/hooks.js
+++ b/context/app/static/js/components/workspaces/hooks.js
@@ -55,7 +55,12 @@ function useWorkspacesList() {
     mutate();
   }
 
-  return { workspacesList, handleDeleteWorkspace, handleCreateWorkspace, handleStopWorkspace };
+  async function handleStartWorkspace(workspaceId) {
+    await startJob({ workspaceId, workspacesEndpoint, workspacesToken });
+    mutate();
+  }
+
+  return { workspacesList, handleDeleteWorkspace, handleCreateWorkspace, handleStopWorkspace, handleStartWorkspace };
 }
 
 function useCreateAndLaunchWorkspace() {

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext } from 'react';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
 import { AppContext } from 'js/components/Providers';
@@ -30,7 +30,7 @@ import CreateWorkspaceDialog from 'js/components/workspaces/CreateWorkspaceDialo
 import { combineMetadata } from 'js/pages/utils/entity-utils';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import { useDatasetsCollections } from 'js/hooks/useDatasetsCollections';
-import { createAndLaunchWorkspace } from 'js/components/workspaces/utils';
+import { useDatasetWorkspace } from './hooks';
 
 function NotebookButton(props) {
   return (
@@ -54,15 +54,7 @@ function SummaryDataChildren({
 }) {
   const { isWorkspacesUser } = useContext(AppContext);
 
-  const createNotebook = useCallback(
-    async ({ workspaceName }) => {
-      await createAndLaunchWorkspace({
-        path: `${entity_type.toLowerCase()}/${uuid}.ws.ipynb`,
-        body: { workspace_name: workspaceName },
-      });
-    },
-    [entity_type, uuid],
-  );
+  const createDatasetWorkspace = useDatasetWorkspace({ entity_type, uuid });
 
   return (
     <>
@@ -84,7 +76,7 @@ function SummaryDataChildren({
       {isWorkspacesUser && (
         <>
           <CreateWorkspaceDialog
-            handleCreateWorkspace={createNotebook}
+            handleCreateWorkspace={createDatasetWorkspace}
             buttonComponent={NotebookButton}
             disabled={!hasNotebook}
             defaultName={`${hubmap_id} Workspace`}

--- a/context/app/static/js/pages/Dataset/hooks.js
+++ b/context/app/static/js/pages/Dataset/hooks.js
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+import { useCreateAndLaunchWorkspace } from 'js/components/workspaces/hooks';
+
+function useDatasetWorkspace({ entity_type, uuid }) {
+  const createAndLaunchWorkspace = useCreateAndLaunchWorkspace();
+
+  return useCallback(
+    async ({ workspaceName }) => {
+      await createAndLaunchWorkspace({
+        path: `/entities/${entity_type.toLowerCase()}/${uuid}.ws.ipynb`,
+        body: { workspace_name: workspaceName },
+      });
+    },
+    [createAndLaunchWorkspace, entity_type, uuid],
+  );
+}
+
+export { useDatasetWorkspace };

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -65,6 +65,7 @@
         "sass": "^1.53.0",
         "searchkit": "^2.4.1-alpha.4",
         "styled-components": "^5.1.0",
+        "swr": "^2.1.5",
         "typeface-inter": "^3.12.0",
         "universal-cookie": "^4.0.3",
         "use-debounce": "^8.0.1",
@@ -47565,6 +47566,17 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/swr": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.5.tgz",
+      "integrity": "sha512-/OhfZMcEpuz77KavXST5q6XE9nrOBOVcBLWjMT+oAE/kQHyE3PASrevXCtQDZ8aamntOfFkbVJp7Il9tNBQWrw==",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -49058,6 +49070,14 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/util": {
       "version": "0.11.1",
@@ -88310,6 +88330,14 @@
         "util.promisify": "~1.0.0"
       }
     },
+    "swr": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.1.5.tgz",
+      "integrity": "sha512-/OhfZMcEpuz77KavXST5q6XE9nrOBOVcBLWjMT+oAE/kQHyE3PASrevXCtQDZ8aamntOfFkbVJp7Il9tNBQWrw==",
+      "requires": {
+        "use-sync-external-store": "^1.2.0"
+      }
+    },
     "symbol-observable": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
@@ -89438,6 +89466,11 @@
           "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         }
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA=="
     },
     "util": {
       "version": "0.11.1",

--- a/context/package.json
+++ b/context/package.json
@@ -58,6 +58,7 @@
     "sass": "^1.53.0",
     "searchkit": "^2.4.1-alpha.4",
     "styled-components": "^5.1.0",
+    "swr": "^2.1.5",
     "typeface-inter": "^3.12.0",
     "universal-cookie": "^4.0.3",
     "use-debounce": "^8.0.1",


### PR DESCRIPTION
Workspaces are now started when launching on the workspace page or in actions where a workspace is created and launched immediately. Previously, workspaces were started on the loading page which caused workspaces you may have stopped to start again unexpectedly.

Introduces [swr](https://swr.vercel.app/docs/getting-started) to better manage external data. The workspaces data used to generate the workspaces list is revalidated when `mutate` is called and, among other situations, when a tab is refocused. Workspace lists across tabs should now reflect each workspace's true status.