### PR TITLE
NickAkhmetov/HMP-294 - No header for unauthenticated users

### DIFF
--- a/CHANGELOG-no-auth-for-unauthed.md
+++ b/CHANGELOG-no-auth-for-unauthed.md
@@ -1,0 +1,1 @@
+- Disable auth header/token inclusion for unauthenticated users.

--- a/context/app/static/js/components/publications/PublicationVignette/hooks.ts
+++ b/context/app/static/js/components/publications/PublicationVignette/hooks.ts
@@ -24,14 +24,18 @@ export function usePublicationVignetteConfs({ uuid, vignetteDirName, vignette }:
   if (data) {
     const urlHandler = (url: string, isZarr: boolean) => {
       return `${url.replace('{{ base_url }}', `${assetsEndpoint}/${uuid}/data`)}${
-        isZarr ? '' : `?token=${groupsToken}`
+        isZarr || !groupsToken ? '' : `?token=${groupsToken}`
       }`;
     };
 
     const requestInitHandler = () => {
-      return {
-        headers: { Authorization: `Bearer ${groupsToken}` },
-      };
+      // Only include the Authorization header if the user is logged in/has a groups token
+      if (groupsToken) {
+        return {
+          headers: { Authorization: `Bearer ${groupsToken}` },
+        };
+      }
+      return {};
     };
     // Formats the vitessce config data to replace the {{ base_url }} placeholder with the actual url.
     // TODO: Improve this `unknown`; I couldn't figure out how to import the appropriate `VitessceConfig` type from Vitessce.


### PR DESCRIPTION
This PR disables the auth header/groups token inclusion when the current user is not logged in in order to enable access to publication vignettes in Globus after the embargo is up.

Screenshot taken with env pointed at the stage endpoints, note the `Log In` prompt at the top right as evidence of being unauthed:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/b709eacd-019f-46d9-96ee-527b2b5da3e8)

Original slack discussion for posterity: https://hubmapconsortium.slack.com/archives/C011RF3NQ23/p1689702903588899