### PR TITLE
NickAkhmetov/Restore display of publication status for preprints

### DIFF
--- a/CHANGELOG-fix-missing-preprint-info.md
+++ b/CHANGELOG-fix-missing-preprint-info.md
@@ -1,0 +1,1 @@
+- Restore display of publication status for preprints.

--- a/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.jsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.jsx
@@ -12,7 +12,10 @@ import SummaryItem from 'js/components/detailPage/summary/SummaryItem';
 import StatusIcon from 'js/components/detailPage/StatusIcon';
 import { FlexEnd, JsonButton, StyledTypography } from './style';
 
-const datasetEntityTypes = ['Dataset', 'Support', 'Publication'];
+const datasetEntityTypes = ['Dataset', 'Support', 'Publication', 'Preprint'];
+const publicationEntityTypes = ['Publication', 'Preprint'];
+
+const entitiesWithStatus = datasetEntityTypes.concat(...publicationEntityTypes);
 
 function SummaryData({
   entity_type,
@@ -24,7 +27,7 @@ function SummaryData({
   children,
   mapped_external_group_name,
 }) {
-  const isPublication = entity_type === 'Publication';
+  const isPublication = publicationEntityTypes.includes(entity_type);
   const LeftTextContainer = isPublication ? React.Fragment : 'div';
   return (
     <>
@@ -40,7 +43,7 @@ function SummaryData({
         }
         buttons={
           <FlexEnd>
-            {datasetEntityTypes.includes(entity_type) && (
+            {entitiesWithStatus.includes(entity_type) && (
               <>
                 <SummaryItem statusIcon={<StatusIcon status={status} />}>{status}</SummaryItem>
                 <SummaryItem>{`${mapped_data_access_level} Access`}</SummaryItem>


### PR DESCRIPTION
This PR fixes the display of preprint publications' status; it was broken by my change to make the entity header display `Preprint`.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/4dc2bae7-b7ac-4886-91bf-6a1c35896d8c)
