### PR TITLE
Nickakhmetov/HMP-204 Change preprint date label and standardize "last modified date"

### DIFF
--- a/CHANGELOG-hmp-204-preprint-date-change.md
+++ b/CHANGELOG-hmp-204-preprint-date-change.md
@@ -1,0 +1,1 @@
+- Adjust display of information for preprints to explicitly label them as preprints where appropriate.

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -88,7 +88,7 @@ def _get_entities(entity_type, constraints={}, uuids=None):
         # Publication Date
         'published_timestamp',
 
-        # Modification Date
+        # Last Modified
         'last_modified_timestamp',
 
         # Creation Date

--- a/context/app/static/js/components/detailPage/summary/Summary/Summary.spec.js
+++ b/context/app/static/js/components/detailPage/summary/Summary/Summary.spec.js
@@ -18,7 +18,7 @@ test('timestamps display when defined', () => {
       last_modified_timestamp={1596724856094}
     />,
   );
-  const textToTest = ['Creation Date', 'Modification Date'];
+  const textToTest = ['Creation Date', 'Last Modified'];
   textToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 
   expect(screen.getAllByText('2020-08-06')).toHaveLength(2);
@@ -36,7 +36,7 @@ test('publication prefered to creation, if available', () => {
       last_modified_timestamp={1596724856094}
     />,
   );
-  const textToTest = ['Publication Date', 'Modification Date'];
+  const textToTest = ['Publication Date', 'Last Modified'];
   textToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 
   expect(screen.getAllByText('2020-08-06')).toHaveLength(2);
@@ -46,7 +46,7 @@ test('publication prefered to creation, if available', () => {
 test('timestamps do not display when undefined', () => {
   render(<Summary title="fakedoi" entity_type="Fakeentity" uuid="fakeuuid" />);
 
-  const textToTest = ['Creation Date', 'Modification Date'];
+  const textToTest = ['Creation Date', 'Last Modified'];
   textToTest.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 
   expect(screen.getAllByText('Undefined')).toHaveLength(2);

--- a/context/app/static/js/components/detailPage/summary/SummaryBody/SummaryBody.jsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryBody/SummaryBody.jsx
@@ -44,7 +44,7 @@ function SummaryBody({
         ) : (
           <StyledCreationDate label="Creation Date" timestamp={created_timestamp} />
         )}
-        <StyledModificationDate label="Modification Date" timestamp={last_modified_timestamp} />
+        <StyledModificationDate label="Last Modified" timestamp={last_modified_timestamp} />
       </Flex>
     </SummaryPaper>
   );

--- a/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
+++ b/context/app/static/js/components/publications/PublicationSummary/PublicationSummary.jsx
@@ -26,6 +26,7 @@ function PublicationSummary({
   publication_doi,
   hubmap_id,
   publication_date,
+  publication_status: isPublished,
 }) {
   const hasDOI = Boolean(publication_doi);
   const doiURL = `https://doi.org/${publication_doi}`;
@@ -34,7 +35,7 @@ function PublicationSummary({
     <DetailPageSection id="summary">
       <SummaryData
         title={title}
-        entity_type={entity_type}
+        entity_type={isPublished ? entity_type : 'Preprint'}
         uuid={uuid}
         status={status}
         mapped_data_access_level={mapped_data_access_level}
@@ -83,7 +84,11 @@ function PublicationSummary({
         >
           <AggsList uuid={uuid} field="mapped_organ" />
         </LabelledSectionText>
-        <LabelledSectionText label="Publication Date" bottomSpacing={2} data-testid="publication-date">
+        <LabelledSectionText
+          label={isPublished ? 'Publication Date' : 'Preprint Date'}
+          bottomSpacing={2}
+          data-testid="publication-date"
+        >
           {publication_date}
         </LabelledSectionText>
       </SectionPaper>

--- a/context/app/static/js/components/publications/PublicationsPanelList/utils.js
+++ b/context/app/static/js/components/publications/PublicationsPanelList/utils.js
@@ -17,7 +17,7 @@ function buildSecondaryText(contributors, publication_venue) {
 
 function buildPublicationPanelProps(publicationHit) {
   const {
-    _source: { uuid, title, contributors = [], publication_venue, publication_date },
+    _source: { uuid, title, contributors = [], publication_venue, publication_date, publication_status },
   } = publicationHit;
 
   return {
@@ -25,7 +25,7 @@ function buildPublicationPanelProps(publicationHit) {
     href: `/browse/publication/${uuid}`,
     title,
     secondaryText: buildSecondaryText(contributors, publication_venue),
-    rightText: `Published: ${publication_date}`,
+    rightText: `${publication_status ? 'Published' : 'Preprint Date'}: ${publication_date}`,
   };
 }
 

--- a/context/app/static/js/components/publications/PublicationsPanelList/utils.spec.js
+++ b/context/app/static/js/components/publications/PublicationsPanelList/utils.spec.js
@@ -31,6 +31,17 @@ const preprintPublicationHit = {
   },
 };
 
+const peerReviewedPublicationHit = {
+  _source: {
+    uuid: 'abc234',
+    title: 'Publication DEF',
+    contributors: [professorOak],
+    publication_status: true,
+    publication_venue,
+    publication_date: '2022-03-02',
+  },
+};
+
 describe('buildAbbreviatedContributors', () => {
   test("should return the contributor's name if there is only a single contributor", () => {
     const contributors = [ash];
@@ -65,12 +76,21 @@ describe('buildSecondaryText', () => {
 });
 
 describe('buildPublicationsPanelProps', () => {
-  test('should return the props require for the panel list', () => {
+  test('should return the props require for the panel list for a preprint', () => {
     expect(buildPublicationPanelProps(preprintPublicationHit)).toEqual({
       key: 'abc123',
       href: '/browse/publication/abc123',
       title: 'Publication ABC',
       secondaryText: 'Ash Ketchum | Pallet Town Times',
+      rightText: 'Preprint Date: 2022-03-02',
+    });
+  });
+  test('should return the props required for the panel list of a peer reviewed paper', () => {
+    expect(buildPublicationPanelProps(peerReviewedPublicationHit)).toEqual({
+      key: 'abc123',
+      href: '/browse/publication/abc234',
+      title: 'Publication DEF',
+      secondaryText: 'Professor Oak | Pallet Town Times',
       rightText: 'Published: 2022-03-02',
     });
   });

--- a/context/app/static/js/components/publications/PublicationsPanelList/utils.spec.js
+++ b/context/app/static/js/components/publications/PublicationsPanelList/utils.spec.js
@@ -33,7 +33,7 @@ const preprintPublicationHit = {
 
 const peerReviewedPublicationHit = {
   _source: {
-    uuid: 'abc234',
+    uuid: 'def234',
     title: 'Publication DEF',
     contributors: [professorOak],
     publication_status: true,
@@ -87,8 +87,8 @@ describe('buildPublicationsPanelProps', () => {
   });
   test('should return the props required for the panel list of a peer reviewed paper', () => {
     expect(buildPublicationPanelProps(peerReviewedPublicationHit)).toEqual({
-      key: 'abc123',
-      href: '/browse/publication/abc234',
+      key: 'def234',
+      href: '/browse/publication/def234',
       title: 'Publication DEF',
       secondaryText: 'Professor Oak | Pallet Town Times',
       rightText: 'Published: 2022-03-02',

--- a/end-to-end/cypress/e2e/portal/publication-page.cy.js
+++ b/end-to-end/cypress/e2e/portal/publication-page.cy.js
@@ -46,8 +46,10 @@ describe("Publication page", () => {
         .should("contain", "Kidney (Left)")
         .and("contain", "Spleen");
     });
-    it("has a publication date", () => {
-      cy.findByTestId("publication-date").contains("2021-10-18");
+    it("has a publication date, which is labeled as a preprint date", () => {
+      cy.findByTestId("publication-date")
+        .should("contain", "2021-10-18")
+        .and("contain", "Preprint");
     });
     it("has a table of contents with links to the summary, data, visualizations, files, authors, and provenance sections", () => {
       cy.findByTestId("table-of-contents")


### PR DESCRIPTION
This PR
- Adjusts the date text in preprint search results on the `publications` page from `published` to `preprint date` to avoid confusion
- Adjusts the `publication date` label and `publication` entity name (above publication name) on the publication pages of preprints to indicate that the user is viewing a preprint

Screenshots were taken the `test` environment.

Published search results:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/fbbd2049-57bb-468c-9e5c-dba9b26da77c)

Preprint search results:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/9c93b968-fc31-4dcd-b83f-8903e5ad90ad)

Published publication page:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/29775a8a-e0a1-431c-acb3-b3292733fa85)

Preprint publication page:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/93399a87-3ace-4620-a8c5-91cb62c6260b)
