### PR TITLE
John conroy/add file browser to publication page HMP-9

### DIFF
--- a/CHANGELOG-add-file-browser-to-publication-page.md
+++ b/CHANGELOG-add-file-browser-to-publication-page.md
@@ -1,0 +1,1 @@
+- Add files section to publication page.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -21,6 +21,13 @@ class VitessceConfLiftedUUID:
     vis_lifted_uuid: str
 
 
+@dataclass
+class PublicationJSONLiftedUUID:
+    publication_json: dict
+    vis_lifted_uuid: str
+
+
+
 def _get_hits(response_json):
     '''
     The repeated key makes error messages ambiguous.
@@ -283,6 +290,7 @@ class ApiClient():
         Returns a dataclass with vitessce_conf and is_lifted.
         '''
         publication_json = {}
+        publication_ancillary_uuid= None
         publication_ancillary_descendant = self.get_descendant_to_lift('publication_ancillary',
                                                                        entity["uuid"])
         if publication_ancillary_descendant:
@@ -296,7 +304,9 @@ class ApiClient():
                 current_app.logger.error(
                     f'Fetching publication ancillary json threw error: {traceback.format_exc()}')
 
-        return publication_json
+        return PublicationJSONLiftedUUID(
+            publication_json=publication_json, 
+            vis_lifted_uuid=publication_ancillary_uuid)
 
 
 def _make_query(constraints, uuids):

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -27,7 +27,6 @@ class PublicationJSONLiftedUUID:
     vis_lifted_uuid: str
 
 
-
 def _get_hits(response_json):
     '''
     The repeated key makes error messages ambiguous.
@@ -290,7 +289,7 @@ class ApiClient():
         Returns a dataclass with vitessce_conf and is_lifted.
         '''
         publication_json = {}
-        publication_ancillary_uuid= None
+        publication_ancillary_uuid = None
         publication_ancillary_descendant = self.get_descendant_to_lift('publication_ancillary',
                                                                        entity["uuid"])
         if publication_ancillary_descendant:
@@ -305,7 +304,7 @@ class ApiClient():
                     f'Fetching publication ancillary json threw error: {traceback.format_exc()}')
 
         return PublicationJSONLiftedUUID(
-            publication_json=publication_json, 
+            publication_json=publication_json,
             vis_lifted_uuid=publication_ancillary_uuid)
 
 

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -65,9 +65,9 @@ def details(type, uuid):
         })
 
     if type == 'publication':
-        publication_anicillary_data = client.get_publication_ancillary_json(entity)
-        flask_data.update({'vignette_json': publication_anicillary_data.publication_json,
-                           'vis_lifted_uuid': publication_anicillary_data.vis_lifted_uuid
+        publication_ancillary_data = client.get_publication_ancillary_json(entity)
+        flask_data.update({'vignette_json': publication_ancillary_data.publication_json,
+                           'vis_lifted_uuid': publication_ancillary_data.vis_lifted_uuid
                            })
 
     template = 'base-pages/react-content.html'

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -65,7 +65,10 @@ def details(type, uuid):
         })
 
     if type == 'publication':
-        flask_data.update({'vignette_json': client.get_publication_ancillary_json(entity)})
+        publication_anicillary_data = client.get_publication_ancillary_json(entity)
+        flask_data.update({'vignette_json': publication_anicillary_data.publication_json,
+                           'vis_lifted_uuid': publication_anicillary_data.vis_lifted_uuid
+                           })
 
     template = 'base-pages/react-content.html'
     return render_template(

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -101,7 +101,7 @@ function Routes({ flaskData }) {
   if (urlPath.startsWith('/browse/publication/')) {
     return (
       <Route>
-        <Publication publication={entity} vignette_json={vignette_json} />
+        <Publication publication={entity} vignette_json={vignette_json} visLiftedUUID={vis_lifted_uuid} />
       </Route>
     );
   }

--- a/context/app/static/js/components/detailPage/files/FileBrowserDirectory/FileBrowserDirectory.jsx
+++ b/context/app/static/js/components/detailPage/files/FileBrowserDirectory/FileBrowserDirectory.jsx
@@ -31,7 +31,8 @@ function FileBrowserDirectory({ dirName, children, depth }) {
         role="button"
         tabIndex="0"
       >
-        <td>
+        <td colSpan={4}>
+          {/* colSpan should match the number of cells in a FileBrowserFile row. */}
           <Directory $depth={depth}>
             {isExpanded ? (
               <>
@@ -47,8 +48,6 @@ function FileBrowserDirectory({ dirName, children, depth }) {
             {dirName}
           </Directory>
         </td>
-        <td />
-        <td />
       </StyledTableRow>
       {isExpanded && children}
     </>

--- a/context/app/static/js/components/detailPage/files/FileBrowserFile/FileBrowserFile.jsx
+++ b/context/app/static/js/components/detailPage/files/FileBrowserFile/FileBrowserFile.jsx
@@ -20,6 +20,7 @@ function FileBrowserFile({ fileObj, depth }) {
 
   const fileUrl = `${assetsEndpoint}/${uuid}/${fileObj.rel_path}${tokenParam}`;
 
+  // colSpan in FileBrowserDirectory should match the number of cells in the row.
   return (
     <StyledRow>
       <td>

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -7,6 +7,7 @@ import { getCombinedDatasetStatus, getSectionOrder } from 'js/components/detailP
 import PublicationSummary from 'js/components/publications/PublicationSummary';
 import PublicationsVisualizationSection from 'js/components/publications/PublicationVisualizationsSection/';
 import PublicationsDataSection from 'js/components/publications/PublicationsDataSection';
+import Files from 'js/components/detailPage/files/Files';
 import useEntityStore from 'js/stores/useEntityStore';
 
 const entityStoreSelector = (state) => state.setAssayMetadata;
@@ -23,6 +24,7 @@ function Publication({ publication, vignette_json }) {
     contributors,
     ancestor_ids,
     publication_venue,
+    files,
   } = publication;
 
   const setAssayMetadata = useEntityStore(entityStoreSelector);
@@ -32,10 +34,11 @@ function Publication({ publication, vignette_json }) {
 
   const shouldDisplaySection = {
     visualizations: Boolean(Object.keys(vignette_json).length),
+    files: true,
   };
 
   const sectionOrder = getSectionOrder(
-    ['summary', 'data', 'visualizations', 'authors', 'provenance'],
+    ['summary', 'data', 'visualizations', 'files', 'authors', 'provenance'],
     shouldDisplaySection,
   );
 
@@ -50,6 +53,7 @@ function Publication({ publication, vignette_json }) {
       {shouldDisplaySection.visualizations && (
         <PublicationsVisualizationSection vignette_json={vignette_json} uuid={uuid} />
       )}
+      <Files files={files} uuid={uuid} hubmap_id={hubmap_id} />
       <ContributorsTable contributors={contributors} title="Authors" />
       <ProvSection uuid={uuid} assayMetadata={publication} />
     </DetailLayout>

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -12,7 +12,7 @@ import useEntityStore from 'js/stores/useEntityStore';
 
 const entityStoreSelector = (state) => state.setAssayMetadata;
 
-function Publication({ publication, vignette_json }) {
+function Publication({ publication, vignette_json, visLiftedUUID }) {
   const {
     title,
     uuid,
@@ -53,7 +53,7 @@ function Publication({ publication, vignette_json }) {
       {shouldDisplaySection.visualizations && (
         <PublicationsVisualizationSection vignette_json={vignette_json} uuid={uuid} />
       )}
-      <Files files={files} uuid={uuid} hubmap_id={hubmap_id} />
+      <Files files={files} uuid={uuid} hubmap_id={hubmap_id} visLiftedUUID={visLiftedUUID} />
       <ContributorsTable contributors={contributors} title="Authors" />
       <ProvSection uuid={uuid} assayMetadata={publication} />
     </DetailLayout>


### PR DESCRIPTION
Adds files section to publication pages. While we do have pipeline support for publications with files, no publications with files exist now.

@tsliaw The mockup doesn't include Globus links, but the typical files section includes Globus links for both the main entity and 'support' entity.

<img width="1164" alt="Screen Shot 2023-05-30 at 11 23 06 AM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/de4fd707-60a0-4a47-b53f-0535f93f4a4d">
