### PR TITLE
NickAkhmetov / HMP-100 Improve vitessce conf generation errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,8 @@
     "[javascriptreact]": {
         "editor.defaultFormatter": "dbaeumer.vscode-eslint"
     },
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.autopep8"
+    },
+    "python.formatting.provider": "autopep8",
 }

--- a/CHANGELOG-hmp-100-fix-vitessce-conf-gen-errors.md
+++ b/CHANGELOG-hmp-100-fix-vitessce-conf-gen-errors.md
@@ -1,0 +1,3 @@
+- Fixed support page entity header so the application doesn't crash to a white screen when scrolling down on Support entities' pages.
+- Add error handling for cases where the image pyramid descendants are missing file metadata.
+- Add more informative error messages on vitessce conf gen failures

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -177,18 +177,17 @@ class ApiClient():
             # TODO: Entity structure will change in the future to be consistent
             # about "files". Bill confirms that when the new structure comes in
             # there will be a period of backward compatibility to allow us to migrate.
-            
 
             metadata = derived_entity.get('metadata', {})
 
             if (metadata.get('files')):
                 derived_entity['files'] = metadata.get('files', [])
                 vitessce_conf = self.get_vitessce_conf_cells_and_lifted_uuid(
-                    derived_entity, marker=marker, wrap_error=wrap_error
-                ).vitessce_conf
-                vis_lifted_uuid = derived_entity['uuid'] 
-            else: # no files
-                vitessce_conf = _create_vitessce_error('No files found in lifted image pyramid descendants metadata.')
+                    derived_entity, marker=marker, wrap_error=wrap_error).vitessce_conf
+                vis_lifted_uuid = derived_entity['uuid']
+            else:  # no files
+                vitessce_conf = _create_vitessce_error(
+                    'No files found in lifted image pyramid descendants metadata.')
 
         elif not entity.get('files') or not entity.get('data_types'):
             vitessce_conf = ConfCells(None, None)
@@ -494,17 +493,18 @@ def _get_latest_uuid(revisions):
     return max(clean_revisions,
                key=lambda revision: revision['revision_number'])['uuid']
 
+
 def _create_vitessce_error(error):
     return ConfCells({
-                    'name': 'Error',
-                    'version': '1.0.4',
-                    'datasets': [],
-                    'initStrategy': 'none',
-                    'layout': [{
+        'name': 'Error',
+        'version': '1.0.4',
+        'datasets': [],
+        'initStrategy': 'none',
+        'layout': [{
                         'component': 'description',
                         "props": {
                             "description": format('Error while generating the Vitessce configuration: ' + error),
                         },
-                        'x': 0, 'y': 0, 'w': 12, 'h': 1
-                    }],
-                }, None)
+            'x': 0, 'y': 0, 'w': 12, 'h': 1
+        }],
+    }, None)

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -186,8 +186,8 @@ class ApiClient():
                     derived_entity, marker=marker, wrap_error=wrap_error).vitessce_conf
                 vis_lifted_uuid = derived_entity['uuid']
             else:  # no files
-                error = f'Related entity {derived_entity["uuid"]} \
-                    is missing files information in its metadata.'
+                error = f'Related image entity {derived_entity["uuid"]} \
+                    is missing file information (no "files" key found in its metadata).'
                 current_app.logger.info(
                     f'Missing metadata error encountered in dataset \
                         {entity["uuid"]}: {error}')

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -186,8 +186,11 @@ class ApiClient():
                     derived_entity, marker=marker, wrap_error=wrap_error).vitessce_conf
                 vis_lifted_uuid = derived_entity['uuid']
             else:  # no files
-                error = f'Related entity {derived_entity["uuid"]} is missing files information in its metadata.'
-                current_app.logger.info(f'Missing metadata error encountered in dataset {entity["uuid"]}: {error}')
+                error = f'Related entity {derived_entity["uuid"]} \
+                    is missing files information in its metadata.'
+                current_app.logger.info(
+                    f'Missing metadata error encountered in dataset \
+                        {entity["uuid"]}: {error}')
                 vitessce_conf = _create_vitessce_error(error)
 
         elif not entity.get('files') or not entity.get('data_types'):

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -180,14 +180,15 @@ class ApiClient():
 
             metadata = derived_entity.get('metadata', {})
 
-            if (metadata.get('files')):
+            if metadata.get('files'):
                 derived_entity['files'] = metadata.get('files', [])
                 vitessce_conf = self.get_vitessce_conf_cells_and_lifted_uuid(
                     derived_entity, marker=marker, wrap_error=wrap_error).vitessce_conf
                 vis_lifted_uuid = derived_entity['uuid']
             else:  # no files
-                vitessce_conf = _create_vitessce_error(
-                    'No files found in lifted image pyramid descendants metadata.')
+                error = f'Related entity {derived_entity["uuid"]} is missing files information in its metadata.'
+                current_app.logger.info(f'Missing metadata error encountered in dataset {entity["uuid"]}: {error}')
+                vitessce_conf = _create_vitessce_error(error)
 
         elif not entity.get('files') or not entity.get('data_types'):
             vitessce_conf = ConfCells(None, None)

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -500,11 +500,12 @@ def _create_vitessce_error(error):
         'version': '1.0.4',
         'datasets': [],
         'initStrategy': 'none',
-        'layout': [{
-                        'component': 'description',
-                        "props": {
-                            "description": format('Error while generating the Vitessce configuration: ' + error),
-                        },
-            'x': 0, 'y': 0, 'w': 12, 'h': 1
-        }],
+        'layout': [
+            {
+                'component': 'description',
+                "props": {
+                    "description": 'Error while generating the Vitessce configuration: ' + error,
+                },
+                'x': 0, 'y': 0, 'w': 12, 'h': 1
+            }],
     }, None)

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -173,7 +173,7 @@ class ApiClient():
 
         # First, try "vis-lifting": Display image pyramids on their parent entity pages.
         if image_pyramid_descendants:
-            derived_entity = {} # image_pyramid_descendants
+            derived_entity = image_pyramid_descendants
             # TODO: Entity structure will change in the future to be consistent
             # about "files". Bill confirms that when the new structure comes in
             # there will be a period of backward compatibility to allow us to migrate.

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
@@ -29,8 +29,6 @@ const entityToFieldsMap = {
     title: ({ title }) => title,
     'publication venue': ({ publication_venue }) => publication_venue,
   },
-  // Don't display any header items for Support entities
-  Support: {},
 };
 
 const AnimatedFlexContainer = animated(FlexContainer);
@@ -60,7 +58,7 @@ function EntityHeaderContent({ assayMetadata, shouldDisplayHeader, vizIsFullscre
                 ? Object.entries(entityToFieldsMap[entity_type]).map(([label, fn]) => (
                     <EntityHeaderItem text={fn(assayMetadata) || `undefined ${label}`} key={label} />
                   ))
-                : `No fields defined for entity type ${entity_type}`}
+                : null}
             </>
           )}
           {vizIsFullscreen && (

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
@@ -29,6 +29,7 @@ const entityToFieldsMap = {
     title: ({ title }) => title,
     'publication venue': ({ publication_venue }) => publication_venue,
   },
+  // Don't display any header items for Support entities
   Support: {},
 };
 

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.jsx
@@ -29,6 +29,7 @@ const entityToFieldsMap = {
     title: ({ title }) => title,
     'publication venue': ({ publication_venue }) => publication_venue,
   },
+  Support: {},
 };
 
 const AnimatedFlexContainer = animated(FlexContainer);
@@ -54,9 +55,11 @@ function EntityHeaderContent({ assayMetadata, shouldDisplayHeader, vizIsFullscre
             <>
               <StyledSvgIcon component={entityIconMap[entity_type]} />
               <EntityHeaderItem text={hubmap_id} />
-              {Object.entries(entityToFieldsMap[entity_type]).map(([label, fn]) => (
-                <EntityHeaderItem text={fn(assayMetadata) || `undefined ${label}`} key={label} />
-              ))}
+              {entity_type in entityToFieldsMap
+                ? Object.entries(entityToFieldsMap[entity_type]).map(([label, fn]) => (
+                    <EntityHeaderItem text={fn(assayMetadata) || `undefined ${label}`} key={label} />
+                  ))
+                : `No fields defined for entity type ${entity_type}`}
             </>
           )}
           {vizIsFullscreen && (


### PR DESCRIPTION
This PR

- Fixes support page entity header so the application doesn't crash to a white screen when scrolling down on Support entities' pages
- Adds handling for cases where the image pyramid descendants are missing file metadata
- Add more informative error messages on vitessce conf gen failures

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/1a88c164-0001-4262-94b1-926d1a13ca2c)
