### PR TITLE
John conroy/remove dataset subtypes from charts HMP-185

### DIFF
--- a/CHANGELOG-remove-non-datasets-from-datasets-charts.md
+++ b/CHANGELOG-remove-non-datasets-from-datasets-charts.md
@@ -1,0 +1,1 @@
+- Remove publications and other dataset subtypes from dataset charts.

--- a/context/app/static/js/components/home/HuBMAPDatasetsChart/HuBMAPDatasetsChart.jsx
+++ b/context/app/static/js/components/home/HuBMAPDatasetsChart/HuBMAPDatasetsChart.jsx
@@ -12,7 +12,7 @@ import {
   getDocCountScale,
 } from 'js/shared-styles/charts/AssayTypeBarChart/utils';
 import { ChartArea } from 'js/shared-styles/charts/AssayTypeBarChart/style';
-import { excludeSupportEntitiesClause } from 'js/helpers/queries';
+import { includeOnlyDatasetsClause } from 'js/helpers/queries';
 import HuBMAPDatasetsChartDropdown from '../HuBMAPDatasetsChartDropdown';
 
 const organTypesQuery = {
@@ -23,11 +23,11 @@ const organTypesQuery = {
 };
 
 const assayOrganTypesQuery = {
-  query: excludeSupportEntitiesClause,
+  query: includeOnlyDatasetsClause,
   ...getAssayTypesCompositeAggsQuery('origin_samples.mapped_organ.keyword', 'organ_type'),
 };
 const assayDonorSexQuery = {
-  query: excludeSupportEntitiesClause,
+  query: includeOnlyDatasetsClause,
   ...getAssayTypesCompositeAggsQuery('donor.mapped_metadata.sex.keyword', 'donor_sex'),
 };
 

--- a/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.jsx
+++ b/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.jsx
@@ -12,7 +12,7 @@ import {
 } from 'js/shared-styles/charts/AssayTypeBarChart/utils';
 import { ChartArea } from 'js/shared-styles/charts/AssayTypeBarChart/style';
 import { combineQueryClauses } from 'js/helpers/functions';
-import { excludeSupportEntitiesClause } from 'js/helpers/queries';
+import { includeOnlyDatasetsClause } from 'js/helpers/queries';
 
 const assayOrganTypesQuery = getAssayTypesCompositeAggsQuery('origin_samples.mapped_organ.keyword', 'organ_type');
 
@@ -22,7 +22,7 @@ function OrganDatasetsChart({ search }) {
       Object.assign(assayOrganTypesQuery, {
         query: combineQueryClauses([
           { bool: { must: { terms: { 'origin_samples.mapped_organ.keyword': search } } } },
-          excludeSupportEntitiesClause,
+          includeOnlyDatasetsClause,
         ]),
       }),
     [search],

--- a/context/app/static/js/helpers/queries.js
+++ b/context/app/static/js/helpers/queries.js
@@ -21,6 +21,16 @@ export const excludeSupportEntitiesClause = {
   },
 };
 
+export const includeOnlyDatasetsClause = {
+  bool: {
+    must: {
+      term: {
+        'entity_type.keyword': 'Dataset',
+      },
+    },
+  },
+};
+
 export function getAncestorsQuery(descendantUUID) {
   return {
     bool: {


### PR DESCRIPTION
Removes publications and other dataset subtypes from dataset charts. Also, removes the already merged changelog. I believe it wasn't cleaned up because it wasn't a markdown file?

<img width="1377" alt="Screen Shot 2023-06-20 at 1 01 38 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/8912962b-2a52-416c-80c2-b4ca5cba5022">
