### PR TITLE
John conroy/scroll prov HMP-258

### DIFF
--- a/CHANGELOG-scroll-prov.md
+++ b/CHANGELOG-scroll-prov.md
@@ -1,0 +1,2 @@
+- Set max vertical height and enable vertical scrolling for provenance graph.
+- Set initial vertical scroll position in provenance graph to halfway.

--- a/context/app/static/js/components/detailPage/provenance/NodeElement/NodeElement.jsx
+++ b/context/app/static/js/components/detailPage/provenance/NodeElement/NodeElement.jsx
@@ -1,18 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Typography from '@material-ui/core/Typography';
 
 import useProvenanceStore from 'js/stores/useProvenanceStore';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { AsteriskWrapper } from './style';
 
-const provenanceStoreUUIDSelector = (state) => state.uuid;
+const uuidSelector = (state) => state.uuid;
+const setHasRenderedSelector = (state) => state.setHasRendered;
 
 function NodeElement({ node, title, columnWidth }) {
   const style = node.nodeType === 'input' || node.nodeType === 'output' ? { width: columnWidth || 100 } : null;
 
   const displayTitle = title || node.title || node.name;
 
-  const uuid = useProvenanceStore(provenanceStoreUUIDSelector);
+  const uuid = useProvenanceStore(uuidSelector);
+  const setHasRendered = useProvenanceStore(setHasRenderedSelector);
+
+  useEffect(() => {
+    setHasRendered();
+  }, [setHasRendered]);
 
   return (
     <SecondaryBackgroundTooltip title={displayTitle}>

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
@@ -6,7 +6,7 @@ import { LightBlueLink } from 'js/shared-styles/Links';
 import ShowDerivedEntitiesButton from 'js/components/detailPage/provenance/ShowDerivedEntitiesButton';
 import useProvenanceStore from 'js/stores/useProvenanceStore';
 import ProvVis from '../ProvVis';
-import { StyledPaper, Flex, StyledTypography, StyledDiv, maxGraphHeight } from './style';
+import { StyledPaper, Flex, StyledTypography, ScrollDiv, maxGraphHeight } from './style';
 import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
 
 const setUUIDSelector = (state) => state.setUUID;
@@ -103,7 +103,7 @@ function ProvGraph({ provData, entity_type, uuid }) {
   }, [hasRendered, scrollDivRef]);
 
   return (
-    <StyledDiv ref={scrollDivRef}>
+    <ScrollDiv ref={scrollDivRef}>
       <ProvVis
         provData={provData}
         getNameForActivity={getNameForActivity}
@@ -111,7 +111,7 @@ function ProvGraph({ provData, entity_type, uuid }) {
         renderDetailPane={renderDetailPane}
         entity_type={entity_type}
       />
-    </StyledDiv>
+    </ScrollDiv>
   );
 }
 

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
@@ -91,6 +91,7 @@ function ProvGraph({ provData, entity_type, uuid }) {
     return null;
   }
 
+  // Set vertical scroll position to halfway.
   useEffect(() => {
     if (hasRendered) {
       const scrollEl = document.getElementsByClassName('scroll-container-wrapper')[0];

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import SectionItem from 'js/components/detailPage/SectionItem';
@@ -6,7 +6,7 @@ import { LightBlueLink } from 'js/shared-styles/Links';
 import ShowDerivedEntitiesButton from 'js/components/detailPage/provenance/ShowDerivedEntitiesButton';
 import useProvenanceStore from 'js/stores/useProvenanceStore';
 import ProvVis from '../ProvVis';
-import { StyledPaper, Flex, StyledTypography, ScrollDiv, maxGraphHeight } from './style';
+import { StyledPaper, Flex, StyledTypography, StyledDiv, maxGraphHeight } from './style';
 import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
 
 const setUUIDSelector = (state) => state.setUUID;
@@ -91,19 +91,18 @@ function ProvGraph({ provData, entity_type, uuid }) {
     return null;
   }
 
-  const scrollDivRef = useRef(null);
-
   useEffect(() => {
     if (hasRendered) {
-      scrollDivRef.current.scroll({
-        top: Math.floor((scrollDivRef.current.scrollHeight - maxGraphHeight) / 2),
+      const scrollEl = document.getElementsByClassName('scroll-container-wrapper')[0];
+      scrollEl.scroll({
+        top: Math.floor((scrollEl.scrollHeight - maxGraphHeight) / 2),
         behavior: 'instant',
       });
     }
-  }, [hasRendered, scrollDivRef]);
+  }, [hasRendered]);
 
   return (
-    <ScrollDiv ref={scrollDivRef}>
+    <StyledDiv>
       <ProvVis
         provData={provData}
         getNameForActivity={getNameForActivity}
@@ -111,7 +110,7 @@ function ProvGraph({ provData, entity_type, uuid }) {
         renderDetailPane={renderDetailPane}
         entity_type={entity_type}
       />
-    </ScrollDiv>
+    </StyledDiv>
   );
 }
 

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 
 import SectionItem from 'js/components/detailPage/SectionItem';
@@ -6,10 +6,11 @@ import { LightBlueLink } from 'js/shared-styles/Links';
 import ShowDerivedEntitiesButton from 'js/components/detailPage/provenance/ShowDerivedEntitiesButton';
 import useProvenanceStore from 'js/stores/useProvenanceStore';
 import ProvVis from '../ProvVis';
-import { StyledPaper, Flex, StyledTypography } from './style';
+import { StyledPaper, Flex, StyledTypography, StyledDiv, maxGraphHeight } from './style';
 import '@hms-dbmi-bgm/react-workflow-viz/dist/react-workflow-viz.min.css';
 
-const provenanceStoreSelector = (state) => state.setUUID;
+const setUUIDSelector = (state) => state.setUUID;
+const hasRenderedSelector = (state) => state.hasRendered;
 
 function DetailPanel({ node, timeKey, uuid, typeKey, idKey, getNameForActivity, getNameForEntity }) {
   const { prov } = node.meta;
@@ -64,7 +65,8 @@ function ProvGraph({ provData, entity_type, uuid }) {
   const timeKey = isOld ? 'prov:generatedAtTime' : 'hubmap:created_timestamp';
   const typeKey = isOld ? 'prov:type' : 'hubmap:entity_type';
 
-  const setUUID = useProvenanceStore(provenanceStoreSelector);
+  const setUUID = useProvenanceStore(setUUIDSelector);
+  const hasRendered = useProvenanceStore(hasRenderedSelector);
 
   useEffect(() => {
     setUUID(uuid);
@@ -89,14 +91,27 @@ function ProvGraph({ provData, entity_type, uuid }) {
     return null;
   }
 
+  const scrollDivRef = useRef(null);
+
+  useEffect(() => {
+    if (hasRendered) {
+      scrollDivRef.current.scroll({
+        top: Math.floor((scrollDivRef.current.scrollHeight - maxGraphHeight) / 2),
+        behavior: 'instant',
+      });
+    }
+  }, [hasRendered, scrollDivRef]);
+
   return (
-    <ProvVis
-      provData={provData}
-      getNameForActivity={getNameForActivity}
-      getNameForEntity={getNameForEntity}
-      renderDetailPane={renderDetailPane}
-      entity_type={entity_type}
-    />
+    <StyledDiv ref={scrollDivRef}>
+      <ProvVis
+        provData={provData}
+        getNameForActivity={getNameForActivity}
+        getNameForEntity={getNameForEntity}
+        renderDetailPane={renderDetailPane}
+        entity_type={entity_type}
+      />
+    </StyledDiv>
   );
 }
 

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.spec.js
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.spec.js
@@ -10,6 +10,13 @@ import donorProv from './fixtures/donor_prov';
 
 import ProvGraph from './ProvGraph';
 
+// eslint-disable-next-line testing-library/no-node-access
+document.getElementsByClassName = () => [
+  {
+    scroll: jest.fn(),
+  },
+];
+
 const server = setupServer(
   rest.post(`/${appProviderEndpoints.elasticsearchEndpoint}`, (req, res, ctx) => {
     const descendantData = {

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/style.js
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/style.js
@@ -15,13 +15,10 @@ const StyledTypography = styled(Typography)`
 `;
 
 const maxGraphHeight = 500;
-const ScrollDiv = styled.div`
-  max-height: ${maxGraphHeight}px;
-  overflow-x: auto;
-  overflow-y: auto;
+const StyledDiv = styled.div`
   .scroll-container-wrapper {
-    overflow: visible !important; // Override react-workflow-viz styles.
+    max-height: ${maxGraphHeight}px;
   }
 `;
 
-export { StyledPaper, Flex, StyledTypography, ScrollDiv, maxGraphHeight };
+export { StyledPaper, Flex, StyledTypography, StyledDiv, maxGraphHeight };

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/style.js
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/style.js
@@ -14,4 +14,14 @@ const StyledTypography = styled(Typography)`
   margin-top: ${(props) => props.theme.spacing(2)}px;
 `;
 
-export { StyledPaper, Flex, StyledTypography };
+const maxGraphHeight = 500;
+const ScrollDiv = styled.div`
+  max-height: ${maxGraphHeight}px;
+  overflow-x: auto;
+  overflow-y: auto;
+  .scroll-container-wrapper {
+    overflow: visible !important; // Override react-workflow-viz styles.
+  }
+`;
+
+export { StyledPaper, Flex, StyledTypography, ScrollDiv, maxGraphHeight };

--- a/context/app/static/js/stores/useProvenanceStore.js
+++ b/context/app/static/js/stores/useProvenanceStore.js
@@ -7,6 +7,14 @@ import immer from './immerMiddleware';
 const useProvenanceStore = create(
   immer((set, get) => ({
     uuid: '',
+    hasRendered: false,
+    setHasRendered: () => {
+      if (get().hasRendered === false) {
+        set((state) => {
+          state.hasRendered = true;
+        });
+      }
+    },
     setUUID: (uuid) =>
       set((state) => {
         state.uuid = uuid;


### PR DESCRIPTION
Feels a bit hacky. I had a slightly less hacky version before the [commit to introduce the dom selector](https://github.com/hubmapconsortium/portal-ui/commit/13475bd7d1c001e34e94fd8228e00eda236c4d6f), but the detail pane would be inside the scrollbox without the changes introduced in the commit.

Initial position without detail pane.
<img width="1353" alt="Screen Shot 2023-07-13 at 4 18 34 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/493f2d07-afd1-4dda-a093-3783dbf2dea1">

Initial position with detail pane outside of scrollbox.
<img width="1385" alt="Screen Shot 2023-07-13 at 4 18 26 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/240563b6-5527-4ff8-b6ae-9f825d368ef8">

Graph without scroll.
<img width="1398" alt="Screen Shot 2023-07-13 at 4 29 10 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/6ad9d97e-4e77-4bad-aac1-9a70fee0d849">

