### PR TITLE
John conroy/collection dataset query HMP-257

### DIFF
--- a/CHANGELOG-collection-dataset-query.md
+++ b/CHANGELOG-collection-dataset-query.md
@@ -1,0 +1,1 @@
+- Get collection datasets from separate search-api query instead of the collection es document.

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
@@ -6,29 +6,12 @@ import Typography from '@material-ui/core/Typography';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
 import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
-import {
-  lastModifiedTimestampCol,
-  organCol,
-  dataTypesCol,
-  statusCol,
-} from 'js/components/detailPage/derivedEntities/columns';
+
 import { useCollectionsDatasets } from './hooks';
 
-const columns = [
-  organCol,
-  dataTypesCol,
-  lastModifiedTimestampCol,
-  {
-    id: 'created_by_user_displayname',
-    label: 'Contact',
-    renderColumnCell: ({ created_by_user_displayname }) => created_by_user_displayname,
-  },
-  statusCol,
-];
 function CollectionDatasetsTable({ datasets }) {
-  const data = useCollectionsDatasets({
+  const { datasets: data, columns } = useCollectionsDatasets({
     ids: datasets.map((d) => d.uuid),
-    sourceFields: ['hubmap_id', 'entity_type', ...columns.map((c) => c.id)],
   });
 
   return (

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
@@ -1,31 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import format from 'date-fns/format';
 import Paper from '@material-ui/core/Paper';
-import Table from '@material-ui/core/Table';
 import Typography from '@material-ui/core/Typography';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableHead from '@material-ui/core/TableHead';
-import TableRow from '@material-ui/core/TableRow';
 
-import { StyledTableContainer, HeaderCell } from 'js/shared-styles/tables';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
+import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
+import { lastModifiedTimestampCol } from 'js/components/detailPage/derivedEntities/columns';
 import { useCollectionsDatasets } from './hooks';
-import { StyledLink } from './style';
 
+const columns = [
+  {
+    id: 'origin_samples_unique_mapped_organs',
+    label: 'Organ',
+    renderColumnCell: ({ origin_samples_unique_mapped_organs }) => origin_samples_unique_mapped_organs.join(', '),
+  },
+  {
+    id: 'mapped_data_types',
+    label: 'Assay Types',
+    renderColumnCell: ({ mapped_data_types }) => mapped_data_types.join(', '),
+  },
+  lastModifiedTimestampCol,
+  {
+    id: 'created_by_user_displayname',
+    label: 'Contact',
+    renderColumnCell: ({ created_by_user_displayname }) => created_by_user_displayname,
+  },
+  { id: 'mapped_status', label: 'Status', renderColumnCell: ({ mapped_status }) => mapped_status },
+];
 function CollectionDatasetsTable({ datasets }) {
-  const columns = [
-    { id: 'hubmap_id', label: 'HuBMAP ID' },
-    { id: 'origin_samples_unique_mapped_organs', label: 'Organ' },
-    { id: 'mapped_data_types', label: 'Assay Types' },
-    { id: 'last_modified_timestamp', label: 'Last Modified' },
-    { id: 'created_by_user_displayname', label: 'Contact' },
-    { id: 'mapped_status', label: 'Status' },
-  ];
-
-  const data = useCollectionsDatasets({ ids: datasets.map((d) => d.uuid), sourceFields: columns.map((c) => c.id) });
+  const data = useCollectionsDatasets({
+    ids: datasets.map((d) => d.uuid),
+    sourceFields: ['hubmap_id', 'entity_type', ...columns.map((c) => c.id)],
+  });
 
   return (
     <DetailPageSection id="datasets-table">
@@ -34,33 +41,7 @@ function CollectionDatasetsTable({ datasets }) {
         {datasets.length} Datasets
       </Typography>
       <Paper>
-        <StyledTableContainer>
-          <Table stickyHeader>
-            <TableHead>
-              <TableRow>
-                {columns.map((column) => (
-                  <HeaderCell key={column.id}>{column.label}</HeaderCell>
-                ))}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {data.map(({ _source: dataset }) => (
-                <TableRow key={dataset.hubmap_id}>
-                  <TableCell>
-                    <StyledLink href={`/browse/dataset/${dataset.uuid}`} variant="body2">
-                      {dataset.hubmap_id}
-                    </StyledLink>
-                  </TableCell>
-                  <TableCell>{dataset.origin_samples_unique_mapped_organs.join(' ')} </TableCell>
-                  <TableCell>{dataset.mapped_data_types}</TableCell>
-                  <TableCell>{format(dataset.last_modified_timestamp, 'yyyy-MM-dd')}</TableCell>
-                  <TableCell>{dataset.created_by_user_displayname}</TableCell>
-                  <TableCell>{dataset.mapped_status}</TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </StyledTableContainer>
+        <RelatedEntitiesTable columns={columns} entities={data} entityType="dataset" />
       </Paper>
     </DetailPageSection>
   );

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
@@ -12,17 +12,20 @@ import TableRow from '@material-ui/core/TableRow';
 import { StyledTableContainer, HeaderCell } from 'js/shared-styles/tables';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
+import { useCollectionsDatasets } from './hooks';
 import { StyledLink } from './style';
 
 function CollectionDatasetsTable({ datasets }) {
   const columns = [
     { id: 'hubmap_id', label: 'HuBMAP ID' },
-    { id: 'organ', label: 'Organ' },
-    { id: 'data_types', label: 'Assay Types' },
+    { id: 'origin_samples_unique_mapped_organs', label: 'Organ' },
+    { id: 'mapped_data_types', label: 'Assay Types' },
     { id: 'last_modified_timestamp', label: 'Last Modified' },
-    { id: 'properties.created_by_user_displayname', label: 'Contact' },
-    { id: 'status', label: 'Status' },
+    { id: 'created_by_user_displayname', label: 'Contact' },
+    { id: 'mapped_status', label: 'Status' },
   ];
+
+  const data = useCollectionsDatasets({ ids: datasets.map((d) => d.uuid), sourceFields: columns.map((c) => c.id) });
 
   return (
     <DetailPageSection id="datasets-table">
@@ -41,18 +44,18 @@ function CollectionDatasetsTable({ datasets }) {
               </TableRow>
             </TableHead>
             <TableBody>
-              {datasets.map((dataset) => (
+              {data.map(({ _source: dataset }) => (
                 <TableRow key={dataset.hubmap_id}>
                   <TableCell>
                     <StyledLink href={`/browse/dataset/${dataset.uuid}`} variant="body2">
                       {dataset.hubmap_id}
                     </StyledLink>
                   </TableCell>
-                  <TableCell />
-                  <TableCell>{dataset.data_types}</TableCell>
+                  <TableCell>{dataset.origin_samples_unique_mapped_organs.join(' ')} </TableCell>
+                  <TableCell>{dataset.mapped_data_types}</TableCell>
                   <TableCell>{format(dataset.last_modified_timestamp, 'yyyy-MM-dd')}</TableCell>
                   <TableCell>{dataset.created_by_user_displayname}</TableCell>
-                  <TableCell>{dataset.status}</TableCell>
+                  <TableCell>{dataset.mapped_status}</TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/CollectionDatasetsTable.jsx
@@ -6,27 +6,24 @@ import Typography from '@material-ui/core/Typography';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { DetailPageSection } from 'js/components/detailPage/style';
 import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
-import { lastModifiedTimestampCol } from 'js/components/detailPage/derivedEntities/columns';
+import {
+  lastModifiedTimestampCol,
+  organCol,
+  dataTypesCol,
+  statusCol,
+} from 'js/components/detailPage/derivedEntities/columns';
 import { useCollectionsDatasets } from './hooks';
 
 const columns = [
-  {
-    id: 'origin_samples_unique_mapped_organs',
-    label: 'Organ',
-    renderColumnCell: ({ origin_samples_unique_mapped_organs }) => origin_samples_unique_mapped_organs.join(', '),
-  },
-  {
-    id: 'mapped_data_types',
-    label: 'Assay Types',
-    renderColumnCell: ({ mapped_data_types }) => mapped_data_types.join(', '),
-  },
+  organCol,
+  dataTypesCol,
   lastModifiedTimestampCol,
   {
     id: 'created_by_user_displayname',
     label: 'Contact',
     renderColumnCell: ({ created_by_user_displayname }) => created_by_user_displayname,
   },
-  { id: 'mapped_status', label: 'Status', renderColumnCell: ({ mapped_status }) => mapped_status },
+  statusCol,
 ];
 function CollectionDatasetsTable({ datasets }) {
   const data = useCollectionsDatasets({

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.js
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.js
@@ -7,6 +7,7 @@ function useCollectionsDatasets({ ids, sourceFields }) {
       ...getIDsQuery(ids),
     },
     _source: sourceFields,
+    size: 10000,
   };
 
   const { searchHits: datasets } = useSearchHits(query);

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.js
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.js
@@ -1,17 +1,35 @@
 import { useSearchHits } from 'js/hooks/useSearchData';
 import { getIDsQuery } from 'js/helpers/queries';
+import {
+  lastModifiedTimestampCol,
+  organCol,
+  dataTypesCol,
+  statusCol,
+} from 'js/components/detailPage/derivedEntities/columns';
 
-function useCollectionsDatasets({ ids, sourceFields }) {
+const columns = [
+  organCol,
+  dataTypesCol,
+  lastModifiedTimestampCol,
+  {
+    id: 'created_by_user_displayname',
+    label: 'Contact',
+    renderColumnCell: ({ created_by_user_displayname }) => created_by_user_displayname,
+  },
+  statusCol,
+];
+
+function useCollectionsDatasets({ ids }) {
   const query = {
     query: {
       ...getIDsQuery(ids),
     },
-    _source: sourceFields,
+    _source: ['hubmap_id', 'entity_type', ...columns.map((c) => c.id)],
     size: 10000,
   };
 
   const { searchHits: datasets } = useSearchHits(query);
-  return datasets;
+  return { columns, datasets };
 }
 
 export { useCollectionsDatasets };

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.js
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.js
@@ -1,0 +1,16 @@
+import { useSearchHits } from 'js/hooks/useSearchData';
+import { getIDsQuery } from 'js/helpers/queries';
+
+function useCollectionsDatasets({ ids, sourceFields }) {
+  const query = {
+    query: {
+      ...getIDsQuery(ids),
+    },
+    _source: sourceFields,
+  };
+
+  const { searchHits: datasets } = useSearchHits(query);
+  return datasets;
+}
+
+export { useCollectionsDatasets };

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/style.js
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/style.js
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-import Link from '@material-ui/core/Link';
-
-const StyledLink = styled(Link)`
-  color: ${(props) => props.theme.palette.info.main};
-`;
-
-export { StyledLink };

--- a/context/app/static/js/components/detailPage/derivedEntities/columns.js
+++ b/context/app/static/js/components/detailPage/derivedEntities/columns.js
@@ -12,28 +12,6 @@ const lastModifiedTimestampCol = {
   renderColumnCell: ({ last_modified_timestamp }) => format(last_modified_timestamp, 'yyyy-MM-dd'),
 };
 
-const derivedSamplesColumns = [
-  {
-    id: 'origin_samples_unique_mapped_organs',
-    label: 'Organ',
-    renderColumnCell: ({ origin_samples_unique_mapped_organs }) => origin_samples_unique_mapped_organs.join(', '),
-  },
-  { id: 'sample_category', label: 'Sample Category', renderColumnCell: ({ sample_category }) => sample_category },
-  descendantCountsCol,
-  lastModifiedTimestampCol,
-];
-
-const derivedDatasetsColumns = [
-  {
-    id: 'mapped_data_types',
-    label: 'Data Types',
-    renderColumnCell: ({ mapped_data_types }) => mapped_data_types.join(', '),
-  },
-  { id: 'status', label: 'Status', renderColumnCell: ({ status }) => status },
-  descendantCountsCol,
-  lastModifiedTimestampCol,
-];
-
 const organCol = {
   id: 'origin_samples_unique_mapped_organs',
   label: 'Organ',
@@ -47,5 +25,14 @@ const dataTypesCol = {
 };
 
 const statusCol = { id: 'mapped_status', label: 'Status', renderColumnCell: ({ mapped_status }) => mapped_status };
+
+const derivedSamplesColumns = [
+  organCol,
+  { id: 'sample_category', label: 'Sample Category', renderColumnCell: ({ sample_category }) => sample_category },
+  descendantCountsCol,
+  lastModifiedTimestampCol,
+];
+
+const derivedDatasetsColumns = [dataTypesCol, statusCol, descendantCountsCol, lastModifiedTimestampCol];
 
 export { derivedSamplesColumns, derivedDatasetsColumns, lastModifiedTimestampCol, organCol, dataTypesCol, statusCol };

--- a/context/app/static/js/components/detailPage/derivedEntities/columns.js
+++ b/context/app/static/js/components/detailPage/derivedEntities/columns.js
@@ -34,4 +34,18 @@ const derivedDatasetsColumns = [
   lastModifiedTimestampCol,
 ];
 
-export { derivedSamplesColumns, derivedDatasetsColumns, lastModifiedTimestampCol };
+const organCol = {
+  id: 'origin_samples_unique_mapped_organs',
+  label: 'Organ',
+  renderColumnCell: ({ origin_samples_unique_mapped_organs }) => origin_samples_unique_mapped_organs.join(', '),
+};
+
+const dataTypesCol = {
+  id: 'mapped_data_types',
+  label: 'Data Types',
+  renderColumnCell: ({ mapped_data_types }) => mapped_data_types.join(', '),
+};
+
+const statusCol = { id: 'mapped_status', label: 'Status', renderColumnCell: ({ mapped_status }) => mapped_status };
+
+export { derivedSamplesColumns, derivedDatasetsColumns, lastModifiedTimestampCol, organCol, dataTypesCol, statusCol };

--- a/context/app/static/js/components/publications/PublicationRelatedEntities/hooks.js
+++ b/context/app/static/js/components/publications/PublicationRelatedEntities/hooks.js
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
 
 import { useSearchHits } from 'js/hooks/useSearchData';
-import { lastModifiedTimestampCol } from 'js/components/detailPage/derivedEntities/columns';
+import {
+  lastModifiedTimestampCol,
+  organCol,
+  dataTypesCol,
+  statusCol,
+} from 'js/components/detailPage/derivedEntities/columns';
 
 import { getAncestorsQuery } from 'js/helpers/queries';
 
@@ -14,7 +19,7 @@ function useAncestorSearchHits(descendantUUID) {
         'hubmap_id',
         'entity_type',
         'mapped_data_types',
-        'status',
+        'mapped_status',
         'descendant_counts',
         'last_modified_timestamp',
         'mapped_metadata',
@@ -82,11 +87,7 @@ function usePublicationsRelatedEntities(uuid) {
       tabLabel: 'Samples',
       data: ancestorsSplitByEntityType.Sample,
       columns: [
-        {
-          id: 'origin_samples_unique_mapped_organs.mapped_organ',
-          label: 'Organ',
-          renderColumnCell: ({ origin_samples_unique_mapped_organs }) => origin_samples_unique_mapped_organs.join(', '),
-        },
+        organCol,
         { id: 'sample_category', label: 'Sample Category', renderColumnCell: ({ sample_category }) => sample_category },
         lastModifiedTimestampCol,
       ],
@@ -96,21 +97,7 @@ function usePublicationsRelatedEntities(uuid) {
       entityType: 'Dataset',
       tabLabel: 'Datasets',
       data: ancestorsSplitByEntityType.Dataset,
-      columns: [
-        {
-          id: 'mapped_data_types',
-          label: 'Data Types',
-          renderColumnCell: ({ mapped_data_types }) => mapped_data_types.join(', '),
-        },
-
-        {
-          id: 'origin_samples_unique_mapped_organs.mapped_organ',
-          label: 'Organ',
-          renderColumnCell: ({ origin_samples_unique_mapped_organs }) => origin_samples_unique_mapped_organs.join(', '),
-        },
-        { id: 'status', label: 'Status', renderColumnCell: ({ status }) => status },
-        lastModifiedTimestampCol,
-      ],
+      columns: [dataTypesCol, organCol, statusCol, lastModifiedTimestampCol],
     },
   ];
 

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/style.js
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/style.js
@@ -5,6 +5,7 @@ const StyledDiv = styled.div`
   width: 100%;
   overflow-y: auto;
   min-height: 0px; // flex overflow fix
+  max-height: 340px;
 `;
 
 export { StyledDiv };

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/style.js
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/style.js
@@ -5,7 +5,7 @@ const StyledDiv = styled.div`
   width: 100%;
   overflow-y: auto;
   min-height: 0px; // flex overflow fix
-  max-height: 340px;
+  max-height: 340px; // Cuts off the last row partially to cue users to scroll.
 `;
 
 export { StyledDiv };


### PR DESCRIPTION
- Get collection datasets from separate search-api query instead of the collection es document.
- Use `RelatedEntitiesTable` for display.
- Fix display of organ column.

<img width="1271" alt="Screen Shot 2023-07-12 at 12 26 58 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/52a29207-338e-4a56-b3c8-f664b8ed36b1">
