### PR TITLE
NickAkhmetov / HMP-97 Add Jupyter Notebook download button to expanded visualization

### DIFF
--- a/CHANGELOG-hmp-97-add-download-notebook-to-expanded-view.md
+++ b/CHANGELOG-hmp-97-add-download-notebook-to-expanded-view.md
@@ -1,1 +1,1 @@
-- Add Jupyter Notebook download button to expanded visualization view
+- Add Jupyter Notebook download button to expanded visualization view.

--- a/CHANGELOG-hmp-97-add-download-notebook-to-expanded-view.md
+++ b/CHANGELOG-hmp-97-add-download-notebook-to-expanded-view.md
@@ -1,0 +1,1 @@
+- Add Jupyter Notebook download button to expanded visualization view

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
@@ -4,7 +4,9 @@ import { useTransition, animated } from 'react-spring';
 
 import VizualizationThemeSwitch from 'js/components/detailPage/visualization/VisualizationThemeSwitch';
 import VisualizationCollapseButton from 'js/components/detailPage/visualization/VisualizationCollapseButton';
+import VisualizationNotebookButton from 'js/components/detailPage/visualization/VisualizationNotebookButton';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
+import useVisualizationStore from 'js/stores/useVisualizationStore';
 import { StyledSvgIcon, FlexContainer, RightDiv } from './style';
 import EntityHeaderItem from '../EntityHeaderItem';
 import VisualizationShareButtonWrapper from '../VisualizationShareButtonWrapper';
@@ -31,6 +33,8 @@ const entityToFieldsMap = {
 
 const AnimatedFlexContainer = animated(FlexContainer);
 
+const vizNotebookIdSelector = (state) => state.vizNotebookId;
+
 function EntityHeaderContent({ assayMetadata, shouldDisplayHeader, vizIsFullscreen }) {
   const transitions = useTransition(shouldDisplayHeader, null, {
     from: { opacity: vizIsFullscreen ? 1 : 0 },
@@ -39,6 +43,8 @@ function EntityHeaderContent({ assayMetadata, shouldDisplayHeader, vizIsFullscre
   });
 
   const { hubmap_id, entity_type } = assayMetadata;
+
+  const vizNotebookId = useVisualizationStore(vizNotebookIdSelector);
 
   return transitions.map(
     ({ item, key, props }) =>
@@ -55,6 +61,7 @@ function EntityHeaderContent({ assayMetadata, shouldDisplayHeader, vizIsFullscre
           )}
           {vizIsFullscreen && (
             <RightDiv>
+              {vizNotebookId && <VisualizationNotebookButton uuid={vizNotebookId} />}
               <VisualizationShareButtonWrapper />
               <VizualizationThemeSwitch />
               <VisualizationCollapseButton />

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -75,13 +75,12 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, should
   } = useVisualizationStore(visualizationStoreSelector);
 
   // Propagate UUID to the store if there is a notebook so we can display the download button when the visualization is expanded
+  // Reruns every time vizIsFullscreen changes to ensure the proper notebook's UUID is used
   useEffect(() => {
     if (hasNotebook) {
       setVizNotebookId(uuid);
-    } else {
-      setVizNotebookId(null);
     }
-  }, [hasNotebook, setVizNotebookId, uuid]);
+  }, [hasNotebook, vizIsFullscreen, setVizNotebookId, uuid]);
 
   const [vitessceErrors, setVitessceErrors] = useState([]);
   const [isVisibleFirefoxWarning, setIsVisibleFirefoxWarning] = useState(sniffBrowser() === 'Firefox');

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -50,6 +50,7 @@ const visualizationStoreSelector = (state) => ({
   onCopyUrlWarning: state.onCopyUrlWarning,
   onCopyUrlSnackbarOpen: state.onCopyUrlSnackbarOpen,
   setOnCopyUrlSnackbarOpen: state.setOnCopyUrlSnackbarOpen,
+  setVizNotebookId: state.setVizNotebookId,
 });
 const sharedInfoSnackbarProps = {
   anchorOrigin: {
@@ -70,7 +71,17 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, should
     onCopyUrlWarning,
     onCopyUrlSnackbarOpen,
     setOnCopyUrlSnackbarOpen,
+    setVizNotebookId,
   } = useVisualizationStore(visualizationStoreSelector);
+
+  // Propagate UUID to the store if there is a notebook so we can display the download button when the visualization is expanded
+  useEffect(() => {
+    if (hasNotebook) {
+      setVizNotebookId(uuid);
+    } else {
+      setVizNotebookId(null);
+    }
+  }, [hasNotebook, setVizNotebookId, uuid]);
 
   const [vitessceErrors, setVitessceErrors] = useState([]);
   const [isVisibleFirefoxWarning, setIsVisibleFirefoxWarning] = useState(sniffBrowser() === 'Firefox');

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback, useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
 import { AppContext } from 'js/components/Providers';

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useCallback } from 'react';
+import React, { useContext, useCallback, useEffect } from 'react';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
 import { AppContext } from 'js/components/Providers';
@@ -162,7 +162,9 @@ function DatasetDetail({ assayMetadata, vitData, hasNotebook, visLiftedUUID }) {
   useSendUUIDEvent(entity_type, uuid);
 
   const setAssayMetadata = useEntityStore(entityStoreSelector);
-  setAssayMetadata({ hubmap_id, entity_type, mapped_data_types, mapped_organ });
+  useEffect(() => {
+    setAssayMetadata({ hubmap_id, entity_type, mapped_data_types, mapped_organ });
+  }, [entity_type, hubmap_id, mapped_data_types, mapped_organ, setAssayMetadata]);
 
   // TODO: When all environments are clean, data_types array fallbacks shouldn't be needed.
   return (

--- a/context/app/static/js/stores/useVisualizationStore.js
+++ b/context/app/static/js/stores/useVisualizationStore.js
@@ -27,6 +27,8 @@ const useVisualizationStore = create((set) => ({
   setOnCopyUrlWarning: (val) => set({ onCopyUrlWarning: val }),
   onCopyUrlSnackbarOpen: false,
   setOnCopyUrlSnackbarOpen: (val) => set({ onCopyUrlSnackbarOpen: val }),
+  vizNotebookId: null,
+  setVizNotebookId: (val) => set({ vizNotebookId: val }),
 }));
 
 export default useVisualizationStore;


### PR DESCRIPTION
This PR adds the Jupyter Notebook download button to the expanded visualization view.

- vizNotebookId / setVizNotebookId states have been added to the Visualization store
- When a visualization with a notebook mounts, the vizNotebookId is set to the uuid of the visualization; if the visualization does not have a notebook, the value is set to null.
- The `EntityHeaderContent` component accesses the `vizNotebookId` value in the store and conditionally inserts the download button if it's not null.

**Screenshot** with tab-focused button visible at the top right:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/ae013c55-8479-4846-af73-be1160945a57)
