### PR TITLE
NickAkhmetov / HMP-99 Bump portal-visualization version to 0.0.11

### DIFF
--- a/CHANGELOG-hmp-99-fix-marker-genes
+++ b/CHANGELOG-hmp-99-fix-marker-genes
@@ -1,0 +1,3 @@
+- Update portal-visualization version to 0.0.11.
+- Add automatic conversion from HUGO to ENSEMBL ID's for marker gene URL parameters.
+- Fix spatial view disconnect from other views when marker gene URL parameters are provided.

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -11,7 +11,7 @@ hubmap-api-py-client>=0.0.9
 hubmap-commons>=2.0.12
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.10.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.11.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.


### PR DESCRIPTION
This PR is to be merged in only after merge of https://github.com/hubmapconsortium/portal-visualization/pull/78 and release; I'm marking this as a draft in the meantime.

This PR bumps the version of portal-visualization to implement the fixes related to HMP-99 which were done in the scope of that version change.