### PR TITLE
John conroy/remove support files from publications HMP-175

### DIFF
--- a/CHANGELOG-hmp-99-fix-marker-genes
+++ b/CHANGELOG-hmp-99-fix-marker-genes
@@ -1,3 +1,0 @@
-- Update portal-visualization version to 0.0.11.
-- Add automatic conversion from HUGO to ENSEMBL ID's for marker gene URL parameters.
-- Fix spatial view disconnect from other views when marker gene URL parameters are provided.

--- a/CHANGELOG-remove-support-files-from-publications.md
+++ b/CHANGELOG-remove-support-files-from-publications.md
@@ -1,0 +1,1 @@
+- Remove globus link for lifted publication ancillary entities on publication pages.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -66,9 +66,7 @@ def details(type, uuid):
 
     if type == 'publication':
         publication_ancillary_data = client.get_publication_ancillary_json(entity)
-        flask_data.update({'vignette_json': publication_ancillary_data.publication_json,
-                           'vis_lifted_uuid': publication_ancillary_data.vis_lifted_uuid
-                           })
+        flask_data.update({'vignette_json': publication_ancillary_data.publication_json})
 
     template = 'base-pages/react-content.html'
     return render_template(

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -102,7 +102,7 @@ function Routes({ flaskData }) {
   if (urlPath.startsWith('/browse/publication/')) {
     return (
       <Route>
-        <Publication publication={entity} vignette_json={vignette_json} visLiftedUUID={vis_lifted_uuid} />
+        <Publication publication={entity} vignette_json={vignette_json} />
       </Route>
     );
   }

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -12,7 +12,7 @@ import useEntityStore from 'js/stores/useEntityStore';
 
 const entityStoreSelector = (state) => state.setAssayMetadata;
 
-function Publication({ publication, vignette_json, visLiftedUUID }) {
+function Publication({ publication, vignette_json }) {
   const {
     title,
     uuid,
@@ -53,7 +53,7 @@ function Publication({ publication, vignette_json, visLiftedUUID }) {
       {shouldDisplaySection.visualizations && (
         <PublicationsVisualizationSection vignette_json={vignette_json} uuid={uuid} />
       )}
-      <Files files={files} uuid={uuid} hubmap_id={hubmap_id} visLiftedUUID={visLiftedUUID} />
+      <Files files={files} uuid={uuid} hubmap_id={hubmap_id} />
       <ContributorsTable contributors={contributors} title="Authors" />
       <ProvSection uuid={uuid} assayMetadata={publication} />
     </DetailLayout>


### PR DESCRIPTION
Remove globus link for lifted publication ancillary entities on publication pages.