### PR TITLE
NickAkhmetov / Hotfix null user groups case

### DIFF
--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -31,7 +31,7 @@ function App(props) {
   const { endpoints, globalAlertMd } = flaskData;
   delete flaskData.endpoints;
   delete flaskData.globalAlertMd;
-  const isWorkspacesUser = userGroups.includes('Workspaces') || workspacesUsers.includes(userEmail);
+  const isWorkspacesUser = userGroups?.includes('Workspaces') || workspacesUsers.includes(userEmail);
 
   return (
     <Providers


### PR DESCRIPTION
This PR fixes the white screen currently blocking site access.

Since `userGroups` has a default of `[]` in its destructuring assignment, it looks safe to do `userGroups.includes`; however, when I spun `main` up locally, I instantly ran into a type error that blocked the homepage from loading due to `userGroups`' value being `null`. As documented in the `MDN`, [the default value is not applied if the key is `null`, only if it is `undefined`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment#default_value)