### PR TITLE
NickAkhmetov / Hotfix Donor Page Metadata Table

### DIFF
--- a/CHANGELOG-donor-hotfix.md
+++ b/CHANGELOG-donor-hotfix.md
@@ -1,0 +1,1 @@
+- Fix donor metadata table as well

--- a/CHANGELOG-donor-hotfix.md
+++ b/CHANGELOG-donor-hotfix.md
@@ -1,1 +1,1 @@
-- Fix donor metadata table as well
+- Fix donor metadata table display.

--- a/context/app/static/js/pages/Donor/Donor.jsx
+++ b/context/app/static/js/pages/Donor/Donor.jsx
@@ -68,7 +68,7 @@ function DonorDetail() {
           description={description}
           group_name={group_name}
         />
-        {shouldDisplaySection.metadata && <MetadataTable />}
+        {shouldDisplaySection.metadata && <MetadataTable metadata={mapped_metadata} hubmap_id={hubmap_id} />}
         <DerivedEntitiesSection sectionId="derived" />
         <ProvSection />
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} />}


### PR DESCRIPTION
This builds on to my previous hotfix for #3127 to restore metadata table functionality on the donor page after fixing it on the other browse pages.