### PR TITLE
Nickakhmetov/HMP-275 Fix publication tooltip appearing on other pages

### DIFF
--- a/CHANGELOG-hmp-275.md
+++ b/CHANGELOG-hmp-275.md
@@ -1,0 +1,1 @@
+- Fix publication tooltip errantly appearing on other pages

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesSectionHeader/RelatedEntitiesSectionHeader.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesSectionHeader/RelatedEntitiesSectionHeader.jsx
@@ -4,12 +4,12 @@ import Button from '@material-ui/core/Button';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 
-function RelatedEntitiesSectionHeader({ header, searchPageHref }) {
+function RelatedEntitiesSectionHeader({ header, searchPageHref, iconTooltipText }) {
   return (
     <SpacedSectionButtonRow
       leftText={
         <div>
-          <SectionHeader iconTooltipText="HuBMAP data created or used by the publication.">{header}</SectionHeader>
+          <SectionHeader iconTooltipText={iconTooltipText}>{header}</SectionHeader>
         </div>
       }
       buttons={

--- a/context/app/static/js/components/publications/PublicationRelatedEntities/PublicationRelatedEntities.jsx
+++ b/context/app/static/js/components/publications/PublicationRelatedEntities/PublicationRelatedEntities.jsx
@@ -17,6 +17,7 @@ function PublicationRelatedEntities({ uuid }) {
         <RelatedEntitiesSectionHeader
           header="Data"
           uuid={uuid}
+          iconTooltipText="HuBMAP data created or used by the publication."
           searchPageHref={`/search?descendant_ids[0]=${uuid}&entity_type[0]=${entities[openIndex].entityType}`}
         />
       }


### PR DESCRIPTION
I adjusted the approach to displaying the tooltip text so that it has to be passed in to the `RelatedEntitiesSectionHeader` instead of it providing its own hardcoded tooltip.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/0d8a9293-7b98-4729-9c8d-a2a7cc5ec0cb)
