### PR TITLE
John conroy/reverse toc nowrap

### DIFF
--- a/CHANGELOG-reverse-toc-nowrap.md
+++ b/CHANGELOG-reverse-toc-nowrap.md
@@ -1,0 +1,1 @@
+- Reverse no-wrap styles causing table of contents to overflow.

--- a/context/app/static/js/shared-styles/sections/TableOfContents/style.js
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/style.js
@@ -21,7 +21,6 @@ const StyledItemLink = styled(Link)`
   padding-left: 4px;
   border-left: 3px solid transparent;
   margin-bottom: ${(props) => props.theme.spacing(0.25)}px;
-  white-space: nowrap;
 
   &:hover {
     border-left: 3px solid #c4c4c4; // TODO: Move to theme.


### PR DESCRIPTION
Reversing styles recently introduced which cause overflow in the table of contents.

Before

<img width="507" alt="Screen Shot 2023-07-20 at 5 00 08 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/b1716493-292d-46a1-a356-623648b02c28">

After

<img width="487" alt="Screen Shot 2023-07-20 at 5 00 29 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/b0f70ce3-9d5e-4ed7-97f8-92e0ed612210">
<img width="710" alt="Screen Shot 2023-07-20 at 5 00 42 PM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/3eb2ead9-ca05-414b-971b-1c514ad30d59">
