### PR TITLE
Nickakhmetov/HMP-269 Implement time-gated publication slide

### DIFF
--- a/CHANGELOG-hmp-269-implement-publication-slide.md
+++ b/CHANGELOG-hmp-269-implement-publication-slide.md
@@ -1,0 +1,1 @@
+- Add publication slide to homepage.

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,7 +1,7 @@
 from flask import (render_template, current_app, abort,
                    session, request)
 
-from .utils import get_default_flask_data, make_blueprint, get_organs
+from .utils import get_default_flask_data, make_blueprint, get_organs, get_enable_publications
 
 
 blueprint = make_blueprint(__name__)
@@ -9,7 +9,8 @@ blueprint = make_blueprint(__name__)
 
 @blueprint.route('/')
 def index():
-    flask_data = {**get_default_flask_data(), 'organs_count': len(get_organs())}
+    flask_data = {**get_default_flask_data(), 'organs_count': len(get_organs()),
+                  'enable_publications': get_enable_publications()}
     return render_template(
         'base-pages/react-content.html',
         flask_data=flask_data,

--- a/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
+++ b/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
@@ -36,7 +36,7 @@ const slides = [
 const publicationSlide = {
   title: 'Discover the publications reporting the breakthroughs of  mapping the human body with HuBMAP data',
   body: 'Explore publications authored by scientists in the consortium involving HuBMAP data. Additional publications will be coming in the future as the consortium continue to create mappings of the human body. View the press release reporting on these publications.',
-  image: <CarouselImage {...getCDNCarouselImageSrcSet('publications')} alt="HuBMAP Publications" key="Publications" />,
+  image: <CarouselImage {...getCDNCarouselImageSrcSet('publication')} alt="HuBMAP Publications" key="Publications" />,
   buttonHref: '/publications',
 };
 

--- a/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
+++ b/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 
 import CarouselImage from 'js/components/home/CarouselImage';
 
+import { useFlaskDataContext } from 'js/components/Contexts';
 import ImageCarousel from '../ImageCarousel';
 import ImageCarouselControlButtons from '../ImageCarouselControlButtons';
 import ImageCarouselCallToAction from '../ImageCarouselCallToAction';
@@ -32,10 +33,25 @@ const slides = [
   },
 ];
 
+const publicationSlide = {
+  title: 'Discover the publications reporting the breakthroughs of  mapping the human body with HuBMAP data',
+  body: 'Explore publications authored by scientists in the consortium involving HuBMAP data. Additional publications will be coming in the future as the consortium continue to create mappings of the human body. View the press release reporting on these publications.',
+  image: <CarouselImage {...getCDNCarouselImageSrcSet('publications')} alt="HuBMAP Publications" key="Publications" />,
+  buttonHref: '/publications',
+};
+
+const slidesWithPublications = [publicationSlide, ...slides];
+
 function ImageCarouselContainer() {
-  // Set random intial image index:
-  const [selectedImageIndex, setSelectedImageIndex] = useState(Math.floor(Math.random() * slides.length));
-  const { title, body, buttonHref } = slides[selectedImageIndex];
+  const { enable_publications: enablePublications } = useFlaskDataContext();
+  const slidesToUse = enablePublications ? slidesWithPublications : slides;
+  // Set random intial image index if publications are not yet enabled
+  // If publications are enabled, use publication slide first
+  const [selectedImageIndex, setSelectedImageIndex] = useState(
+    enablePublications ? 0 : Math.floor(Math.random() * slidesToUse.length),
+  );
+
+  const { title, body, buttonHref } = slidesToUse[selectedImageIndex];
   return (
     <Flex>
       <CallToActionWrapper>
@@ -43,13 +59,13 @@ function ImageCarouselContainer() {
         <ImageCarouselControlButtons
           selectedImageIndex={selectedImageIndex}
           setSelectedImageIndex={setSelectedImageIndex}
-          numImages={slides.length}
+          numImages={slidesToUse.length}
         />
       </CallToActionWrapper>
       <ImageCarousel
         selectedImageIndex={selectedImageIndex}
         setSelectedImageIndex={setSelectedImageIndex}
-        images={slides.map((slide) => slide.image)}
+        images={slidesToUse.map((slide) => slide.image)}
       />
     </Flex>
   );

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -58,4 +58,6 @@ def get_organs():
 
 def get_enable_publications():
     current_timestamp = datetime.now().timestamp()
-    return current_timestamp > 1689778800  # 2023-07-19 at 15:00:00 UTC
+    # 2023-07-19 at 15:00:00 UTC
+    publication_embargo_end_timestamp = 1689778800
+    return current_app.config.get('ENABLE_PUBLICATIONS') or current_timestamp > publication_embargo_end_timestamp

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlparse
 from flask import (current_app, request, session, Blueprint)
+from datetime import datetime
 
 from .api.client import ApiClient
 from .api.mock_client import MockApiClient
@@ -53,3 +54,8 @@ def get_organs():
     dir_path = Path(dirname(__file__) + '/organ')
     organs = {p.stem: safe_load(p.read_text()) for p in dir_path.glob('*.yaml')}
     return organs
+
+
+def get_enable_publications():
+    current_timestamp = datetime.now().timestamp()
+    return current_timestamp > 1689778800  # 2023-07-19 at 15:00:00 UTC

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -60,4 +60,5 @@ def get_enable_publications():
     current_timestamp = datetime.now().timestamp()
     # 2023-07-19 at 15:00:00 UTC
     publication_embargo_end_timestamp = 1689778800
-    return current_app.config.get('ENABLE_PUBLICATIONS') or current_timestamp > publication_embargo_end_timestamp
+    return current_app.config.get('ENABLE_PUBLICATIONS') or \
+        current_timestamp > publication_embargo_end_timestamp


### PR DESCRIPTION
This PR adds a flag sent from the server-side which is enabled after the unix timestamp passes 2023-07-19 at 15:00:00 UTC (the end of the publication embargo). This behavior can be overridden by adding the `ENABLE_PUBLICATIONS` key to `app.conf` and setting it to `True` for ease of testing (e.g. in `dev`/`test`)

The time gate works by running a comparison of the current unix timestamp against the timestamp of 2023-07-19 at 15:00:00 UTC (1689778800). I cross-checked the timestamp from `datetime.now().timestamp()` with https://www.unixtimestamp.com/ (which I used to derive the embargo expiration timestamp) to confirm this method works for all time zones.

The flag enables the new hubmap publications slide, which links to `/publications` with its get started button and pulls the proper image from s3. When the flag is enabled, the randomization of the starting slide index is also disabled.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/abdd55cd-3499-4d93-9f94-ff2aab9051c2)
