### PR TITLE
John conroy/remove origin sample dependencies HMP-169

### DIFF
--- a/CHANGELOG-remove-origin-sample-dependencies.md
+++ b/CHANGELOG-remove-origin-sample-dependencies.md
@@ -1,0 +1,1 @@
+- Use `origin_samples` field instead of `origin_sample` throughout.

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -110,7 +110,7 @@ def _get_entities(entity_type, constraints={}, uuids=None):
         'created_by_user_email',
     ]
     if entity_type in ['samples', 'datasets']:
-        extra_fields += ['donor.hubmap_id', 'origin_sample.mapped_organ']
+        extra_fields += ['donor.hubmap_id', 'origin_samples_unique_mapped_organs']
     if entity_type in ['samples']:
         extra_fields += ['sample_category']
     entities = client.get_entities(

--- a/context/app/static/js/components/cells/DatasetTableRow/DatasetTableRow.jsx
+++ b/context/app/static/js/components/cells/DatasetTableRow/DatasetTableRow.jsx
@@ -6,6 +6,7 @@ import ExpandableRow from 'js/shared-styles/tables/ExpandableRow';
 import ExpandableRowCell from 'js/shared-styles/tables/ExpandableRowCell';
 import CellsCharts from 'js/components/cells/CellsCharts';
 import useCellsChartLoadingStore from 'js/stores/useCellsChartLoadingStore';
+import { getOriginSamplesOrgan } from 'js/helpers/functions';
 
 const storeSelector = (state) => ({ loadingUUID: state.loadingUUID, fetchedUUIDs: state.fetchedUUIDs });
 
@@ -37,7 +38,7 @@ function MetadataCells({ donor: { mapped_metadata } }) {
 }
 
 function DatasetTableRow({ datasetMetadata, numCells, cellVariableName, minExpression, queryType, isExpandedToStart }) {
-  const { hubmap_id, uuid, origin_sample, mapped_data_types, donor, last_modified_timestamp } = datasetMetadata;
+  const { hubmap_id, uuid, mapped_data_types, donor, last_modified_timestamp } = datasetMetadata;
 
   const { loadingUUID, fetchedUUIDs } = useCellsChartLoadingStore(storeSelector);
 
@@ -61,7 +62,7 @@ function DatasetTableRow({ datasetMetadata, numCells, cellVariableName, minExpre
           {hubmap_id}
         </LightBlueLink>
       </ExpandableRowCell>
-      <ExpandableRowCell>{origin_sample.mapped_organ}</ExpandableRowCell>
+      <ExpandableRowCell>{getOriginSamplesOrgan(datasetMetadata)}</ExpandableRowCell>
       <ExpandableRowCell>{mapped_data_types.join(', ')}</ExpandableRowCell>
       <MetadataCells donor={donor} />
       <ExpandableRowCell>{format(last_modified_timestamp, 'yyyy-MM-dd')}</ExpandableRowCell>

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/hooks.js
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/hooks.js
@@ -43,7 +43,7 @@ function getSearchQuery(cellsResults) {
       'uuid',
       'hubmap_id',
       'mapped_data_types',
-      'origin_sample.mapped_organ',
+      'origin_samples_unique_mapped_organs',
       'donor',
       'last_modified_timestamp',
     ],

--- a/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
+++ b/context/app/static/js/components/cells/DatasetsTable/DatasetsTable.jsx
@@ -12,7 +12,7 @@ import { useExpandTransition } from 'js/hooks/useExpand';
 
 const columns = [
   { id: 'hubmap_id', label: 'HuBMAP ID' },
-  { id: 'origin_sample.mapped_organ', label: 'Organ' },
+  { id: 'origin_samples_unique_mapped_organs', label: 'Organ' },
   { id: 'mapped_data_types', label: 'Mapped Data Types' },
   { id: 'donor.mapped_metadata.age_value', label: 'Donor Age' },
   { id: 'donor.mapped_metadata.body_mass_index_value', label: 'Donor BMI' },

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.js
@@ -15,6 +15,7 @@ function getFieldFromHitFields(hitFields, identifier) {
   const matchedSamplePath = matchSamplePath(identifier);
   if (matchedSamplePath.length > 0) {
     // source_samples and origin_samples are arrays and must be handled accordingly.
+    // TODO: Update design to reflect samples and datasets which have multiple origin samples with different organs.
     return get(hitFields, [matchedSamplePath, '0', ...identifier.split('.').slice(1)]);
   }
 

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.js
@@ -1,12 +1,21 @@
 import get from 'lodash/get';
 
-import { paths } from 'js/components/entity-search/SearchWrapper/metadataDocumentPaths';
+const samplePaths = ['origin_samples', 'source_samples'];
+
+function matchSamplePath(fieldIdentifier) {
+  return samplePaths.reduce((matchedPath, path) => {
+    if (fieldIdentifier.startsWith(path)) {
+      return path;
+    }
+    return matchedPath;
+  }, '');
+}
 
 function getFieldFromHitFields(hitFields, identifier) {
-  const datasetSamplePath = paths.dataset.sample;
-  if (identifier.startsWith(datasetSamplePath)) {
-    // Unlike origin_sample, source_sample is an array and cannot be accessed with lodash/get.
-    return hitFields?.source_sample?.[0].metadata?.[identifier.replace(`${datasetSamplePath}.`, '')];
+  const matchedSamplePath = matchSamplePath(identifier);
+  if (matchedSamplePath.length > 0) {
+    // source_samples and origin_samples are arrays and must be handled accordingly.
+    return get(hitFields, [matchedSamplePath, '0', identifier.replace(`${matchedSamplePath}.`, '')]);
   }
 
   return get(hitFields, identifier);

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.js
@@ -15,7 +15,7 @@ function getFieldFromHitFields(hitFields, identifier) {
   const matchedSamplePath = matchSamplePath(identifier);
   if (matchedSamplePath.length > 0) {
     // source_samples and origin_samples are arrays and must be handled accordingly.
-    return get(hitFields, [matchedSamplePath, '0', identifier.replace(`${matchedSamplePath}.`, '')]);
+    return get(hitFields, [matchedSamplePath, '0', ...identifier.split('.').slice(1)]);
   }
 
   return get(hitFields, identifier);

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.spec.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.spec.js
@@ -18,6 +18,14 @@ test('returns metadata field from source_sample', () => {
   expect(getFieldFromHitFields(hitFields, `${datasetSamplePath}.animal`)).toBe('cat');
 });
 
+test('returns top level field from source_sample', () => {
+  const hitFields = {
+    a: { b: 'c' },
+    source_samples: [{ animal: 'cat' }],
+  };
+  expect(getFieldFromHitFields(hitFields, 'source_samples.animal')).toBe('cat');
+});
+
 test('returns undefined if source_sample does not exist', () => {
   const hitFields = {
     a: { b: 'c' },

--- a/context/app/static/js/components/entity-search/ResultsTable/utils.spec.js
+++ b/context/app/static/js/components/entity-search/ResultsTable/utils.spec.js
@@ -13,7 +13,7 @@ test('returns nested non source_sample fields', () => {
 test('returns metadata field from source_sample', () => {
   const hitFields = {
     a: { b: 'c' },
-    source_sample: [{ metadata: { animal: 'cat' } }],
+    source_samples: [{ metadata: { animal: 'cat' } }],
   };
   expect(getFieldFromHitFields(hitFields, `${datasetSamplePath}.animal`)).toBe('cat');
 });
@@ -28,7 +28,7 @@ test('returns undefined if source_sample does not exist', () => {
 test('returns undefined if source_sample exists, but the field does not', () => {
   const hitFields = {
     a: { b: 'c' },
-    source_sample: [{ metadata: { animal: 'cat' } }],
+    source_samples: [{ metadata: { animal: 'cat' } }],
   };
   expect(getFieldFromHitFields(hitFields, `${datasetSamplePath}.fruit`)).toBeUndefined();
 });

--- a/context/app/static/js/components/entity-search/SearchWrapper/metadataDocumentPaths.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/metadataDocumentPaths.js
@@ -11,7 +11,7 @@ const paths = {
   },
   dataset: {
     donor: `donor.${donorMetadataPath}`,
-    sample: `source_sample.${sampleMetdataPath}`,
+    sample: `source_samples.${sampleMetdataPath}`,
     dataset: 'metadata.metadata',
   },
 };

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.js
@@ -128,7 +128,7 @@ function buildDonorFields(entityType) {
 function buildDatasetFields() {
   const tileFields = {
     ...createDatasetFacet({ fieldName: 'mapped_data_types', label: 'Data Types', type: 'string' }),
-    ...createDatasetFacet({ fieldName: 'origin_sample.mapped_organ', label: 'Organ', type: 'string' }),
+    ...createDatasetFacet({ fieldName: 'origin_samples.mapped_organ', label: 'Organ', type: 'string' }),
   };
   const tableFields = {
     ...tileFields,
@@ -139,7 +139,7 @@ function buildDatasetFields() {
 
 function buildSampleFields() {
   const tileFields = {
-    ...createSampleFacet({ fieldName: 'origin_sample.mapped_organ', label: 'Organ', type: 'string' }),
+    ...createSampleFacet({ fieldName: 'origin_samples.mapped_organ', label: 'Organ', type: 'string' }),
     ...createSampleFacet({ fieldName: 'sample_category', label: 'Sample Category', type: 'string' }),
   };
 

--- a/context/app/static/js/components/entity-search/SearchWrapper/utils.spec.js
+++ b/context/app/static/js/components/entity-search/SearchWrapper/utils.spec.js
@@ -41,7 +41,7 @@ describe('appendKeywordToFieldName', () => {
 
   test('should return the correct path for sample metadata in datasets', () => {
     expect(prependMetadataPathToFieldName({ fieldName: 'health_status', pageEntityType: 'dataset' })).toBe(
-      'source_sample.metadata.health_status',
+      'source_samples.metadata.health_status',
     );
   });
 

--- a/context/app/static/js/components/entity-tile/EntityTile/EntityTile.stories.js
+++ b/context/app/static/js/components/entity-tile/EntityTile/EntityTile.stories.js
@@ -38,7 +38,7 @@ Sample.args = {
   entityData: {
     last_modified_timestamp: Date.now(),
     sample_category: 'Sample Category',
-    origin_sample: { mapped_organ: 'Organ Type' },
+    origin_samples: [{ mapped_organ: 'Organ Type' }, { mapped_organ: 'Organ Type 2' }],
   },
   descendantCounts: { Sample: 1, Dataset: 2 },
 };
@@ -51,7 +51,7 @@ const datasetArgs = {
   entityData: {
     last_modified_timestamp: Date.now(),
 
-    origin_sample: { mapped_organ: 'Organ Type' },
+    origin_samples: [{ mapped_organ: 'Organ Type' }, { mapped_organ: 'Organ Type 2' }],
     mapped_data_types: ['Data Type 1', 'Data Type 2'],
     thumbnail_file: {
       file_uuid: 'ffff0185e2163e03da79489140fee0d1',

--- a/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.jsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.jsx
@@ -3,17 +3,17 @@ import PropTypes from 'prop-types';
 
 import Tile from 'js/shared-styles/tiles/Tile';
 import EntityTileThumbnail from 'js/components/entity-tile/EntityTileThumbnail';
+import { getOriginSamplesOrgan } from 'js/helpers/functions';
 import { Flex, StyledDiv, BodyWrapper } from './style';
 
 const thumbnailDimension = 80;
 function EntityTileBody({ entity_type, id, entityData, invertColors }) {
   const { thumbnail_file } = entityData;
-
   return (
     <BodyWrapper $thumbnailDimension={thumbnailDimension}>
       <StyledDiv>
         <Tile.Title>{id}</Tile.Title>
-        {'origin_sample' in entityData && <Tile.Text>{entityData.origin_sample.mapped_organ}</Tile.Text>}
+        {'origin_samples' in entityData && <Tile.Text>{getOriginSamplesOrgan(entityData)}</Tile.Text>}
         {'sample_category' in entityData && <Tile.Text>{entityData.sample_category}</Tile.Text>}
         {'mapped_data_types' in entityData && <Tile.Text>{entityData.mapped_data_types.join(', ')}</Tile.Text>}
         {entity_type === 'Donor' && 'mapped_metadata' in entityData && (

--- a/context/app/static/js/components/home/FacetSearch/FacetSearch.jsx
+++ b/context/app/static/js/components/home/FacetSearch/FacetSearch.jsx
@@ -11,7 +11,7 @@ import { getMatchingTerms, getAggsQuery } from './utils';
 const baseLabels = {
   'mapped_metadata.sex': 'Sex',
   'mapped_metadata.race': 'Race',
-  'origin_sample.mapped_organ': 'Organ',
+  'origin_samples.mapped_organ': 'Organ',
   sample_category: 'Sample Category',
   mapped_data_types: 'Data Type',
 };
@@ -26,7 +26,7 @@ const allLabels = {
 const donorAggsQuery = getAggsQuery('donor', ['mapped_metadata.sex', 'mapped_metadata.race'], 100);
 const sampleAggsQuery = getAggsQuery(
   'sample',
-  ['donor.mapped_metadata.sex', 'donor.mapped_metadata.race', 'origin_sample.mapped_organ', 'sample_category'],
+  ['donor.mapped_metadata.sex', 'donor.mapped_metadata.race', 'origin_samples.mapped_organ', 'sample_category'],
   100,
 );
 
@@ -35,7 +35,7 @@ const datasetAggsQuery = getAggsQuery(
   [
     'donor.mapped_metadata.sex',
     'donor.mapped_metadata.race',
-    'origin_sample.mapped_organ',
+    'origin_samples.mapped_organ',
     'source_sample.sample_category',
     'mapped_data_types',
   ],

--- a/context/app/static/js/components/home/FacetSearch/FacetSearch.jsx
+++ b/context/app/static/js/components/home/FacetSearch/FacetSearch.jsx
@@ -20,7 +20,7 @@ const allLabels = {
   ...baseLabels,
   'donor.mapped_metadata.sex': baseLabels['mapped_metadata.sex'],
   'donor.mapped_metadata.race': baseLabels['mapped_metadata.race'],
-  'source_sample.sample_category': baseLabels.sample_category,
+  'source_samples.sample_category': baseLabels.sample_category,
 };
 
 const donorAggsQuery = getAggsQuery('donor', ['mapped_metadata.sex', 'mapped_metadata.race'], 100);
@@ -36,7 +36,7 @@ const datasetAggsQuery = getAggsQuery(
     'donor.mapped_metadata.sex',
     'donor.mapped_metadata.race',
     'origin_samples.mapped_organ',
-    'source_sample.sample_category',
+    'source_samples.sample_category',
     'mapped_data_types',
   ],
   100,

--- a/context/app/static/js/components/home/HuBMAPDatasetsChart/HuBMAPDatasetsChart.jsx
+++ b/context/app/static/js/components/home/HuBMAPDatasetsChart/HuBMAPDatasetsChart.jsx
@@ -18,13 +18,13 @@ import HuBMAPDatasetsChartDropdown from '../HuBMAPDatasetsChartDropdown';
 const organTypesQuery = {
   size: 0,
   aggs: {
-    organ_types: { terms: { field: 'origin_sample.mapped_organ.keyword', size: 10000 } },
+    organ_types: { terms: { field: 'origin_samples.mapped_organ.keyword', size: 10000 } },
   },
 };
 
 const assayOrganTypesQuery = {
   query: excludeSupportEntitiesClause,
-  ...getAssayTypesCompositeAggsQuery('origin_sample.mapped_organ.keyword', 'organ_type'),
+  ...getAssayTypesCompositeAggsQuery('origin_samples.mapped_organ.keyword', 'organ_type'),
 };
 const assayDonorSexQuery = {
   query: excludeSupportEntitiesClause,
@@ -63,7 +63,7 @@ function HuBMAPDatasetsChart() {
   const colorOptions = [
     {
       dropdownLabel: { name: 'Organ Type' },
-      facetName: 'origin_sample.mapped_organ',
+      facetName: 'origin_samples.mapped_organ',
       values: organTypes,
     },
     {

--- a/context/app/static/js/components/organ/Assays/Assays.jsx
+++ b/context/app/static/js/components/organ/Assays/Assays.jsx
@@ -33,7 +33,7 @@ function Assays({ organTerms }) {
                 {
                   bool: {
                     should: organTerms.map((searchTerm) => ({
-                      term: { 'origin_sample.mapped_organ.keyword': searchTerm },
+                      term: { 'origin_samples.mapped_organ.keyword': searchTerm },
                     })),
                   },
                 },

--- a/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.jsx
+++ b/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.jsx
@@ -21,7 +21,7 @@ function OrganDatasetsChart({ search }) {
     () =>
       Object.assign(assayOrganTypesQuery, {
         query: combineQueryClauses([
-          { bool: { must: { terms: { 'origin_sample.mapped_organ.keyword': search } } } },
+          { bool: { must: { terms: { 'origin_samples.mapped_organ.keyword': search } } } },
           excludeSupportEntitiesClause,
         ]),
       }),

--- a/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.jsx
+++ b/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.jsx
@@ -14,7 +14,7 @@ import { ChartArea } from 'js/shared-styles/charts/AssayTypeBarChart/style';
 import { combineQueryClauses } from 'js/helpers/functions';
 import { excludeSupportEntitiesClause } from 'js/helpers/queries';
 
-const assayOrganTypesQuery = getAssayTypesCompositeAggsQuery('origin_sample.mapped_organ.keyword', 'organ_type');
+const assayOrganTypesQuery = getAssayTypesCompositeAggsQuery('origin_samples.mapped_organ.keyword', 'organ_type');
 
 function OrganDatasetsChart({ search }) {
   const updatedQuery = useMemo(
@@ -53,7 +53,7 @@ function OrganDatasetsChart({ search }) {
     colorScale,
     dataTypeScale,
     keys: search,
-    colorFacetName: 'origin_sample.mapped_organ',
+    colorFacetName: 'origin_samples.mapped_organ',
     margin,
     dataTypes,
   };

--- a/context/app/static/js/components/organ/Samples/Samples.jsx
+++ b/context/app/static/js/components/organ/Samples/Samples.jsx
@@ -51,7 +51,7 @@ function Samples({ organTerms }) {
             {
               bool: {
                 should: organTerms.map((searchTerm) => ({
-                  term: { 'origin_sample.mapped_organ.keyword': searchTerm },
+                  term: { 'origin_samples.mapped_organ.keyword': searchTerm },
                 })),
               },
             },

--- a/context/app/static/js/components/organ/utils.js
+++ b/context/app/static/js/components/organ/utils.js
@@ -2,7 +2,7 @@ function getSearchURL({ entityType, organTerms, assay }) {
   const query = new URLSearchParams();
   query.set('entity_type[0]', entityType);
   organTerms.forEach((term, i) => {
-    query.set(`origin_sample.mapped_organ[${i}]`, term);
+    query.set(`origin_samples.mapped_organ[${i}]`, term);
   });
   if (assay) {
     query.set('mapped_data_types[0]', assay);

--- a/context/app/static/js/components/organ/utils.spec.js
+++ b/context/app/static/js/components/organ/utils.spec.js
@@ -6,8 +6,8 @@ test('construct search url w/o assay', () => {
   expect(path).toEqual('/search');
   expect(decodeURI(query).split('&')).toEqual([
     'entity_type[0]=Whatever',
-    'origin_sample.mapped_organ[0]=Elbow+(Left)',
-    'origin_sample.mapped_organ[1]=Elbow+(Right)',
+    'origin_samples.mapped_organ[0]=Elbow+(Left)',
+    'origin_samples.mapped_organ[1]=Elbow+(Right)',
   ]);
 });
 
@@ -17,7 +17,7 @@ test('construct search url w/ assay', () => {
   expect(path).toEqual('/search');
   expect(decodeURI(query).split('&')).toEqual([
     'entity_type[0]=Whatever',
-    'origin_sample.mapped_organ[0]=Nose',
+    'origin_samples.mapped_organ[0]=Nose',
     'mapped_data_types[0]=something+FISH',
   ]);
 });

--- a/context/app/static/js/components/searchPage/ResultsTable/utils.js
+++ b/context/app/static/js/components/searchPage/ResultsTable/utils.js
@@ -1,22 +1,17 @@
-function getByPath(nested, field) {
-  const path = field.id;
-  let current = nested;
-  const pathEls = path.split('.');
-  while (pathEls.length) {
-    const nextEl = pathEls.shift();
-    if (typeof current === 'object' && nextEl in current) {
-      current = current[nextEl];
-    } else {
-      return null;
-    }
-  }
+import { getFieldFromHitFields } from 'js/components/entity-search/ResultsTable/utils';
+
+function getByPath(hitSource, field) {
+  const fieldValue = getFieldFromHitFields(hitSource, field.id);
+
   if ('translations' in field) {
-    return field.translations[current];
+    return field.translations[fieldValue];
   }
-  if (Array.isArray(current)) {
-    return current.join(' / ');
+
+  if (Array.isArray(fieldValue)) {
+    return fieldValue.join(' / ');
   }
-  return current;
+
+  return fieldValue;
 }
 
 export { getByPath };

--- a/context/app/static/js/components/searchPage/config.js
+++ b/context/app/static/js/components/searchPage/config.js
@@ -57,7 +57,7 @@ const donorConfig = {
 const sampleConfig = {
   filters: {
     'Sample Metadata': [
-      listFilter('origin_sample.mapped_organ', 'Organ'),
+      listFilter('origin_samples.mapped_organ', 'Organ'),
       listFilter('sample_category', 'Sample Category'),
     ],
     'Donor Metadata': makeDonorMetadataFilters(false),
@@ -68,7 +68,7 @@ const sampleConfig = {
       field('hubmap_id', 'HuBMAP ID'),
       field('group_name', 'Group'),
       field('sample_category', 'Sample Category'),
-      field('origin_sample.mapped_organ', 'Organ'),
+      field('origin_samples.mapped_organ', 'Organ'),
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],
     tile: sharedTileFields,
@@ -80,8 +80,8 @@ const datasetConfig = {
   filters: {
     'Dataset Metadata': [
       listFilter('mapped_data_types', 'Data Type'),
-      listFilter('origin_sample.mapped_organ', 'Organ'),
-      listFilter('source_sample.sample_category', 'Sample Category'),
+      listFilter('origin_samples.mapped_organ', 'Organ'),
+      listFilter('source_samples.sample_category', 'Sample Category'),
       hierarchicalFilter(['mapped_status', 'mapped_data_access_level'], 'Status'),
       listFilter('mapped_consortium', 'Consortium'),
     ],
@@ -93,7 +93,7 @@ const datasetConfig = {
       field('hubmap_id', 'HuBMAP ID'),
       field('group_name', 'Group'),
       field('mapped_data_types', 'Data Types'),
-      field('origin_sample.mapped_organ', 'Organ'),
+      field('origin_samples.mapped_organ', 'Organ'),
       field('mapped_status', 'Status'),
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -141,5 +141,7 @@ export function filterObjectByKeys(obj, keys) {
 }
 
 export function getOriginSamplesOrgan(entity) {
+  // Until we have multi-assay datasets, we expect there to only be one unique organ across origin samples.
+  // TODO: Update design to reflect samples and datasets which have multiple origin samples with different organs.
   return entity?.origin_samples_unique_mapped_organs?.[0];
 }

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -143,5 +143,5 @@ export function filterObjectByKeys(obj, keys) {
 export function getOriginSamplesOrgan(entity) {
   // Until we have multi-assay datasets, we expect there to only be one unique organ across origin samples.
   // TODO: Update design to reflect samples and datasets which have multiple origin samples with different organs.
-  return entity?.origin_samples_unique_mapped_organs?.[0];
+  return entity?.origin_samples?.[0]?.mapped_organ;
 }

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -139,3 +139,7 @@ export function filterObjectByKeys(obj, keys) {
       };
     }, {});
 }
+
+export function getOriginSamplesOrgan(entity) {
+  return entity?.origin_samples_unique_mapped_organs?.[0];
+}

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -95,12 +95,11 @@ function DatasetDetail({ assayMetadata, vitData, hasNotebook, visLiftedUUID }) {
     metadata,
     files,
     donor,
-    source_sample,
+    source_samples,
     uuid,
     data_types,
     mapped_data_types,
-    origin_sample,
-    origin_sample: { mapped_organ },
+    origin_samples,
     group_name,
     created_by_user_displayname,
     created_by_user_email,
@@ -120,9 +119,13 @@ function DatasetDetail({ assayMetadata, vitData, hasNotebook, visLiftedUUID }) {
   } = assayMetadata;
   const isLatest = !('next_revision_uuid' in assayMetadata);
 
+  // TODO: Update design to reflect samples and datasets which have multiple origin samples with different organs.
+  const origin_sample = origin_samples[0];
+  const { mapped_organ } = origin_sample;
+
   const combinedStatus = getCombinedDatasetStatus({ sub_status, status });
 
-  const combinedMetadata = combineMetadata(donor, origin_sample, source_sample, metadata);
+  const combinedMetadata = combineMetadata(donor, origin_sample, source_samples, metadata);
 
   const collectionsData = useDatasetsCollections([uuid]);
 

--- a/context/app/static/js/pages/Organs/hooks.js
+++ b/context/app/static/js/pages/Organs/hooks.js
@@ -8,7 +8,7 @@ const query = {
     },
   },
   aggs: {
-    'origin_sample.mapped_organ': { terms: { field: 'origin_sample.mapped_organ.keyword', size: 10000 } },
+    'origin_samples.mapped_organ': { terms: { field: 'origin_samples.mapped_organ.keyword', size: 10000 } },
   },
 };
 
@@ -40,7 +40,7 @@ function useOrgansDatasetCounts(organs) {
 
   const organsWithDatasetCounts = addDatasetCountsToOrgans(
     organs,
-    searchData.aggregations['origin_sample.mapped_organ'].buckets,
+    searchData.aggregations['origin_samples.mapped_organ'].buckets,
   );
 
   return { organsWithDatasetCounts, isLoading };

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -27,7 +27,7 @@ function SampleDetail({ assayMetadata }) {
     donor,
     protocol_url,
     sample_category,
-    origin_sample: { mapped_organ },
+    origin_samples,
     group_name,
     created_by_user_displayname,
     created_by_user_email,
@@ -40,6 +40,10 @@ function SampleDetail({ assayMetadata }) {
     rui_location,
     descendant_counts,
   } = assayMetadata;
+
+  // TODO: Update design to reflect samples and datasets which have multiple origin samples with different organs.
+  const origin_sample = origin_samples[0];
+  const { mapped_organ } = origin_sample;
 
   const combinedMetadata = combineMetadata(donor, undefined, undefined, metadata);
 

--- a/context/app/static/js/pages/entity-search/DatasetSearch/DatasetSearch.jsx
+++ b/context/app/static/js/pages/entity-search/DatasetSearch/DatasetSearch.jsx
@@ -7,8 +7,8 @@ const { tableFields } = buildDatasetFields();
 
 const facets = Object.assign(
   createDatasetFacet({ fieldName: 'mapped_data_types', label: 'Data Type', type: 'string' }),
-  createDatasetFacet({ fieldName: 'origin_sample.mapped_organ', label: 'Organ', type: 'string' }),
-  createDatasetFacet({ fieldName: 'source_sample.sample_category', label: 'Sample Category', type: 'string' }),
+  createDatasetFacet({ fieldName: 'origin_samples.mapped_organ', label: 'Organ', type: 'string' }),
+  createDatasetFacet({ fieldName: 'source_samples.sample_category', label: 'Sample Category', type: 'string' }),
   createDatasetFacet({ fieldName: 'mapped_consortium', label: 'Consortium', type: 'string' }),
   createDatasetFacet({ fieldName: 'mapped_status', label: 'Status', type: 'string' }),
   createDatasetFacet({ fieldName: 'mapped_data_access_level', label: 'Access Level', type: 'string' }),

--- a/context/app/static/js/pages/utils/entity-utils.js
+++ b/context/app/static/js/pages/utils/entity-utils.js
@@ -7,17 +7,17 @@ function prefixDonorMetadata(donor) {
   return addPrefix('donor.', donorMetadata);
 }
 
-function prefixSampleMetadata(source_sample) {
-  const sampleMetadatas = (source_sample || []).filter((sample) => sample?.metadata).map((sample) => sample.metadata);
+function prefixSampleMetadata(source_samples) {
+  const sampleMetadatas = (source_samples || []).filter((sample) => sample?.metadata).map((sample) => sample.metadata);
   return sampleMetadatas.map((sampleMetadata) => addPrefix('sample.', sampleMetadata));
 }
 
-function combineMetadata(donor, origin_sample, source_sample, metadata) {
+function combineMetadata(donor, origin_sample, source_samples, metadata) {
   const combinedMetadata = {
     ...(metadata?.metadata || {}),
     ...prefixDonorMetadata(donor),
   };
-  prefixSampleMetadata(source_sample).forEach((sampleMetadata) => {
+  prefixSampleMetadata(source_samples).forEach((sampleMetadata) => {
     Object.assign(combinedMetadata, sampleMetadata);
   });
 

--- a/context/app/static/js/pages/utils/entity-utils.spec.js
+++ b/context/app/static/js/pages/utils/entity-utils.spec.js
@@ -3,17 +3,17 @@ import { combineMetadata } from './entity-utils';
 test('robust against undefined data', () => {
   const donor = undefined;
   const origin_sample = undefined;
-  const source_sample = undefined;
+  const source_samples = undefined;
   const metadata = undefined;
-  expect(combineMetadata(donor, origin_sample, source_sample, metadata)).toEqual({});
+  expect(combineMetadata(donor, origin_sample, source_samples, metadata)).toEqual({});
 });
 
 test('robust against empty objects', () => {
   const donor = {};
   const origin_sample = {};
-  const source_sample = [];
+  const source_samples = [];
   const metadata = {};
-  expect(combineMetadata(donor, origin_sample, source_sample, metadata)).toEqual({});
+  expect(combineMetadata(donor, origin_sample, source_samples, metadata)).toEqual({});
 });
 
 test('combines appropiately structured metadata', () => {
@@ -36,7 +36,7 @@ test('combines appropiately structured metadata', () => {
     sample_category: 'Organ',
     // Currently, not seeing any metadata here, but that may change.
   };
-  const source_sample = [
+  const source_samples = [
     {
       // mapped_metadata seems to be empty.
       mapped_metadata: {},
@@ -55,7 +55,7 @@ test('combines appropiately structured metadata', () => {
       assay_type: 'PAS microscopy',
     },
   };
-  expect(combineMetadata(donor, origin_sample, source_sample, metadata)).toEqual({
+  expect(combineMetadata(donor, origin_sample, source_samples, metadata)).toEqual({
     analyte_class: 'polysaccharides',
     assay_category: 'imaging',
     assay_type: 'PAS microscopy',

--- a/context/app/static/js/schema.org.js
+++ b/context/app/static/js/schema.org.js
@@ -1,6 +1,6 @@
 function getDatasetLD(entity) {
   // Based on https://developers.google.com/search/docs/data-types/dataset#guidelines
-  const assayOrganString = `${entity.mapped_data_types} of ${entity.origin_sample.mapped_organ}`;
+  const assayOrganString = `${entity.mapped_data_types} of ${entity.origin_samples_unique_mapped_organs.join(', ')}`;
   let name = `${assayOrganString} from unknown donor`;
   let fallbackDescription = name;
 

--- a/context/app/static/js/schema.org.spec.js
+++ b/context/app/static/js/schema.org.spec.js
@@ -3,9 +3,7 @@ import { getDatasetLD } from './schema.org';
 test('full', () => {
   const entity = {
     mapped_data_types: ['Nifty Assay'],
-    origin_sample: {
-      mapped_organ: 'Elbow',
-    },
+    origin_samples_unique_mapped_organs: ['Elbow'],
     donor: {
       mapped_metadata: {
         sex: 'male',
@@ -45,9 +43,7 @@ test('full', () => {
 test('minimal, with donor', () => {
   const entity = {
     mapped_data_types: ['Nifty Assay'],
-    origin_sample: {
-      mapped_organ: 'Elbow',
-    },
+    origin_samples_unique_mapped_organs: ['Elbow'],
     donor: {
       mapped_metadata: {},
     },
@@ -77,9 +73,7 @@ test('minimal, with donor', () => {
 test('no donor', () => {
   const entity = {
     mapped_data_types: ['Nifty Assay'],
-    origin_sample: {
-      mapped_organ: 'Elbow',
-    },
+    origin_samples_unique_mapped_organs: ['Elbow'],
     created_by_user_displayname: 'Lisa',
     group_name: 'The Simpsons',
     description: 'too short :(',
@@ -99,5 +93,31 @@ test('no donor', () => {
     ],
     description: 'Nifty Assay of Elbow from unknown donor. too short :(',
     name: 'Nifty Assay of Elbow from unknown donor',
+  });
+});
+
+test('multiple organs', () => {
+  const entity = {
+    mapped_data_types: ['Nifty Assay'],
+    origin_samples_unique_mapped_organs: ['Elbow', 'Knee'],
+    created_by_user_displayname: 'Lisa',
+    group_name: 'The Simpsons',
+    description: 'too short :(',
+  };
+  expect(getDatasetLD(entity)).toEqual({
+    '@context': 'https://schema.org/',
+    '@type': 'Dataset',
+    creator: [
+      {
+        '@type': 'Person',
+        name: 'Lisa',
+      },
+      {
+        '@type': 'Organization',
+        name: 'The Simpsons',
+      },
+    ],
+    description: 'Nifty Assay of Elbow, Knee from unknown donor. too short :(',
+    name: 'Nifty Assay of Elbow, Knee from unknown donor',
   });
 });

--- a/etc/dev/organ-utils/make_organ_dir.py
+++ b/etc/dev/organ-utils/make_organ_dir.py
@@ -192,7 +192,7 @@ def get_search_response(es_url):
             "aggs": {
                 agg_name: {
                     "terms": {
-                        "field": "origin_sample.mapped_organ.keyword",
+                        "field": "origin_samples.mapped_organ.keyword",
                         "size": 100
                     }
                 }


### PR DESCRIPTION
We need to move from `origin_sample`, an object, to `origin_samples` which is an array of objects so we can remove `origin_sample` from the ES index and unblock publications. This PR and the follow-up PR #3122 are meant to change to using `origin_samples` quickly with little refactoring. This PR also moves from `source_sample` to `source_samples`, but `source_sample` was already an array of objects. 

Ideally we can get this in, perform some extensive QA, and address refactoring/updates in future PRs. In some areas of our UI (nested ES docs, icons), it is less straightforward to handle multiple `origin_samples`. I've used the first sample in the array in those cases and marked those areas with TODOs and have filed issues in an [epic](https://hms-dbmi.atlassian.net/browse/HMP-163).

A little background.

We use `origin_sample` to determine the organ for a sample or dataset. As of now all but a few of our datasets have only a single origin sample. The datasets with multiple `origin_samples` can be viewed [here](https://portal.hubmapconsortium.org/search?mapped_data_types[0]=LC-MS%20Bottom%20Up&origin_sample.mapped_organ[0]=Small%20Intestine&origin_sample.mapped_organ[1]=Large%20Intestine&entity_type[0]=Dataset). We expect more datasets with multiple `origin_samples` when we begin to ingest multi-assay datasets.

A few questions that have arisen.

- The existing datasets with multiple `origin_samples` with different organs still only have a single donor. Should we expect to handle datasets with multiple donors in the future?
- Will the `origin_samples` always be organs?
- How can we determine which datasets will have multiple organs? Assay type?

Once merged, I'll make a release and get these changes on to dev/test. Joe will then remove `origin_sample` and `source_sample` from the index and we can perform QA. 

A few areas to pay attention to when performing QA.

- The datasets table in the cells UI results.
- Both the dataset and samples search pages on the primary routes and `/test-search`. Check both the table and tiles views.
- Organs landing page, `/organ`, and organ detail pages. The aggregations counts will change slightly for small and large intestines, but otherwise the pages should remain the same. Check that once you follow the links to the search page from the organ page the correct filters are shown.
- Dataset and sample detail pages.