### PR TITLE
NickAkhmetov/HMP-19 Improve perceived performance of vignette accordion on publication pages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "eslint.workingDirectories": ["./context"]
+    "eslint.workingDirectories": [
+        "./context"
+    ],
+    "[javascriptreact]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
 }

--- a/CHANGELOG-fix-publication-vignettes.md
+++ b/CHANGELOG-fix-publication-vignettes.md
@@ -1,0 +1,1 @@
+- Fix issues switching between different visualizations on the Publication page

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -1,9 +1,9 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Vitessce } from 'vitessce';
 import Paper from '@material-ui/core/Paper';
 import FullscreenRoundedIcon from '@material-ui/icons/FullscreenRounded';
-import debounce from 'lodash/debounce';
 import Bowser from 'bowser';
+import debounce from 'lodash/debounce';
+import React, { useCallback, useEffect, useState } from 'react';
+import { Vitessce } from 'vitessce';
 
 import { dependencies } from 'package';
 
@@ -14,23 +14,23 @@ import DropdownListboxOption from 'js/shared-styles/dropdowns/DropdownListboxOpt
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import useVisualizationStore from 'js/stores/useVisualizationStore';
-import VisualizationThemeSwitch from '../VisualizationThemeSwitch';
-import VisualizationShareButton from '../VisualizationShareButton';
 import VisualizationNotebookButton from '../VisualizationNotebookButton';
-import {
-  vitessceFixedHeight,
-  bodyExpandedCSS,
-  ExpandButton,
-  VitessceInfoSnackbar,
-  ErrorSnackbar,
-  ExpandableDiv,
-  StyledFooterText,
-  SelectionButton,
-  StyledSectionHeader,
-  Flex,
-  StyledDetailPageSection,
-} from './style';
+import VisualizationShareButton from '../VisualizationShareButton';
+import VisualizationThemeSwitch from '../VisualizationThemeSwitch';
 import { useVitessceConfig } from './hooks';
+import {
+  ErrorSnackbar,
+  ExpandButton,
+  ExpandableDiv,
+  Flex,
+  SelectionButton,
+  StyledDetailPageSection,
+  StyledFooterText,
+  StyledSectionHeader,
+  VitessceInfoSnackbar,
+  bodyExpandedCSS,
+  vitessceFixedHeight,
+} from './style';
 
 function sniffBrowser() {
   const { browser } = Bowser.parse(window.navigator.userAgent);
@@ -58,7 +58,7 @@ const sharedInfoSnackbarProps = {
   },
   autoHideDuration: 4000,
 };
-function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader }) {
+function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, shouldMountVitessce = true }) {
   const {
     vizIsFullscreen,
     expandViz,
@@ -180,13 +180,15 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader }) {
                 </Alert>
               </ErrorSnackbar>
             )}
-            <Vitessce
-              config={vitessceConfig[vitessceSelection] || vitessceConfig}
-              theme={vizTheme}
-              onConfigChange={handleVitessceConfigDebounced}
-              height={vizIsFullscreen ? null : vitessceFixedHeight}
-              onWarn={addError}
-            />
+            {shouldMountVitessce && (
+              <Vitessce
+                config={vitessceConfig[vitessceSelection] || vitessceConfig}
+                theme={vizTheme}
+                onConfigChange={handleVitessceConfigDebounced}
+                height={vizIsFullscreen ? null : vitessceFixedHeight}
+                onWarn={addError}
+              />
+            )}
           </ExpandableDiv>
         </Paper>
         <StyledFooterText variant="body2">

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
@@ -1,5 +1,5 @@
-import React, { Suspense } from 'react';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import React, { Suspense } from 'react';
 
 import { DetailPageSection } from 'js/components/detailPage/style';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
@@ -8,11 +8,11 @@ import { VisualizationBackground } from './style';
 
 const Visualization = React.lazy(() => import('../Visualization'));
 
-function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader }) {
+function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader, hasBeenMounted }) {
   return (
     <Suspense
       fallback={
-        <DetailPageSection id="visualization">
+        <DetailPageSection id={`visualization-${uuid}`}>
           <SpacedSectionButtonRow
             leftText={shouldDisplayHeader ? <StyledSectionHeader>Visualization</StyledSectionHeader> : undefined}
           />
@@ -27,6 +27,7 @@ function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader 
         uuid={uuid}
         hasNotebook={hasNotebook}
         shouldDisplayHeader={shouldDisplayHeader}
+        shouldMountVitessce={hasBeenMounted}
       />
     </Suspense>
   );

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
@@ -8,11 +8,11 @@ import { VisualizationBackground } from './style';
 
 const Visualization = React.lazy(() => import('../Visualization'));
 
-function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader, hasBeenMounted }) {
+function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader, hasBeenMounted, isPublicationPage }) {
   return (
     <Suspense
       fallback={
-        <DetailPageSection id={`visualization-${uuid}`}>
+        <DetailPageSection id={isPublicationPage ? `visualization-${uuid}` : 'visualization'}>
           <SpacedSectionButtonRow
             leftText={shouldDisplayHeader ? <StyledSectionHeader>Visualization</StyledSectionHeader> : undefined}
           />

--- a/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
+++ b/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
@@ -6,7 +6,7 @@ import VisualizationWrapper from 'js/components/detailPage/visualization/Visuali
 
 import { fillUrls } from './utils';
 
-async function fetchVitessceConf({ assetsEndpoint, uuid, filePath, groupsToken, vignetteDirName }) {
+async function fetchVitessceConf({ assetsEndpoint, uuid, filePath, groupsToken, vignetteDirName, signal }) {
   const urlHandler = (url, isZarr) => {
     return `${url.replace('{{ base_url }}', `${assetsEndpoint}/${uuid}/data`)}${isZarr ? '' : `?token=${groupsToken}`}`;
   };
@@ -19,6 +19,7 @@ async function fetchVitessceConf({ assetsEndpoint, uuid, filePath, groupsToken, 
   const response = await fetch(
     `${assetsEndpoint}/${uuid}/vignettes/${vignetteDirName}/${filePath}?token=${groupsToken}`,
     {
+      signal,
       headers: {
         'Content-Type': 'application/json',
       },
@@ -33,22 +34,46 @@ async function fetchVitessceConf({ assetsEndpoint, uuid, filePath, groupsToken, 
   return fillUrls(conf, urlHandler, requestInitHandler);
 }
 
-function PublicationVignette({ vignette, vignetteDirName, uuid }) {
+function PublicationVignette({ vignette, vignetteDirName, uuid, mounted }) {
   const { assetsEndpoint, groupsToken } = useContext(AppContext);
 
   const [vitessceConfs, setVitessceConfs] = useState(undefined);
 
+  // Workaround to make the visualization render only after the accordion section has been expanded while
+  // still letting the prerequisites for the visualizations prefetch
+  const [hasBeenMounted, setHasBeenMounted] = useState(false);
   useEffect(() => {
+    if (mounted) {
+      setHasBeenMounted(true);
+    }
+  }, [mounted]);
+
+  useEffect(() => {
+    const abortController = new AbortController();
     async function getAndSetVitessceConf() {
       const figuresConfs = await Promise.all(
         vignette.figures.map((figure) => {
-          return fetchVitessceConf({ assetsEndpoint, uuid, filePath: figure.file, groupsToken, vignetteDirName });
+          return fetchVitessceConf({
+            assetsEndpoint,
+            uuid,
+            filePath: figure.file,
+            groupsToken,
+            vignetteDirName,
+            signal: abortController.signal,
+          });
         }),
       );
       setVitessceConfs(figuresConfs);
     }
-    getAndSetVitessceConf();
-  }, [assetsEndpoint, groupsToken, uuid, vignette.figures, vignetteDirName]);
+    // Only fetch the vitessce confs if they haven't been fetched yet
+    if (!vitessceConfs) {
+      getAndSetVitessceConf();
+      return () => {
+        abortController.abort();
+      };
+    }
+    return () => {};
+  }, [assetsEndpoint, groupsToken, uuid, vignette.figures, vignetteDirName, vitessceConfs]);
 
   if (vitessceConfs) {
     return (
@@ -59,6 +84,7 @@ function PublicationVignette({ vignette, vignetteDirName, uuid }) {
           uuid={uuid}
           hasNotebook={false}
           shouldDisplayHeader={false}
+          hasBeenMounted={hasBeenMounted}
         />
       </>
     );

--- a/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
+++ b/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
@@ -85,6 +85,7 @@ function PublicationVignette({ vignette, vignetteDirName, uuid, mounted }) {
           hasNotebook={false}
           shouldDisplayHeader={false}
           hasBeenMounted={hasBeenMounted}
+          isPublicationPage
         />
       </>
     );

--- a/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
+++ b/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 
 import { AppContext } from 'js/components/Providers';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper';
+import useStickyToggle from 'js/hooks/useStickyToggle';
 
 import { fillUrls } from './utils';
 
@@ -34,19 +35,8 @@ async function fetchVitessceConf({ assetsEndpoint, uuid, filePath, groupsToken, 
   return fillUrls(conf, urlHandler, requestInitHandler);
 }
 
-function PublicationVignette({ vignette, vignetteDirName, uuid, mounted }) {
-  const { assetsEndpoint, groupsToken } = useContext(AppContext);
-
+function useVitessceConfs(assetsEndpoint, groupsToken, uuid, vignette, vignetteDirName) {
   const [vitessceConfs, setVitessceConfs] = useState(undefined);
-
-  // Workaround to make the visualization render only after the accordion section has been expanded while
-  // still letting the prerequisites for the visualizations prefetch
-  const [hasBeenMounted, setHasBeenMounted] = useState(false);
-  useEffect(() => {
-    if (mounted) {
-      setHasBeenMounted(true);
-    }
-  }, [mounted]);
 
   useEffect(() => {
     const abortController = new AbortController();
@@ -74,6 +64,18 @@ function PublicationVignette({ vignette, vignetteDirName, uuid, mounted }) {
     }
     return () => {};
   }, [assetsEndpoint, groupsToken, uuid, vignette.figures, vignetteDirName, vitessceConfs]);
+
+  return vitessceConfs;
+}
+
+function PublicationVignette({ vignette, vignetteDirName, uuid, mounted }) {
+  const { assetsEndpoint, groupsToken } = useContext(AppContext);
+
+  const vitessceConfs = useVitessceConfs(assetsEndpoint, groupsToken, uuid, vignette, vignetteDirName);
+
+  // Workaround to make the visualization render only after the accordion section has been expanded while
+  // still letting the prerequisites for the visualizations prefetch
+  const hasBeenMounted = useStickyToggle(mounted);
 
   if (vitessceConfs) {
     return (

--- a/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
+++ b/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
@@ -1,7 +1,7 @@
 import Accordion from '@material-ui/core/ExpansionPanel';
 import Typography from '@material-ui/core/Typography';
 import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
-import React, { startTransition, useCallback, useMemo, useState } from 'react';
+import React, { memo, useCallback, useMemo, useState } from 'react';
 
 import { DetailPageSection } from 'js/components/detailPage/style';
 import PublicationVignette from 'js/components/publications/PublicationVignette';
@@ -12,14 +12,15 @@ import { StyledAccordionDetails } from './style';
 function PublicationsVisualizationSection({ vignette_json: { vignettes }, uuid }) {
   const [expandedIndex, setExpandedIndex] = useState(0);
 
+  const [displayedVignettes, setDisplayedVignettes] = useState({
+    ...[true].concat(Array(vignettes.length - 1).fill(false)),
+  });
+
   const sortedVignettes = useMemo(() => {
     return vignettes.sort((a, b) => a.directory_name.localeCompare(b.directory_name));
   }, [vignettes]);
 
-  const handleChange = useCallback(
-    (i) => (event, isExpanded) => startTransition(setExpandedIndex(isExpanded ? i : false)),
-    [],
-  );
+  const handleChange = useCallback((i) => (event, isExpanded) => setExpandedIndex(isExpanded ? i : false), []);
 
   return (
     <DetailPageSection id="visualizations">
@@ -29,14 +30,19 @@ function PublicationsVisualizationSection({ vignette_json: { vignettes }, uuid }
           <Accordion
             key={vignette.name}
             expanded={i === expandedIndex}
-            TransitionProps={{ mountOnEnter: i !== 0 }}
+            TransitionProps={{ onEntered: () => setDisplayedVignettes((prev) => ({ ...prev, [i]: true })) }}
             onChange={handleChange(i)}
           >
             <PrimaryColorAccordionSummary $isExpanded={i === expandedIndex} expandIcon={<ArrowDropUpRoundedIcon />}>
               <Typography variant="subtitle1">{`Vignette ${i + 1}: ${vignette.name}`}</Typography>
             </PrimaryColorAccordionSummary>
             <StyledAccordionDetails>
-              <PublicationVignette vignette={vignette} uuid={uuid} vignetteDirName={vignette.directory_name} />
+              <PublicationVignette
+                vignette={vignette}
+                uuid={uuid}
+                vignetteDirName={vignette.directory_name}
+                mounted={displayedVignettes[i]}
+              />
             </StyledAccordionDetails>
           </Accordion>
         );
@@ -45,4 +51,4 @@ function PublicationsVisualizationSection({ vignette_json: { vignettes }, uuid }
   );
 }
 
-export default PublicationsVisualizationSection;
+export default memo(PublicationsVisualizationSection);

--- a/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
+++ b/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
@@ -1,43 +1,46 @@
-import React, { useState } from 'react';
 import Accordion from '@material-ui/core/ExpansionPanel';
 import Typography from '@material-ui/core/Typography';
 import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
+import React, { startTransition, useCallback, useMemo, useState } from 'react';
 
-import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
 import PublicationVignette from 'js/components/publications/PublicationVignette';
 import PrimaryColorAccordionSummary from 'js/shared-styles/accordions/PrimaryColorAccordionSummary';
+import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { StyledAccordionDetails } from './style';
 
 function PublicationsVisualizationSection({ vignette_json: { vignettes }, uuid }) {
   const [expandedIndex, setExpandedIndex] = useState(0);
 
-  const handleChange = (i) => (event, isExpanded) => {
-    setExpandedIndex(isExpanded ? i : false);
-  };
+  const sortedVignettes = useMemo(() => {
+    return vignettes.sort((a, b) => a.directory_name.localeCompare(b.directory_name));
+  }, [vignettes]);
+
+  const handleChange = useCallback(
+    (i) => (event, isExpanded) => startTransition(setExpandedIndex(isExpanded ? i : false)),
+    [],
+  );
 
   return (
     <DetailPageSection id="visualizations">
       <SectionHeader>Visualizations</SectionHeader>
-      {vignettes
-        .sort((a, b) => a.directory_name.localeCompare(b.directory_name))
-        .map((vignette, i) => {
-          return (
-            <Accordion
-              key={vignette.name}
-              expanded={i === expandedIndex}
-              TransitionProps={{ mountOnEnter: i !== 0 }}
-              onChange={handleChange(i)}
-            >
-              <PrimaryColorAccordionSummary $isExpanded={i === expandedIndex} expandIcon={<ArrowDropUpRoundedIcon />}>
-                <Typography variant="subtitle1">{`Vignette ${i + 1}: ${vignette.name}`}</Typography>
-              </PrimaryColorAccordionSummary>
-              <StyledAccordionDetails>
-                <PublicationVignette vignette={vignette} uuid={uuid} vignetteDirName={vignette.directory_name} />
-              </StyledAccordionDetails>
-            </Accordion>
-          );
-        })}
+      {sortedVignettes.map((vignette, i) => {
+        return (
+          <Accordion
+            key={vignette.name}
+            expanded={i === expandedIndex}
+            TransitionProps={{ mountOnEnter: i !== 0 }}
+            onChange={handleChange(i)}
+          >
+            <PrimaryColorAccordionSummary $isExpanded={i === expandedIndex} expandIcon={<ArrowDropUpRoundedIcon />}>
+              <Typography variant="subtitle1">{`Vignette ${i + 1}: ${vignette.name}`}</Typography>
+            </PrimaryColorAccordionSummary>
+            <StyledAccordionDetails>
+              <PublicationVignette vignette={vignette} uuid={uuid} vignetteDirName={vignette.directory_name} />
+            </StyledAccordionDetails>
+          </Accordion>
+        );
+      })}
     </DetailPageSection>
   );
 }

--- a/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
+++ b/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
@@ -1,7 +1,7 @@
 import Accordion from '@material-ui/core/ExpansionPanel';
 import Typography from '@material-ui/core/Typography';
 import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import { DetailPageSection } from 'js/components/detailPage/style';
 import PublicationVignette from 'js/components/publications/PublicationVignette';
@@ -51,4 +51,4 @@ function PublicationsVisualizationSection({ vignette_json: { vignettes }, uuid }
   );
 }
 
-export default memo(PublicationsVisualizationSection);
+export default PublicationsVisualizationSection;

--- a/context/app/static/js/hooks/useStickyToggle.js
+++ b/context/app/static/js/hooks/useStickyToggle.js
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+
+// Returns a boolean that is set to true if the passed condition is ever not falsy
+function useStickyToggle(toggleCondition) {
+  const [hasBeenToggled, setHasBeenToggled] = useState(false);
+
+  useEffect(() => {
+    if (toggleCondition) {
+      setHasBeenToggled(true);
+    }
+  }, [toggleCondition]);
+
+  return hasBeenToggled;
+}
+
+export default useStickyToggle;

--- a/context/app/static/js/pages/Donor/Donor.jsx
+++ b/context/app/static/js/pages/Donor/Donor.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+
 import MetadataTable from 'js/components/detailPage/MetadataTable';
 import ProvSection from 'js/components/detailPage/provenance/ProvSection';
 import Summary from 'js/components/detailPage/summary/Summary';
@@ -45,7 +46,9 @@ function DonorDetail({ assayMetadata }) {
   );
 
   const setAssayMetadata = useEntityStore(entityStoreSelector);
-  setAssayMetadata({ hubmap_id, entity_type, sex, race, age_value, age_unit });
+  useEffect(() => {
+    setAssayMetadata({ hubmap_id, entity_type, sex, race, age_value, age_unit });
+  }, [hubmap_id, entity_type, sex, race, age_value, age_unit, setAssayMetadata]);
 
   useSendUUIDEvent(entity_type, uuid);
 

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import ContributorsTable from 'js/components/detailPage/ContributorsTable/ContributorsTable';
 import DetailLayout from 'js/components/detailPage/DetailLayout';
@@ -26,7 +26,9 @@ function Publication({ publication, vignette_json }) {
   } = publication;
 
   const setAssayMetadata = useEntityStore(entityStoreSelector);
-  setAssayMetadata({ hubmap_id, entity_type, title, publication_venue });
+  useEffect(() => {
+    setAssayMetadata({ hubmap_id, entity_type, title, publication_venue });
+  }, [hubmap_id, entity_type, title, publication_venue, setAssayMetadata]);
 
   const shouldDisplaySection = {
     visualizations: Boolean(Object.keys(vignette_json).length),

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-import { getCombinedDatasetStatus, getSectionOrder } from 'js/components/detailPage/utils';
 import ContributorsTable from 'js/components/detailPage/ContributorsTable/ContributorsTable';
-import PublicationsDataSection from 'js/components/publications/PublicationsDataSection';
-import PublicationsVisualizationSection from 'js/components/publications/PublicationVisualizationsSection/';
-import PublicationSummary from 'js/components/publications/PublicationSummary';
-import ProvSection from 'js/components/detailPage/provenance/ProvSection';
 import DetailLayout from 'js/components/detailPage/DetailLayout';
+import ProvSection from 'js/components/detailPage/provenance/ProvSection';
+import { getCombinedDatasetStatus, getSectionOrder } from 'js/components/detailPage/utils';
+import PublicationSummary from 'js/components/publications/PublicationSummary';
+import PublicationsVisualizationSection from 'js/components/publications/PublicationVisualizationsSection/';
+import PublicationsDataSection from 'js/components/publications/PublicationsDataSection';
 import useEntityStore from 'js/stores/useEntityStore';
 
 const entityStoreSelector = (state) => state.setAssayMetadata;

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Typography from '@material-ui/core/Typography';
 
 import { LightBlueLink } from 'js/shared-styles/Links';
@@ -56,7 +56,9 @@ function SampleDetail({ assayMetadata }) {
   );
 
   const setAssayMetadata = useEntityStore(entityStoreSelector);
-  setAssayMetadata({ hubmap_id, entity_type, mapped_organ, sample_category });
+  useEffect(() => {
+    setAssayMetadata({ hubmap_id, entity_type, mapped_organ, sample_category });
+  }, [hubmap_id, entity_type, mapped_organ, sample_category, setAssayMetadata]);
 
   useSendUUIDEvent(entity_type, uuid);
 


### PR DESCRIPTION
This PR adjusts the behavior of the vitessce visualizations on the publication page:
- All accordion contents are initially rendered to prefetch vitessce conf
- Vitessce conf fetching is disabled when a conf already exists for that vignette
- Stale requests for vitessce conf data are aborted if effect re-triggers before it completes
- The `Vitessce` component is only mounted once the accordion it's in finishes expanding

In essence, this PR should make it so that the animation of switching from one vignette to another goes smoothly in more cases; however, this still has limitations. If a user tries to go to another vignette while the current one is still loading, the event does not immediately register; this is because Vitessce fires a lot of effects etc when it's first mounted which introduces a lot of actions into the main thread, and React 16 is not able to interrupt renders that are in progress or defer updates. In the future, once we update our React version, it should be able to interrupt the render cycle and execute the transition faster.


https://github.com/hubmapconsortium/portal-ui/assets/19957804/231db720-ca0b-4dc2-ba41-5a6160e012a7


In the demo above, we can see the initial animation from Vitessce filling in the available space; prior to these changes, React would attempt to do both this and the accordion animation simultaneously, hit lag from the Vitessce initialization, pause for a second, then display the expanded vignette with loading already in progress, skipping the accordion animation.