### PR TITLE
NickAkhmetov / HMP-102 Fix header offset of vitessce container on preview page

### DIFF
--- a/CHANGELOG-hmp-102-fix-expanded-preview.md
+++ b/CHANGELOG-hmp-102-fix-expanded-preview.md
@@ -1,0 +1,1 @@
+- Fix overlap between expanded preview visualization and its header.

--- a/context/app/static/js/components/detailPage/visualization/Visualization/style.js
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/style.js
@@ -9,9 +9,7 @@ import { entityHeaderHeight } from 'js/components/detailPage/entityHeader/Entity
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
 
-const totalHeightOffset = window.location.pathname.startsWith('/preview')
-  ? headerHeight
-  : headerHeight + entityHeaderHeight;
+const totalHeightOffset = headerHeight + entityHeaderHeight;
 
 const vitessceFixedHeight = 600;
 


### PR DESCRIPTION
This PR adjusts the height offset of the vitessce container when it's expanded on the preview page; there was previously an exception for paths starting with `/preview` which excluded the entity header from being included in this offset.

I'm holding off from requesting reviews until after the long weekend so as to not disturb anyone's rest; I just had some spare time with nothing to do so I figured I'd pick a low-hanging fruit 😄 

Expanded preview page visualization after changes:

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/dee8e9f7-3f30-4a7f-bdcb-5d316d56bdf6)

