### PR TITLE
HMP-174 Restore `MetadataTable` props

### DIFF
--- a/CHANGELOG-hmp-174-fix-metadata-table.md
+++ b/CHANGELOG-hmp-174-fix-metadata-table.md
@@ -1,0 +1,1 @@
+- Restore metadata table display

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
@@ -49,11 +49,7 @@ function tableDataToRows(tableData) {
   );
 }
 
-function MetadataTable() {
-  const {
-    entity: { mapped_metadata: tableData = {}, hubmap_id },
-  } = useFlaskDataContext();
-
+function MetadataTable({ metadata: tableData = {}, hubmap_id }) {
   const columns = [
     { id: 'key', label: 'Key' },
     { id: 'value', label: 'Value' },

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useFlaskDataContext } from 'js/components/Contexts';
 import Paper from '@material-ui/core/Paper';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';


### PR DESCRIPTION
Following up on #3126, I was able to identify which change caused the regression we observed after @lchoy isolated the commits which it happened in; this revert should correct the display of metadata tables.

The `mapped_metadata` in flaskData did not include 

Example dataset:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/09094179-58b5-441e-a073-06ed6d238fa8)
