### PR TITLE
NickAkhmetov/ Publication Page console error bugfixes

### DIFF
--- a/CHANGELOG-fix-minor-publication-errors.md
+++ b/CHANGELOG-fix-minor-publication-errors.md
@@ -1,0 +1,6 @@
+- Update from deprecated createMuiTheme function to createTheme
+- Add propTypes entry for vignette_json
+- Fix proptypes error with DOI string being passed as boolean
+- Fix semantically invalid HTML nesting errors (ul inside of p, p inside of p)
+- Import Accordion instead of deprecated ExpansionPanel
+- Add handling for SUBMITTED status to StatusIcon

--- a/CHANGELOG-fix-minor-publication-errors.md
+++ b/CHANGELOG-fix-minor-publication-errors.md
@@ -1,6 +1,6 @@
-- Update from deprecated createMuiTheme function to createTheme
-- Add propTypes entry for vignette_json
-- Fix proptypes error with DOI string being passed as boolean
-- Fix semantically invalid HTML nesting errors (ul inside of p, p inside of p)
-- Import Accordion instead of deprecated ExpansionPanel
-- Add handling for SUBMITTED status to StatusIcon
+- Update from deprecated createMuiTheme function to createTheme.
+- Add propTypes entry for vignette_json.
+- Fix proptypes error with DOI string being passed as boolean.
+- Fix semantically invalid HTML nesting errors (ul inside of p, p inside of p).
+- Import Accordion instead of deprecated ExpansionPanel.
+- Add handling for SUBMITTED status to StatusIcon.

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -298,6 +298,7 @@ Routes.propTypes = {
     metadata: PropTypes.object,
     organs_count: PropTypes.number,
     vignette_data: PropTypes.object,
+    vignette_json: PropTypes.object,
   }),
 };
 

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -297,7 +297,6 @@ Routes.propTypes = {
     organs: PropTypes.object,
     metadata: PropTypes.object,
     organs_count: PropTypes.number,
-    vignette_data: PropTypes.object,
     vignette_json: PropTypes.object,
   }),
 };

--- a/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.jsx
+++ b/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { ColoredStatusIcon } from './style';
 
 function getColor(status) {
-  if (['NEW', 'REOPENED', 'QA', 'LOCKED', 'PROCESSING', 'HOLD'].includes(status)) {
+  if (['NEW', 'REOPENED', 'QA', 'LOCKED', 'PROCESSING', 'HOLD', 'SUBMITTED'].includes(status)) {
     return 'info';
   }
 

--- a/context/app/static/js/components/entity-search/facets/FacetAccordion/style.js
+++ b/context/app/static/js/components/entity-search/facets/FacetAccordion/style.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
 import Typography from '@material-ui/core/Typography';
 
 import { StyledAccordionSummary } from 'js/components/searchPage/filters/style';

--- a/context/app/static/js/components/entity-search/facets/FacetGroupAccordion/style.js
+++ b/context/app/static/js/components/entity-search/facets/FacetGroupAccordion/style.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
 
 import { StyledAccordion, StyledAccordionSummary } from 'js/components/searchPage/filters/style';
 

--- a/context/app/static/js/components/publications/PublicationCitation/PublicationCitation.jsx
+++ b/context/app/static/js/components/publications/PublicationCitation/PublicationCitation.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Typography from '@material-ui/core/Typography';
 
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
@@ -17,9 +16,7 @@ function PublicationCitation({ contributors, title, publication_date, publicatio
 
   return (
     <LabelledSectionText label="Citation" iconTooltipText="Citation is provided in NLM format." bottomSpacing={1}>
-      <Typography variant="body1">
-        {citation} DOI: <OutboundIconLink href={doiURL}>{doiURL}</OutboundIconLink>
-      </Typography>
+      {citation} DOI: <OutboundIconLink href={doiURL}>{doiURL}</OutboundIconLink>
     </LabelledSectionText>
   );
 }

--- a/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
+++ b/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
@@ -63,14 +63,14 @@ function PublicationSummary({
           doiURL={doiURL}
         />
         {contacts && (
-          <LabelledSectionText label="Corresponding Authors" bottomSpacing={2}>
+          <LabelledSectionText label="Corresponding Authors" bottomSpacing={2} childContainerComponent="div">
             <CorrespondingAuthorsList contacts={contacts} />
           </LabelledSectionText>
         )}
-        <LabelledSectionText label="Data Types" bottomSpacing={2}>
+        <LabelledSectionText label="Data Types" bottomSpacing={2} childContainerComponent="div">
           <AggsList uuid={uuid} field="mapped_data_types" />
         </LabelledSectionText>
-        <LabelledSectionText label="Organs" bottomSpacing={2}>
+        <LabelledSectionText label="Organs" bottomSpacing={2} childContainerComponent="div">
           <AggsList uuid={uuid} field="mapped_organ" />
         </LabelledSectionText>
         <LabelledSectionText label="Publication Date" bottomSpacing={2}>

--- a/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
+++ b/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
@@ -27,6 +27,7 @@ function PublicationSummary({
   hubmap_id,
   publication_date,
 }) {
+  const hasDOI = Boolean(publication_doi);
   const doiURL = `https://doi.org/${publication_doi}`;
 
   return (
@@ -40,9 +41,9 @@ function PublicationSummary({
         entityCanBeSaved={entityCanBeSaved}
         mapped_external_group_name={mapped_external_group_name}
       >
-        <SummaryItem showDivider={doiURL}>{hubmap_id}</SummaryItem>
-        {doiURL && (
-          <SummaryItem showDivider={doiURL}>
+        <SummaryItem showDivider={hasDOI}>{hubmap_id}</SummaryItem>
+        {hasDOI && (
+          <SummaryItem showDivider={hasDOI}>
             <OutboundIconLink href={doiURL}>{doiURL}</OutboundIconLink>
           </SummaryItem>
         )}

--- a/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
+++ b/context/app/static/js/components/publications/PublicationVisualizationsSection/PublicationsVisualizationSection.jsx
@@ -1,4 +1,4 @@
-import Accordion from '@material-ui/core/ExpansionPanel';
+import Accordion from '@material-ui/core/Accordion';
 import Typography from '@material-ui/core/Typography';
 import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
 import React, { useCallback, useMemo, useState } from 'react';

--- a/context/app/static/js/components/searchPage/filters/FilterInnerAccordion/style.js
+++ b/context/app/static/js/components/searchPage/filters/FilterInnerAccordion/style.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
 
 import { StyledAccordionSummary } from 'js/components/searchPage/filters/style';
 

--- a/context/app/static/js/components/searchPage/filters/FilterOuterAccordion/style.js
+++ b/context/app/static/js/components/searchPage/filters/FilterOuterAccordion/style.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
 
 import { StyledAccordion, StyledAccordionSummary } from 'js/components/searchPage/filters/style';
 

--- a/context/app/static/js/components/searchPage/filters/style.js
+++ b/context/app/static/js/components/searchPage/filters/style.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components';
 import { withStyles } from '@material-ui/core/styles';
 
-// In the latest version, "ExpansionPanel" is renamed to "Accordion".
-import AccordionSummary from '@material-ui/core/ExpansionPanelSummary';
-import Accordion from '@material-ui/core/ExpansionPanel';
+// In the latest version, "Accordion" is renamed to "Accordion".
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import Accordion from '@material-ui/core/Accordion';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 const StyledAccordion = styled(Accordion)`

--- a/context/app/static/js/shared-styles/accordions/PrimaryColorAccordionSummary/style.js
+++ b/context/app/static/js/shared-styles/accordions/PrimaryColorAccordionSummary/style.js
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 
-import AccordionSummary from '@material-ui/core/ExpansionPanelSummary';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
 
 const PrimaryColorAccordionSummary = styled(AccordionSummary)`
   ${(props) =>

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/StepAccordion.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
-import Accordion from '@material-ui/core/ExpansionPanel';
-import AccordionDetails from '@material-ui/core/ExpansionPanelDetails';
+import Accordion from '@material-ui/core/Accordion';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
 import ArrowDropUpRoundedIcon from '@material-ui/icons/ArrowDropUpRounded';
 
 import { useStore } from 'js/shared-styles/accordions/AccordionSteps/store';

--- a/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
+++ b/context/app/static/js/shared-styles/accordions/StepAccordion/style.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import Typography from '@material-ui/core/Typography';
-import AccordionSummary from '@material-ui/core/ExpansionPanelSummary';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
 import CheckCircleRoundedIcon from '@material-ui/icons/CheckCircleRounded';
 
 const iconHeight = '1.5rem';

--- a/context/app/static/js/shared-styles/sections/LabelledSectionText/LabelledSectionText.jsx
+++ b/context/app/static/js/shared-styles/sections/LabelledSectionText/LabelledSectionText.jsx
@@ -6,7 +6,7 @@ import Typography from '@material-ui/core/Typography';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { StyledDiv, Flex, StyledInfoIcon } from './style';
 
-function LabelledSectionText({ children, label, iconTooltipText, bottomSpacing, className }) {
+function LabelledSectionText({ children, label, iconTooltipText, bottomSpacing, className, childContainerComponent }) {
   return (
     <StyledDiv className={className} $bottomSpacing={bottomSpacing}>
       <Flex>
@@ -19,7 +19,9 @@ function LabelledSectionText({ children, label, iconTooltipText, bottomSpacing, 
           </SecondaryBackgroundTooltip>
         )}
       </Flex>
-      <Typography variant="body1">{children}</Typography>
+      <Typography component={childContainerComponent} variant="body1">
+        {children}
+      </Typography>
     </StyledDiv>
   );
 }
@@ -28,11 +30,13 @@ LabelledSectionText.propTypes = {
   label: PropTypes.string.isRequired,
   iconTooltipText: PropTypes.string,
   bottomSpacing: PropTypes.number,
+  childContainerComponent: PropTypes.elementType,
 };
 
 LabelledSectionText.defaultProps = {
   iconTooltipText: undefined,
   bottomSpacing: undefined,
+  childContainerComponent: undefined,
 };
 
 export default LabelledSectionText;

--- a/context/app/static/js/shared-styles/sections/LabelledSectionText/LabelledSectionText.jsx
+++ b/context/app/static/js/shared-styles/sections/LabelledSectionText/LabelledSectionText.jsx
@@ -6,7 +6,14 @@ import Typography from '@material-ui/core/Typography';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { StyledDiv, Flex, StyledInfoIcon } from './style';
 
-function LabelledSectionText({ children, label, iconTooltipText, bottomSpacing, className, childContainerComponent }) {
+function LabelledSectionText({
+  children,
+  label,
+  iconTooltipText,
+  bottomSpacing,
+  className,
+  childContainerComponent = 'p',
+}) {
   return (
     <StyledDiv className={className} $bottomSpacing={bottomSpacing}>
       <Flex>

--- a/context/app/static/js/theme.jsx
+++ b/context/app/static/js/theme.jsx
@@ -1,10 +1,10 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createTheme } from '@material-ui/core/styles';
 
 const purple = '#444A65';
 const blue = '#2A6FB8';
 
 // default HuBMAP color and font theme
-const theme = createMuiTheme({
+const theme = createTheme({
   palette: {
     primary: {
       main: purple,


### PR DESCRIPTION
This PR cleans up some of the errors we would see in the browser console when viewing the Publication page:

- `createMuiTheme` function call has been changed to `createTheme`
- `vignette_json` now has a proptypes entry
- `doiUrl` string that always evaluates to true is no longer used as divider condition
- Import the `Accordion` components instead of the deprecated `ExpansionPanel`
- Add handling for `SUBMITTED` status to StatusIcon

The following errors remain in the browser console:
- Entity/Provenance API failures (I'm assuming this is dev env only)
- `fade` color utility was renamed to `alpha` - this appears to be from MUI internals, nothing in our code uses the `fade` utility
- Any errors coming from the Vitessce component (e.g. a missing key for list items error, mipmap generation, etc)