### PR TITLE
John conroy/fix publication duplication HMP-140

### DIFF
--- a/CHANGELOG-fix-publication-duplication.md
+++ b/CHANGELOG-fix-publication-duplication.md
@@ -1,0 +1,1 @@
+- Fix duplication of publications as both published and pre-print.

--- a/context/app/static/js/pages/Publications/hooks.js
+++ b/context/app/static/js/pages/Publications/hooks.js
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { useSearchHits } from 'js/hooks/useSearchData';
-import { buildPublicationPanelProps } from './utils';
+import { buildPublicationsSeparatedByStatus } from './utils';
 
 const getAllPublicationsQuery = {
   post_filter: { term: { 'entity_type.keyword': 'Publication' } },
@@ -18,28 +18,7 @@ function usePublications() {
     setOpenTabIndex(newIndex);
   };
 
-  const publicationsPanelsPropsSeparatedByStatus = publications.reduce(
-    (acc, publication) => {
-      const {
-        _source: { publication_status },
-      } = publication;
-
-      if (publication_status === undefined) {
-        return acc;
-      }
-
-      const publicationProps = buildPublicationPanelProps(publication);
-
-      if (publication_status) {
-        acc.published.push(publicationProps);
-      } else {
-        acc.preprint.push(publicationProps);
-      }
-
-      return acc;
-    },
-    { published: [], preprint: [] },
-  );
+  const publicationsPanelsPropsSeparatedByStatus = buildPublicationsSeparatedByStatus(publications);
 
   return {
     publicationsPanelsPropsSeparatedByStatus,

--- a/context/app/static/js/pages/Publications/hooks.js
+++ b/context/app/static/js/pages/Publications/hooks.js
@@ -30,11 +30,11 @@ function usePublications() {
 
       const publicationProps = buildPublicationPanelProps(publication);
 
-      if (!publication_status) {
+      if (publication_status) {
+        acc.published.push(publicationProps);
+      } else {
         acc.preprint.push(publicationProps);
       }
-
-      acc.published.push(publicationProps);
 
       return acc;
     },

--- a/context/app/static/js/pages/Publications/utils.js
+++ b/context/app/static/js/pages/Publications/utils.js
@@ -29,4 +29,34 @@ function buildPublicationPanelProps(publicationHit) {
   };
 }
 
-export { buildAbbreviatedContributors, buildSecondaryText, buildPublicationPanelProps };
+function buildPublicationsSeparatedByStatus(publications) {
+  return publications.reduce(
+    (acc, publication) => {
+      const {
+        _source: { publication_status },
+      } = publication;
+
+      if (publication_status === undefined) {
+        return acc;
+      }
+
+      const publicationProps = buildPublicationPanelProps(publication);
+
+      if (publication_status) {
+        acc.published.push(publicationProps);
+      } else {
+        acc.preprint.push(publicationProps);
+      }
+
+      return acc;
+    },
+    { published: [], preprint: [] },
+  );
+}
+
+export {
+  buildAbbreviatedContributors,
+  buildSecondaryText,
+  buildPublicationPanelProps,
+  buildPublicationsSeparatedByStatus,
+};

--- a/context/app/static/js/pages/Publications/utils.spec.js
+++ b/context/app/static/js/pages/Publications/utils.spec.js
@@ -1,4 +1,9 @@
-import { buildSecondaryText, buildAbbreviatedContributors, buildPublicationPanelProps } from './utils';
+import {
+  buildSecondaryText,
+  buildAbbreviatedContributors,
+  buildPublicationPanelProps,
+  buildPublicationsSeparatedByStatus,
+} from './utils';
 
 const ash = {
   first_name: 'Ash',
@@ -19,6 +24,28 @@ const brock = {
 };
 
 const publication_venue = 'Pallet Town Times';
+
+const preprintPublicationHit = {
+  _source: {
+    uuid: 'abc123',
+    title: 'Publication ABC',
+    contributors: [ash],
+    publication_status: false,
+    publication_venue,
+    publication_date: '2022-03-02',
+  },
+};
+
+const publishedPublicationHit = {
+  _source: {
+    uuid: 'def456',
+    title: 'Publication DEF',
+    contributors: [professorOak],
+    publication_status: true,
+    publication_venue,
+    publication_date: '2022-03-02',
+  },
+};
 
 describe('buildAbbreviatedContributors', () => {
   test("should return the contributor's name if there is only a single contributor", () => {
@@ -55,22 +82,37 @@ describe('buildSecondaryText', () => {
 
 describe('buildPublicationsPanelProps', () => {
   test('should return the props require for the panel list', () => {
-    const publicationHit = {
-      _source: {
-        uuid: 'abc123',
-        title: 'Publication ABC',
-        contributors: [ash],
-        publication_venue,
-        publication_date: '2022-03-02',
-      },
-    };
-
-    expect(buildPublicationPanelProps(publicationHit)).toEqual({
+    expect(buildPublicationPanelProps(preprintPublicationHit)).toEqual({
       key: 'abc123',
       href: '/browse/publication/abc123',
       title: 'Publication ABC',
       secondaryText: 'Ash Ketchum | Pallet Town Times',
       rightText: 'Published: 2022-03-02',
+    });
+  });
+});
+
+describe('buildPublicationsSeparatedByStatus', () => {
+  test('should return sorted publications', () => {
+    expect(buildPublicationsSeparatedByStatus([preprintPublicationHit, publishedPublicationHit])).toEqual({
+      preprint: [
+        {
+          key: 'abc123',
+          href: '/browse/publication/abc123',
+          title: 'Publication ABC',
+          secondaryText: 'Ash Ketchum | Pallet Town Times',
+          rightText: 'Published: 2022-03-02',
+        },
+      ],
+      published: [
+        {
+          key: 'def456',
+          href: '/browse/publication/def456',
+          title: 'Publication DEF',
+          secondaryText: 'Professor Oak | Pallet Town Times',
+          rightText: 'Published: 2022-03-02',
+        },
+      ],
     });
   });
 });


### PR DESCRIPTION
Fix duplication of publications as both published and pre-print.

We should fetch the publications data differently instead of making one big request. Ideally we'd make an aggregations request to populate the counts published/pre-print tabs, and then separate scrolling requests for each tab. We really only expect a handful of publications in the short to medium term so I've filed an issue and will table it for now.