### PR TITLE
NickAkhmetov/HMP-207 Fix publication header

### DIFF
--- a/CHANGELOG-hmp-207-fix-line-break.md
+++ b/CHANGELOG-hmp-207-fix-line-break.md
@@ -1,0 +1,1 @@
+- Adjust publication header to appear on one line only.

--- a/CHANGELOG-hmp-207-fix-line-break.md
+++ b/CHANGELOG-hmp-207-fix-line-break.md
@@ -1,1 +1,1 @@
-- Adjust publication header to appear on one line only.
+- Adjusted publication header to appear on one line only.

--- a/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.jsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.jsx
@@ -24,17 +24,19 @@ function SummaryData({
   children,
   mapped_external_group_name,
 }) {
+  const isPublication = entity_type === 'Publication';
+  const LeftTextContainer = isPublication ? React.Fragment : 'div';
   return (
     <>
       <SummaryTitle data-testid="entity-type">{entity_type}</SummaryTitle>
       <SpacedSectionButtonRow
         leftText={
-          <div>
+          <LeftTextContainer>
             <StyledTypography variant="h2" data-testid="entity-title">
               {title}
             </StyledTypography>
             {children && <FlexEnd data-testid="summary-data-parent">{children}</FlexEnd>}
-          </div>
+          </LeftTextContainer>
         }
         buttons={
           <FlexEnd>

--- a/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
+++ b/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
@@ -43,7 +43,7 @@ function PublicationSummary({
       >
         <SummaryItem showDivider={hasDOI}>{hubmap_id}</SummaryItem>
         {hasDOI && (
-          <SummaryItem showDivider={hasDOI}>
+          <SummaryItem showDivider={false}>
             <OutboundIconLink href={doiURL}>{doiURL}</OutboundIconLink>
           </SummaryItem>
         )}


### PR DESCRIPTION
This PR adjusts the publication header to match designs:
- The DOI no longer has a divider after it
- The header information now appears in one line if it fits; otherwise, it wraps after the DOI.
- The header change is only applied to the publication page; a refactor may be in order eventually to make the header components easier to work with.

Sample publication page:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/13f8ebac-aacf-4b34-9db3-ccb4030cc41c)

Sample publication page with wrapping on smaller viewport:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/19fdfea4-2437-4f91-8dec-a027d66ff377)

Sample dataset page (unchanged):
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/ead625b6-2785-4db9-a16b-d91307123c5f)
