### PR TITLE
[Suggestion] Trim header entity names with CSS

### DIFF
--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderItem/EntityHeaderItem.jsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderItem/EntityHeaderItem.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Typography from '@material-ui/core/Typography';
 
-import { VerticalDivider } from './style';
-import { truncateText } from './utils';
+import { VerticalDivider, EntityName } from './style';
 
 function EntityHeaderItem({ text }) {
   return (
     <>
-      <Typography variant="body1">{truncateText(text)}</Typography>
+      <EntityName variant="body1">{text}</EntityName>
       <VerticalDivider orientation="vertical" flexItem />
     </>
   );

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderItem/style.js
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderItem/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import Divider from '@material-ui/core/Divider';
+import { Typography } from '@material-ui/core';
 
 const VerticalDivider = styled(Divider)`
   margin-left: ${(props) => props.theme.spacing(2)}px;
@@ -8,4 +9,12 @@ const VerticalDivider = styled(Divider)`
   align-self: center;
 `;
 
-export { VerticalDivider };
+const EntityName = styled(Typography)`
+  max-width: 50ch;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+`;
+
+export { VerticalDivider, EntityName };


### PR DESCRIPTION
This PR is meant to demonstrate that the text trim behavior is possible with CSS.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/353b5b3f-53da-4d35-8205-bf08a099164a)

My original suggestion in the other PR with `max-width: 100ch` set the upper boundary of the width too high since the `ch` unit's size is calculated from the width of the `0` character from the font in use; with non-monospaced fonts (i.e. if you're not using a coding or typewriter font), this means that spaces/narrow letters/punctuation don't "count" towards that 100 character width as much as they should.

We should still keep the `truncateText` utility/the corresponding spec, there may be other uses for it throughout the site.