### PR TITLE
HMP-225 Remove element-level white fill style

### DIFF
--- a/CHANGELOG-hmp-103-round-2.md
+++ b/CHANGELOG-hmp-103-round-2.md
@@ -1,1 +1,1 @@
-- Expanded test suite for Publication pages
+- Expand test suite for Publication pages.

--- a/CHANGELOG-hubmap-logo.md
+++ b/CHANGELOG-hubmap-logo.md
@@ -1,0 +1,1 @@
+- Restore footer HuBMAP logo visibility.

--- a/context/app/static/assets/svg/hubmap-logo.svg
+++ b/context/app/static/assets/svg/hubmap-logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 24.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-     viewBox="0 0 700 162" style="fill: white; enable-background:new 0 0 700 162;" xml:space="preserve">
+     viewBox="0 0 700 162" style="enable-background:new 0 0 700 162;" xml:space="preserve">
     <path d="M99.9,0.47v161.37H56.26V94.06H43.2v67.78H-0.44V0.47H43.2v57.71h13.06V0.47H99.9z M212.06,29.57v132.26h-42.6l0.73-10.99
         c-2.9,4.46-6.48,7.8-10.73,10.04c-4.25,2.23-9.14,3.34-14.67,3.34c-6.29,0-11.51-1.06-15.65-3.19c-4.15-2.13-7.2-4.95-9.17-8.47
         c-1.97-3.52-3.2-7.19-3.68-11.01c-0.48-3.82-0.73-11.41-0.73-22.77V29.57h41.88v90c0,10.3,0.33,16.41,0.98,18.34


### PR DESCRIPTION
This PR fixes the style of the HuBMAP SVG to remove the `fill:white` style defined on the file level. The color is now properly applied as white in the header and as purple in the footer.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/79dc3163-e5b4-4dce-8309-0018c4584c27)
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/64877d7e-8db0-49c1-8f8b-dfe5d8711294)
