### PR TITLE
Bump Vitessce version and add uids to Vitessce configs

### DIFF
--- a/CHANGELOG-vitessce-v3.md
+++ b/CHANGELOG-vitessce-v3.md
@@ -1,0 +1,1 @@
+- Add uids to places in which multiple Vitessce configurations are listed in a dropdown

--- a/context/app/preview/cell-type-annotations.md
+++ b/context/app/preview/cell-type-annotations.md
@@ -6,204 +6,494 @@ created_by_user_email: rsatija@nygenome.org
 vitessce_conf:
   [
     {
-      'version': '0.1.0',
-      'name': 'HBM336.FWTN.636',
-      'layers':
-        [
-          {
-            'name': 'cells',
-            'type': 'CELLS',
-            'fileType': 'cells.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cells.json',
+      "version": "1.0.16",
+      "name": "HBM336.FWTN.636",
+      "uid": "HBM336.FWTN.636",
+      "datasets": [
+        {
+          "uid": "d62b501a-46d3-4de7-a13c-6fcc06b7d806",
+          "name": "d62b501a-46d3-4de7-a13c-6fcc06b7d806",
+          "files": [
+            {
+              "fileType": "cells.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cells.json",
+              "options": {
+                "embeddingTypes": [
+                  "UMAP"
+                ]
+              }
+            },
+            {
+              "fileType": "cell-sets.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cell-sets.json"
+            },
+            {
+              "fileType": "expression-matrix.zarr",
+              "url": "https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.expression-matrix.zarr"
+            }
+          ]
+        }
+      ],
+      "coordinationSpace": {
+        "embeddingType": {
+          "UMAP": "UMAP"
+        },
+        "embeddingZoom": {
+          "A": 3
+        },
+        "embeddingTargetX": {
+          "A": 0
+        },
+        "embeddingTargetY": {
+          "A": 0
+        },
+        "spatialZoom": {},
+        "spatialTargetX": {},
+        "spatialTargetY": {}
+      },
+      "layout": [
+        {
+          "component": "obsSets",
+          "x": 4,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "obsSetSizes",
+          "x": 8,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "scatterplot",
+          "props": {
+            "mapping": "UMAP",
+            "view": {
+              "target": [
+                0,
+                0,
+                0
+              ],
+              "zoom": 3
+            }
           },
-          {
-            'name': 'cell-sets',
-            'type': 'CELL-SETS',
-            'fileType': 'cell-sets.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cell-sets.json',
-          },
-          {
-            'name': 'expression-matrix',
-            'type': 'EXPRESSION-MATRIX',
-            'fileType': 'expression-matrix.zarr',
-            'url': 'https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.expression-matrix.zarr',
-          },
-        ],
-      'public': true,
-      'staticLayout':
-        [
-          { 'component': 'cellSets', 'x': 4, 'y': 0, 'w': 4, 'h': 4 },
-          { 'component': 'cellSetSizes', 'x': 8, 'y': 0, 'w': 4, 'h': 4 },
-          {
-            'component': 'scatterplot',
-            'props': { 'mapping': 'UMAP', 'view': { 'zoom': 3, 'target': [0, 0, 0] } },
-            'x': 0,
-            'y': 0,
-            'w': 4,
-            'h': 4,
-          },
-          { 'component': 'heatmap', 'x': 0, 'y': 4, 'w': 12, 'h': 4 },
-        ],
+          "x": 0,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {
+            "embeddingType": "UMAP",
+            "embeddingZoom": "A",
+            "embeddingTargetX": "A",
+            "embeddingTargetY": "A"
+          }
+        },
+        {
+          "component": "heatmap",
+          "x": 0,
+          "y": 4,
+          "w": 12,
+          "h": 4,
+          "coordinationScopes": {}
+        }
+      ],
+      "initStrategy": "auto"
     },
     {
-      'version': '0.1.0',
-      'name': 'HBM984.GRBB.858',
-      'layers':
-        [
-          {
-            'name': 'cells',
-            'type': 'CELLS',
-            'fileType': 'cells.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cells.json',
+      "version": "1.0.16",
+      "name": "HBM984.GRBB.858",
+      "uid": "HBM984.GRBB.858",
+      "datasets": [
+        {
+          "uid": "7e218643-22c9-4ecb-a749-9c29b96c489b",
+          "name": "7e218643-22c9-4ecb-a749-9c29b96c489b",
+          "files": [
+            {
+              "fileType": "cells.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cells.json",
+              "options": {
+                "embeddingTypes": [
+                  "UMAP"
+                ]
+              }
+            },
+            {
+              "fileType": "cell-sets.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cell-sets.json"
+            },
+            {
+              "fileType": "expression-matrix.zarr",
+              "url": "https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.expression-matrix.zarr"
+            }
+          ]
+        }
+      ],
+      "coordinationSpace": {
+        "embeddingType": {
+          "UMAP": "UMAP"
+        },
+        "embeddingZoom": {
+          "A": 3
+        },
+        "embeddingTargetX": {
+          "A": 0
+        },
+        "embeddingTargetY": {
+          "A": 0
+        },
+        "spatialZoom": {},
+        "spatialTargetX": {},
+        "spatialTargetY": {}
+      },
+      "layout": [
+        {
+          "component": "obsSets",
+          "x": 4,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "obsSetSizes",
+          "x": 8,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "scatterplot",
+          "props": {
+            "mapping": "UMAP",
+            "view": {
+              "target": [
+                0,
+                0,
+                0
+              ],
+              "zoom": 3
+            }
           },
-          {
-            'name': 'cell-sets',
-            'type': 'CELL-SETS',
-            'fileType': 'cell-sets.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cell-sets.json',
-          },
-          {
-            'name': 'expression-matrix',
-            'type': 'EXPRESSION-MATRIX',
-            'fileType': 'expression-matrix.zarr',
-            'url': 'https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.expression-matrix.zarr',
-          },
-        ],
-      'public': true,
-      'staticLayout':
-        [
-          { 'component': 'cellSets', 'x': 4, 'y': 0, 'w': 4, 'h': 4 },
-          { 'component': 'cellSetSizes', 'x': 8, 'y': 0, 'w': 4, 'h': 4 },
-          {
-            'component': 'scatterplot',
-            'props': { 'mapping': 'UMAP', 'view': { 'zoom': 3, 'target': [0, 0, 0] } },
-            'x': 0,
-            'y': 0,
-            'w': 4,
-            'h': 4,
-          },
-          { 'component': 'heatmap', 'x': 0, 'y': 4, 'w': 12, 'h': 4 },
-        ],
+          "x": 0,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {
+            "embeddingType": "UMAP",
+            "embeddingZoom": "A",
+            "embeddingTargetX": "A",
+            "embeddingTargetY": "A"
+          }
+        },
+        {
+          "component": "heatmap",
+          "x": 0,
+          "y": 4,
+          "w": 12,
+          "h": 4,
+          "coordinationScopes": {}
+        }
+      ],
+      "initStrategy": "auto"
     },
     {
-      'version': '0.1.0',
-      'name': 'HBM556.QMSM.776',
-      'layers':
-        [
-          {
-            'name': 'cells',
-            'type': 'CELLS',
-            'fileType': 'cells.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cells.json',
+      "version": "1.0.16",
+      "name": "HBM556.QMSM.776",
+      "uid": "HBM556.QMSM.776",
+      "datasets": [
+        {
+          "uid": "25f2fec7-61b5-45cf-b8da-824fd5582574",
+          "name": "25f2fec7-61b5-45cf-b8da-824fd5582574",
+          "files": [
+            {
+              "fileType": "cells.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cells.json",
+              "options": {
+                "embeddingTypes": [
+                  "UMAP"
+                ]
+              }
+            },
+            {
+              "fileType": "cell-sets.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cell-sets.json"
+            },
+            {
+              "fileType": "expression-matrix.zarr",
+              "url": "https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.expression-matrix.zarr"
+            }
+          ]
+        }
+      ],
+      "coordinationSpace": {
+        "embeddingType": {
+          "UMAP": "UMAP"
+        },
+        "embeddingZoom": {
+          "A": 3
+        },
+        "embeddingTargetX": {
+          "A": 0
+        },
+        "embeddingTargetY": {
+          "A": 0
+        },
+        "spatialZoom": {},
+        "spatialTargetX": {},
+        "spatialTargetY": {}
+      },
+      "layout": [
+        {
+          "component": "obsSets",
+          "x": 4,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "obsSetSizes",
+          "x": 8,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "scatterplot",
+          "props": {
+            "mapping": "UMAP",
+            "view": {
+              "target": [
+                0,
+                0,
+                0
+              ],
+              "zoom": 3
+            }
           },
-          {
-            'name': 'cell-sets',
-            'type': 'CELL-SETS',
-            'fileType': 'cell-sets.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cell-sets.json',
-          },
-          {
-            'name': 'expression-matrix',
-            'type': 'EXPRESSION-MATRIX',
-            'fileType': 'expression-matrix.zarr',
-            'url': 'https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.expression-matrix.zarr',
-          },
-        ],
-      'public': true,
-      'staticLayout':
-        [
-          { 'component': 'cellSets', 'x': 4, 'y': 0, 'w': 4, 'h': 4 },
-          { 'component': 'cellSetSizes', 'x': 8, 'y': 0, 'w': 4, 'h': 4 },
-          {
-            'component': 'scatterplot',
-            'props': { 'mapping': 'UMAP', 'view': { 'zoom': 3, 'target': [0, 0, 0] } },
-            'x': 0,
-            'y': 0,
-            'w': 4,
-            'h': 4,
-          },
-          { 'component': 'heatmap', 'x': 0, 'y': 4, 'w': 12, 'h': 4 },
-        ],
+          "x": 0,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {
+            "embeddingType": "UMAP",
+            "embeddingZoom": "A",
+            "embeddingTargetX": "A",
+            "embeddingTargetY": "A"
+          }
+        },
+        {
+          "component": "heatmap",
+          "x": 0,
+          "y": 4,
+          "w": 12,
+          "h": 4,
+          "coordinationScopes": {}
+        }
+      ],
+      "initStrategy": "auto"
     },
     {
-      'version': '0.1.0',
-      'name': 'HBM472.NTNN.543',
-      'layers':
-        [
-          {
-            'name': 'cells',
-            'type': 'CELLS',
-            'fileType': 'cells.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cells.json',
+      "version": "1.0.16",
+      "name": "HBM472.NTNN.543",
+      "uid": "HBM472.NTNN.543",
+      "datasets": [
+        {
+          "uid": "aec4be3a-df4b-4778-99b0-ae102c671933",
+          "name": "aec4be3a-df4b-4778-99b0-ae102c671933",
+          "files": [
+            {
+              "fileType": "cells.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cells.json",
+              "options": {
+                "embeddingTypes": [
+                  "UMAP"
+                ]
+              }
+            },
+            {
+              "fileType": "cell-sets.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cell-sets.json"
+            },
+            {
+              "fileType": "expression-matrix.zarr",
+              "url": "https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.expression-matrix.zarr"
+            }
+          ]
+        }
+      ],
+      "coordinationSpace": {
+        "embeddingType": {
+          "UMAP": "UMAP"
+        },
+        "embeddingZoom": {
+          "A": 3
+        },
+        "embeddingTargetX": {
+          "A": 0
+        },
+        "embeddingTargetY": {
+          "A": 0
+        },
+        "spatialZoom": {},
+        "spatialTargetX": {},
+        "spatialTargetY": {}
+      },
+      "layout": [
+        {
+          "component": "obsSets",
+          "x": 4,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "obsSetSizes",
+          "x": 8,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "scatterplot",
+          "props": {
+            "mapping": "UMAP",
+            "view": {
+              "target": [
+                0,
+                0,
+                0
+              ],
+              "zoom": 3
+            }
           },
-          {
-            'name': 'cell-sets',
-            'type': 'CELL-SETS',
-            'fileType': 'cell-sets.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cell-sets.json',
-          },
-          {
-            'name': 'expression-matrix',
-            'type': 'EXPRESSION-MATRIX',
-            'fileType': 'expression-matrix.zarr',
-            'url': 'https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.expression-matrix.zarr',
-          },
-        ],
-      'public': true,
-      'staticLayout':
-        [
-          { 'component': 'cellSets', 'x': 4, 'y': 0, 'w': 4, 'h': 4 },
-          { 'component': 'cellSetSizes', 'x': 8, 'y': 0, 'w': 4, 'h': 4 },
-          {
-            'component': 'scatterplot',
-            'props': { 'mapping': 'UMAP', 'view': { 'zoom': 3, 'target': [0, 0, 0] } },
-            'x': 0,
-            'y': 0,
-            'w': 4,
-            'h': 4,
-          },
-          { 'component': 'heatmap', 'x': 0, 'y': 4, 'w': 12, 'h': 4 },
-        ],
+          "x": 0,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {
+            "embeddingType": "UMAP",
+            "embeddingZoom": "A",
+            "embeddingTargetX": "A",
+            "embeddingTargetY": "A"
+          }
+        },
+        {
+          "component": "heatmap",
+          "x": 0,
+          "y": 4,
+          "w": 12,
+          "h": 4,
+          "coordinationScopes": {}
+        }
+      ],
+      "initStrategy": "auto"
     },
     {
-      'version': '0.1.0',
-      'name': 'HBM396.RPRR.624',
-      'layers':
-        [
-          {
-            'name': 'cells',
-            'type': 'CELLS',
-            'fileType': 'cells.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cells.json',
+      "version": "1.0.16",
+      "name": "HBM396.RPRR.624",
+      "uid": "HBM396.RPRR.624",
+      "datasets": [
+        {
+          "uid": "02d5668a-ef7e-4445-b223-9501d41a63da",
+          "name": "02d5668a-ef7e-4445-b223-9501d41a63da",
+          "files": [
+            {
+              "fileType": "cells.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cells.json",
+              "options": {
+                "embeddingTypes": [
+                  "UMAP"
+                ]
+              }
+            },
+            {
+              "fileType": "cell-sets.json",
+              "url": "https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cell-sets.json"
+            },
+            {
+              "fileType": "expression-matrix.zarr",
+              "url": "https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.expression-matrix.zarr"
+            }
+          ]
+        }
+      ],
+      "coordinationSpace": {
+        "embeddingType": {
+          "UMAP": "UMAP"
+        },
+        "embeddingZoom": {
+          "A": 3
+        },
+        "embeddingTargetX": {
+          "A": 0
+        },
+        "embeddingTargetY": {
+          "A": 0
+        },
+        "spatialZoom": {},
+        "spatialTargetX": {},
+        "spatialTargetY": {}
+      },
+      "layout": [
+        {
+          "component": "obsSets",
+          "x": 4,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "obsSetSizes",
+          "x": 8,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {}
+        },
+        {
+          "component": "scatterplot",
+          "props": {
+            "mapping": "UMAP",
+            "view": {
+              "target": [
+                0,
+                0,
+                0
+              ],
+              "zoom": 3
+            }
           },
-          {
-            'name': 'cell-sets',
-            'type': 'CELL-SETS',
-            'fileType': 'cell-sets.json',
-            'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cell-sets.json',
-          },
-          {
-            'name': 'expression-matrix',
-            'type': 'EXPRESSION-MATRIX',
-            'fileType': 'expression-matrix.zarr',
-            'url': 'https://vitessce-data.storage.googleapis.com/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.expression-matrix.zarr',
-          },
-        ],
-      'public': true,
-      'staticLayout':
-        [
-          { 'component': 'cellSets', 'x': 4, 'y': 0, 'w': 4, 'h': 4 },
-          { 'component': 'cellSetSizes', 'x': 8, 'y': 0, 'w': 4, 'h': 4 },
-          {
-            'component': 'scatterplot',
-            'props': { 'mapping': 'UMAP', 'view': { 'zoom': 3, 'target': [0, 0, 0] } },
-            'x': 0,
-            'y': 0,
-            'w': 4,
-            'h': 4,
-          },
-          { 'component': 'heatmap', 'x': 0, 'y': 4, 'w': 12, 'h': 4 },
-        ],
+          "x": 0,
+          "y": 0,
+          "w": 4,
+          "h": 4,
+          "coordinationScopes": {
+            "embeddingType": "UMAP",
+            "embeddingZoom": "A",
+            "embeddingTargetX": "A",
+            "embeddingTargetY": "A"
+          }
+        },
+        {
+          "component": "heatmap",
+          "x": 0,
+          "y": 4,
+          "w": 12,
+          "h": 4,
+          "coordinationScopes": {}
+        }
+      ],
+      "initStrategy": "auto"
     },
   ]
 ---

--- a/context/app/preview/multimodal-mass-spectrometry-imaging-data.md
+++ b/context/app/preview/multimodal-mass-spectrometry-imaging-data.md
@@ -6,7 +6,8 @@ created_by_user_email: hut3@psu.edu
 vitessce_conf:
   [
     {
-      "version": "1.0.7",
+      "version": "1.0.16",
+      "uid": "3D Human Liver",
       "name": "3D Human Liver",
       "description": "",
       "datasets": [
@@ -15,24 +16,23 @@ vitessce_conf:
           "name": "Human dataset",
           "files": [
             {
-              "type": "raster",
               "fileType": "raster.json",
               "options": {
-                "schemaVersion": "0.0.2",
-                "usePhysicalSizeScaling": true,
                 "images": [
                   {
-                    "name": "Human Liver",
-                    "type": "ome-tiff",
-                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_3d.raster.pyramid.ome.tiff",
                     "metadata": {
                       "isBitmask": false
-                    }
+                    },
+                    "name": "Human Liver",
+                    "type": "ome-tiff",
+                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_3d.raster.pyramid.ome.tiff"
                   }
                 ],
                 "renderLayers": [
                   "Human Liver"
-                ]
+                ],
+                "schemaVersion": "0.0.2",
+                "usePhysicalSizeScaling": true
               }
             }
           ]
@@ -42,20 +42,17 @@ vitessce_conf:
         "dataset": {
           "human": "human-liver"
         },
-        "spatialZoom": {
-          "A": -0.7884025211167491
+        "spatialAxisFixed": {
+          "A": false
+        },
+        "spatialOrbitAxis": {
+          "A": null
         },
         "spatialRotation": {
           "A": 0
         },
-        "spatialTargetX": {
-          "A": 494.0703579375883
-        },
-        "spatialTargetY": {
-          "A": 358.7471084680066
-        },
-        "spatialTargetZ": {
-          "A": 18.79732498306471
+        "spatialRotationOrbit": {
+          "A": -14.282115869017636
         },
         "spatialRotationX": {
           "A": -19.113264220037628
@@ -66,98 +63,101 @@ vitessce_conf:
         "spatialRotationZ": {
           "A": null
         },
-        "spatialRotationOrbit": {
-          "A": -14.282115869017636
+        "spatialTargetX": {
+          "A": 494.0703579375883
         },
-        "spatialOrbitAxis": {
-          "A": null
+        "spatialTargetY": {
+          "A": 358.7471084680066
         },
-        "spatialAxisFixed": {
-          "A": false
+        "spatialTargetZ": {
+          "A": 18.79732498306471
         },
-        "spatialRasterLayers": {
+        "spatialZoom": {
+          "A": -0.7884025211167491
+        },
+        "spatialImageLayer": {
           "A": [
             {
-              "type": "raster",
-              "index": 0,
-              "visible": true,
-              "colormap": null,
-              "opacity": 1,
-              "domainType": "Min/Max",
-              "transparentColor": null,
-              "renderingMode": "Maximum Intensity Projection",
-              "use3d": true,
               "channels": [
                 {
+                  "color": [
+                    0,
+                    0,
+                    255
+                  ],
                   "selection": {
                     "c": 0,
                     "t": 0,
                     "z": 3
                   },
-                  "color": [
-                    0,
-                    0,
-                    255
-                  ],
-                  "visible": true,
                   "slider": [
                     0.942477822303772,
                     1.5707963705062866
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
+                  "color": [
+                    0,
+                    255,
+                    0
+                  ],
                   "selection": {
                     "c": 1,
                     "t": 0,
                     "z": 3
                   },
-                  "color": [
-                    0,
-                    255,
-                    0
-                  ],
-                  "visible": true,
                   "slider": [
                     0.9142034876346589,
                     1.5707963705062866
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
-                  "selection": {
-                    "c": 2,
-                    "t": 0,
-                    "z": 3
-                  },
                   "color": [
                     255,
                     0,
                     255
                   ],
-                  "visible": true,
-                  "slider": [
-                    0.942477822303772,
-                    1.5707963705062866
-                  ]
-                },
-                {
                   "selection": {
-                    "c": 3,
+                    "c": 2,
                     "t": 0,
                     "z": 3
                   },
+                  "slider": [
+                    0.942477822303772,
+                    1.5707963705062866
+                  ],
+                  "visible": true
+                },
+                {
                   "color": [
                     255,
                     255,
                     0
                   ],
-                  "visible": true,
+                  "selection": {
+                    "c": 3,
+                    "t": 0,
+                    "z": 3
+                  },
                   "slider": [
                     0.9487610077857971,
                     1.5707963705062866
-                  ]
+                  ],
+                  "visible": true
                 }
               ],
+              "colormap": null,
+              "domainType": "Min/Max",
+              "index": 0,
+              "opacity": 1,
+              "renderingMode": "Maximum Intensity Projection",
               "resolution": 0,
+              "transparentColor": null,
+              "type": "raster",
+              "use3d": true,
+              "visible": true,
               "xSlice": [
                 0,
                 768
@@ -177,56 +177,57 @@ vitessce_conf:
       "layout": [
         {
           "component": "spatial",
-          "coordinationScopes": {
-            "dataset": "human",
-            "spatialZoom": "A",
-            "spatialRotation": "A",
-            "spatialTargetX": "A",
-            "spatialTargetY": "A",
-            "spatialTargetZ": "A",
-            "spatialRotationX": "A",
-            "spatialRotationY": "A",
-            "spatialRotationZ": "A",
-            "spatialRotationOrbit": "A",
-            "spatialOrbitAxis": "A",
-            "spatialAxisFixed": "A",
-            "spatialRasterLayers": "A",
-            "spatialCellsLayer": "A"
-          },
           "x": 0,
           "y": 0,
           "w": 8,
-          "h": 12
-        },
-        {
-          "component": "layerController",
+          "h": 12,
           "coordinationScopes": {
             "dataset": "human",
-            "spatialZoom": "A",
+            "spatialAxisFixed": "A",
+            "spatialOrbitAxis": "A",
             "spatialRotation": "A",
-            "spatialTargetX": "A",
-            "spatialTargetY": "A",
-            "spatialTargetZ": "A",
+            "spatialRotationOrbit": "A",
             "spatialRotationX": "A",
             "spatialRotationY": "A",
             "spatialRotationZ": "A",
-            "spatialRotationOrbit": "A",
-            "spatialOrbitAxis": "A",
-            "spatialAxisFixed": "A",
-            "spatialRasterLayers": "A",
-            "spatialCellsLayer": "A"
-          },
+            "spatialTargetX": "A",
+            "spatialTargetY": "A",
+            "spatialTargetZ": "A",
+            "spatialZoom": "A",
+            "spatialImageLayer": "A",
+            "spatialSegmentationLayer": "A"
+          }
+        },
+        {
+          "component": "layerController",
           "x": 8,
           "y": 0,
           "w": 4,
-          "h": 12
+          "h": 12,
+          "coordinationScopes": {
+            "dataset": "human",
+            "spatialAxisFixed": "A",
+            "spatialOrbitAxis": "A",
+            "spatialRotation": "A",
+            "spatialRotationOrbit": "A",
+            "spatialRotationX": "A",
+            "spatialRotationY": "A",
+            "spatialRotationZ": "A",
+            "spatialTargetX": "A",
+            "spatialTargetY": "A",
+            "spatialTargetZ": "A",
+            "spatialZoom": "A",
+            "spatialImageLayer": "A",
+            "spatialSegmentationLayer": "A"
+          }
         }
       ],
       "initStrategy": "auto"
     },
     {
-      "version": "1.0.7",
+      "version": "1.0.16",
       "name": "3D Human Liver with annotations",
+      "uid": "3D Human Liver with annotations",
       "description": "",
       "datasets": [
         {
@@ -234,55 +235,58 @@ vitessce_conf:
           "name": "Human dataset",
           "files": [
             {
-              "type": "raster",
               "fileType": "raster.json",
               "options": {
-                "schemaVersion": "0.0.2",
-                "usePhysicalSizeScaling": false,
                 "images": [
                   {
-                    "name": "Human Liver",
-                    "type": "ome-tiff",
-                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_3d.raster.pyramid.ome.tiff",
                     "metadata": {
                       "isBitmask": false
-                    }
+                    },
+                    "name": "Human Liver",
+                    "type": "ome-tiff",
+                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_3d.raster.pyramid.ome.tiff"
                   },
                   {
-                    "name": "Cell Segmentations (Sixth slice only)",
-                    "type": "ome-tiff",
-                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_topslice.cell_ids.ome.tiff",
                     "metadata": {
                       "isBitmask": true
-                    }
+                    },
+                    "name": "Cell Segmentations (Sixth slice only)",
+                    "type": "ome-tiff",
+                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_topslice.cell_ids.ome.tiff"
                   }
                 ],
                 "renderLayers": [
                   "Human Liver",
                   "Cell Segmentations (Sixth slice only)"
-                ]
+                ],
+                "schemaVersion": "0.0.2",
+                "usePhysicalSizeScaling": false
               }
             },
             {
-              "type": "cells",
               "fileType": "anndata-cells.zarr",
               "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_topslice.h5ad.zarr",
               "options": {
-                "xy": "obsm/X_spatial",
                 "mappings": {
-                  "Protein-based t-SNE": {
-                    "key": "obsm/X_protein_tsne",
-                    "dims": [0, 1]
-                  },
                   "Lipid/metabolite-based t-SNE": {
-                    "key": "obsm/X_lipmet_tsne",
-                    "dims": [0, 1]
+                    "dims": [
+                      0,
+                      1
+                    ],
+                    "key": "obsm/X_lipmet_tsne"
+                  },
+                  "Protein-based t-SNE": {
+                    "dims": [
+                      0,
+                      1
+                    ],
+                    "key": "obsm/X_protein_tsne"
                   }
-                }
+                },
+                "xy": "obsm/X_spatial"
               }
             },
             {
-              "type": "cell-sets",
               "fileType": "anndata-cell-sets.zarr",
               "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_topslice.h5ad.zarr",
               "options": [
@@ -297,12 +301,11 @@ vitessce_conf:
               ]
             },
             {
-              "type": "expression-matrix",
               "fileType": "anndata-expression-matrix.zarr",
               "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/human_topslice.h5ad.zarr",
               "options": {
-                "matrix": "layers/X_uint8",
-                "geneAlias": "var/feature_name"
+                "geneAlias": "var/feature_name",
+                "matrix": "layers/X_uint8"
               }
             }
           ]
@@ -312,20 +315,21 @@ vitessce_conf:
         "dataset": {
           "human": "human-liver-annot"
         },
-        "spatialZoom": {
-          "A": -0.7884025211167491
+        "embeddingType": {
+          "A": "Protein-based t-SNE",
+          "B": "Lipid/metabolite-based t-SNE"
+        },
+        "spatialAxisFixed": {
+          "A": false
+        },
+        "spatialOrbitAxis": {
+          "A": null
         },
         "spatialRotation": {
           "A": 0
         },
-        "spatialTargetX": {
-          "A": 494.0703579375883
-        },
-        "spatialTargetY": {
-          "A": 358.7471084680066
-        },
-        "spatialTargetZ": {
-          "A": 18.79732498306471
+        "spatialRotationOrbit": {
+          "A": -14.282115869017636
         },
         "spatialRotationX": {
           "A": -19.113264220037628
@@ -336,104 +340,118 @@ vitessce_conf:
         "spatialRotationZ": {
           "A": null
         },
-        "spatialRotationOrbit": {
-          "A": -14.282115869017636
+        "spatialTargetX": {
+          "A": 494.0703579375883
         },
-        "spatialOrbitAxis": {
-          "A": null
+        "spatialTargetY": {
+          "A": 358.7471084680066
         },
-        "spatialAxisFixed": {
-          "A": false
+        "spatialTargetZ": {
+          "A": 18.79732498306471
         },
-        "spatialRasterLayers": {
+        "spatialZoom": {
+          "A": -0.7884025211167491
+        },
+        "spatialImageLayer": {
           "A": [
             {
-              "type": "raster",
-              "index": 0,
-              "visible": true,
-              "colormap": null,
-              "opacity": 1,
-              "domainType": "Min/Max",
-              "transparentColor": null,
-              "renderingMode": "Maximum Intensity Projection",
-              "use3d": false,
               "channels": [
                 {
+                  "color": [
+                    0,
+                    0,
+                    255
+                  ],
                   "selection": {
                     "c": 0,
                     "t": 0,
                     "z": 6
                   },
-                  "color": [
-                    0,
-                    0,
-                    255
-                  ],
-                  "visible": true,
                   "slider": [
                     0.942477822303772,
                     1.5707963705062866
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
+                  "color": [
+                    0,
+                    255,
+                    0
+                  ],
                   "selection": {
                     "c": 1,
                     "t": 0,
                     "z": 6
                   },
-                  "color": [
-                    0,
-                    255,
-                    0
-                  ],
-                  "visible": true,
                   "slider": [
                     0.9142034876346589,
                     1.5707963705062866
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
-                  "selection": {
-                    "c": 2,
-                    "t": 0,
-                    "z": 6
-                  },
                   "color": [
                     255,
                     0,
                     255
                   ],
-                  "visible": true,
-                  "slider": [
-                    0.942477822303772,
-                    1.5707963705062866
-                  ]
-                },
-                {
                   "selection": {
-                    "c": 3,
+                    "c": 2,
                     "t": 0,
                     "z": 6
                   },
+                  "slider": [
+                    0.942477822303772,
+                    1.5707963705062866
+                  ],
+                  "visible": true
+                },
+                {
                   "color": [
                     255,
                     255,
                     0
                   ],
-                  "visible": true,
+                  "selection": {
+                    "c": 3,
+                    "t": 0,
+                    "z": 6
+                  },
                   "slider": [
                     0.9487610077857971,
                     1.5707963705062866
-                  ]
+                  ],
+                  "visible": true
                 }
-              ]
+              ],
+              "colormap": null,
+              "domainType": "Min/Max",
+              "index": 0,
+              "opacity": 1,
+              "renderingMode": "Maximum Intensity Projection",
+              "transparentColor": null,
+              "type": "raster",
+              "use3d": false,
+              "visible": true
             },
             {
               "channels": [
                 {
-                  "color": [255, 255, 255],
-                  "selection": { "c": 0, "t": 0, "z": 0 },
-                  "slider": [2, 1998],
+                  "color": [
+                    255,
+                    255,
+                    255
+                  ],
+                  "selection": {
+                    "c": 0,
+                    "t": 0,
+                    "z": 0
+                  },
+                  "slider": [
+                    2,
+                    1998
+                  ],
                   "visible": true
                 }
               ],
@@ -442,70 +460,67 @@ vitessce_conf:
               "index": 1,
               "opacity": 1,
               "renderingMode": "Additive",
-              "transparentColor": [0, 0, 0],
+              "transparentColor": [
+                0,
+                0,
+                0
+              ],
               "type": "bitmask",
               "use3d": false,
               "visible": true
             }
           ]
-        },
-        "embeddingType": {
-          "A": "Protein-based t-SNE",
-          "B": "Lipid/metabolite-based t-SNE"
         }
       },
       "layout": [
         {
           "component": "spatial",
-          "coordinationScopes": {
-            "dataset": "human",
-            "spatialZoom": "A",
-            "spatialRotation": "A",
-            "spatialTargetX": "A",
-            "spatialTargetY": "A",
-            "spatialTargetZ": "A",
-            "spatialRotationX": "A",
-            "spatialRotationY": "A",
-            "spatialRotationZ": "A",
-            "spatialRotationOrbit": "A",
-            "spatialOrbitAxis": "A",
-            "spatialAxisFixed": "A",
-            "spatialRasterLayers": "A",
-            "spatialCellsLayer": "A"
-          },
           "x": 0,
           "y": 0,
           "w": 6,
-          "h": 6
-        },
-        {
-          "component": "layerController",
+          "h": 6,
           "coordinationScopes": {
             "dataset": "human",
-            "spatialZoom": "A",
+            "spatialAxisFixed": "A",
+            "spatialOrbitAxis": "A",
             "spatialRotation": "A",
-            "spatialTargetX": "A",
-            "spatialTargetY": "A",
-            "spatialTargetZ": "A",
+            "spatialRotationOrbit": "A",
             "spatialRotationX": "A",
             "spatialRotationY": "A",
             "spatialRotationZ": "A",
-            "spatialRotationOrbit": "A",
-            "spatialOrbitAxis": "A",
-            "spatialAxisFixed": "A",
-            "spatialRasterLayers": "A",
-            "spatialCellsLayer": "A"
-          },
+            "spatialTargetX": "A",
+            "spatialTargetY": "A",
+            "spatialTargetZ": "A",
+            "spatialZoom": "A",
+            "spatialImageLayer": "A",
+            "spatialSegmentationLayer": "A"
+          }
+        },
+        {
+          "component": "layerController",
           "x": 6,
           "y": 0,
           "w": 2,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "human",
+            "spatialAxisFixed": "A",
+            "spatialOrbitAxis": "A",
+            "spatialRotation": "A",
+            "spatialRotationOrbit": "A",
+            "spatialRotationX": "A",
+            "spatialRotationY": "A",
+            "spatialRotationZ": "A",
+            "spatialTargetX": "A",
+            "spatialTargetY": "A",
+            "spatialTargetZ": "A",
+            "spatialZoom": "A",
+            "spatialImageLayer": "A",
+            "spatialSegmentationLayer": "A"
+          }
         },
         {
           "component": "heatmap",
-          "coordinationScopes": {
-            "dataset": "human"
-          },
           "props": {
             "transpose": true,
             "variablesLabelOverride": "feature"
@@ -513,59 +528,63 @@ vitessce_conf:
           "x": 0,
           "y": 6,
           "w": 6,
-          "h": 6
-        },
-        {
-          "component": "cellSets",
+          "h": 6,
           "coordinationScopes": {
             "dataset": "human"
-          },
+          }
+        },
+        {
+          "component": "obsSets",
           "x": 10,
           "y": 0,
           "w": 2,
-          "h": 6
-        },
-        {
-          "component": "genes",
+          "h": 6,
           "coordinationScopes": {
             "dataset": "human"
-          },
+          }
+        },
+        {
+          "component": "featureList",
           "props": {
             "variablesLabelOverride": "feature"
           },
           "x": 8,
           "y": 0,
           "w": 2,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "human"
+          }
         },
         {
           "component": "scatterplot",
-          "coordinationScopes": {
-            "dataset": "human",
-            "embeddingType": "A"
-          },
           "x": 6,
           "y": 6,
           "w": 3,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "human",
+            "embeddingType": "A"
+          }
         },
         {
           "component": "scatterplot",
-          "coordinationScopes": {
-            "dataset": "human",
-            "embeddingType": "B"
-          },
           "x": 9,
           "y": 6,
           "w": 3,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "human",
+            "embeddingType": "B"
+          }
         }
       ],
       "initStrategy": "auto"
     },
     {
-      "version": "1.0.7",
+      "version": "1.0.16",
       "name": "2D Mouse Liver",
+      "uid": "2D Mouse Liver",
       "description": "",
       "datasets": [
         {
@@ -573,33 +592,32 @@ vitessce_conf:
           "name": "Mouse dataset",
           "files": [
             {
-              "type": "raster",
               "fileType": "raster.json",
               "options": {
-                "schemaVersion": "0.0.2",
-                "usePhysicalSizeScaling": true,
                 "images": [
                   {
-                    "name": "Mouse Liver",
-                    "type": "ome-tiff",
-                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.raster.pyramid.ome.tiff",
                     "metadata": {
                       "isBitmask": false
-                    }
+                    },
+                    "name": "Mouse Liver",
+                    "type": "ome-tiff",
+                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.raster.pyramid.ome.tiff"
                   },
                   {
-                    "name": "Cell Segmentations",
-                    "type": "ome-tiff",
-                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.cell_ids.ome.tiff",
                     "metadata": {
                       "isBitmask": true
-                    }
+                    },
+                    "name": "Cell Segmentations",
+                    "type": "ome-tiff",
+                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.cell_ids.ome.tiff"
                   }
                 ],
                 "renderLayers": [
                   "Mouse Liver",
                   "Cell Segmentations"
-                ]
+                ],
+                "schemaVersion": "0.0.2",
+                "usePhysicalSizeScaling": true
               }
             }
           ]
@@ -609,122 +627,122 @@ vitessce_conf:
         "dataset": {
           "mouse": "mouse-liver"
         },
-        "spatialRasterLayers": {
+        "spatialImageLayer": {
           "mouse": [
             {
-              "type": "raster",
-              "index": 0,
-              "visible": true,
-              "colormap": null,
-              "opacity": 1,
-              "domainType": "Min/Max",
-              "transparentColor": null,
-              "renderingMode": "Additive",
-              "use3d": false,
               "channels": [
                 {
-                  "selection": {
-                    "c": 0,
-                    "t": 0,
-                    "z": 0
-                  },
                   "color": [
                     0,
                     0,
                     255
                   ],
-                  "visible": true,
+                  "selection": {
+                    "c": 0,
+                    "t": 0,
+                    "z": 0
+                  },
                   "slider": [
                     1,
                     616
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
+                  "color": [
+                    0,
+                    255,
+                    0
+                  ],
                   "selection": {
                     "c": 1,
                     "t": 0,
                     "z": 0
                   },
-                  "color": [
-                    0,
-                    255,
-                    0
-                  ],
-                  "visible": true,
                   "slider": [
                     1,
                     5916
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
+                  "color": [
+                    255,
+                    0,
+                    255
+                  ],
                   "selection": {
                     "c": 2,
                     "t": 0,
                     "z": 0
                   },
-                  "color": [
-                    255,
-                    0,
-                    255
-                  ],
-                  "visible": true,
                   "slider": [
                     1,
                     13273
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
-                  "selection": {
-                    "c": 3,
-                    "t": 0,
-                    "z": 0
-                  },
                   "color": [
                     255,
                     255,
                     0
                   ],
-                  "visible": true,
-                  "slider": [
-                    25,
-                    57627
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "bitmask",
-              "index": 1,
-              "visible": false,
-              "colormap": null,
-              "opacity": 1,
-              "domainType": "Min/Max",
-              "transparentColor": [
-                0,
-                0,
-                0
-              ],
-              "renderingMode": "Additive",
-              "use3d": false,
-              "channels": [
-                {
                   "selection": {
-                    "c": 0,
+                    "c": 3,
                     "t": 0,
                     "z": 0
                   },
+                  "slider": [
+                    25,
+                    57627
+                  ],
+                  "visible": true
+                }
+              ],
+              "colormap": null,
+              "domainType": "Min/Max",
+              "index": 0,
+              "opacity": 1,
+              "renderingMode": "Additive",
+              "transparentColor": null,
+              "type": "raster",
+              "use3d": false,
+              "visible": true
+            },
+            {
+              "channels": [
+                {
                   "color": [
                     255,
                     255,
                     255
                   ],
-                  "visible": true,
+                  "selection": {
+                    "c": 0,
+                    "t": 0,
+                    "z": 0
+                  },
                   "slider": [
                     2,
                     957
-                  ]
+                  ],
+                  "visible": true
                 }
-              ]
+              ],
+              "colormap": null,
+              "domainType": "Min/Max",
+              "index": 1,
+              "opacity": 1,
+              "renderingMode": "Additive",
+              "transparentColor": [
+                0,
+                0,
+                0
+              ],
+              "type": "bitmask",
+              "use3d": false,
+              "visible": false
             }
           ]
         }
@@ -732,43 +750,44 @@ vitessce_conf:
       "layout": [
         {
           "component": "spatial",
-          "coordinationScopes": {
-            "dataset": "mouse",
-            "spatialRasterLayers": "mouse"
-          },
           "x": 0,
           "y": 0,
           "w": 8,
-          "h": 12
+          "h": 12,
+          "coordinationScopes": {
+            "dataset": "mouse",
+            "spatialImageLayer": "mouse"
+          }
         },
         {
           "component": "description",
-          "coordinationScopes": {
-            "dataset": "mouse",
-            "spatialRasterLayers": "mouse"
-          },
           "x": 8,
           "y": 9,
           "w": 4,
-          "h": 3
+          "h": 3,
+          "coordinationScopes": {
+            "dataset": "mouse",
+            "spatialImageLayer": "mouse"
+          }
         },
         {
           "component": "layerController",
-          "coordinationScopes": {
-            "dataset": "mouse",
-            "spatialRasterLayers": "mouse"
-          },
           "x": 8,
           "y": 0,
           "w": 4,
-          "h": 9
+          "h": 9,
+          "coordinationScopes": {
+            "dataset": "mouse",
+            "spatialImageLayer": "mouse"
+          }
         }
       ],
       "initStrategy": "auto"
     },
     {
-      "version": "1.0.7",
+      "version": "1.0.16",
       "name": "2D Mouse Liver with annotations",
+      "uid": "2D Mouse Liver with annotations",
       "description": "",
       "datasets": [
         {
@@ -776,55 +795,58 @@ vitessce_conf:
           "name": "Mouse dataset",
           "files": [
             {
-              "type": "raster",
               "fileType": "raster.json",
               "options": {
-                "schemaVersion": "0.0.2",
-                "usePhysicalSizeScaling": true,
                 "images": [
                   {
-                    "name": "Mouse Liver",
-                    "type": "ome-tiff",
-                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.raster.pyramid.ome.tiff",
                     "metadata": {
                       "isBitmask": false
-                    }
+                    },
+                    "name": "Mouse Liver",
+                    "type": "ome-tiff",
+                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.raster.pyramid.ome.tiff"
                   },
                   {
-                    "name": "Cell Segmentations",
-                    "type": "ome-tiff",
-                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.cell_ids.ome.tiff",
                     "metadata": {
                       "isBitmask": true
-                    }
+                    },
+                    "name": "Cell Segmentations",
+                    "type": "ome-tiff",
+                    "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.cell_ids.ome.tiff"
                   }
                 ],
                 "renderLayers": [
                   "Mouse Liver",
                   "Cell Segmentations"
-                ]
+                ],
+                "schemaVersion": "0.0.2",
+                "usePhysicalSizeScaling": true
               }
             },
             {
-              "type": "cells",
               "fileType": "anndata-cells.zarr",
               "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.h5ad.zarr",
               "options": {
-                "xy": "obsm/X_spatial",
                 "mappings": {
-                  "Protein-based t-SNE": {
-                    "key": "obsm/X_protein_tsne",
-                    "dims": [0, 1]
-                  },
                   "Lipid/metabolite-based t-SNE": {
-                    "key": "obsm/X_lipmet_tsne",
-                    "dims": [0, 1]
+                    "dims": [
+                      0,
+                      1
+                    ],
+                    "key": "obsm/X_lipmet_tsne"
+                  },
+                  "Protein-based t-SNE": {
+                    "dims": [
+                      0,
+                      1
+                    ],
+                    "key": "obsm/X_protein_tsne"
                   }
-                }
+                },
+                "xy": "obsm/X_spatial"
               }
             },
             {
-              "type": "cell-sets",
               "fileType": "anndata-cell-sets.zarr",
               "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.h5ad.zarr",
               "options": [
@@ -839,12 +861,11 @@ vitessce_conf:
               ]
             },
             {
-              "type": "expression-matrix",
               "fileType": "anndata-expression-matrix.zarr",
               "url": "https://storage.googleapis.com/vitessce-data/0.0.31/master_release/tian/mouse_2d.h5ad.zarr",
               "options": {
-                "matrix": "layers/X_uint8",
-                "geneAlias": "var/feature_name"
+                "geneAlias": "var/feature_name",
+                "matrix": "layers/X_uint8"
               }
             }
           ]
@@ -854,182 +875,179 @@ vitessce_conf:
         "dataset": {
           "mouse": "mouse-liver-annot"
         },
-        "spatialRasterLayers": {
+        "embeddingType": {
+          "A": "Protein-based t-SNE",
+          "B": "Lipid/metabolite-based t-SNE"
+        },
+        "spatialImageLayer": {
           "A": [
             {
-              "type": "raster",
-              "index": 0,
-              "visible": true,
-              "colormap": null,
-              "opacity": 1,
-              "domainType": "Min/Max",
-              "transparentColor": null,
-              "renderingMode": "Additive",
-              "use3d": false,
               "channels": [
                 {
-                  "selection": {
-                    "c": 0,
-                    "t": 0,
-                    "z": 0
-                  },
                   "color": [
                     0,
                     0,
                     255
                   ],
-                  "visible": true,
+                  "selection": {
+                    "c": 0,
+                    "t": 0,
+                    "z": 0
+                  },
                   "slider": [
                     1,
                     616
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
+                  "color": [
+                    0,
+                    255,
+                    0
+                  ],
                   "selection": {
                     "c": 1,
                     "t": 0,
                     "z": 0
                   },
-                  "color": [
-                    0,
-                    255,
-                    0
-                  ],
-                  "visible": true,
                   "slider": [
                     1,
                     5916
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
+                  "color": [
+                    255,
+                    0,
+                    255
+                  ],
                   "selection": {
                     "c": 2,
                     "t": 0,
                     "z": 0
                   },
-                  "color": [
-                    255,
-                    0,
-                    255
-                  ],
-                  "visible": true,
                   "slider": [
                     1,
                     13273
-                  ]
+                  ],
+                  "visible": true
                 },
                 {
-                  "selection": {
-                    "c": 3,
-                    "t": 0,
-                    "z": 0
-                  },
                   "color": [
                     255,
                     255,
                     0
                   ],
-                  "visible": true,
-                  "slider": [
-                    25,
-                    57627
-                  ]
-                }
-              ]
-            },
-            {
-              "type": "bitmask",
-              "index": 1,
-              "visible": true,
-              "colormap": null,
-              "opacity": 1,
-              "domainType": "Min/Max",
-              "transparentColor": [
-                0,
-                0,
-                0
-              ],
-              "renderingMode": "Additive",
-              "use3d": false,
-              "channels": [
-                {
                   "selection": {
-                    "c": 0,
+                    "c": 3,
                     "t": 0,
                     "z": 0
                   },
+                  "slider": [
+                    25,
+                    57627
+                  ],
+                  "visible": true
+                }
+              ],
+              "colormap": null,
+              "domainType": "Min/Max",
+              "index": 0,
+              "opacity": 1,
+              "renderingMode": "Additive",
+              "transparentColor": null,
+              "type": "raster",
+              "use3d": false,
+              "visible": true
+            },
+            {
+              "channels": [
+                {
                   "color": [
                     255,
                     255,
                     255
                   ],
-                  "visible": true,
+                  "selection": {
+                    "c": 0,
+                    "t": 0,
+                    "z": 0
+                  },
                   "slider": [
                     2,
                     957
-                  ]
+                  ],
+                  "visible": true
                 }
-              ]
+              ],
+              "colormap": null,
+              "domainType": "Min/Max",
+              "index": 1,
+              "opacity": 1,
+              "renderingMode": "Additive",
+              "transparentColor": [
+                0,
+                0,
+                0
+              ],
+              "type": "bitmask",
+              "use3d": false,
+              "visible": true
             }
           ]
-        },
-        "embeddingType": {
-          "A": "Protein-based t-SNE",
-          "B": "Lipid/metabolite-based t-SNE"
         }
       },
       "layout": [
         {
           "component": "spatial",
-          "coordinationScopes": {
-            "dataset": "mouse",
-            "spatialZoom": "A",
-            "spatialRotation": "A",
-            "spatialTargetX": "A",
-            "spatialTargetY": "A",
-            "spatialTargetZ": "A",
-            "spatialRotationX": "A",
-            "spatialRotationY": "A",
-            "spatialRotationZ": "A",
-            "spatialRotationOrbit": "A",
-            "spatialOrbitAxis": "A",
-            "spatialAxisFixed": "A",
-            "spatialRasterLayers": "A",
-            "spatialCellsLayer": "A"
-          },
           "x": 0,
           "y": 0,
           "w": 6,
-          "h": 6
-        },
-        {
-          "component": "layerController",
+          "h": 6,
           "coordinationScopes": {
             "dataset": "mouse",
-            "spatialZoom": "A",
+            "spatialAxisFixed": "A",
+            "spatialOrbitAxis": "A",
             "spatialRotation": "A",
-            "spatialTargetX": "A",
-            "spatialTargetY": "A",
-            "spatialTargetZ": "A",
+            "spatialRotationOrbit": "A",
             "spatialRotationX": "A",
             "spatialRotationY": "A",
             "spatialRotationZ": "A",
-            "spatialRotationOrbit": "A",
-            "spatialOrbitAxis": "A",
-            "spatialAxisFixed": "A",
-            "spatialRasterLayers": "A",
-            "spatialCellsLayer": "A"
-          },
+            "spatialTargetX": "A",
+            "spatialTargetY": "A",
+            "spatialTargetZ": "A",
+            "spatialZoom": "A",
+            "spatialImageLayer": "A",
+            "spatialSegmentationLayer": "A"
+          }
+        },
+        {
+          "component": "layerController",
           "x": 6,
           "y": 0,
           "w": 2,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "mouse",
+            "spatialAxisFixed": "A",
+            "spatialOrbitAxis": "A",
+            "spatialRotation": "A",
+            "spatialRotationOrbit": "A",
+            "spatialRotationX": "A",
+            "spatialRotationY": "A",
+            "spatialRotationZ": "A",
+            "spatialTargetX": "A",
+            "spatialTargetY": "A",
+            "spatialTargetZ": "A",
+            "spatialZoom": "A",
+            "spatialImageLayer": "A",
+            "spatialSegmentationLayer": "A"
+          }
         },
         {
           "component": "heatmap",
-          "coordinationScopes": {
-            "dataset": "mouse"
-          },
           "props": {
             "transpose": true,
             "variablesLabelOverride": "feature"
@@ -1037,52 +1055,55 @@ vitessce_conf:
           "x": 0,
           "y": 6,
           "w": 6,
-          "h": 6
-        },
-        {
-          "component": "cellSets",
+          "h": 6,
           "coordinationScopes": {
             "dataset": "mouse"
-          },
+          }
+        },
+        {
+          "component": "obsSets",
           "x": 10,
           "y": 0,
           "w": 2,
-          "h": 6
-        },
-        {
-          "component": "genes",
+          "h": 6,
           "coordinationScopes": {
             "dataset": "mouse"
-          },
+          }
+        },
+        {
+          "component": "featureList",
           "props": {
             "variablesLabelOverride": "feature"
           },
           "x": 8,
           "y": 0,
           "w": 2,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "mouse"
+          }
         },
         {
           "component": "scatterplot",
-          "coordinationScopes": {
-            "dataset": "mouse",
-            "embeddingType": "A"
-          },
           "x": 6,
           "y": 6,
           "w": 3,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "mouse",
+            "embeddingType": "A"
+          }
         },
         {
           "component": "scatterplot",
-          "coordinationScopes": {
-            "dataset": "mouse",
-            "embeddingType": "B"
-          },
           "x": 9,
           "y": 6,
           "w": 3,
-          "h": 6
+          "h": 6,
+          "coordinationScopes": {
+            "dataset": "mouse",
+            "embeddingType": "B"
+          }
         }
       ],
       "initStrategy": "auto"

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -58,7 +58,7 @@ const sharedInfoSnackbarProps = {
   },
   autoHideDuration: 4000,
 };
-function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, shouldMountVitessce = true }) {
+function Visualization({ vitData, uuid, uuidSuffix, hasNotebook, shouldDisplayHeader, shouldMountVitessce = true }) {
   const {
     vizIsFullscreen,
     expandViz,
@@ -112,6 +112,8 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, should
 
   const isMultiDataset = Array.isArray(vitessceConfig);
   const version = dependencies.vitessce.replace('^', '');
+
+  const vitessceUid = `${uuid}${uuidSuffix || ''}${isMultiDataset ? vitessceSelection : ''}`;
 
   return (
     vitessceConfig &&
@@ -187,6 +189,7 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, should
                 onConfigChange={handleVitessceConfigDebounced}
                 height={vizIsFullscreen ? null : vitessceFixedHeight}
                 onWarn={addError}
+                uid={vitessceUid}
               />
             )}
           </ExpandableDiv>

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
@@ -8,7 +8,15 @@ import { VisualizationBackground } from './style';
 
 const Visualization = React.lazy(() => import('../Visualization'));
 
-function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader, hasBeenMounted, isPublicationPage }) {
+function VisualizationWrapper({
+  vitData,
+  uuid,
+  uuidSuffix,
+  hasNotebook,
+  shouldDisplayHeader,
+  hasBeenMounted,
+  isPublicationPage,
+}) {
   return (
     <Suspense
       fallback={
@@ -25,6 +33,7 @@ function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader,
       <Visualization
         vitData={vitData}
         uuid={uuid}
+        uuidSuffix={uuidSuffix}
         hasNotebook={hasNotebook}
         shouldDisplayHeader={shouldDisplayHeader}
         shouldMountVitessce={hasBeenMounted}

--- a/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
+++ b/context/app/static/js/components/publications/PublicationVignette/PublicationVignette.jsx
@@ -84,6 +84,7 @@ function PublicationVignette({ vignette, vignetteDirName, uuid, mounted }) {
         <VisualizationWrapper
           vitData={vitessceConfs.length === 1 ? vitessceConfs[0] : vitessceConfs}
           uuid={uuid}
+          uuidSuffix={vignetteDirName}
           hasNotebook={false}
           shouldDisplayHeader={false}
           hasBeenMounted={hasBeenMounted}

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -73,7 +73,7 @@
         "uuid": "^8.3.2",
         "vega": "^5.17.3",
         "vega-lite": "^4.13.1",
-        "vitessce": "^2.0.3",
+        "vitessce": "^3.0.0",
         "web-vitals": "^1.1.0",
         "whatwg-fetch": "^3.0.0",
         "yup": "^0.32.11",
@@ -3221,9 +3221,9 @@
       }
     },
     "node_modules/@deck.gl/carto/node_modules/d3-array": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
-      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
       "dependencies": {
         "internmap": "1 - 2"
       },
@@ -3863,17 +3863,17 @@
       }
     },
     "node_modules/@hms-dbmi/viv": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.13.6.tgz",
-      "integrity": "sha512-CeP/qehola+vGi4okZV6/TcuzUW4CHa6noWvqq63N/JLhox1HSn0J2qu/Eduj7wpsX+Tvibk2eXV6K8GbiXm5A==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.13.7.tgz",
+      "integrity": "sha512-uaDCnZCBNCM4yud013h368TesMyId9c7DME9ijh0tbvE8kI6m7VqviYyJ+uTWOUiu/sZTBiHWQsz44M+LVBtbw==",
       "dependencies": {
-        "@vivjs/constants": "0.13.6",
-        "@vivjs/extensions": "0.13.6",
-        "@vivjs/layers": "0.13.6",
-        "@vivjs/loaders": "0.13.6",
-        "@vivjs/types": "0.13.6",
-        "@vivjs/viewers": "0.13.6",
-        "@vivjs/views": "0.13.6"
+        "@vivjs/constants": "0.13.7",
+        "@vivjs/extensions": "0.13.7",
+        "@vivjs/layers": "0.13.7",
+        "@vivjs/loaders": "0.13.7",
+        "@vivjs/types": "0.13.7",
+        "@vivjs/viewers": "0.13.7",
+        "@vivjs/views": "0.13.7"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -5188,194 +5188,234 @@
       }
     },
     "node_modules/@loaders.gl/3d-tiles": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.3.1.tgz",
-      "integrity": "sha512-rhDjA/23w7VmWWv+2IduhvKFr2dxUDEs20w3BOBuN8HZG7BccrV/ffJwGHibn9/1SdzHhqUrrSXWNwkcKdFUvA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.4.4.tgz",
+      "integrity": "sha512-o6z8h5541OYTQT546p1FJlMjiqFvTu29C6W9F9X3rPIUdnBirTpCubgpHcAw53AIDOrvlIxBKH/KDkqoxFIylQ==",
       "dependencies": {
-        "@loaders.gl/draco": "3.3.1",
-        "@loaders.gl/gltf": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/math": "3.3.1",
-        "@loaders.gl/tiles": "3.3.1",
+        "@loaders.gl/draco": "3.4.4",
+        "@loaders.gl/gltf": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/math": "3.4.4",
+        "@loaders.gl/tiles": "3.4.4",
         "@math.gl/core": "^3.5.1",
-        "@math.gl/geospatial": "^3.5.1"
+        "@math.gl/geospatial": "^3.5.1",
+        "long": "^5.2.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^3.2.0"
+        "@loaders.gl/core": "^3.4.0"
       }
     },
+    "node_modules/@loaders.gl/3d-tiles/node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
     "node_modules/@loaders.gl/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-molMKfNbg/6T705VCW2XOKcXPfYZGj9XimQ6YVE4bSN+wwGpkni63ABuqndUllVga98CBZUBZplCQ0ljg6Bv3A==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.4.tgz",
+      "integrity": "sha512-uutqjvf91WJZx7WbSmJy75AHFNCPDnnweFnVmdAEflF6ohc+uAdjltqz6tGD3PxbT8LjNLTOk60kxyC/QwDBqQ==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
-        "@probe.gl/log": "^3.5.0"
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/worker-utils": "3.4.4",
+        "@probe.gl/log": "^4.0.1"
+      }
+    },
+    "node_modules/@loaders.gl/core/node_modules/@probe.gl/env": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.0.4.tgz",
+      "integrity": "sha512-sYNGqesDfWD6dFP5oNZtTeFA4Z6ak5T4a8BNPdNhoqy7PK9w70JHrb6mv+RKWqKXq33KiwCDWL7fYxx2HuEH2w==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
+      }
+    },
+    "node_modules/@loaders.gl/core/node_modules/@probe.gl/log": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.0.4.tgz",
+      "integrity": "sha512-WpmXl6njlBMwrm8HBh/b4kSp/xnY1VVmeT4PWUKF+RkVbFuKQbsU11dA1IxoMd7gSY+5DGIwxGfAv1H5OMzA4A==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "@probe.gl/env": "4.0.4"
       }
     },
     "node_modules/@loaders.gl/draco": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.3.1.tgz",
-      "integrity": "sha512-O73j+HpuKXhsoaD6jxYf1m8RDaE73eKWiBRwj8ExkhtFFmCnI02ERNuPhSbt7oN9xjEBuAuLBN2DpBtayKLhcA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.4.tgz",
+      "integrity": "sha512-VtJffpDbcdA0/uJzzJIET3B5j96cz6g5f93Wg2tlGtvnKZvJs4bjyojur4p7u5ElHJARm36F91N7Td4jGvMbYw==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
+        "@loaders.gl/worker-utils": "3.4.4",
         "draco3d": "1.5.5"
       }
     },
     "node_modules/@loaders.gl/gis": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.3.1.tgz",
-      "integrity": "sha512-Yzs84xMhPb8I4tjWYSGEso1SKwLF3dKY+C0AJbsUyL9zjljHcPSDjdHHdx6inBO+OoGjXr2HstPtPoaTyfKfaw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.4.tgz",
+      "integrity": "sha512-QwGOdpaE/jb1KsgHEkkiUD7C+dHWSDJKfMKM5OStIMPABX0Cxd8MSqyQ8+BOFWM7kdqXdMvgRjB9912R6T4AHQ==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "node_modules/@loaders.gl/gltf": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.3.1.tgz",
-      "integrity": "sha512-FQgtA0DxtmZygRGCbQcgn6KzgwUgVzlyajVL+Lydo25qZ2MqafCdvGDQQaNz1bQSUtIReYKuOjig9YlycPYZaA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.4.tgz",
+      "integrity": "sha512-8dbyZChWXku+OoL64rccFa60uxBhbRLdDelfCZqopRxwI/JF8ZCAEGuoFAftw84sU97JmfJbnCtcMMc8bebv4w==",
       "dependencies": {
-        "@loaders.gl/draco": "3.3.1",
-        "@loaders.gl/images": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/textures": "3.3.1",
+        "@loaders.gl/draco": "3.4.4",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/textures": "3.4.4",
         "@math.gl/core": "^3.5.1"
       }
     },
     "node_modules/@loaders.gl/images": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.3.1.tgz",
-      "integrity": "sha512-A3JgiPSmL/0D/u67+huXfOHg4pEU9BUMtboxmVc/F0jC/aueli6/Erlco4Bf0Ci4fy9+eApmHD4eKmFSamdNCw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.4.tgz",
+      "integrity": "sha512-ViMh58oZ2GLsKCoYBH4nYMvi5fHeVZXiLAABVP+AVU54Jrf+PZYm8y8KaC22zBmGEZ15hGhJF/dNeOpgqZ+V4w==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.3.1"
+        "@loaders.gl/loader-utils": "3.4.4"
       }
     },
     "node_modules/@loaders.gl/loader-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.3.1.tgz",
-      "integrity": "sha512-yp3ngZw4O9OY7O3d8DCFwsuwDGR4IlDqJCFp47CVS3crrpANBOP12hBZl1uLZJQ8KN1gFXp0tIQtp5/J2bv+Hg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.4.tgz",
+      "integrity": "sha512-EFY/YBniNyfZk0ojnBitl+xRL3Du8tinOwdFnWD0rVIf61+bFifFI0fJys8/tgrlF6sfiKdYbupow8G/a3xF2g==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
-        "@probe.gl/stats": "^3.5.0"
+        "@loaders.gl/worker-utils": "3.4.4",
+        "@probe.gl/stats": "^4.0.1"
+      }
+    },
+    "node_modules/@loaders.gl/loader-utils/node_modules/@probe.gl/stats": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.4.tgz",
+      "integrity": "sha512-SDuSY/D4yDL6LQDa69l/GCcnZLRiGYdyvYkxWb0CgnzTPdPrcdrzGkzkvpC3zsA4fEFw2smlDje370QGHwlisg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@loaders.gl/math": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.3.1.tgz",
-      "integrity": "sha512-s2ApdsxBsHqmZlopx3DOL2pav5S9iobdbAXD1ZEUWzTFcxcSIf0Z1CYIWKPBlUuzRJYaqd5fxHewfC4Er4sF5A==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.4.4.tgz",
+      "integrity": "sha512-l5ZGV7gAznj0nFjfiKIP9qIrSKLLiaRvGC2pmbM4J+2A674Sj59WwoZiASYNevOlByjScIwyZWe62wcneuyIWw==",
       "dependencies": {
-        "@loaders.gl/images": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
         "@math.gl/core": "^3.5.1"
       }
     },
     "node_modules/@loaders.gl/mvt": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.3.1.tgz",
-      "integrity": "sha512-I6E6gmtDTSAUZIP0gY8PVcjFVPVWby3l3c95JkFKpqyKyPWFEPOkxuxWk34TQXHe09Zj9GEEav/bMC6GvEit/Q==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.4.4.tgz",
+      "integrity": "sha512-qxGe+EmuaDlXBs/EeBFzIKipgv+YrAm2BlHzyxLOsdBVmay9q31OYCqdigVw3Fc5h30D65hOfBC6k1lKo4OUyw==",
       "dependencies": {
-        "@loaders.gl/gis": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
+        "@loaders.gl/gis": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "node_modules/@loaders.gl/schema": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.3.1.tgz",
-      "integrity": "sha512-VpVFLCc+38P0ddJ5478NnXN60YhNx9/dYHy1Y9ccOGTzaXPn8uFqM7DW/eNaJ7ikyiAWeSD75TpSQPzBrAd5MQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.4.tgz",
+      "integrity": "sha512-+lESS+cUSgXst9kxaW2LTxWMVMrT96cv0TWfsSryA11EVsxr50aSPWC+K0BHe7k60+80pQWEt4iyMRgVHM+6tg==",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
       }
     },
     "node_modules/@loaders.gl/terrain": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.3.1.tgz",
-      "integrity": "sha512-WCABqgdzsIL0j5zP7xhBhIkz4nQ8EsSOyAS0bKGXlUWLWGZ9L9oVKSL4AHGgm4ult5S7ogZrPnMs7iSO9nab0g==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.4.4.tgz",
+      "integrity": "sha512-IXX9uBlhRaehKMkFBmIclbexygTkRtDXTGg1r5p+SOITTnt1QYCM2J2q49Fntpi19reyVl9n+DzA81Pb8YeNLg==",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
         "@mapbox/martini": "^0.2.0"
       }
     },
     "node_modules/@loaders.gl/textures": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.3.1.tgz",
-      "integrity": "sha512-LjWprbSPTPvL+pnKKxqTVs1vuzysj8JJDMI374wSs2EQIBkxWgACjitR0+E7+DZ4qId1DtRmhW+L7x0SflekaA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.4.tgz",
+      "integrity": "sha512-CD1CPKvXJy3TzzCq42xpwrpYdjimJ7bKf5GSwDs2+qx/fZDnmJBk9z/762VzXyUwTpgGFk3XzbEwkP6H4vkESg==",
       "dependencies": {
-        "@loaders.gl/images": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
+        "@loaders.gl/worker-utils": "3.4.4",
         "ktx-parse": "^0.0.4",
         "texture-compressor": "^1.0.2"
       }
     },
     "node_modules/@loaders.gl/tiles": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.3.1.tgz",
-      "integrity": "sha512-dcy+3sYqLZehPLn4FrnViqZskwoxJbDzbtWcrcBE313GLcu+k0E1B+eZss0xwWfb89TltZqfugBVIUd/LW41FA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.4.4.tgz",
+      "integrity": "sha512-Z2doHX4+9RTDpQZJ2EHqxcwXxvqWkJoD8i4wh/DvSZgp9Ccot4L7wb907gHyYvDZ3lzQc0mx7LVcC6BBNvKS8w==",
       "dependencies": {
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/math": "3.3.1",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/math": "3.4.4",
         "@math.gl/core": "^3.5.1",
         "@math.gl/culling": "^3.5.1",
         "@math.gl/geospatial": "^3.5.1",
         "@math.gl/web-mercator": "^3.5.1",
-        "@probe.gl/stats": "^3.5.0"
+        "@probe.gl/stats": "^4.0.1"
       },
       "peerDependencies": {
-        "@loaders.gl/core": "^3.2.0"
+        "@loaders.gl/core": "^3.4.0"
+      }
+    },
+    "node_modules/@loaders.gl/tiles/node_modules/@probe.gl/stats": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.4.tgz",
+      "integrity": "sha512-SDuSY/D4yDL6LQDa69l/GCcnZLRiGYdyvYkxWb0CgnzTPdPrcdrzGkzkvpC3zsA4fEFw2smlDje370QGHwlisg==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@loaders.gl/worker-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.3.1.tgz",
-      "integrity": "sha512-r1u358xZEMKUsv7gOabmc6fA6knWArYU0BqeWOaJHyN/72ESuDZrzjtk+Adux9rIJLlxrMHLq/o/WCsO1tmrYw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.4.tgz",
+      "integrity": "sha512-ltqMd+BsAk3QGPLycZODukL1wNyBEb04X6wpI3rC5NWByzwSippwWTW4g4QnS3Q9zgMFV4jR/YV6CRp/GiVzvQ==",
       "dependencies": {
         "@babel/runtime": "^7.3.1"
       }
     },
     "node_modules/@luma.gl/constants": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.19.tgz",
-      "integrity": "sha512-TNbONy1CQXCZ5+VOAiLh6G9wvvSwMgZxJJtbubhCgkHeR7Up+iTql6gaOF5qIX0SuQbltp7jvB5U5uEml2zUKg=="
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.20.tgz",
+      "integrity": "sha512-5yG+ybkUZ4j6kLPWMZjN4Hun2yLB0MyEpNCRKAUN9/yS9UIWA7unyVxjSf2vnE7k/7dywtxlbXegASNFgNVGxw=="
     },
     "node_modules/@luma.gl/core": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.19.tgz",
-      "integrity": "sha512-AfJNOrj4rEb/CJObxPUi8Ywe3z4sHzBkndRTWd01te4x7i9/0wjN/iuMMEyr/2OyHTMr/iMbh7ePwisExYhRQw==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.20.tgz",
+      "integrity": "sha512-xJr96G6vhYcznYHC84fbeOG3fgNM4lFwj9bd0VPcg/Kfe8otUeN1Hl0AKHCCtNn48PiMSg3LKbaiRfNUMhaffQ==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
-        "@luma.gl/engine": "8.5.19",
-        "@luma.gl/gltools": "8.5.19",
-        "@luma.gl/shadertools": "8.5.19",
-        "@luma.gl/webgl": "8.5.19"
+        "@luma.gl/constants": "8.5.20",
+        "@luma.gl/engine": "8.5.20",
+        "@luma.gl/gltools": "8.5.20",
+        "@luma.gl/shadertools": "8.5.20",
+        "@luma.gl/webgl": "8.5.20"
       }
     },
     "node_modules/@luma.gl/engine": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.19.tgz",
-      "integrity": "sha512-QlyTUTKcrRZ8qclloH9dldGeBN7SY8qPwtt7g6bTrsRMWQjdAQVfGtjJUkqxV2qIEEOSIdU07t5xFYCEES2M/w==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.20.tgz",
+      "integrity": "sha512-+0ryJ/4gL1pWaEgZimY21jUPt1LYiO6Cqte8TNUprCfAHoAStsuzD7jwgEqnM6jJOUEdIxQ3w0z3Dzw/0KIE+w==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
-        "@luma.gl/gltools": "8.5.19",
-        "@luma.gl/shadertools": "8.5.19",
-        "@luma.gl/webgl": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
+        "@luma.gl/gltools": "8.5.20",
+        "@luma.gl/shadertools": "8.5.20",
+        "@luma.gl/webgl": "8.5.20",
         "@math.gl/core": "^3.5.0",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/stats": "^3.5.0",
@@ -5383,11 +5423,11 @@
       }
     },
     "node_modules/@luma.gl/experimental": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.19.tgz",
-      "integrity": "sha512-shsql6mD3Ta7S1fghxvuE2ETtB5uo36TOzkhBLhZdnifOQJFKF7tcKSP0DQ5o+XfiySgSDtAEgRhbhpMe8aGBg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.20.tgz",
+      "integrity": "sha512-V1Jp68rYMPtwMdf+50r3NSYsGV3srjwZ+lcK2ew4DshjedDbYwLqTGMWcOyBhY3K3aCl2LH3Fhn0hAY+3NTLGA==",
       "dependencies": {
-        "@luma.gl/constants": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
         "@math.gl/core": "^3.5.0",
         "earcut": "^2.0.6"
       },
@@ -5401,34 +5441,34 @@
       }
     },
     "node_modules/@luma.gl/gltools": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.19.tgz",
-      "integrity": "sha512-ZeoJntgvkhf3kP88EqvwKkkQhc76ozY1iu6etyVoBv0GwXJQ6z9IF3jH+iTlOq3VW0jGb5u7RaRLh6aTowSwHQ==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.20.tgz",
+      "integrity": "sha512-5pP6ph9FSX5gHiVWQM1DmYRUnriklzKUG9yaqlQsKEqCFsOcKB0EfK3MfBVXIfsOdP/1bJZ9Dlz/zV19soWVhg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/log": "^3.5.0",
         "@types/offscreencanvas": "^2019.7.0"
       }
     },
     "node_modules/@luma.gl/shadertools": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.19.tgz",
-      "integrity": "sha512-Jn/gCAagMA9Rl4/AtKrdghRwWT8dCO2XBGI+WE5HPZPP2anTzN7DgDxUwKf+vEH8fFNOsr+jLdUXubIrRU3vTw==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.20.tgz",
+      "integrity": "sha512-q1lrCZy1ncIFb4mMjsYgISLzNP6eMnhLUY+Oltj/qjAMcPEssCeHN2+XGfP/CVtU+O7sC+5JY2bQGaTs6HQ/Qw==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
         "@math.gl/core": "^3.5.0"
       }
     },
     "node_modules/@luma.gl/webgl": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.19.tgz",
-      "integrity": "sha512-WzLYAujxYKpBN9fXgxeAR4Ww4+p9Z+bMNGZe4Ya8glWDVWimDuAEPtM9AkJrQ36c5RHEQLOQdsAIrsEzN7teIg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.20.tgz",
+      "integrity": "sha512-p/kt9KztywH4l+09XHoZ4cPFOoE7xlZXIBMT8rxRVgfe1w0lvi7QYh4tOG7gk+iixQ34EyDQacoHCsabdpmqQg==",
       "dependencies": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
-        "@luma.gl/gltools": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
+        "@luma.gl/gltools": "8.5.20",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/stats": "^3.5.0"
       }
@@ -5476,17 +5516,12 @@
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "node_modules/@mapbox/tile-cover": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/tile-cover/-/tile-cover-3.0.2.tgz",
-      "integrity": "sha512-A6qvtttsYI66BYi8JMD0v7BzxeuXJf6qSzufmdvvYxDJyXqATZ7ig6OKHFCW7/OsUjpfFu3rB54JM/yHUOVB9g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tile-cover/-/tile-cover-3.0.1.tgz",
+      "integrity": "sha512-R8aoFY/87HWBOL9E2eBqzOY2lpfWYXCcTNgBpIxAv67rqQeD4IfnHD0iPXg/Z1cqXrklegEYZCp/7ZR/RsWqBQ==",
       "dependencies": {
-        "@mapbox/tilebelt": "^1.0.1"
+        "tilebelt": "^1.0.1"
       }
-    },
-    "node_modules/@mapbox/tilebelt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/tilebelt/-/tilebelt-1.0.2.tgz",
-      "integrity": "sha512-tGJN2VIgWrXqBTPIxFVklklIpcy6ss8W5ouq+cjNLXPXFraRaDR4Ice+5Q8/uLX+6aH23lWBMydOIn8PcdVcpA=="
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "1.2.5",
@@ -6470,9 +6505,9 @@
       "dev": true
     },
     "node_modules/@petamoriken/float16": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.0.tgz",
-      "integrity": "sha512-AhVAm6SQ+zgxIiOzwVdUcDmKlu/qU39FiYD2UD6kQQaVenrn0dGZewIghWAENGQsvC+1avLCuT+T2/3Gsp/W3w=="
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.1.tgz",
+      "integrity": "sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg=="
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
@@ -19264,9 +19299,17 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.186",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
+    },
+    "node_modules/@types/lodash-es": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==",
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/lodash.get": {
       "version": "4.4.5",
@@ -19277,9 +19320,9 @@
       }
     },
     "node_modules/@types/mapbox-gl": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.10.tgz",
-      "integrity": "sha512-nMVEcu9bAcenvx6oPWubQSPevsekByjOfKjlkr+8P91vawtkxTnopDoXXq1Qn/f4cg3zt0Z2W9DVsVsKRNXJTw==",
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.11.tgz",
+      "integrity": "sha512-4vSwPSTQIawZTFRiTY2R74aZwAiM9gE6KGj871xdyAPpa+DmEObXxQQXqL2PsMH31/rP9nxJ2Kv0boeTVJMXVw==",
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -19541,6 +19584,11 @@
       "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
       "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
+    },
     "node_modules/@types/set-cookie-parser": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
@@ -19604,6 +19652,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
     },
     "node_modules/@types/vfile-message": {
       "version": "2.0.0",
@@ -19974,62 +20027,66 @@
       }
     },
     "node_modules/@vitessce/all": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/all/-/all-2.0.3.tgz",
-      "integrity": "sha512-JO35nEcUXsXvNxkGvu4hmbZkEn4+geLi3V+IbSF/OKDi2jFM72GBAcrVgaK0JaGenoFhNeUh07/2oukb6v6EVg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/all/-/all-3.0.0.tgz",
+      "integrity": "sha512-rpLv8oKNKD8WrzLm0k4A3kJ4CVMfcE1aODFpAJ9EX+lM66NPZiH+KA+11PlLORvQAohK/qg7BS/rji5xIV7suA==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/csv": "2.0.3",
-        "@vitessce/description": "2.0.3",
-        "@vitessce/feature-list": "2.0.3",
-        "@vitessce/genomic-profiles": "2.0.3",
-        "@vitessce/heatmap": "2.0.3",
-        "@vitessce/json": "2.0.3",
-        "@vitessce/layer-controller": "2.0.3",
-        "@vitessce/obs-sets-manager": "2.0.3",
-        "@vitessce/scatterplot-embedding": "2.0.3",
-        "@vitessce/scatterplot-gating": "2.0.3",
-        "@vitessce/spatial": "2.0.3",
-        "@vitessce/statistical-plots": "2.0.3",
-        "@vitessce/status": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "@vitessce/zarr": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/csv": "3.0.0",
+        "@vitessce/description": "3.0.0",
+        "@vitessce/feature-list": "3.0.0",
+        "@vitessce/genomic-profiles": "3.0.0",
+        "@vitessce/heatmap": "3.0.0",
+        "@vitessce/json": "3.0.0",
+        "@vitessce/layer-controller": "3.0.0",
+        "@vitessce/obs-sets-manager": "3.0.0",
+        "@vitessce/ome-tiff": "3.0.0",
+        "@vitessce/plugins": "3.0.0",
+        "@vitessce/scatterplot-embedding": "3.0.0",
+        "@vitessce/scatterplot-gating": "3.0.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/spatial": "3.0.0",
+        "@vitessce/statistical-plots": "3.0.0",
+        "@vitessce/status": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "@vitessce/zarr": "3.0.0",
+        "zod": "^3.21.4"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@vitessce/config": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/config/-/config-2.0.3.tgz",
-      "integrity": "sha512-/Spffx20p46DvjRqPTCTmELFSbqqDpxi1Fa9KK0s21piSjLzDGZIW0JLHDm40RTgY0brww52UsHiWKr3+L/E9g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/config/-/config-3.0.0.tgz",
+      "integrity": "sha512-P/Ot7RxPe82J/WULjx/9SrluJeVcV4e/71Pl2vMiv+ShLmf/SPTTo5DTr7Uh9qdxfLVXfyHxU6r2TyGKQN6quw==",
       "dependencies": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/utils": "3.0.0"
       }
     },
     "node_modules/@vitessce/constants": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/constants/-/constants-2.0.3.tgz",
-      "integrity": "sha512-toQk9alwBoYLg07+wozP/2odRF6dTAdbpV/eT1FTthceEMsW2UchUBCdVhmL3W9hPykFrWU/IFLQwg71GkodNA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/constants/-/constants-3.0.0.tgz",
+      "integrity": "sha512-vI+Q9a6rxRplVSfX0V3zwYZAPMFmH6nZZvMfdNIGkmm+bONl/E+QfILIi7fcw7sQTnDVr+WmZXQ8IXkMGrov2A==",
       "dependencies": {
-        "@vitessce/constants-internal": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0"
       }
     },
     "node_modules/@vitessce/constants-internal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/constants-internal/-/constants-internal-2.0.3.tgz",
-      "integrity": "sha512-f7RquXtnF3mf8UTjh3w88RDjSpSh8T9cv13O46RKgc3CCuQ6x1XAeIO56ERaB34hE4n0TORF0N69i5kiKiOWRg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/constants-internal/-/constants-internal-3.0.0.tgz",
+      "integrity": "sha512-DPu3yqsEUlX2413/RKKd9oYq37uTlTU/CAMY2DxXN7ZzwLK3gT/DbclKiiCiinFI38IROcofhJ008Iv6+ASC3w=="
     },
     "node_modules/@vitessce/csv": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/csv/-/csv-2.0.3.tgz",
-      "integrity": "sha512-2wGgRvVhiQUaUOPbQxBdASwJ/9f8fVy5L93R64XZgqZbCRVGyGf5fY3G45Nt+uZgVziUZPSq/mhBhJB61Ec3Mg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/csv/-/csv-3.0.0.tgz",
+      "integrity": "sha512-arGM1T5vx9lXVrDyFVJhAkFq5Nr8IMTOOS6SBnrw7Y4CyobWbvhtQ9ERkJ/v/JLjngCc+v5zCS3IZsbCwoIHIw==",
       "dependencies": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
         "d3-dsv": "^1.1.1"
       }
@@ -20043,69 +20100,68 @@
       }
     },
     "node_modules/@vitessce/description": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/description/-/description-2.0.3.tgz",
-      "integrity": "sha512-O4AVpZx1CTn0phPDaNii8/cFC1uShP41YidU+ZFZrt/xmmqt2ZghPqeEoN3HN9Qc7BqvXQJzfX49Dmxpbx4QeQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/description/-/description-3.0.0.tgz",
+      "integrity": "sha512-eBYVtq9J/KbLdcqkmpTTaAh4DEMVJ6nkVOez78Wh/BXuW6oKBxA3Krn0s9VQiRbJVXrCoU5ZQ8R3RBq4mEJmEw==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/vit-s": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/vit-s": "3.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@vitessce/export-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/export-utils/-/export-utils-2.0.3.tgz",
-      "integrity": "sha512-mN9bP4+IqBk7wYwSHw8KuEV2hfMqtUd9dMyXrAGOtZfenLWo8Zfyu0JdIMeRo6L/KryF9JPmtt4W2s654N+bCA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/export-utils/-/export-utils-3.0.0.tgz",
+      "integrity": "sha512-8JBL/kLcXrFrnpGJAz/A6xiOzDH8y/jwxz95FOA3FRH76RCtL0Rx4WDE2/5h/4RZXKOvEiDe1ccT68ZaXhjhJA==",
       "dependencies": {
         "bowser": "^2.11.0",
         "lz-string": "^1.4.4"
       }
     },
     "node_modules/@vitessce/feature-list": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/feature-list/-/feature-list-2.0.3.tgz",
-      "integrity": "sha512-dqgWa5vsFYVV0f8gFqJB26QhNaGigzmPEdZWwkDvWIYfWlccTTXjjwEyQYw9z/lRu/dfRz0NLMItzbVywtstlg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/feature-list/-/feature-list-3.0.0.tgz",
+      "integrity": "sha512-tRIelE9sQl/tnX+8kOlMpaF++tPOL9t5vSMx78TzN/b+RdlDzlU/d98Gkmik+MICaafgIqfQcXsrnY1fonxPYA==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0",
         "react-virtualized": "^9.22.2",
-        "uuid": "^3.3.2"
+        "uuid": "^9.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@vitessce/feature-list/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@vitessce/genomic-profiles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/genomic-profiles/-/genomic-profiles-2.0.3.tgz",
-      "integrity": "sha512-twCDkV/PxbERfdNXeBZeK3ihLnaGljYht33KbXhIFkrv8ZNAUyuw+yvXDlWP/+nDVV8vcEMw3o8gEO7fYBx0UA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/genomic-profiles/-/genomic-profiles-3.0.0.tgz",
+      "integrity": "sha512-PP6sERkTBcWL94KE9knfLHPaCeBvrRe9G8C6Tl9EhUjJ1gQ78PDNjHx87BOtNdJ73ZJfR0S9/oYJ3bJ8MXsihw==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
         "higlass-no-github-deps": "1.11.13",
         "higlass-register": "^0.3.0",
         "higlass-zarr-datafetchers": "^0.2.1",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -20121,9 +20177,9 @@
       }
     },
     "node_modules/@vitessce/gl": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/gl/-/gl-2.0.3.tgz",
-      "integrity": "sha512-ummv3tT0/nst+O1kDLgvy/ZG4mqQNdfDupywLaSBUU0iuaBab66geFSShwDSdcUzaNI/yCH2pL7HG0yFzVY+BQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/gl/-/gl-3.0.0.tgz",
+      "integrity": "sha512-zTuqk8aCh9LhADvGmGbOKYgKk8lO35Zqjj7B6j8q8mJsQtc5g8kkvgJrUb/NG93HzKK0J1/yerM7jgeye2ESCA==",
       "dependencies": {
         "@deck.gl/aggregation-layers": "~8.8.6",
         "@deck.gl/core": "~8.8.6",
@@ -20132,7 +20188,7 @@
         "@deck.gl/layers": "~8.8.6",
         "@deck.gl/mesh-layers": "~8.8.6",
         "@deck.gl/react": "~8.8.6",
-        "@hms-dbmi/viv": "~0.13.6",
+        "@hms-dbmi/viv": "~0.13.7",
         "@loaders.gl/3d-tiles": "^3.0.0",
         "@loaders.gl/core": "^3.0.0",
         "@loaders.gl/images": "^3.0.0",
@@ -20154,65 +20210,66 @@
         "@turf/boolean-within": "^6.5.0",
         "@turf/centroid": "^6.5.0",
         "@turf/helpers": "^6.5.0",
-        "@vitessce/utils": "2.0.3",
+        "@vitessce/utils": "3.0.0",
         "deck.gl": "~8.8.6",
         "glslify": "^7.0.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6",
         "mathjs": "^9.2.0",
         "nebula.gl": "0.23.8"
       }
     },
     "node_modules/@vitessce/heatmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/heatmap/-/heatmap-2.0.3.tgz",
-      "integrity": "sha512-vnS/0WWE2YrPM2riVN71674I/k8uZ8lrGpd3ciRbvzTy77LGeg1hhGPhqsq6I6ftYk0eXPdHwH52iwFXjFhG7g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/heatmap/-/heatmap-3.0.0.tgz",
+      "integrity": "sha512-yKM0q5t35gCsY9j/uja7Nmp+aAPJX6/qJg8LfljzTgyi9hkirQWQv8c1J5r8IHLF3p4y7gtqLZI9YvfI3H7JTQ==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/tooltip": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "@vitessce/workers": "2.0.3",
-        "lodash": "^4.17.21",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/legend": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/tooltip": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "@vitessce/workers": "3.0.0",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0",
-        "uuid": "^3.3.2"
+        "uuid": "^9.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@vitessce/heatmap/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@vitessce/icons": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/icons/-/icons-2.0.3.tgz",
-      "integrity": "sha512-GGyUvA+XhXRg1TsduGSm7V0ApNBUdiZPUfU7ytvuwwm7fPPHlnxCHl2eKhmClvBTn/Vtog+9aBIoh2qod1bqAg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/icons/-/icons-3.0.0.tgz",
+      "integrity": "sha512-VPdLerYIGvw+zYfgY+OhOLUVGBQXpBSJX3eS/g06UVlh0xWObYWArnEXTyULG0wBurYpx0nJSexrlmImVqoP1w=="
     },
     "node_modules/@vitessce/json": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/json/-/json-2.0.3.tgz",
-      "integrity": "sha512-THDLtfdepl0gSjnCOK7HLhgOpLrKjBhoUfwtBBwqupjM9qpVd6XhXkhClkJUq1pyTFO8Vk2NE0jV1gkkOu4TCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/json/-/json-3.0.0.tgz",
+      "integrity": "sha512-YKbw1d1dV0EUclMl5OXSZMHvqy+6eVv7aqHt8aKR3l7nHmSEjjc6u5yA8/dRGwIUovKlRT5a/zaY2ERNNBL2Fw==",
       "dependencies": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "ajv": "^6.10.0",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
-        "zarr": "0.5.1"
+        "lodash-es": "^4.17.21",
+        "zarr": "0.5.1",
+        "zod": "^3.21.4"
       }
     },
     "node_modules/@vitessce/json/node_modules/d3-array": {
@@ -20224,37 +20281,107 @@
       }
     },
     "node_modules/@vitessce/layer-controller": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/layer-controller/-/layer-controller-2.0.3.tgz",
-      "integrity": "sha512-KoGZf0G8mIO7FFpTC2AoRGzrsG/iKJr4H9yy885KedS0AXymrJnZR/pfZRUy6LxoVqZtdXFIfLm8TyX/wWA15Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/layer-controller/-/layer-controller-3.0.0.tgz",
+      "integrity": "sha512-lKvWIG7AuhQ7LKxNgEwuHkWvN5QEFJ7mD8DrH/ZX2qzcwInbZjUlKjfQtUXqjkfNfOSSAH00yBYW9ULgRKEpqg==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
         "@material-ui/icons": "~4.11.2",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "lodash": "^4.17.21",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@vitessce/obs-sets-manager": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/obs-sets-manager/-/obs-sets-manager-2.0.3.tgz",
-      "integrity": "sha512-IiUqjb0vB9eM5IUQH5aKPhqDZfZhPoHSGtqy0PxnS9ltc45xXYXahaI6jcqexd0A5HgIbhQ2Jpr3/lb1/fHo+w==",
+    "node_modules/@vitessce/legend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/legend/-/legend-3.0.0.tgz",
+      "integrity": "sha512-immQCfLfRMfIKbbc1nvCvQdVRC5ES5Mhwjnaa0ClQBqSJFyhfA5+2uHVoL+I56zZovOFx3ImNsmDv2WKai7x/Q==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/icons": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/utils": "3.0.0",
+        "colormap": "^2.3.2",
+        "d3-axis": "^3.0.0",
+        "d3-color": "^1.4.0",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.3",
+        "d3-selection": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@vitessce/legend/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/@vitessce/legend/node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vitessce/legend/node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/@vitessce/legend/node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/@vitessce/legend/node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vitessce/legend/node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/@vitessce/obs-sets-manager": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/obs-sets-manager/-/obs-sets-manager-3.0.0.tgz",
+      "integrity": "sha512-bWWHNrR1vGzlh5zmqgpDE33RaXtJ8BzmZq2Hr+uRCaOmnxSogfZ+96HoguqNO556nRl6xrg6ekHr92vyJb49cA==",
+      "dependencies": {
+        "@material-ui/core": "~4.12.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/icons": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "rc-tooltip": "^5.2.2",
         "rc-tree": "2.1.0",
         "react-color-with-lodash": "^2.19.5"
@@ -20313,9 +20440,9 @@
       }
     },
     "node_modules/@vitessce/obs-sets-manager/node_modules/rc-util": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.29.2.tgz",
-      "integrity": "sha512-xHT9Dr3RD6tyvCibnH10l3mudC6TJjWNr9UDy3CrOGZqTY354OfdwP87ahKNe0b3A1dsysDldvx0SBuswhlOeA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.33.0.tgz",
+      "integrity": "sha512-mq2NkEAnHklq4fgU/JqjiE0PS8+8u33gEWw2bDUNDPck3OroPpSgw/8oEyuFrvPgaZEmt9BgQdh59JfQt2cU+w==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "react-is": "^16.12.0"
@@ -20325,40 +20452,74 @@
         "react-dom": ">=16.9.0"
       }
     },
+    "node_modules/@vitessce/ome-tiff": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/ome-tiff/-/ome-tiff-3.0.0.tgz",
+      "integrity": "sha512-i7R8QrPBymCIl0sbZU79fGPzAk05PTNGWjg3vLmRk3Sh+E8n9580zzgTVUFrTZYol5kKM8jak4ss9BCo2JZIYQ==",
+      "dependencies": {
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "ajv": "^6.10.0",
+        "d3-array": "^2.4.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/@vitessce/ome-tiff/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/@vitessce/plugins": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/plugins/-/plugins-3.0.0.tgz",
+      "integrity": "sha512-IgIWdaF1WCacbEiQcmCftzfGFCqkso0qkN1kCD0abvDXxwiY1AcJMj6NDZdyMqNZmtKVn6WxoqPmnwf9bO1d0g==",
+      "dependencies": {
+        "zod": "^3.21.4"
+      }
+    },
     "node_modules/@vitessce/scatterplot": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot/-/scatterplot-2.0.3.tgz",
-      "integrity": "sha512-a0MbUO4ZpHnDEkxsFYeghgoaGkrKFVgiPyDGiqixBs+bMI39ODPNX9d0caUBcnpKlKfWasu58r9s5FMvtvcXtg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot/-/scatterplot-3.0.0.tgz",
+      "integrity": "sha512-GyksFiJPCy55kfzDpB8CSgdUhtbsVvZQehmmrxGKGQs28cjlTp0tLMoSC4/RzS6+7JRjpBZucJHxJftTkxl9Jw==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/icons": "2.0.3",
-        "@vitessce/tooltip": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@material-ui/icons": "~4.11.2",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/icons": "3.0.0",
+        "@vitessce/tooltip": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1",
         "d3-force": "^2.1.1",
         "d3-quadtree": "^1.0.7",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@vitessce/scatterplot-embedding": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-embedding/-/scatterplot-embedding-2.0.3.tgz",
-      "integrity": "sha512-G9kQ2GwbFjVvIuZo6VDlp6dRyJd/wghu0cGgIADJ2KYJfT2YcuIvo6qEZozomMCGnxTSrTAKdlhPGLZ8CfoNiQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-embedding/-/scatterplot-embedding-3.0.0.tgz",
+      "integrity": "sha512-OkKOf8VsepVKmS2plrduMvNOrDQR3Hy5WZKMNbCn/XxiPWcjhK+syKUQcAW5XiJMavspZdOpjdlmb1YBIieXCw==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/scatterplot": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/legend": "3.0.0",
+        "@vitessce/scatterplot": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0"
       },
       "peerDependencies": {
@@ -20374,18 +20535,18 @@
       }
     },
     "node_modules/@vitessce/scatterplot-gating": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-gating/-/scatterplot-gating-2.0.3.tgz",
-      "integrity": "sha512-7nCM1Iby2CRG819gvFRXnUTtZo7w/mu7K9+FDOYHbqL0AK0omuPak7cvxToiOx2K/QW4KnU1DR7n2dxd/7Wg/A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-gating/-/scatterplot-gating-3.0.0.tgz",
+      "integrity": "sha512-/NrGdseRgNyhvYXJTK9hshED+pOG5TbebSeLbmuuZRtQCIrZ/Jm9g9TGWW8be/TB+3bG53cQZKQ7cRBG/4CPkg==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/scatterplot": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/scatterplot": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0"
       },
       "peerDependencies": {
@@ -20410,23 +20571,63 @@
         "d3-timer": "1 - 2"
       }
     },
+    "node_modules/@vitessce/schemas": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/schemas/-/schemas-3.0.0.tgz",
+      "integrity": "sha512-DeASD3zcXXTyk3P63AXVqvgI3vUaTobZAI5sCRZXPnlsBWMp7iXj/dsNjU63XdHXAUj5drk23ex6M8wU/uDQvw==",
+      "dependencies": {
+        "@types/lodash": "^4.14.191",
+        "@types/lodash-es": "^4.17.7",
+        "@types/semver": "^7.3.13",
+        "@types/uuid": "^9.0.1",
+        "@vitessce/constants": "3.0.0",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/plugins": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "lodash-es": "^4.17.21",
+        "semver": "^7.3.8",
+        "uuid": "^9.0.0",
+        "zod": "^3.21.4"
+      }
+    },
+    "node_modules/@vitessce/schemas/node_modules/semver": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@vitessce/schemas/node_modules/uuid": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@vitessce/sets-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/sets-utils/-/sets-utils-2.0.3.tgz",
-      "integrity": "sha512-Mg1EO7BlfkZ2sF7N3HP8RiYNyyKWrm3+vqFgsB2vNkLC/PIrsR1mK5f180zovtYWnhpMs8JL/j9EOGep9niguQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/sets-utils/-/sets-utils-3.0.0.tgz",
+      "integrity": "sha512-fbECoQibQDN4dxXXdbPPTum/GCm7S6jTdCZDlrSPzebJP/qDuFk00c0Y0C7ZYrUsTh+tK7OHt4L4CD6CvC9S4A==",
       "dependencies": {
         "@turf/centroid": "^6.5.0",
         "@turf/helpers": "^6.5.0",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "ajv": "^6.10.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/utils": "3.0.0",
         "concaveman": "^1.2.1",
         "d3-dsv": "^1.1.1",
         "internmap": "^2.0.3",
         "json2csv": "^5.0.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "tinycolor2": "^1.4.1",
-        "uuid": "^3.3.2"
+        "uuid": "^9.0.0"
       }
     },
     "node_modules/@vitessce/sets-utils/node_modules/internmap": {
@@ -20438,30 +20639,30 @@
       }
     },
     "node_modules/@vitessce/sets-utils/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@vitessce/spatial": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/spatial/-/spatial-2.0.3.tgz",
-      "integrity": "sha512-uUQMb7IDY/YycpBKELCuKyNDWhTFpT+YTNOQHnZ8ry8Mk9QNgrEGJ0nOjLmbYGC23l/Fvd64bDjTjXMmRASHmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/spatial/-/spatial-3.0.0.tgz",
+      "integrity": "sha512-TgXGph75vdpqSKic2Xx4ZwFYqSEAA16lXTWwXPiy5ewtbmsuq0EfYAaj1fjYsmF8oQKJQeUQ3IWVXBEs14XJnw==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/scatterplot": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/tooltip": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/legend": "3.0.0",
+        "@vitessce/scatterplot": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/tooltip": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6",
         "mathjs": "^9.2.0",
         "plur": "^5.1.0",
@@ -20472,13 +20673,13 @@
       }
     },
     "node_modules/@vitessce/spatial-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/spatial-utils/-/spatial-utils-2.0.3.tgz",
-      "integrity": "sha512-/2zO3aBhgkV2owe25lrfpPLclDhDQrh6WhT6DWXexXbLgYW5Sfds0Hs86bUabJF4/pQll6M4J8m6CCHnVxJUCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/spatial-utils/-/spatial-utils-3.0.0.tgz",
+      "integrity": "sha512-rNEun0Zwv+buCfjufLjcKKtUkVmB7GrBCfBrLc4FZ8HdTt+InlcALESTwheKc+Q8uwsBlydEn4c9bxX0sE9Gxg==",
       "dependencies": {
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "lodash": "^4.17.21",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6",
         "mathjs": "^9.2.0"
       }
@@ -20492,18 +20693,18 @@
       }
     },
     "node_modules/@vitessce/statistical-plots": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/statistical-plots/-/statistical-plots-2.0.3.tgz",
-      "integrity": "sha512-6iAjr+2af0iqRyCt49SVNZYOgMeGf/LJEs+0LGB+BpAlK5wfl0bPRPi5i6CCV1r81FK/Z9RmM681a3mN7wEisA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/statistical-plots/-/statistical-plots-3.0.0.tgz",
+      "integrity": "sha512-2H13S7bAZzplBe60t2QHzaOdfmbgtvXqWyiMMCAk/llB+A+WmKwnA1PPkLDK+x1u+j5eXLK8eo1Zlf/lBInq9g==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vega": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vega": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
@@ -20518,13 +20719,13 @@
       }
     },
     "node_modules/@vitessce/status": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/status/-/status-2.0.3.tgz",
-      "integrity": "sha512-S0QtuR2ndXh2sxv/h2RLX9d9YeoVbv6mr8vQGBoMJhjKfw0U/zla+HJjzg90cbgYkeAnk5T9jXmYwjGgvWQIfQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/status/-/status-3.0.0.tgz",
+      "integrity": "sha512-NEzT3RjMr0hvzTLzmaN3GEg3AFmrPNL+U803805veGtdyqfGqsxKnggI+y2eN4aGWXehk4YpAFHJBH5dr7YqFA==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1"
       },
       "peerDependencies": {
@@ -20532,34 +20733,36 @@
       }
     },
     "node_modules/@vitessce/tooltip": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/tooltip/-/tooltip-2.0.3.tgz",
-      "integrity": "sha512-RDnZAsHgefdxTV9FyvsJZB1DHfeIMJnaDA6N5UOt+qjPjgk8IrBxaqjQ6VuzgPi6dkOeEY0YM49DD4NUJGDNDA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/tooltip/-/tooltip-3.0.0.tgz",
+      "integrity": "sha512-MT0xwdOiINAh/mUMY64f8IaMErBzEwDUZU33NsLz4hVf+WUpZHT1es7s+4wwK/od8XzeqrqiQm0Le6qWAz7fNg==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/vit-s": "2.0.3"
+        "@vitessce/vit-s": "3.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@vitessce/utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/utils/-/utils-2.0.3.tgz",
-      "integrity": "sha512-JE8C1MayxEDSZhtN85Y9kKUWDudjwAExeQ+LjOZy7zJ2OO9eJE4dzCdUmIyRZYYComnf2g5e6sDhp4jt4mP/8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/utils/-/utils-3.0.0.tgz",
+      "integrity": "sha512-VoI0ucFjknFRyIS8E7vwmBKV6dkeiBImmafuV7IEM7rxIQ/hd8zqg+3bgjpqSBUQRxoLyxgvrPprF/eJnkRP7A==",
       "dependencies": {
-        "@vitessce/sets-utils": "2.0.3",
+        "@vitessce/sets-utils": "3.0.0",
         "bowser": "^2.11.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "lz-string": "^1.4.4"
       }
     },
     "node_modules/@vitessce/vega": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/vega/-/vega-2.0.3.tgz",
-      "integrity": "sha512-laSXu7nnS0s3iIU9nHamS9aqVHf/fDPAYjXqBtUnuzvvPDfn4pcF5osAJ/iMi6EJjsMLZRKmvboXOu/XCgf04A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/vega/-/vega-3.0.0.tgz",
+      "integrity": "sha512-PKVr9qRMxpLzSmmE6Q19IxLU+9dyDfkJmvcKUIFZT+sKXk471D7e6T1DzhR2UaFV5y5mQhbWGOqCtQkv7evIPg==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
+        "@vitessce/tooltip": "3.0.0",
+        "clsx": "^1.1.1",
         "react-vega": "^7.4.4",
         "vega": "^5.21.0",
         "vega-lite": "^5.1.1",
@@ -20575,9 +20778,9 @@
       "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg=="
     },
     "node_modules/@vitessce/vega/node_modules/@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "node_modules/@vitessce/vega/node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -20668,9 +20871,9 @@
       }
     },
     "node_modules/@vitessce/vega/node_modules/tslib": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
     },
     "node_modules/@vitessce/vega/node_modules/vega-event-selector": {
       "version": "3.0.1",
@@ -20678,18 +20881,18 @@
       "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
     },
     "node_modules/@vitessce/vega/node_modules/vega-expression": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
-      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+      "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "vega-util": "^1.17.1"
       }
     },
     "node_modules/@vitessce/vega/node_modules/vega-lite": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.6.1.tgz",
-      "integrity": "sha512-Dij2OkJcmK+/2pIcLambjV/vWmhP11ypL3YqDVryBfJxP1m+ZgZU+8/SOEP3B2R1MhmmT7JDYQUtiNcGi1/2ig==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.9.3.tgz",
+      "integrity": "sha512-S1B81aOkMC/iDU2skeS7ROaIaJuxvGx1PW1LO9ECe2dsrfsaDHk20SGsEhPSKZAgSxOghJ0+AuYdU0glRNjN1Q==",
       "dependencies": {
         "@types/clone": "~2.1.1",
         "clone": "~2.1.2",
@@ -20697,10 +20900,10 @@
         "fast-json-stable-stringify": "~2.1.0",
         "json-stringify-pretty-compact": "~3.0.0",
         "tslib": "~2.5.0",
-        "vega-event-selector": "~3.0.0",
-        "vega-expression": "~5.0.0",
-        "vega-util": "~1.17.0",
-        "yargs": "~17.6.2"
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.1.0",
+        "vega-util": "~1.17.2",
+        "yargs": "~17.7.2"
       },
       "bin": {
         "vl2pdf": "bin/vl2pdf",
@@ -20709,10 +20912,10 @@
         "vl2vg": "bin/vl2vg"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "vega": "^5.22.0"
+        "vega": "^5.24.0"
       }
     },
     "node_modules/@vitessce/vega/node_modules/vega-tooltip": {
@@ -20724,9 +20927,9 @@
       }
     },
     "node_modules/@vitessce/vega/node_modules/vega-util": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
-      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+      "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
     },
     "node_modules/@vitessce/vega/node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -20753,9 +20956,9 @@
       }
     },
     "node_modules/@vitessce/vega/node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -20778,27 +20981,42 @@
       }
     },
     "node_modules/@vitessce/vit-s": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/vit-s/-/vit-s-2.0.3.tgz",
-      "integrity": "sha512-a6WxP+uMiYlzQlgjloMqXCBM3GogZEvfTBHBrhtkDmPAYatNNmP2JRqyRpX9VtO20NRagw0e6c/sTAszFu4Efw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/vit-s/-/vit-s-3.0.0.tgz",
+      "integrity": "sha512-dEUkpX1bMrMg69TVX0btV/BNBGBWiWod4Cx2V/CzDQiB3737ypTijvsxNhc0qIRn1jy7DgcU7TrC9BxnE5UHcg==",
       "dependencies": {
         "@material-ui/core": "~4.12.3",
         "@material-ui/icons": "~4.11.2",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "ajv": "^6.10.0",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/plugins": "3.0.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/utils": "3.0.0",
         "clsx": "^1.1.1",
+        "d3-array": "^2.4.0",
         "fast-deep-equal": "^3.1.3",
         "internmap": "^2.0.3",
         "jss-plugin-global": "^10.9.2",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "react-grid-layout-with-lodash": "^1.3.5",
-        "uuid": "^3.3.2",
+        "uuid": "^9.0.0",
         "zustand": "^3.5.10"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
+    },
+    "node_modules/@vitessce/vit-s/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/@vitessce/vit-s/node_modules/d3-array/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "node_modules/@vitessce/vit-s/node_modules/internmap": {
       "version": "2.0.3",
@@ -20809,35 +21027,34 @@
       }
     },
     "node_modules/@vitessce/vit-s/node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@vitessce/workers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/workers/-/workers-2.0.3.tgz",
-      "integrity": "sha512-7VPCBlEAzoQIkyZsxaxlYrjpWgK6IiwZxyyzqH+xmB+U/VSc0UFrN/zMm3mPjrGKM/MVrJYGx1ORY8HWrZECWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/workers/-/workers-3.0.0.tgz",
+      "integrity": "sha512-n21uA5JV53Nb5OGzSuUA0JtySdFvwSN6ykQOvYJwx9zpwIRc8Enz1CE7aj2wgp59M9uvGvqlAX3f5RNC7Tx6jQ==",
       "dependencies": {
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       }
     },
     "node_modules/@vitessce/zarr": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/zarr/-/zarr-2.0.3.tgz",
-      "integrity": "sha512-LlAK0QXFlW5vRg8Zaz8vF6Ms0aPT5ff8BTidRYlxPi9XxBeVAjxyLAm9GQl3axAQmwaDlM0r5mZlpAFY0kF8Cg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/zarr/-/zarr-3.0.0.tgz",
+      "integrity": "sha512-0L3cDdYWasCGpJwv6ey+jnCqtHPHsceNuLd98UbWs66Heg3FSQ/jetbzWgrluXN5Rr6cCRKcFRpfWURV6rSQ6w==",
       "dependencies": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "zarr": "0.5.1"
       }
     },
@@ -20850,35 +21067,35 @@
       }
     },
     "node_modules/@vivjs/constants": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/constants/-/constants-0.13.6.tgz",
-      "integrity": "sha512-nt9WMcUFgs24zVcLitvD5vcnnkephiG/6qDou16LOWPaWhODH2W/TbymOYHQp6MRoKKi3pIhIFeUxx/Ig1rUzw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/constants/-/constants-0.13.7.tgz",
+      "integrity": "sha512-YX3XkDZoHuiFFg9MwpaEMZCQR7jfB8dXwsiUbwfXLq7dcIoBlVaVnJDO3nb8gdwN+w2B3M2BiuK6aKF7BNw+zA==",
       "dependencies": {
         "@luma.gl/constants": "~8.5.16"
       }
     },
     "node_modules/@vivjs/extensions": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/extensions/-/extensions-0.13.6.tgz",
-      "integrity": "sha512-yaz6OB3pdvMt5cJA1COnx9Vcw0zQIvfA8+/X1xxGBG87NDeQR0FY/vSMBe/nCTxcoYNFvxF8uWrXc2wWZWHWiw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/extensions/-/extensions-0.13.7.tgz",
+      "integrity": "sha512-xHtpECEeoaEFibsOgHmOTGayZbuQI5v8PAe4qgJZ4gkpRNRAPerZC3oPXuFkUFcBx4aYqQso8XuQMoIWxCIHag==",
       "dependencies": {
-        "@vivjs/constants": "0.13.6"
+        "@vivjs/constants": "0.13.7"
       },
       "peerDependencies": {
         "@deck.gl/core": "~8.8.6"
       }
     },
     "node_modules/@vivjs/layers": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/layers/-/layers-0.13.6.tgz",
-      "integrity": "sha512-thNulJNyvNJFn009847mKfdP4KNBr0j4udSbIB+u7sI2uEWBXt2Wnq7xgCep0AWT5SdHNtL5IqOk8B38RPvuTA==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/layers/-/layers-0.13.7.tgz",
+      "integrity": "sha512-LOFxhnExK9nVa7429MYUbtEmSeZBUXY6G4OAP0AG91blAyDna6nLp14S1a9RYOumMli+PdVefYk4kbi7yX1OBQ==",
       "dependencies": {
         "@math.gl/core": "^3.5.7",
         "@math.gl/culling": "^3.5.7",
-        "@vivjs/constants": "0.13.6",
-        "@vivjs/extensions": "0.13.6",
-        "@vivjs/loaders": "0.13.6",
-        "@vivjs/types": "0.13.6"
+        "@vivjs/constants": "0.13.7",
+        "@vivjs/extensions": "0.13.7",
+        "@vivjs/loaders": "0.13.7",
+        "@vivjs/types": "0.13.7"
       },
       "peerDependencies": {
         "@deck.gl/core": "~8.8.6",
@@ -20891,11 +21108,11 @@
       }
     },
     "node_modules/@vivjs/loaders": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/loaders/-/loaders-0.13.6.tgz",
-      "integrity": "sha512-9KeCQ+I1yGvX/Y06CSEoY2xniZ305zAYCkhPCzX9kjb8BiRn97ci5DVNwfr2ajtSPXRiFhn9ITlSWBm8767Pbg==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/loaders/-/loaders-0.13.7.tgz",
+      "integrity": "sha512-POzRu02oUFzWyR1sJqEZ8du6MnKqjy06bAxKvmlv/zVuIkf/w7Vgd8VFtPeoJPuR0NikWLFZOZ+M0fG+/PaweQ==",
       "dependencies": {
-        "@vivjs/types": "0.13.6",
+        "@vivjs/types": "0.13.7",
         "fast-xml-parser": "^3.16.0",
         "geotiff": "^2.0.5",
         "lzw-tiff-decoder": "^0.1.1",
@@ -20904,22 +21121,22 @@
       }
     },
     "node_modules/@vivjs/types": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/types/-/types-0.13.6.tgz",
-      "integrity": "sha512-pp9xGA3czWxRlSOWDYbt8noCUm2MTRrOmaQzuvsGPx0fZecvL+HbEzW3zQTyxRYJJQBqgkHqXNZfLkvwGCpRQw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/types/-/types-0.13.7.tgz",
+      "integrity": "sha512-F0t80B49L8NbEG9eHW4iswSE1tUPASQM5VNVkWLqeSffGKg7YI9e4pDikx9KkwpWfNxOs673QJWzTzz6ze4YPA==",
       "dependencies": {
-        "@vivjs/constants": "0.13.6",
+        "@vivjs/constants": "0.13.7",
         "math.gl": "^3.5.7"
       }
     },
     "node_modules/@vivjs/viewers": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/viewers/-/viewers-0.13.6.tgz",
-      "integrity": "sha512-EZ55ebDIwntZs3t1gFYhM/kqi4RF+SHgEISTmvsVOcaJuUQlczxXwzJDe3KhRFGHEariJvIpObKaU3CurwdkKw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/viewers/-/viewers-0.13.7.tgz",
+      "integrity": "sha512-yyoxwnDLxsUSM1IPQ4NFZIfXR7U+UOeKpRcYgoX69Mh7ADbUoBNJilsbwU0Z8Y52qeI7PN3d5aPW3qoJsow3Jg==",
       "dependencies": {
-        "@vivjs/constants": "0.13.6",
-        "@vivjs/extensions": "0.13.6",
-        "@vivjs/views": "0.13.6",
+        "@vivjs/constants": "0.13.7",
+        "@vivjs/extensions": "0.13.7",
+        "@vivjs/views": "0.13.7",
         "fast-deep-equal": "^3.1.3"
       },
       "peerDependencies": {
@@ -20928,13 +21145,13 @@
       }
     },
     "node_modules/@vivjs/views": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/views/-/views-0.13.6.tgz",
-      "integrity": "sha512-E/ix+BB5W2zKdLcIBQkPDAePS+++kOfDlq9BNdMXyUc2yVRxgYK5Bs3TXjPWLDqPkRcG6xlBI18Ajb38iRhOAQ==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/views/-/views-0.13.7.tgz",
+      "integrity": "sha512-dUqUA/4Zqo+JiEqKcZrAuKK3NOcjQL1H9i+xlqwiMi7CLy59KV7DlS7LfcIIm4potXNZfd4945AUR96ceTSLBA==",
       "dependencies": {
         "@math.gl/core": "^3.5.7",
-        "@vivjs/layers": "0.13.6",
-        "@vivjs/loaders": "0.13.6",
+        "@vivjs/layers": "0.13.7",
+        "@vivjs/loaders": "0.13.7",
         "math.gl": "^3.5.7"
       },
       "peerDependencies": {
@@ -24842,6 +25059,14 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
       "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
+    },
+    "node_modules/colormap": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.2.tgz",
+      "integrity": "sha512-jDOjaoEEmA9AgA11B/jCSAvYE95r3wRoAyTf3LEHGiUVlNHJaL1mRkf5AyLSpQBVGfTEPwGEqCIzL+kgr2WgNA==",
+      "dependencies": {
+        "lerp": "^1.0.3"
+      }
     },
     "node_modules/colors": {
       "version": "1.4.0",
@@ -36930,6 +37155,11 @@
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
+    "node_modules/lerp": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
+      "integrity": "sha512-70Rh4rCkJDvwWiTsyZ1HmJGvnyfFah4m6iTux29XmasRiZPDBpT9Cfa4ai73+uLZxnlKruUS62jj2lb11wURiA=="
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -38186,7 +38416,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -39386,9 +39615,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.42",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.42.tgz",
-      "integrity": "sha512-tjI9goqwzkflKSTxJo+jC/W8riTFwEjjunssmFvAWlvNVApjbkJM7UHggyKO0q1Fd/kZVKY77H7C9A0XKhhAFw==",
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
       "dependencies": {
         "moment": "^2.29.4"
       },
@@ -42169,9 +42398,9 @@
       "dev": true
     },
     "node_modules/pub-sub-es": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.0.1.tgz",
-      "integrity": "sha512-KuL5i+1YdQ/o9xGCz7AsG6hb6PBUFhKNIt3NhZ6Jh/d6F3fVfURyq5fAAwxPcpJS6kkrR4vOYyzZfMpYI8sxlQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.0.2.tgz",
+      "integrity": "sha512-CQqZaKOGF6tWb+6XUGJNMHFZ308ZrgjNXTR4einx265b/L/yYKNEpcD7PkYLNq3CBV0K3qyIXSbX2Jg63ra9sw=="
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -42257,11 +42486,11 @@
       }
     },
     "node_modules/quadbin": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/quadbin/-/quadbin-0.1.5.tgz",
-      "integrity": "sha512-/MQnN7V73myA+31gTxldTGN8ixqrUCXtUoDvRKSI9QZJOaq0cS9SNQkdToMxjC3ZSM2hN7mleOAn+9QVNlPZOg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/quadbin/-/quadbin-0.1.9.tgz",
+      "integrity": "sha512-5V6m6+cL/6+uBl3hYL+CWF06rRvlHkIepYKGQjTLYaHhu9InPppql0+0ROiCaOQdz8gPNlgge3glk5Qg1mWOYw==",
       "dependencies": {
-        "@mapbox/tile-cover": "^3.0.2"
+        "@mapbox/tile-cover": "3.0.1"
       },
       "engines": {
         "node": ">=14"
@@ -42513,9 +42742,9 @@
       }
     },
     "node_modules/rc-motion": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.6.3.tgz",
-      "integrity": "sha512-xFLkes3/7VL/J+ah9jJruEW/Akbx5F6jVa2wG5o/ApGKQKSOd5FR3rseHLL9+xtJg4PmCwo6/1tqhDO/T+jFHA==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.7.3.tgz",
+      "integrity": "sha512-2xUvo8yGHdOHeQbdI8BtBsCIrWKchEmFEIskf0nmHtJsou+meLd/JE+vnvSX2JxcBrJtXY2LuBpxAOxrbY/wMQ==",
       "dependencies": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -42527,9 +42756,9 @@
       }
     },
     "node_modules/rc-motion/node_modules/rc-util": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.29.2.tgz",
-      "integrity": "sha512-xHT9Dr3RD6tyvCibnH10l3mudC6TJjWNr9UDy3CrOGZqTY354OfdwP87ahKNe0b3A1dsysDldvx0SBuswhlOeA==",
+      "version": "5.33.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.33.0.tgz",
+      "integrity": "sha512-mq2NkEAnHklq4fgU/JqjiE0PS8+8u33gEWw2bDUNDPck3OroPpSgw/8oEyuFrvPgaZEmt9BgQdh59JfQt2cU+w==",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "react-is": "^16.12.0"
@@ -44323,9 +44552,9 @@
       }
     },
     "node_modules/react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "version": "9.22.5",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.5.tgz",
+      "integrity": "sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==",
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "clsx": "^1.0.4",
@@ -44335,8 +44564,8 @@
         "react-lifecycles-compat": "^3.0.4"
       },
       "peerDependencies": {
-        "react": "^15.3.0 || ^16.0.0-alpha",
-        "react-dom": "^15.3.0 || ^16.0.0-alpha"
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-virtualized-auto-sizer": {
@@ -46956,9 +47185,9 @@
       "dev": true
     },
     "node_modules/splaytree": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.1.tgz",
-      "integrity": "sha512-9FaQ18FF0+sZc/ieEeXHt+Jw2eSpUgUtTLDYB/HXKWvhYVyOc7h1hzkn5MMO3GPib9MmXG1go8+OsBBzs/NMww=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.2.tgz",
+      "integrity": "sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A=="
     },
     "node_modules/split-string": {
       "version": "3.1.0",
@@ -47954,6 +48183,12 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/tilebelt": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tilebelt/-/tilebelt-1.0.1.tgz",
+      "integrity": "sha512-cxHzpa5JgsugY9NUVRH43gPaGJw/29LecAn4X7UGOP64+kB8pU4VQ3bIhSyfb5Mk4jDxwl3yk330L/EIhbJ5aw==",
+      "deprecated": "This module is now under the @mapbox namespace: install @mapbox/tilebelt instead"
     },
     "node_modules/timers-browserify": {
       "version": "2.0.11",
@@ -50383,14 +50618,14 @@
       }
     },
     "node_modules/vitessce": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-2.0.3.tgz",
-      "integrity": "sha512-tOy7rU68JabkAQN8LYaCG3CLWtEOJxdbraJQnHr72CLxtctrXzwF8jYtXbNixdf7ZWZg/V3smaT1p5iKOAQauw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-3.0.0.tgz",
+      "integrity": "sha512-tfHSK5xZM9KYeu+/f+a02g4b7VL7E3pOmWTSxSd59svIxRJ9zTk2jadO6rMhJMG3sVqTVVSAiy93FNReX0FkJw==",
       "dependencies": {
-        "@vitessce/all": "2.0.3",
-        "@vitessce/config": "2.0.3",
-        "@vitessce/constants": "2.0.3",
-        "@vitessce/export-utils": "2.0.3"
+        "@vitessce/all": "3.0.0",
+        "@vitessce/config": "3.0.0",
+        "@vitessce/constants": "3.0.0",
+        "@vitessce/export-utils": "3.0.0"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
@@ -51623,9 +51858,9 @@
       "dev": true
     },
     "node_modules/xml-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
-      "integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
+      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw=="
     },
     "node_modules/xmlbuilder": {
       "version": "10.1.1",
@@ -51675,8 +51910,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -51892,6 +52126,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {
@@ -54388,9 +54630,9 @@
       },
       "dependencies": {
         "d3-array": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
-          "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+          "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
           "requires": {
             "internmap": "1 - 2"
           }
@@ -54896,17 +55138,17 @@
       }
     },
     "@hms-dbmi/viv": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.13.6.tgz",
-      "integrity": "sha512-CeP/qehola+vGi4okZV6/TcuzUW4CHa6noWvqq63N/JLhox1HSn0J2qu/Eduj7wpsX+Tvibk2eXV6K8GbiXm5A==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.13.7.tgz",
+      "integrity": "sha512-uaDCnZCBNCM4yud013h368TesMyId9c7DME9ijh0tbvE8kI6m7VqviYyJ+uTWOUiu/sZTBiHWQsz44M+LVBtbw==",
       "requires": {
-        "@vivjs/constants": "0.13.6",
-        "@vivjs/extensions": "0.13.6",
-        "@vivjs/layers": "0.13.6",
-        "@vivjs/loaders": "0.13.6",
-        "@vivjs/types": "0.13.6",
-        "@vivjs/viewers": "0.13.6",
-        "@vivjs/views": "0.13.6"
+        "@vivjs/constants": "0.13.7",
+        "@vivjs/extensions": "0.13.7",
+        "@vivjs/layers": "0.13.7",
+        "@vivjs/loaders": "0.13.7",
+        "@vivjs/types": "0.13.7",
+        "@vivjs/viewers": "0.13.7",
+        "@vivjs/views": "0.13.7"
       }
     },
     "@hookform/resolvers": {
@@ -55911,188 +56153,236 @@
       }
     },
     "@loaders.gl/3d-tiles": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.3.1.tgz",
-      "integrity": "sha512-rhDjA/23w7VmWWv+2IduhvKFr2dxUDEs20w3BOBuN8HZG7BccrV/ffJwGHibn9/1SdzHhqUrrSXWNwkcKdFUvA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/3d-tiles/-/3d-tiles-3.4.4.tgz",
+      "integrity": "sha512-o6z8h5541OYTQT546p1FJlMjiqFvTu29C6W9F9X3rPIUdnBirTpCubgpHcAw53AIDOrvlIxBKH/KDkqoxFIylQ==",
       "requires": {
-        "@loaders.gl/draco": "3.3.1",
-        "@loaders.gl/gltf": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/math": "3.3.1",
-        "@loaders.gl/tiles": "3.3.1",
+        "@loaders.gl/draco": "3.4.4",
+        "@loaders.gl/gltf": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/math": "3.4.4",
+        "@loaders.gl/tiles": "3.4.4",
         "@math.gl/core": "^3.5.1",
-        "@math.gl/geospatial": "^3.5.1"
+        "@math.gl/geospatial": "^3.5.1",
+        "long": "^5.2.1"
+      },
+      "dependencies": {
+        "long": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+        }
       }
     },
     "@loaders.gl/core": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.3.1.tgz",
-      "integrity": "sha512-molMKfNbg/6T705VCW2XOKcXPfYZGj9XimQ6YVE4bSN+wwGpkni63ABuqndUllVga98CBZUBZplCQ0ljg6Bv3A==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-3.4.4.tgz",
+      "integrity": "sha512-uutqjvf91WJZx7WbSmJy75AHFNCPDnnweFnVmdAEflF6ohc+uAdjltqz6tGD3PxbT8LjNLTOk60kxyC/QwDBqQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
-        "@probe.gl/log": "^3.5.0"
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/worker-utils": "3.4.4",
+        "@probe.gl/log": "^4.0.1"
+      },
+      "dependencies": {
+        "@probe.gl/env": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@probe.gl/env/-/env-4.0.4.tgz",
+          "integrity": "sha512-sYNGqesDfWD6dFP5oNZtTeFA4Z6ak5T4a8BNPdNhoqy7PK9w70JHrb6mv+RKWqKXq33KiwCDWL7fYxx2HuEH2w==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        },
+        "@probe.gl/log": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@probe.gl/log/-/log-4.0.4.tgz",
+          "integrity": "sha512-WpmXl6njlBMwrm8HBh/b4kSp/xnY1VVmeT4PWUKF+RkVbFuKQbsU11dA1IxoMd7gSY+5DGIwxGfAv1H5OMzA4A==",
+          "requires": {
+            "@babel/runtime": "^7.0.0",
+            "@probe.gl/env": "4.0.4"
+          }
+        }
       }
     },
     "@loaders.gl/draco": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.3.1.tgz",
-      "integrity": "sha512-O73j+HpuKXhsoaD6jxYf1m8RDaE73eKWiBRwj8ExkhtFFmCnI02ERNuPhSbt7oN9xjEBuAuLBN2DpBtayKLhcA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/draco/-/draco-3.4.4.tgz",
+      "integrity": "sha512-VtJffpDbcdA0/uJzzJIET3B5j96cz6g5f93Wg2tlGtvnKZvJs4bjyojur4p7u5ElHJARm36F91N7Td4jGvMbYw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
+        "@loaders.gl/worker-utils": "3.4.4",
         "draco3d": "1.5.5"
       }
     },
     "@loaders.gl/gis": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.3.1.tgz",
-      "integrity": "sha512-Yzs84xMhPb8I4tjWYSGEso1SKwLF3dKY+C0AJbsUyL9zjljHcPSDjdHHdx6inBO+OoGjXr2HstPtPoaTyfKfaw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-3.4.4.tgz",
+      "integrity": "sha512-QwGOdpaE/jb1KsgHEkkiUD7C+dHWSDJKfMKM5OStIMPABX0Cxd8MSqyQ8+BOFWM7kdqXdMvgRjB9912R6T4AHQ==",
       "requires": {
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
         "@mapbox/vector-tile": "^1.3.1",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "@loaders.gl/gltf": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.3.1.tgz",
-      "integrity": "sha512-FQgtA0DxtmZygRGCbQcgn6KzgwUgVzlyajVL+Lydo25qZ2MqafCdvGDQQaNz1bQSUtIReYKuOjig9YlycPYZaA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/gltf/-/gltf-3.4.4.tgz",
+      "integrity": "sha512-8dbyZChWXku+OoL64rccFa60uxBhbRLdDelfCZqopRxwI/JF8ZCAEGuoFAftw84sU97JmfJbnCtcMMc8bebv4w==",
       "requires": {
-        "@loaders.gl/draco": "3.3.1",
-        "@loaders.gl/images": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/textures": "3.3.1",
+        "@loaders.gl/draco": "3.4.4",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/textures": "3.4.4",
         "@math.gl/core": "^3.5.1"
       }
     },
     "@loaders.gl/images": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.3.1.tgz",
-      "integrity": "sha512-A3JgiPSmL/0D/u67+huXfOHg4pEU9BUMtboxmVc/F0jC/aueli6/Erlco4Bf0Ci4fy9+eApmHD4eKmFSamdNCw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-3.4.4.tgz",
+      "integrity": "sha512-ViMh58oZ2GLsKCoYBH4nYMvi5fHeVZXiLAABVP+AVU54Jrf+PZYm8y8KaC22zBmGEZ15hGhJF/dNeOpgqZ+V4w==",
       "requires": {
-        "@loaders.gl/loader-utils": "3.3.1"
+        "@loaders.gl/loader-utils": "3.4.4"
       }
     },
     "@loaders.gl/loader-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.3.1.tgz",
-      "integrity": "sha512-yp3ngZw4O9OY7O3d8DCFwsuwDGR4IlDqJCFp47CVS3crrpANBOP12hBZl1uLZJQ8KN1gFXp0tIQtp5/J2bv+Hg==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-3.4.4.tgz",
+      "integrity": "sha512-EFY/YBniNyfZk0ojnBitl+xRL3Du8tinOwdFnWD0rVIf61+bFifFI0fJys8/tgrlF6sfiKdYbupow8G/a3xF2g==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
-        "@probe.gl/stats": "^3.5.0"
+        "@loaders.gl/worker-utils": "3.4.4",
+        "@probe.gl/stats": "^4.0.1"
+      },
+      "dependencies": {
+        "@probe.gl/stats": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.4.tgz",
+          "integrity": "sha512-SDuSY/D4yDL6LQDa69l/GCcnZLRiGYdyvYkxWb0CgnzTPdPrcdrzGkzkvpC3zsA4fEFw2smlDje370QGHwlisg==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        }
       }
     },
     "@loaders.gl/math": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.3.1.tgz",
-      "integrity": "sha512-s2ApdsxBsHqmZlopx3DOL2pav5S9iobdbAXD1ZEUWzTFcxcSIf0Z1CYIWKPBlUuzRJYaqd5fxHewfC4Er4sF5A==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/math/-/math-3.4.4.tgz",
+      "integrity": "sha512-l5ZGV7gAznj0nFjfiKIP9qIrSKLLiaRvGC2pmbM4J+2A674Sj59WwoZiASYNevOlByjScIwyZWe62wcneuyIWw==",
       "requires": {
-        "@loaders.gl/images": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
         "@math.gl/core": "^3.5.1"
       }
     },
     "@loaders.gl/mvt": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.3.1.tgz",
-      "integrity": "sha512-I6E6gmtDTSAUZIP0gY8PVcjFVPVWby3l3c95JkFKpqyKyPWFEPOkxuxWk34TQXHe09Zj9GEEav/bMC6GvEit/Q==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/mvt/-/mvt-3.4.4.tgz",
+      "integrity": "sha512-qxGe+EmuaDlXBs/EeBFzIKipgv+YrAm2BlHzyxLOsdBVmay9q31OYCqdigVw3Fc5h30D65hOfBC6k1lKo4OUyw==",
       "requires": {
-        "@loaders.gl/gis": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
+        "@loaders.gl/gis": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
         "@math.gl/polygon": "^3.5.1",
         "pbf": "^3.2.1"
       }
     },
     "@loaders.gl/schema": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.3.1.tgz",
-      "integrity": "sha512-VpVFLCc+38P0ddJ5478NnXN60YhNx9/dYHy1Y9ccOGTzaXPn8uFqM7DW/eNaJ7ikyiAWeSD75TpSQPzBrAd5MQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-3.4.4.tgz",
+      "integrity": "sha512-+lESS+cUSgXst9kxaW2LTxWMVMrT96cv0TWfsSryA11EVsxr50aSPWC+K0BHe7k60+80pQWEt4iyMRgVHM+6tg==",
       "requires": {
         "@types/geojson": "^7946.0.7"
       }
     },
     "@loaders.gl/terrain": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.3.1.tgz",
-      "integrity": "sha512-WCABqgdzsIL0j5zP7xhBhIkz4nQ8EsSOyAS0bKGXlUWLWGZ9L9oVKSL4AHGgm4ult5S7ogZrPnMs7iSO9nab0g==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/terrain/-/terrain-3.4.4.tgz",
+      "integrity": "sha512-IXX9uBlhRaehKMkFBmIclbexygTkRtDXTGg1r5p+SOITTnt1QYCM2J2q49Fntpi19reyVl9n+DzA81Pb8YeNLg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
         "@mapbox/martini": "^0.2.0"
       }
     },
     "@loaders.gl/textures": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.3.1.tgz",
-      "integrity": "sha512-LjWprbSPTPvL+pnKKxqTVs1vuzysj8JJDMI374wSs2EQIBkxWgACjitR0+E7+DZ4qId1DtRmhW+L7x0SflekaA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-3.4.4.tgz",
+      "integrity": "sha512-CD1CPKvXJy3TzzCq42xpwrpYdjimJ7bKf5GSwDs2+qx/fZDnmJBk9z/762VzXyUwTpgGFk3XzbEwkP6H4vkESg==",
       "requires": {
-        "@loaders.gl/images": "3.3.1",
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/schema": "3.3.1",
-        "@loaders.gl/worker-utils": "3.3.1",
+        "@loaders.gl/images": "3.4.4",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/schema": "3.4.4",
+        "@loaders.gl/worker-utils": "3.4.4",
         "ktx-parse": "^0.0.4",
         "texture-compressor": "^1.0.2"
       }
     },
     "@loaders.gl/tiles": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.3.1.tgz",
-      "integrity": "sha512-dcy+3sYqLZehPLn4FrnViqZskwoxJbDzbtWcrcBE313GLcu+k0E1B+eZss0xwWfb89TltZqfugBVIUd/LW41FA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/tiles/-/tiles-3.4.4.tgz",
+      "integrity": "sha512-Z2doHX4+9RTDpQZJ2EHqxcwXxvqWkJoD8i4wh/DvSZgp9Ccot4L7wb907gHyYvDZ3lzQc0mx7LVcC6BBNvKS8w==",
       "requires": {
-        "@loaders.gl/loader-utils": "3.3.1",
-        "@loaders.gl/math": "3.3.1",
+        "@loaders.gl/loader-utils": "3.4.4",
+        "@loaders.gl/math": "3.4.4",
         "@math.gl/core": "^3.5.1",
         "@math.gl/culling": "^3.5.1",
         "@math.gl/geospatial": "^3.5.1",
         "@math.gl/web-mercator": "^3.5.1",
-        "@probe.gl/stats": "^3.5.0"
+        "@probe.gl/stats": "^4.0.1"
+      },
+      "dependencies": {
+        "@probe.gl/stats": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@probe.gl/stats/-/stats-4.0.4.tgz",
+          "integrity": "sha512-SDuSY/D4yDL6LQDa69l/GCcnZLRiGYdyvYkxWb0CgnzTPdPrcdrzGkzkvpC3zsA4fEFw2smlDje370QGHwlisg==",
+          "requires": {
+            "@babel/runtime": "^7.0.0"
+          }
+        }
       }
     },
     "@loaders.gl/worker-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.3.1.tgz",
-      "integrity": "sha512-r1u358xZEMKUsv7gOabmc6fA6knWArYU0BqeWOaJHyN/72ESuDZrzjtk+Adux9rIJLlxrMHLq/o/WCsO1tmrYw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-3.4.4.tgz",
+      "integrity": "sha512-ltqMd+BsAk3QGPLycZODukL1wNyBEb04X6wpI3rC5NWByzwSippwWTW4g4QnS3Q9zgMFV4jR/YV6CRp/GiVzvQ==",
       "requires": {
         "@babel/runtime": "^7.3.1"
       }
     },
     "@luma.gl/constants": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.19.tgz",
-      "integrity": "sha512-TNbONy1CQXCZ5+VOAiLh6G9wvvSwMgZxJJtbubhCgkHeR7Up+iTql6gaOF5qIX0SuQbltp7jvB5U5uEml2zUKg=="
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.20.tgz",
+      "integrity": "sha512-5yG+ybkUZ4j6kLPWMZjN4Hun2yLB0MyEpNCRKAUN9/yS9UIWA7unyVxjSf2vnE7k/7dywtxlbXegASNFgNVGxw=="
     },
     "@luma.gl/core": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.19.tgz",
-      "integrity": "sha512-AfJNOrj4rEb/CJObxPUi8Ywe3z4sHzBkndRTWd01te4x7i9/0wjN/iuMMEyr/2OyHTMr/iMbh7ePwisExYhRQw==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-8.5.20.tgz",
+      "integrity": "sha512-xJr96G6vhYcznYHC84fbeOG3fgNM4lFwj9bd0VPcg/Kfe8otUeN1Hl0AKHCCtNn48PiMSg3LKbaiRfNUMhaffQ==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
-        "@luma.gl/engine": "8.5.19",
-        "@luma.gl/gltools": "8.5.19",
-        "@luma.gl/shadertools": "8.5.19",
-        "@luma.gl/webgl": "8.5.19"
+        "@luma.gl/constants": "8.5.20",
+        "@luma.gl/engine": "8.5.20",
+        "@luma.gl/gltools": "8.5.20",
+        "@luma.gl/shadertools": "8.5.20",
+        "@luma.gl/webgl": "8.5.20"
       }
     },
     "@luma.gl/engine": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.19.tgz",
-      "integrity": "sha512-QlyTUTKcrRZ8qclloH9dldGeBN7SY8qPwtt7g6bTrsRMWQjdAQVfGtjJUkqxV2qIEEOSIdU07t5xFYCEES2M/w==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-8.5.20.tgz",
+      "integrity": "sha512-+0ryJ/4gL1pWaEgZimY21jUPt1LYiO6Cqte8TNUprCfAHoAStsuzD7jwgEqnM6jJOUEdIxQ3w0z3Dzw/0KIE+w==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
-        "@luma.gl/gltools": "8.5.19",
-        "@luma.gl/shadertools": "8.5.19",
-        "@luma.gl/webgl": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
+        "@luma.gl/gltools": "8.5.20",
+        "@luma.gl/shadertools": "8.5.20",
+        "@luma.gl/webgl": "8.5.20",
         "@math.gl/core": "^3.5.0",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/stats": "^3.5.0",
@@ -56100,44 +56390,44 @@
       }
     },
     "@luma.gl/experimental": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.19.tgz",
-      "integrity": "sha512-shsql6mD3Ta7S1fghxvuE2ETtB5uo36TOzkhBLhZdnifOQJFKF7tcKSP0DQ5o+XfiySgSDtAEgRhbhpMe8aGBg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/experimental/-/experimental-8.5.20.tgz",
+      "integrity": "sha512-V1Jp68rYMPtwMdf+50r3NSYsGV3srjwZ+lcK2ew4DshjedDbYwLqTGMWcOyBhY3K3aCl2LH3Fhn0hAY+3NTLGA==",
       "requires": {
-        "@luma.gl/constants": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
         "@math.gl/core": "^3.5.0",
         "earcut": "^2.0.6"
       }
     },
     "@luma.gl/gltools": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.19.tgz",
-      "integrity": "sha512-ZeoJntgvkhf3kP88EqvwKkkQhc76ozY1iu6etyVoBv0GwXJQ6z9IF3jH+iTlOq3VW0jGb5u7RaRLh6aTowSwHQ==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltools/-/gltools-8.5.20.tgz",
+      "integrity": "sha512-5pP6ph9FSX5gHiVWQM1DmYRUnriklzKUG9yaqlQsKEqCFsOcKB0EfK3MfBVXIfsOdP/1bJZ9Dlz/zV19soWVhg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/log": "^3.5.0",
         "@types/offscreencanvas": "^2019.7.0"
       }
     },
     "@luma.gl/shadertools": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.19.tgz",
-      "integrity": "sha512-Jn/gCAagMA9Rl4/AtKrdghRwWT8dCO2XBGI+WE5HPZPP2anTzN7DgDxUwKf+vEH8fFNOsr+jLdUXubIrRU3vTw==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-8.5.20.tgz",
+      "integrity": "sha512-q1lrCZy1ncIFb4mMjsYgISLzNP6eMnhLUY+Oltj/qjAMcPEssCeHN2+XGfP/CVtU+O7sC+5JY2bQGaTs6HQ/Qw==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@math.gl/core": "^3.5.0"
       }
     },
     "@luma.gl/webgl": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.19.tgz",
-      "integrity": "sha512-WzLYAujxYKpBN9fXgxeAR4Ww4+p9Z+bMNGZe4Ya8glWDVWimDuAEPtM9AkJrQ36c5RHEQLOQdsAIrsEzN7teIg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-8.5.20.tgz",
+      "integrity": "sha512-p/kt9KztywH4l+09XHoZ4cPFOoE7xlZXIBMT8rxRVgfe1w0lvi7QYh4tOG7gk+iixQ34EyDQacoHCsabdpmqQg==",
       "requires": {
         "@babel/runtime": "^7.0.0",
-        "@luma.gl/constants": "8.5.19",
-        "@luma.gl/gltools": "8.5.19",
+        "@luma.gl/constants": "8.5.20",
+        "@luma.gl/gltools": "8.5.20",
         "@probe.gl/env": "^3.5.0",
         "@probe.gl/stats": "^3.5.0"
       }
@@ -56184,17 +56474,12 @@
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ=="
     },
     "@mapbox/tile-cover": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/tile-cover/-/tile-cover-3.0.2.tgz",
-      "integrity": "sha512-A6qvtttsYI66BYi8JMD0v7BzxeuXJf6qSzufmdvvYxDJyXqATZ7ig6OKHFCW7/OsUjpfFu3rB54JM/yHUOVB9g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tile-cover/-/tile-cover-3.0.1.tgz",
+      "integrity": "sha512-R8aoFY/87HWBOL9E2eBqzOY2lpfWYXCcTNgBpIxAv67rqQeD4IfnHD0iPXg/Z1cqXrklegEYZCp/7ZR/RsWqBQ==",
       "requires": {
-        "@mapbox/tilebelt": "^1.0.1"
+        "tilebelt": "^1.0.1"
       }
-    },
-    "@mapbox/tilebelt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/tilebelt/-/tilebelt-1.0.2.tgz",
-      "integrity": "sha512-tGJN2VIgWrXqBTPIxFVklklIpcy6ss8W5ouq+cjNLXPXFraRaDR4Ice+5Q8/uLX+6aH23lWBMydOIn8PcdVcpA=="
     },
     "@mapbox/tiny-sdf": {
       "version": "1.2.5",
@@ -56948,9 +57233,9 @@
       "dev": true
     },
     "@petamoriken/float16": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.0.tgz",
-      "integrity": "sha512-AhVAm6SQ+zgxIiOzwVdUcDmKlu/qU39FiYD2UD6kQQaVenrn0dGZewIghWAENGQsvC+1avLCuT+T2/3Gsp/W3w=="
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.1.tgz",
+      "integrity": "sha512-oj3dU9kuMy8AqrreIboVh3KCJGSQO5T+dJ8JQFl369961jTWvPLP1GIlLy0FVoWehXLoI9BXygu/yzuNiIHBlg=="
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.4.3",
@@ -66019,9 +66304,17 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.186",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.186.tgz",
-      "integrity": "sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw=="
+      "version": "4.14.195",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
+      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
+    },
+    "@types/lodash-es": {
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.7.tgz",
+      "integrity": "sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==",
+      "requires": {
+        "@types/lodash": "*"
+      }
     },
     "@types/lodash.get": {
       "version": "4.4.5",
@@ -66032,9 +66325,9 @@
       }
     },
     "@types/mapbox-gl": {
-      "version": "2.7.10",
-      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.10.tgz",
-      "integrity": "sha512-nMVEcu9bAcenvx6oPWubQSPevsekByjOfKjlkr+8P91vawtkxTnopDoXXq1Qn/f4cg3zt0Z2W9DVsVsKRNXJTw==",
+      "version": "2.7.11",
+      "resolved": "https://registry.npmjs.org/@types/mapbox-gl/-/mapbox-gl-2.7.11.tgz",
+      "integrity": "sha512-4vSwPSTQIawZTFRiTY2R74aZwAiM9gE6KGj871xdyAPpa+DmEObXxQQXqL2PsMH31/rP9nxJ2Kv0boeTVJMXVw==",
       "requires": {
         "@types/geojson": "*"
       }
@@ -66295,6 +66588,11 @@
       "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
       "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
+    "@types/semver": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw=="
+    },
     "@types/set-cookie-parser": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.2.tgz",
@@ -66357,6 +66655,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
+    },
+    "@types/uuid": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
+      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ=="
     },
     "@types/vfile-message": {
       "version": "2.0.0",
@@ -66669,59 +66972,63 @@
       }
     },
     "@vitessce/all": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/all/-/all-2.0.3.tgz",
-      "integrity": "sha512-JO35nEcUXsXvNxkGvu4hmbZkEn4+geLi3V+IbSF/OKDi2jFM72GBAcrVgaK0JaGenoFhNeUh07/2oukb6v6EVg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/all/-/all-3.0.0.tgz",
+      "integrity": "sha512-rpLv8oKNKD8WrzLm0k4A3kJ4CVMfcE1aODFpAJ9EX+lM66NPZiH+KA+11PlLORvQAohK/qg7BS/rji5xIV7suA==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/csv": "2.0.3",
-        "@vitessce/description": "2.0.3",
-        "@vitessce/feature-list": "2.0.3",
-        "@vitessce/genomic-profiles": "2.0.3",
-        "@vitessce/heatmap": "2.0.3",
-        "@vitessce/json": "2.0.3",
-        "@vitessce/layer-controller": "2.0.3",
-        "@vitessce/obs-sets-manager": "2.0.3",
-        "@vitessce/scatterplot-embedding": "2.0.3",
-        "@vitessce/scatterplot-gating": "2.0.3",
-        "@vitessce/spatial": "2.0.3",
-        "@vitessce/statistical-plots": "2.0.3",
-        "@vitessce/status": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "@vitessce/zarr": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/csv": "3.0.0",
+        "@vitessce/description": "3.0.0",
+        "@vitessce/feature-list": "3.0.0",
+        "@vitessce/genomic-profiles": "3.0.0",
+        "@vitessce/heatmap": "3.0.0",
+        "@vitessce/json": "3.0.0",
+        "@vitessce/layer-controller": "3.0.0",
+        "@vitessce/obs-sets-manager": "3.0.0",
+        "@vitessce/ome-tiff": "3.0.0",
+        "@vitessce/plugins": "3.0.0",
+        "@vitessce/scatterplot-embedding": "3.0.0",
+        "@vitessce/scatterplot-gating": "3.0.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/spatial": "3.0.0",
+        "@vitessce/statistical-plots": "3.0.0",
+        "@vitessce/status": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "@vitessce/zarr": "3.0.0",
+        "zod": "^3.21.4"
       }
     },
     "@vitessce/config": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/config/-/config-2.0.3.tgz",
-      "integrity": "sha512-/Spffx20p46DvjRqPTCTmELFSbqqDpxi1Fa9KK0s21piSjLzDGZIW0JLHDm40RTgY0brww52UsHiWKr3+L/E9g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/config/-/config-3.0.0.tgz",
+      "integrity": "sha512-P/Ot7RxPe82J/WULjx/9SrluJeVcV4e/71Pl2vMiv+ShLmf/SPTTo5DTr7Uh9qdxfLVXfyHxU6r2TyGKQN6quw==",
       "requires": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/utils": "3.0.0"
       }
     },
     "@vitessce/constants": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/constants/-/constants-2.0.3.tgz",
-      "integrity": "sha512-toQk9alwBoYLg07+wozP/2odRF6dTAdbpV/eT1FTthceEMsW2UchUBCdVhmL3W9hPykFrWU/IFLQwg71GkodNA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/constants/-/constants-3.0.0.tgz",
+      "integrity": "sha512-vI+Q9a6rxRplVSfX0V3zwYZAPMFmH6nZZvMfdNIGkmm+bONl/E+QfILIi7fcw7sQTnDVr+WmZXQ8IXkMGrov2A==",
       "requires": {
-        "@vitessce/constants-internal": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0"
       }
     },
     "@vitessce/constants-internal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/constants-internal/-/constants-internal-2.0.3.tgz",
-      "integrity": "sha512-f7RquXtnF3mf8UTjh3w88RDjSpSh8T9cv13O46RKgc3CCuQ6x1XAeIO56ERaB34hE4n0TORF0N69i5kiKiOWRg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/constants-internal/-/constants-internal-3.0.0.tgz",
+      "integrity": "sha512-DPu3yqsEUlX2413/RKKd9oYq37uTlTU/CAMY2DxXN7ZzwLK3gT/DbclKiiCiinFI38IROcofhJ008Iv6+ASC3w=="
     },
     "@vitessce/csv": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/csv/-/csv-2.0.3.tgz",
-      "integrity": "sha512-2wGgRvVhiQUaUOPbQxBdASwJ/9f8fVy5L93R64XZgqZbCRVGyGf5fY3G45Nt+uZgVziUZPSq/mhBhJB61Ec3Mg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/csv/-/csv-3.0.0.tgz",
+      "integrity": "sha512-arGM1T5vx9lXVrDyFVJhAkFq5Nr8IMTOOS6SBnrw7Y4CyobWbvhtQ9ERkJ/v/JLjngCc+v5zCS3IZsbCwoIHIw==",
       "requires": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
         "d3-dsv": "^1.1.1"
       },
@@ -66737,61 +67044,61 @@
       }
     },
     "@vitessce/description": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/description/-/description-2.0.3.tgz",
-      "integrity": "sha512-O4AVpZx1CTn0phPDaNii8/cFC1uShP41YidU+ZFZrt/xmmqt2ZghPqeEoN3HN9Qc7BqvXQJzfX49Dmxpbx4QeQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/description/-/description-3.0.0.tgz",
+      "integrity": "sha512-eBYVtq9J/KbLdcqkmpTTaAh4DEMVJ6nkVOez78Wh/BXuW6oKBxA3Krn0s9VQiRbJVXrCoU5ZQ8R3RBq4mEJmEw==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/vit-s": "2.0.3"
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/vit-s": "3.0.0"
       }
     },
     "@vitessce/export-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/export-utils/-/export-utils-2.0.3.tgz",
-      "integrity": "sha512-mN9bP4+IqBk7wYwSHw8KuEV2hfMqtUd9dMyXrAGOtZfenLWo8Zfyu0JdIMeRo6L/KryF9JPmtt4W2s654N+bCA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/export-utils/-/export-utils-3.0.0.tgz",
+      "integrity": "sha512-8JBL/kLcXrFrnpGJAz/A6xiOzDH8y/jwxz95FOA3FRH76RCtL0Rx4WDE2/5h/4RZXKOvEiDe1ccT68ZaXhjhJA==",
       "requires": {
         "bowser": "^2.11.0",
         "lz-string": "^1.4.4"
       }
     },
     "@vitessce/feature-list": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/feature-list/-/feature-list-2.0.3.tgz",
-      "integrity": "sha512-dqgWa5vsFYVV0f8gFqJB26QhNaGigzmPEdZWwkDvWIYfWlccTTXjjwEyQYw9z/lRu/dfRz0NLMItzbVywtstlg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/feature-list/-/feature-list-3.0.0.tgz",
+      "integrity": "sha512-tRIelE9sQl/tnX+8kOlMpaF++tPOL9t5vSMx78TzN/b+RdlDzlU/d98Gkmik+MICaafgIqfQcXsrnY1fonxPYA==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0",
         "react-virtualized": "^9.22.2",
-        "uuid": "^3.3.2"
+        "uuid": "^9.0.0"
       },
       "dependencies": {
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
     },
     "@vitessce/genomic-profiles": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/genomic-profiles/-/genomic-profiles-2.0.3.tgz",
-      "integrity": "sha512-twCDkV/PxbERfdNXeBZeK3ihLnaGljYht33KbXhIFkrv8ZNAUyuw+yvXDlWP/+nDVV8vcEMw3o8gEO7fYBx0UA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/genomic-profiles/-/genomic-profiles-3.0.0.tgz",
+      "integrity": "sha512-PP6sERkTBcWL94KE9knfLHPaCeBvrRe9G8C6Tl9EhUjJ1gQ78PDNjHx87BOtNdJ73ZJfR0S9/oYJ3bJ8MXsihw==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
         "higlass-no-github-deps": "1.11.13",
         "higlass-register": "^0.3.0",
         "higlass-zarr-datafetchers": "^0.2.1",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       },
       "dependencies": {
         "d3-array": {
@@ -66805,9 +67112,9 @@
       }
     },
     "@vitessce/gl": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/gl/-/gl-2.0.3.tgz",
-      "integrity": "sha512-ummv3tT0/nst+O1kDLgvy/ZG4mqQNdfDupywLaSBUU0iuaBab66geFSShwDSdcUzaNI/yCH2pL7HG0yFzVY+BQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/gl/-/gl-3.0.0.tgz",
+      "integrity": "sha512-zTuqk8aCh9LhADvGmGbOKYgKk8lO35Zqjj7B6j8q8mJsQtc5g8kkvgJrUb/NG93HzKK0J1/yerM7jgeye2ESCA==",
       "requires": {
         "@deck.gl/aggregation-layers": "~8.8.6",
         "@deck.gl/core": "~8.8.6",
@@ -66816,7 +67123,7 @@
         "@deck.gl/layers": "~8.8.6",
         "@deck.gl/mesh-layers": "~8.8.6",
         "@deck.gl/react": "~8.8.6",
-        "@hms-dbmi/viv": "~0.13.6",
+        "@hms-dbmi/viv": "~0.13.7",
         "@loaders.gl/3d-tiles": "^3.0.0",
         "@loaders.gl/core": "^3.0.0",
         "@loaders.gl/images": "^3.0.0",
@@ -66838,60 +67145,62 @@
         "@turf/boolean-within": "^6.5.0",
         "@turf/centroid": "^6.5.0",
         "@turf/helpers": "^6.5.0",
-        "@vitessce/utils": "2.0.3",
+        "@vitessce/utils": "3.0.0",
         "deck.gl": "~8.8.6",
         "glslify": "^7.0.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6",
         "mathjs": "^9.2.0",
         "nebula.gl": "0.23.8"
       }
     },
     "@vitessce/heatmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/heatmap/-/heatmap-2.0.3.tgz",
-      "integrity": "sha512-vnS/0WWE2YrPM2riVN71674I/k8uZ8lrGpd3ciRbvzTy77LGeg1hhGPhqsq6I6ftYk0eXPdHwH52iwFXjFhG7g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/heatmap/-/heatmap-3.0.0.tgz",
+      "integrity": "sha512-yKM0q5t35gCsY9j/uja7Nmp+aAPJX6/qJg8LfljzTgyi9hkirQWQv8c1J5r8IHLF3p4y7gtqLZI9YvfI3H7JTQ==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/tooltip": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "@vitessce/workers": "2.0.3",
-        "lodash": "^4.17.21",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/legend": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/tooltip": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "@vitessce/workers": "3.0.0",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0",
-        "uuid": "^3.3.2"
+        "uuid": "^9.0.0"
       },
       "dependencies": {
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
     },
     "@vitessce/icons": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/icons/-/icons-2.0.3.tgz",
-      "integrity": "sha512-GGyUvA+XhXRg1TsduGSm7V0ApNBUdiZPUfU7ytvuwwm7fPPHlnxCHl2eKhmClvBTn/Vtog+9aBIoh2qod1bqAg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/icons/-/icons-3.0.0.tgz",
+      "integrity": "sha512-VPdLerYIGvw+zYfgY+OhOLUVGBQXpBSJX3eS/g06UVlh0xWObYWArnEXTyULG0wBurYpx0nJSexrlmImVqoP1w=="
     },
     "@vitessce/json": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/json/-/json-2.0.3.tgz",
-      "integrity": "sha512-THDLtfdepl0gSjnCOK7HLhgOpLrKjBhoUfwtBBwqupjM9qpVd6XhXkhClkJUq1pyTFO8Vk2NE0jV1gkkOu4TCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/json/-/json-3.0.0.tgz",
+      "integrity": "sha512-YKbw1d1dV0EUclMl5OXSZMHvqy+6eVv7aqHt8aKR3l7nHmSEjjc6u5yA8/dRGwIUovKlRT5a/zaY2ERNNBL2Fw==",
       "requires": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "ajv": "^6.10.0",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
-        "zarr": "0.5.1"
+        "lodash-es": "^4.17.21",
+        "zarr": "0.5.1",
+        "zod": "^3.21.4"
       },
       "dependencies": {
         "d3-array": {
@@ -66905,34 +67214,97 @@
       }
     },
     "@vitessce/layer-controller": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/layer-controller/-/layer-controller-2.0.3.tgz",
-      "integrity": "sha512-KoGZf0G8mIO7FFpTC2AoRGzrsG/iKJr4H9yy885KedS0AXymrJnZR/pfZRUy6LxoVqZtdXFIfLm8TyX/wWA15Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/layer-controller/-/layer-controller-3.0.0.tgz",
+      "integrity": "sha512-lKvWIG7AuhQ7LKxNgEwuHkWvN5QEFJ7mD8DrH/ZX2qzcwInbZjUlKjfQtUXqjkfNfOSSAH00yBYW9ULgRKEpqg==",
       "requires": {
         "@material-ui/core": "~4.12.3",
         "@material-ui/icons": "~4.11.2",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "lodash": "^4.17.21",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6"
       }
     },
-    "@vitessce/obs-sets-manager": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/obs-sets-manager/-/obs-sets-manager-2.0.3.tgz",
-      "integrity": "sha512-IiUqjb0vB9eM5IUQH5aKPhqDZfZhPoHSGtqy0PxnS9ltc45xXYXahaI6jcqexd0A5HgIbhQ2Jpr3/lb1/fHo+w==",
+    "@vitessce/legend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/legend/-/legend-3.0.0.tgz",
+      "integrity": "sha512-immQCfLfRMfIKbbc1nvCvQdVRC5ES5Mhwjnaa0ClQBqSJFyhfA5+2uHVoL+I56zZovOFx3ImNsmDv2WKai7x/Q==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/icons": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/utils": "3.0.0",
+        "colormap": "^2.3.2",
+        "d3-axis": "^3.0.0",
+        "d3-color": "^1.4.0",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.3",
+        "d3-selection": "^3.0.0"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        },
+        "d3-axis": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+          "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+        },
+        "d3-interpolate": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+          "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+          "requires": {
+            "d3-color": "1 - 2"
+          }
+        },
+        "d3-scale": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+          "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+          "requires": {
+            "d3-array": "^2.3.0",
+            "d3-format": "1 - 2",
+            "d3-interpolate": "1.2.0 - 2",
+            "d3-time": "^2.1.1",
+            "d3-time-format": "2 - 3"
+          }
+        },
+        "d3-selection": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+          "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+        },
+        "d3-time": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+          "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+          "requires": {
+            "d3-array": "2"
+          }
+        }
+      }
+    },
+    "@vitessce/obs-sets-manager": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/obs-sets-manager/-/obs-sets-manager-3.0.0.tgz",
+      "integrity": "sha512-bWWHNrR1vGzlh5zmqgpDE33RaXtJ8BzmZq2Hr+uRCaOmnxSogfZ+96HoguqNO556nRl6xrg6ekHr92vyJb49cA==",
+      "requires": {
+        "@material-ui/core": "~4.12.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/icons": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "rc-tooltip": "^5.2.2",
         "rc-tree": "2.1.0",
         "react-color-with-lodash": "^2.19.5"
@@ -66973,9 +67345,9 @@
           }
         },
         "rc-util": {
-          "version": "5.29.2",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.29.2.tgz",
-          "integrity": "sha512-xHT9Dr3RD6tyvCibnH10l3mudC6TJjWNr9UDy3CrOGZqTY354OfdwP87ahKNe0b3A1dsysDldvx0SBuswhlOeA==",
+          "version": "5.33.0",
+          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.33.0.tgz",
+          "integrity": "sha512-mq2NkEAnHklq4fgU/JqjiE0PS8+8u33gEWw2bDUNDPck3OroPpSgw/8oEyuFrvPgaZEmt9BgQdh59JfQt2cU+w==",
           "requires": {
             "@babel/runtime": "^7.18.3",
             "react-is": "^16.12.0"
@@ -66983,22 +67355,57 @@
         }
       }
     },
+    "@vitessce/ome-tiff": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/ome-tiff/-/ome-tiff-3.0.0.tgz",
+      "integrity": "sha512-i7R8QrPBymCIl0sbZU79fGPzAk05PTNGWjg3vLmRk3Sh+E8n9580zzgTVUFrTZYol5kKM8jak4ss9BCo2JZIYQ==",
+      "requires": {
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
+        "ajv": "^6.10.0",
+        "d3-array": "^2.4.0",
+        "lodash-es": "^4.17.21"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "requires": {
+            "internmap": "^1.0.0"
+          }
+        }
+      }
+    },
+    "@vitessce/plugins": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/plugins/-/plugins-3.0.0.tgz",
+      "integrity": "sha512-IgIWdaF1WCacbEiQcmCftzfGFCqkso0qkN1kCD0abvDXxwiY1AcJMj6NDZdyMqNZmtKVn6WxoqPmnwf9bO1d0g==",
+      "requires": {
+        "zod": "^3.21.4"
+      }
+    },
     "@vitessce/scatterplot": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot/-/scatterplot-2.0.3.tgz",
-      "integrity": "sha512-a0MbUO4ZpHnDEkxsFYeghgoaGkrKFVgiPyDGiqixBs+bMI39ODPNX9d0caUBcnpKlKfWasu58r9s5FMvtvcXtg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot/-/scatterplot-3.0.0.tgz",
+      "integrity": "sha512-GyksFiJPCy55kfzDpB8CSgdUhtbsVvZQehmmrxGKGQs28cjlTp0tLMoSC4/RzS6+7JRjpBZucJHxJftTkxl9Jw==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/icons": "2.0.3",
-        "@vitessce/tooltip": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@material-ui/icons": "~4.11.2",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/icons": "3.0.0",
+        "@vitessce/tooltip": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1",
         "d3-force": "^2.1.1",
         "d3-quadtree": "^1.0.7",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       },
       "dependencies": {
         "d3-force": {
@@ -67014,18 +67421,19 @@
       }
     },
     "@vitessce/scatterplot-embedding": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-embedding/-/scatterplot-embedding-2.0.3.tgz",
-      "integrity": "sha512-G9kQ2GwbFjVvIuZo6VDlp6dRyJd/wghu0cGgIADJ2KYJfT2YcuIvo6qEZozomMCGnxTSrTAKdlhPGLZ8CfoNiQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-embedding/-/scatterplot-embedding-3.0.0.tgz",
+      "integrity": "sha512-OkKOf8VsepVKmS2plrduMvNOrDQR3Hy5WZKMNbCn/XxiPWcjhK+syKUQcAW5XiJMavspZdOpjdlmb1YBIieXCw==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/scatterplot": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/legend": "3.0.0",
+        "@vitessce/scatterplot": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0"
       },
       "dependencies": {
@@ -67040,18 +67448,18 @@
       }
     },
     "@vitessce/scatterplot-gating": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-gating/-/scatterplot-gating-2.0.3.tgz",
-      "integrity": "sha512-7nCM1Iby2CRG819gvFRXnUTtZo7w/mu7K9+FDOYHbqL0AK0omuPak7cvxToiOx2K/QW4KnU1DR7n2dxd/7Wg/A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/scatterplot-gating/-/scatterplot-gating-3.0.0.tgz",
+      "integrity": "sha512-/NrGdseRgNyhvYXJTK9hshED+pOG5TbebSeLbmuuZRtQCIrZ/Jm9g9TGWW8be/TB+3bG53cQZKQ7cRBG/4CPkg==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/scatterplot": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/scatterplot": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "plur": "^5.1.0"
       },
       "dependencies": {
@@ -67065,23 +67473,56 @@
         }
       }
     },
+    "@vitessce/schemas": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/schemas/-/schemas-3.0.0.tgz",
+      "integrity": "sha512-DeASD3zcXXTyk3P63AXVqvgI3vUaTobZAI5sCRZXPnlsBWMp7iXj/dsNjU63XdHXAUj5drk23ex6M8wU/uDQvw==",
+      "requires": {
+        "@types/lodash": "^4.14.191",
+        "@types/lodash-es": "^4.17.7",
+        "@types/semver": "^7.3.13",
+        "@types/uuid": "^9.0.1",
+        "@vitessce/constants": "3.0.0",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/plugins": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "lodash-es": "^4.17.21",
+        "semver": "^7.3.8",
+        "uuid": "^9.0.0",
+        "zod": "^3.21.4"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.5.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
+          "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "uuid": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
+        }
+      }
+    },
     "@vitessce/sets-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/sets-utils/-/sets-utils-2.0.3.tgz",
-      "integrity": "sha512-Mg1EO7BlfkZ2sF7N3HP8RiYNyyKWrm3+vqFgsB2vNkLC/PIrsR1mK5f180zovtYWnhpMs8JL/j9EOGep9niguQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/sets-utils/-/sets-utils-3.0.0.tgz",
+      "integrity": "sha512-fbECoQibQDN4dxXXdbPPTum/GCm7S6jTdCZDlrSPzebJP/qDuFk00c0Y0C7ZYrUsTh+tK7OHt4L4CD6CvC9S4A==",
       "requires": {
         "@turf/centroid": "^6.5.0",
         "@turf/helpers": "^6.5.0",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
-        "ajv": "^6.10.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/utils": "3.0.0",
         "concaveman": "^1.2.1",
         "d3-dsv": "^1.1.1",
         "internmap": "^2.0.3",
         "json2csv": "^5.0.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "tinycolor2": "^1.4.1",
-        "uuid": "^3.3.2"
+        "uuid": "^9.0.0"
       },
       "dependencies": {
         "internmap": {
@@ -67090,28 +67531,29 @@
           "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
     },
     "@vitessce/spatial": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/spatial/-/spatial-2.0.3.tgz",
-      "integrity": "sha512-uUQMb7IDY/YycpBKELCuKyNDWhTFpT+YTNOQHnZ8ry8Mk9QNgrEGJ0nOjLmbYGC23l/Fvd64bDjTjXMmRASHmw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/spatial/-/spatial-3.0.0.tgz",
+      "integrity": "sha512-TgXGph75vdpqSKic2Xx4ZwFYqSEAA16lXTWwXPiy5ewtbmsuq0EfYAaj1fjYsmF8oQKJQeUQ3IWVXBEs14XJnw==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/scatterplot": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/tooltip": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/legend": "3.0.0",
+        "@vitessce/scatterplot": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/tooltip": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6",
         "mathjs": "^9.2.0",
         "plur": "^5.1.0",
@@ -67129,30 +67571,30 @@
       }
     },
     "@vitessce/spatial-utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/spatial-utils/-/spatial-utils-2.0.3.tgz",
-      "integrity": "sha512-/2zO3aBhgkV2owe25lrfpPLclDhDQrh6WhT6DWXexXbLgYW5Sfds0Hs86bUabJF4/pQll6M4J8m6CCHnVxJUCw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/spatial-utils/-/spatial-utils-3.0.0.tgz",
+      "integrity": "sha512-rNEun0Zwv+buCfjufLjcKKtUkVmB7GrBCfBrLc4FZ8HdTt+InlcALESTwheKc+Q8uwsBlydEn4c9bxX0sE9Gxg==",
       "requires": {
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "lodash": "^4.17.21",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "lodash-es": "^4.17.21",
         "math.gl": "^3.5.6",
         "mathjs": "^9.2.0"
       }
     },
     "@vitessce/statistical-plots": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/statistical-plots/-/statistical-plots-2.0.3.tgz",
-      "integrity": "sha512-6iAjr+2af0iqRyCt49SVNZYOgMeGf/LJEs+0LGB+BpAlK5wfl0bPRPi5i6CCV1r81FK/Z9RmM681a3mN7wEisA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/statistical-plots/-/statistical-plots-3.0.0.tgz",
+      "integrity": "sha512-2H13S7bAZzplBe60t2QHzaOdfmbgtvXqWyiMMCAk/llB+A+WmKwnA1PPkLDK+x1u+j5eXLK8eo1Zlf/lBInq9g==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vega": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vega": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       },
       "dependencies": {
         "d3-array": {
@@ -67166,42 +67608,44 @@
       }
     },
     "@vitessce/status": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/status/-/status-2.0.3.tgz",
-      "integrity": "sha512-S0QtuR2ndXh2sxv/h2RLX9d9YeoVbv6mr8vQGBoMJhjKfw0U/zla+HJjzg90cbgYkeAnk5T9jXmYwjGgvWQIfQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/status/-/status-3.0.0.tgz",
+      "integrity": "sha512-NEzT3RjMr0hvzTLzmaN3GEg3AFmrPNL+U803805veGtdyqfGqsxKnggI+y2eN4aGWXehk4YpAFHJBH5dr7YqFA==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "clsx": "^1.1.1"
       }
     },
     "@vitessce/tooltip": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/tooltip/-/tooltip-2.0.3.tgz",
-      "integrity": "sha512-RDnZAsHgefdxTV9FyvsJZB1DHfeIMJnaDA6N5UOt+qjPjgk8IrBxaqjQ6VuzgPi6dkOeEY0YM49DD4NUJGDNDA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/tooltip/-/tooltip-3.0.0.tgz",
+      "integrity": "sha512-MT0xwdOiINAh/mUMY64f8IaMErBzEwDUZU33NsLz4hVf+WUpZHT1es7s+4wwK/od8XzeqrqiQm0Le6qWAz7fNg==",
       "requires": {
         "@material-ui/core": "~4.12.3",
-        "@vitessce/vit-s": "2.0.3"
+        "@vitessce/vit-s": "3.0.0"
       }
     },
     "@vitessce/utils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/utils/-/utils-2.0.3.tgz",
-      "integrity": "sha512-JE8C1MayxEDSZhtN85Y9kKUWDudjwAExeQ+LjOZy7zJ2OO9eJE4dzCdUmIyRZYYComnf2g5e6sDhp4jt4mP/8Q==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/utils/-/utils-3.0.0.tgz",
+      "integrity": "sha512-VoI0ucFjknFRyIS8E7vwmBKV6dkeiBImmafuV7IEM7rxIQ/hd8zqg+3bgjpqSBUQRxoLyxgvrPprF/eJnkRP7A==",
       "requires": {
-        "@vitessce/sets-utils": "2.0.3",
+        "@vitessce/sets-utils": "3.0.0",
         "bowser": "^2.11.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "lz-string": "^1.4.4"
       }
     },
     "@vitessce/vega": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/vega/-/vega-2.0.3.tgz",
-      "integrity": "sha512-laSXu7nnS0s3iIU9nHamS9aqVHf/fDPAYjXqBtUnuzvvPDfn4pcF5osAJ/iMi6EJjsMLZRKmvboXOu/XCgf04A==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/vega/-/vega-3.0.0.tgz",
+      "integrity": "sha512-PKVr9qRMxpLzSmmE6Q19IxLU+9dyDfkJmvcKUIFZT+sKXk471D7e6T1DzhR2UaFV5y5mQhbWGOqCtQkv7evIPg==",
       "requires": {
         "@material-ui/core": "~4.12.3",
+        "@vitessce/tooltip": "3.0.0",
+        "clsx": "^1.1.1",
         "react-vega": "^7.4.4",
         "vega": "^5.21.0",
         "vega-lite": "^5.1.1",
@@ -67214,9 +67658,9 @@
           "integrity": "sha512-BZIU34bSYye0j/BFcPraiDZ5ka6MJADjcDVELGf7glr9K+iE8NYVjFslJFVWzskSxkLLyCrSPScE82/UUoBSvg=="
         },
         "@types/estree": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-          "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+          "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
         },
         "ansi-regex": {
           "version": "5.0.1",
@@ -67283,9 +67727,9 @@
           }
         },
         "tslib": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
-          "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
+          "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
         },
         "vega-event-selector": {
           "version": "3.0.1",
@@ -67293,18 +67737,18 @@
           "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
         },
         "vega-expression": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
-          "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.1.0.tgz",
+          "integrity": "sha512-u8Rzja/cn2PEUkhQN3zUj3REwNewTA92ExrcASNKUJPCciMkHJEjESwFYuI6DWMCq4hQElQ92iosOAtwzsSTqA==",
           "requires": {
             "@types/estree": "^1.0.0",
             "vega-util": "^1.17.1"
           }
         },
         "vega-lite": {
-          "version": "5.6.1",
-          "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.6.1.tgz",
-          "integrity": "sha512-Dij2OkJcmK+/2pIcLambjV/vWmhP11ypL3YqDVryBfJxP1m+ZgZU+8/SOEP3B2R1MhmmT7JDYQUtiNcGi1/2ig==",
+          "version": "5.9.3",
+          "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.9.3.tgz",
+          "integrity": "sha512-S1B81aOkMC/iDU2skeS7ROaIaJuxvGx1PW1LO9ECe2dsrfsaDHk20SGsEhPSKZAgSxOghJ0+AuYdU0glRNjN1Q==",
           "requires": {
             "@types/clone": "~2.1.1",
             "clone": "~2.1.2",
@@ -67312,10 +67756,10 @@
             "fast-json-stable-stringify": "~2.1.0",
             "json-stringify-pretty-compact": "~3.0.0",
             "tslib": "~2.5.0",
-            "vega-event-selector": "~3.0.0",
-            "vega-expression": "~5.0.0",
-            "vega-util": "~1.17.0",
-            "yargs": "~17.6.2"
+            "vega-event-selector": "~3.0.1",
+            "vega-expression": "~5.1.0",
+            "vega-util": "~1.17.2",
+            "yargs": "~17.7.2"
           }
         },
         "vega-tooltip": {
@@ -67327,9 +67771,9 @@
           }
         },
         "vega-util": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
-          "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
+          "version": "1.17.2",
+          "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.2.tgz",
+          "integrity": "sha512-omNmGiZBdjm/jnHjZlywyYqafscDdHaELHx1q96n5UOz/FlO9JO99P4B3jZg391EFG8dqhWjQilSf2JH6F1mIw=="
         },
         "wrap-ansi": {
           "version": "7.0.0",
@@ -67347,9 +67791,9 @@
           "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
         },
         "yargs": {
-          "version": "17.6.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "requires": {
             "cliui": "^8.0.1",
             "escalade": "^3.1.1",
@@ -67368,58 +67812,75 @@
       }
     },
     "@vitessce/vit-s": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/vit-s/-/vit-s-2.0.3.tgz",
-      "integrity": "sha512-a6WxP+uMiYlzQlgjloMqXCBM3GogZEvfTBHBrhtkDmPAYatNNmP2JRqyRpX9VtO20NRagw0e6c/sTAszFu4Efw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/vit-s/-/vit-s-3.0.0.tgz",
+      "integrity": "sha512-dEUkpX1bMrMg69TVX0btV/BNBGBWiWod4Cx2V/CzDQiB3737ypTijvsxNhc0qIRn1jy7DgcU7TrC9BxnE5UHcg==",
       "requires": {
         "@material-ui/core": "~4.12.3",
         "@material-ui/icons": "~4.11.2",
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "ajv": "^6.10.0",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/plugins": "3.0.0",
+        "@vitessce/schemas": "3.0.0",
+        "@vitessce/utils": "3.0.0",
         "clsx": "^1.1.1",
+        "d3-array": "^2.4.0",
         "fast-deep-equal": "^3.1.3",
         "internmap": "^2.0.3",
         "jss-plugin-global": "^10.9.2",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "react-grid-layout-with-lodash": "^1.3.5",
-        "uuid": "^3.3.2",
+        "uuid": "^9.0.0",
         "zustand": "^3.5.10"
       },
       "dependencies": {
+        "d3-array": {
+          "version": "2.12.1",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+          "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+          "requires": {
+            "internmap": "^1.0.0"
+          },
+          "dependencies": {
+            "internmap": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+              "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
+            }
+          }
+        },
         "internmap": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
           "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
         },
         "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
         }
       }
     },
     "@vitessce/workers": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/workers/-/workers-2.0.3.tgz",
-      "integrity": "sha512-7VPCBlEAzoQIkyZsxaxlYrjpWgK6IiwZxyyzqH+xmB+U/VSc0UFrN/zMm3mPjrGKM/MVrJYGx1ORY8HWrZECWA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/workers/-/workers-3.0.0.tgz",
+      "integrity": "sha512-n21uA5JV53Nb5OGzSuUA0JtySdFvwSN6ykQOvYJwx9zpwIRc8Enz1CE7aj2wgp59M9uvGvqlAX3f5RNC7Tx6jQ==",
       "requires": {
-        "lodash": "^4.17.21"
+        "lodash-es": "^4.17.21"
       }
     },
     "@vitessce/zarr": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@vitessce/zarr/-/zarr-2.0.3.tgz",
-      "integrity": "sha512-LlAK0QXFlW5vRg8Zaz8vF6Ms0aPT5ff8BTidRYlxPi9XxBeVAjxyLAm9GQl3axAQmwaDlM0r5mZlpAFY0kF8Cg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@vitessce/zarr/-/zarr-3.0.0.tgz",
+      "integrity": "sha512-0L3cDdYWasCGpJwv6ey+jnCqtHPHsceNuLd98UbWs66Heg3FSQ/jetbzWgrluXN5Rr6cCRKcFRpfWURV6rSQ6w==",
       "requires": {
-        "@vitessce/constants-internal": "2.0.3",
-        "@vitessce/gl": "2.0.3",
-        "@vitessce/sets-utils": "2.0.3",
-        "@vitessce/spatial-utils": "2.0.3",
-        "@vitessce/utils": "2.0.3",
-        "@vitessce/vit-s": "2.0.3",
+        "@vitessce/constants-internal": "3.0.0",
+        "@vitessce/gl": "3.0.0",
+        "@vitessce/sets-utils": "3.0.0",
+        "@vitessce/spatial-utils": "3.0.0",
+        "@vitessce/utils": "3.0.0",
+        "@vitessce/vit-s": "3.0.0",
         "d3-array": "^2.4.0",
-        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
         "zarr": "0.5.1"
       },
       "dependencies": {
@@ -67434,40 +67895,40 @@
       }
     },
     "@vivjs/constants": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/constants/-/constants-0.13.6.tgz",
-      "integrity": "sha512-nt9WMcUFgs24zVcLitvD5vcnnkephiG/6qDou16LOWPaWhODH2W/TbymOYHQp6MRoKKi3pIhIFeUxx/Ig1rUzw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/constants/-/constants-0.13.7.tgz",
+      "integrity": "sha512-YX3XkDZoHuiFFg9MwpaEMZCQR7jfB8dXwsiUbwfXLq7dcIoBlVaVnJDO3nb8gdwN+w2B3M2BiuK6aKF7BNw+zA==",
       "requires": {
         "@luma.gl/constants": "~8.5.16"
       }
     },
     "@vivjs/extensions": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/extensions/-/extensions-0.13.6.tgz",
-      "integrity": "sha512-yaz6OB3pdvMt5cJA1COnx9Vcw0zQIvfA8+/X1xxGBG87NDeQR0FY/vSMBe/nCTxcoYNFvxF8uWrXc2wWZWHWiw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/extensions/-/extensions-0.13.7.tgz",
+      "integrity": "sha512-xHtpECEeoaEFibsOgHmOTGayZbuQI5v8PAe4qgJZ4gkpRNRAPerZC3oPXuFkUFcBx4aYqQso8XuQMoIWxCIHag==",
       "requires": {
-        "@vivjs/constants": "0.13.6"
+        "@vivjs/constants": "0.13.7"
       }
     },
     "@vivjs/layers": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/layers/-/layers-0.13.6.tgz",
-      "integrity": "sha512-thNulJNyvNJFn009847mKfdP4KNBr0j4udSbIB+u7sI2uEWBXt2Wnq7xgCep0AWT5SdHNtL5IqOk8B38RPvuTA==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/layers/-/layers-0.13.7.tgz",
+      "integrity": "sha512-LOFxhnExK9nVa7429MYUbtEmSeZBUXY6G4OAP0AG91blAyDna6nLp14S1a9RYOumMli+PdVefYk4kbi7yX1OBQ==",
       "requires": {
         "@math.gl/core": "^3.5.7",
         "@math.gl/culling": "^3.5.7",
-        "@vivjs/constants": "0.13.6",
-        "@vivjs/extensions": "0.13.6",
-        "@vivjs/loaders": "0.13.6",
-        "@vivjs/types": "0.13.6"
+        "@vivjs/constants": "0.13.7",
+        "@vivjs/extensions": "0.13.7",
+        "@vivjs/loaders": "0.13.7",
+        "@vivjs/types": "0.13.7"
       }
     },
     "@vivjs/loaders": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/loaders/-/loaders-0.13.6.tgz",
-      "integrity": "sha512-9KeCQ+I1yGvX/Y06CSEoY2xniZ305zAYCkhPCzX9kjb8BiRn97ci5DVNwfr2ajtSPXRiFhn9ITlSWBm8767Pbg==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/loaders/-/loaders-0.13.7.tgz",
+      "integrity": "sha512-POzRu02oUFzWyR1sJqEZ8du6MnKqjy06bAxKvmlv/zVuIkf/w7Vgd8VFtPeoJPuR0NikWLFZOZ+M0fG+/PaweQ==",
       "requires": {
-        "@vivjs/types": "0.13.6",
+        "@vivjs/types": "0.13.7",
         "fast-xml-parser": "^3.16.0",
         "geotiff": "^2.0.5",
         "lzw-tiff-decoder": "^0.1.1",
@@ -67476,33 +67937,33 @@
       }
     },
     "@vivjs/types": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/types/-/types-0.13.6.tgz",
-      "integrity": "sha512-pp9xGA3czWxRlSOWDYbt8noCUm2MTRrOmaQzuvsGPx0fZecvL+HbEzW3zQTyxRYJJQBqgkHqXNZfLkvwGCpRQw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/types/-/types-0.13.7.tgz",
+      "integrity": "sha512-F0t80B49L8NbEG9eHW4iswSE1tUPASQM5VNVkWLqeSffGKg7YI9e4pDikx9KkwpWfNxOs673QJWzTzz6ze4YPA==",
       "requires": {
-        "@vivjs/constants": "0.13.6",
+        "@vivjs/constants": "0.13.7",
         "math.gl": "^3.5.7"
       }
     },
     "@vivjs/viewers": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/viewers/-/viewers-0.13.6.tgz",
-      "integrity": "sha512-EZ55ebDIwntZs3t1gFYhM/kqi4RF+SHgEISTmvsVOcaJuUQlczxXwzJDe3KhRFGHEariJvIpObKaU3CurwdkKw==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/viewers/-/viewers-0.13.7.tgz",
+      "integrity": "sha512-yyoxwnDLxsUSM1IPQ4NFZIfXR7U+UOeKpRcYgoX69Mh7ADbUoBNJilsbwU0Z8Y52qeI7PN3d5aPW3qoJsow3Jg==",
       "requires": {
-        "@vivjs/constants": "0.13.6",
-        "@vivjs/extensions": "0.13.6",
-        "@vivjs/views": "0.13.6",
+        "@vivjs/constants": "0.13.7",
+        "@vivjs/extensions": "0.13.7",
+        "@vivjs/views": "0.13.7",
         "fast-deep-equal": "^3.1.3"
       }
     },
     "@vivjs/views": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@vivjs/views/-/views-0.13.6.tgz",
-      "integrity": "sha512-E/ix+BB5W2zKdLcIBQkPDAePS+++kOfDlq9BNdMXyUc2yVRxgYK5Bs3TXjPWLDqPkRcG6xlBI18Ajb38iRhOAQ==",
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/@vivjs/views/-/views-0.13.7.tgz",
+      "integrity": "sha512-dUqUA/4Zqo+JiEqKcZrAuKK3NOcjQL1H9i+xlqwiMi7CLy59KV7DlS7LfcIIm4potXNZfd4945AUR96ceTSLBA==",
       "requires": {
         "@math.gl/core": "^3.5.7",
-        "@vivjs/layers": "0.13.6",
-        "@vivjs/loaders": "0.13.6",
+        "@vivjs/layers": "0.13.7",
+        "@vivjs/loaders": "0.13.7",
         "math.gl": "^3.5.7"
       }
     },
@@ -70616,6 +71077,14 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.3.0.tgz",
       "integrity": "sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==",
       "dev": true
+    },
+    "colormap": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/colormap/-/colormap-2.3.2.tgz",
+      "integrity": "sha512-jDOjaoEEmA9AgA11B/jCSAvYE95r3wRoAyTf3LEHGiUVlNHJaL1mRkf5AyLSpQBVGfTEPwGEqCIzL+kgr2WgNA==",
+      "requires": {
+        "lerp": "^1.0.3"
+      }
     },
     "colors": {
       "version": "1.4.0",
@@ -80143,6 +80612,11 @@
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
+    "lerp": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
+      "integrity": "sha512-70Rh4rCkJDvwWiTsyZ1HmJGvnyfFah4m6iTux29XmasRiZPDBpT9Cfa4ai73+uLZxnlKruUS62jj2lb11wURiA=="
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -81117,7 +81591,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -81947,9 +82420,9 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
-      "version": "0.5.42",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.42.tgz",
-      "integrity": "sha512-tjI9goqwzkflKSTxJo+jC/W8riTFwEjjunssmFvAWlvNVApjbkJM7UHggyKO0q1Fd/kZVKY77H7C9A0XKhhAFw==",
+      "version": "0.5.43",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.43.tgz",
+      "integrity": "sha512-72j3aNyuIsDxdF1i7CEgV2FfxM1r6aaqJyLB2vwb33mXYyoyLly+F1zbWqhA3/bVIoJ4szlUoMbUnVdid32NUQ==",
       "requires": {
         "moment": "^2.29.4"
       }
@@ -84103,9 +84576,9 @@
       "dev": true
     },
     "pub-sub-es": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.0.1.tgz",
-      "integrity": "sha512-KuL5i+1YdQ/o9xGCz7AsG6hb6PBUFhKNIt3NhZ6Jh/d6F3fVfURyq5fAAwxPcpJS6kkrR4vOYyzZfMpYI8sxlQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/pub-sub-es/-/pub-sub-es-2.0.2.tgz",
+      "integrity": "sha512-CQqZaKOGF6tWb+6XUGJNMHFZ308ZrgjNXTR4einx265b/L/yYKNEpcD7PkYLNq3CBV0K3qyIXSbX2Jg63ra9sw=="
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -84182,11 +84655,11 @@
       }
     },
     "quadbin": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/quadbin/-/quadbin-0.1.5.tgz",
-      "integrity": "sha512-/MQnN7V73myA+31gTxldTGN8ixqrUCXtUoDvRKSI9QZJOaq0cS9SNQkdToMxjC3ZSM2hN7mleOAn+9QVNlPZOg==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/quadbin/-/quadbin-0.1.9.tgz",
+      "integrity": "sha512-5V6m6+cL/6+uBl3hYL+CWF06rRvlHkIepYKGQjTLYaHhu9InPppql0+0ROiCaOQdz8gPNlgge3glk5Qg1mWOYw==",
       "requires": {
-        "@mapbox/tile-cover": "^3.0.2"
+        "@mapbox/tile-cover": "3.0.1"
       }
     },
     "querystring": {
@@ -84379,9 +84852,9 @@
       }
     },
     "rc-motion": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.6.3.tgz",
-      "integrity": "sha512-xFLkes3/7VL/J+ah9jJruEW/Akbx5F6jVa2wG5o/ApGKQKSOd5FR3rseHLL9+xtJg4PmCwo6/1tqhDO/T+jFHA==",
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.7.3.tgz",
+      "integrity": "sha512-2xUvo8yGHdOHeQbdI8BtBsCIrWKchEmFEIskf0nmHtJsou+meLd/JE+vnvSX2JxcBrJtXY2LuBpxAOxrbY/wMQ==",
       "requires": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
@@ -84389,9 +84862,9 @@
       },
       "dependencies": {
         "rc-util": {
-          "version": "5.29.2",
-          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.29.2.tgz",
-          "integrity": "sha512-xHT9Dr3RD6tyvCibnH10l3mudC6TJjWNr9UDy3CrOGZqTY354OfdwP87ahKNe0b3A1dsysDldvx0SBuswhlOeA==",
+          "version": "5.33.0",
+          "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.33.0.tgz",
+          "integrity": "sha512-mq2NkEAnHklq4fgU/JqjiE0PS8+8u33gEWw2bDUNDPck3OroPpSgw/8oEyuFrvPgaZEmt9BgQdh59JfQt2cU+w==",
           "requires": {
             "@babel/runtime": "^7.18.3",
             "react-is": "^16.12.0"
@@ -85717,9 +86190,9 @@
       }
     },
     "react-virtualized": {
-      "version": "9.22.3",
-      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
-      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "version": "9.22.5",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.5.tgz",
+      "integrity": "sha512-YqQMRzlVANBv1L/7r63OHa2b0ZsAaDp1UhVNEdUaXI8A5u6hTpA5NYtUueLH2rFuY/27mTGIBl7ZhqFKzw18YQ==",
       "requires": {
         "@babel/runtime": "^7.7.2",
         "clsx": "^1.0.4",
@@ -87839,9 +88312,9 @@
       "dev": true
     },
     "splaytree": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.1.tgz",
-      "integrity": "sha512-9FaQ18FF0+sZc/ieEeXHt+Jw2eSpUgUtTLDYB/HXKWvhYVyOc7h1hzkn5MMO3GPib9MmXG1go8+OsBBzs/NMww=="
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/splaytree/-/splaytree-3.1.2.tgz",
+      "integrity": "sha512-4OM2BJgC5UzrhVnnJA4BkHKGtjXNzzUfpQjCO8I05xYPsfS/VuQDwjCGGMi8rYQilHEV4j8NBqTFbls/PZEE7A=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -88620,6 +89093,11 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "tilebelt": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tilebelt/-/tilebelt-1.0.1.tgz",
+      "integrity": "sha512-cxHzpa5JgsugY9NUVRH43gPaGJw/29LecAn4X7UGOP64+kB8pU4VQ3bIhSyfb5Mk4jDxwl3yk330L/EIhbJ5aw=="
     },
     "timers-browserify": {
       "version": "2.0.11",
@@ -90599,14 +91077,14 @@
       }
     },
     "vitessce": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-2.0.3.tgz",
-      "integrity": "sha512-tOy7rU68JabkAQN8LYaCG3CLWtEOJxdbraJQnHr72CLxtctrXzwF8jYtXbNixdf7ZWZg/V3smaT1p5iKOAQauw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/vitessce/-/vitessce-3.0.0.tgz",
+      "integrity": "sha512-tfHSK5xZM9KYeu+/f+a02g4b7VL7E3pOmWTSxSd59svIxRJ9zTk2jadO6rMhJMG3sVqTVVSAiy93FNReX0FkJw==",
       "requires": {
-        "@vitessce/all": "2.0.3",
-        "@vitessce/config": "2.0.3",
-        "@vitessce/constants": "2.0.3",
-        "@vitessce/export-utils": "2.0.3"
+        "@vitessce/all": "3.0.0",
+        "@vitessce/config": "3.0.0",
+        "@vitessce/constants": "3.0.0",
+        "@vitessce/export-utils": "3.0.0"
       }
     },
     "vkbeautify": {
@@ -91591,9 +92069,9 @@
       "dev": true
     },
     "xml-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.3.0.tgz",
-      "integrity": "sha512-i4PIrX33Wd66dvwo4syicwlwmnr6wuvvn4f2ku9hA67C2Uk62Xubczuhct+Evnd12/DV71qKNeDdJwES8HX1RA=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
+      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw=="
     },
     "xmlbuilder": {
       "version": "10.1.1",
@@ -91634,8 +92112,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",
@@ -91804,6 +92281,11 @@
         "numcodecs": "^0.2.1",
         "p-queue": "6.2.0"
       }
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     },
     "zustand": {
       "version": "3.7.2",

--- a/context/package.json
+++ b/context/package.json
@@ -66,7 +66,7 @@
     "uuid": "^8.3.2",
     "vega": "^5.17.3",
     "vega-lite": "^4.13.1",
-    "vitessce": "^2.0.3",
+    "vitessce": "^3.0.0",
     "web-vitals": "^1.1.0",
     "whatwg-fetch": "^3.0.0",
     "yup": "^0.32.11",


### PR DESCRIPTION
Fixes the bugs on the preview pages and upgrades to Vitessce v3.0.0.

The changes related to UUIDs originate from not previously having examples with more than one `<Vitessce/>` element rendered on the same HTML page.

The fixes in this PR are needed as of v3.0.0, but they are not ideal.

I am trying to remove the need for the UUID logic, hopefully in a v3.0.1:
- Removing the need for the changes related to `config.uid`: https://github.com/vitessce/vitessce/pull/1587 
- Removing the need for a `uid` prop on the `<Vitessce/>` component: https://github.com/vitessce/vitessce/pull/1596