### PR TITLE
HMP-183 Fix `entityType` TypeError blocking donor pages

### DIFF
--- a/ CHANGELOG-hmp-183-fix-donor-derived-samples.md
+++ b/ CHANGELOG-hmp-183-fix-donor-derived-samples.md
@@ -1,0 +1,1 @@
+- Fix type error on donor pages with no derived samples

--- a/ CHANGELOG-hmp-183-fix-donor-derived-samples.md
+++ b/ CHANGELOG-hmp-183-fix-donor-derived-samples.md
@@ -1,1 +1,0 @@
-- Fix type error on donor pages with no derived samples

--- a/CHANGELOG-hmp-183-fix-donor-derived-samples.md
+++ b/CHANGELOG-hmp-183-fix-donor-derived-samples.md
@@ -1,1 +1,1 @@
-- Fix type error on donor pages with no derived samples
+- Fix type error on donor pages with no derived samples.

--- a/CHANGELOG-hmp-183-fix-donor-derived-samples.md
+++ b/CHANGELOG-hmp-183-fix-donor-derived-samples.md
@@ -1,0 +1,1 @@
+- Fix type error on donor pages with no derived samples

--- a/context/app/static/js/components/detailPage/derivedEntities/DerivedEntitiesSection/DerivedEntitiesSection.jsx
+++ b/context/app/static/js/components/detailPage/derivedEntities/DerivedEntitiesSection/DerivedEntitiesSection.jsx
@@ -7,7 +7,7 @@ import { useDerivedEntitiesSection } from './hooks';
 
 function DerivedEntitiesSection() {
   const {
-    entity: { uuid, entityType },
+    entity: { uuid, entity_type: entityType },
   } = useFlaskDataContext();
   const [openIndex, setOpenIndex] = useState(0);
   const { entities, isLoading } = useDerivedEntitiesSection(uuid);


### PR DESCRIPTION
This PR fixes a minor error in variable referencing; `entityType` was undefined when referenced from flask data due to flask data variables being formatted in `snake_case` instead of `camelCase` for easy searchability between the front/back end.

# Before fix:
https://portal-prod.stage.hubmapconsortium.org/browse/donor/7adf466f027c44278e19b57fb59bacdc
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/b45d0402-3d89-4418-9dac-6d5c6b9cb714)

# After fix:
http://localhost:5001/browse/donor/7adf466f027c44278e19b57fb59bacdc
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/0dc0ab8d-f902-4aad-a44f-1d1d2db4f54c)
