### PR TITLE
Nickakhmetov/HMP-113 Fix provenance table sample calculation logic

### DIFF
--- a/CHANGELOG-hmp-113-fix-provenance-table.md
+++ b/CHANGELOG-hmp-113-fix-provenance-table.md
@@ -1,0 +1,1 @@
+- Fix provenance table sample sorting calculation

--- a/context/app/static/js/components/detailPage/provenance/ProvTable/ProvTable.jsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvTable/ProvTable.jsx
@@ -31,7 +31,7 @@ function ProvTable({ uuid, ancestors, assayMetadata }) {
             {entities.length > 0 &&
               entities
                 .sort((a, b) => a.created_timestamp - b.created_timestamp)
-                .map((item, j) => (
+                .map((item, j, items) => (
                   <ProvTableTile
                     key={item.uuid}
                     uuid={item.uuid}
@@ -39,7 +39,7 @@ function ProvTable({ uuid, ancestors, assayMetadata }) {
                     entity_type={item.entity_type}
                     isCurrentEntity={uuid === item.uuid}
                     isSampleSibling={
-                      j > 0 && item.entity_type === 'Sample' && type[j - 1].sample_category === item.sample_category
+                      j > 0 && item.entity_type === 'Sample' && items[j - 1]?.sample_category === item.sample_category
                     }
                     isFirstTile={j === 0}
                     isLastTile={j === type.length - 1}


### PR DESCRIPTION
The previous `isSampleSibling` logic was using the `Sample` entity type string as the source array for `sample_category` comparison. This led to a typerror being thrown when there were more samples than the length of this string.

This PR fixes the logic to compare the current sample's `sample_category` to the previous one by using the sorted `items` from the `.map` method signature to access the previous item.

To verify fix:
- attempt to access this dataset  on prod: https://portal.hubmapconsortium.org/browse/dataset/d15a20b5c07c638e758a25bb320091e1
- attempt to access this dataset on this branch: http://localhost:5001/browse/dataset/d15a20b5c07c638e758a25bb320091e1