### PR TITLE
NickAkhmetov/HMP-296 Fix seqfish display

### DIFF
--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -50,6 +50,7 @@ const visualizationStoreSelector = (state) => ({
   onCopyUrlSnackbarOpen: state.onCopyUrlSnackbarOpen,
   setOnCopyUrlSnackbarOpen: state.setOnCopyUrlSnackbarOpen,
   setVizNotebookId: state.setVizNotebookId,
+  vitessceState: state.vitessceState,
 });
 const sharedInfoSnackbarProps = {
   anchorOrigin: {
@@ -192,9 +193,14 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, should
               <Vitessce
                 config={vitessceConfig[vitessceSelection] || vitessceConfig}
                 theme={vizTheme}
-                onConfigChange={setVitessceStateDebounced}
+                onConfigChange={(c) => {
+                  // eslint-disable-next-line no-console
+                  console.log(c);
+                  setVitessceStateDebounced?.(c);
+                }}
                 height={vizIsFullscreen ? null : vitessceFixedHeight}
                 onWarn={addError}
+                debug
               />
             )}
           </ExpandableDiv>

--- a/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
@@ -1,15 +1,36 @@
 import { useState, useEffect } from 'react';
 import { decodeURLParamsToConf } from 'vitessce';
 
+const guaranteeUidForConfig = (vData) => {
+  if (Array.isArray(vData)) {
+    return vData.map((v, index) => {
+      if (!v.uid) {
+        return {
+          ...v,
+          uid: `vitessce-${v.name || index}`,
+        };
+      }
+      return v;
+    });
+  }
+  if (!vData.uid) {
+    return {
+      ...vData,
+      uid: 'vitessce-0',
+    };
+  }
+  return vData;
+};
+
 export function useVitessceConfig({ vitData, setVitessceState, setVitessceErrors }) {
-  const [vitessceSelection, setVitessceSelection] = useState(null);
+  const [vitessceSelection, setVitessceSelection] = useState(0);
   const [vitessceConfig, setVitessceConfig] = useState(null);
 
   useEffect(() => {
     function setVitessceDefaults(vData) {
       setVitessceState(Array.isArray(vData) ? vData[0] : vData);
       setVitessceSelection(0);
-      setVitessceConfig(vData);
+      setVitessceConfig(guaranteeUidForConfig(vData));
     }
 
     if (setVitessceState && vitData) {
@@ -30,7 +51,7 @@ export function useVitessceConfig({ vitData, setVitessceState, setVitessceErrors
       }
       let initializedVitDataFromUrl = vitData;
       let initialSelectionFromUrl;
-      // If these is a url conf and the we have a multidataset, use the url conf to find the initial selection of the multi-dataset.
+      // If these is a url conf and we have a multidataset, use the url conf to find the initial selection of the multi-dataset.
       if (Array.isArray(vitData)) {
         initialSelectionFromUrl = Math.max(0, vitData.map(({ name }) => name).indexOf(vitessceURLConf?.name));
         initializedVitDataFromUrl[initialSelectionFromUrl] = vitessceURLConf || vitData[initialSelectionFromUrl];
@@ -39,8 +60,9 @@ export function useVitessceConfig({ vitData, setVitessceState, setVitessceErrors
       }
       setVitessceState(initializedVitDataFromUrl[initialSelectionFromUrl]);
       setVitessceSelection(initialSelectionFromUrl);
-      setVitessceConfig(initializedVitDataFromUrl);
+      setVitessceConfig(guaranteeUidForConfig(initializedVitDataFromUrl));
     }
   }, [setVitessceState, vitData, setVitessceErrors]);
+
   return { vitessceConfig, vitessceSelection, setVitessceSelection };
 }


### PR DESCRIPTION
WIP; depends on updated portal-vis vitessce dependency from this PR: https://github.com/hubmapconsortium/portal-visualization/pull/81 (`pip install -e path/to/portal-visualization`)

After updating portal-visualization so it returns 1.0.16 schema inputs and attaching unique UIDs for each one on the front-end, I'm still having the same issue viewing the other slides from [c9799ce59c4518bd243555c92c4edc21](https://portal-prod.stage.hubmapconsortium.org/browse/dataset/c9799ce59c4518bd243555c92c4edc21) on local; I've confirmed the `uid` is different for each config and that it's not being stripped by the visualization. 