### PR TITLE
kevin-yoo/HMP-302-Implement-icons-for-entity-headers-and-tables-Swedlow-feedback-response

### DIFF
--- a/CHANGELOG-HMP-302-Implement-icons-for-entity-headers-and-tables-Swedlow-feedback-response.MD
+++ b/CHANGELOG-HMP-302-Implement-icons-for-entity-headers-and-tables-Swedlow-feedback-response.MD
@@ -1,0 +1,1 @@
+- Add icons to header of entity pages.

--- a/CHANGELOG-HMP-302-Implement-icons-for-entity-headers-and-tables-Swedlow-feedback-response.MD
+++ b/CHANGELOG-HMP-302-Implement-icons-for-entity-headers-and-tables-Swedlow-feedback-response.MD
@@ -1,1 +1,4 @@
-- Add icons to header of entity pages.
+- Add icons to header links.
+- Add icons to headers of provenance table. 
+- Add icons to tabs in "Derived Sample and Datasets" table.
+-

--- a/CHANGELOG-HMP-302-Implement-icons-for-entity-headers-and-tables-Swedlow-feedback-response.MD
+++ b/CHANGELOG-HMP-302-Implement-icons-for-entity-headers-and-tables-Swedlow-feedback-response.MD
@@ -1,4 +1,4 @@
 - Add icons to header links.
 - Add icons to headers of provenance table. 
 - Add icons to tabs in "Derived Sample and Datasets" table.
--
+

--- a/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
+++ b/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
@@ -4,6 +4,7 @@ import Link from '@material-ui/core/Link';
 import { useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 
+import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import { useAppContext } from 'js/components/Contexts';
 import Menu from '../Menu';
 import ResourceLinks from '../ResourceLinks';
@@ -11,13 +12,14 @@ import Dropdown from '../Dropdown';
 import UserLinks from '../UserLinks';
 import AtlasToolsLinks from '../AtlasToolsLinks';
 import OtherLinks from '../OtherLinks';
-import { Spacer, HeaderButton, FlexNoWrap } from './style';
+import { Spacer, HeaderButton, FlexNoWrap, StyledSvgIcon, HeaderType } from './style';
 import HubmapLogo from '../HubmapLogo';
 
 function HeaderContent({ anchorRef }) {
   const theme = useTheme();
   const shouldDisplayMenu = !useMediaQuery(theme.breakpoints.up('md'));
   const { isAuthenticated, userEmail } = useAppContext();
+
   return (
     <>
       {shouldDisplayMenu && <Menu anchorRef={anchorRef} />}
@@ -28,9 +30,12 @@ function HeaderContent({ anchorRef }) {
         <>
           <FlexNoWrap>
             {['Donor', 'Sample', 'Dataset'].map((type) => (
-              <HeaderButton key={type} href={`/search?entity_type[0]=${type}`} component={Link}>
-                {`${type}s`}
-              </HeaderButton>
+              <HeaderType>
+                <StyledSvgIcon component={entityIconMap[type]} />
+                <HeaderButton key={type} href={`/search?entity_type[0]=${type}`} component={Link}>
+                  {`${type}s`}
+                </HeaderButton>
+              </HeaderType>
             ))}
             <Dropdown title="Other">
               <OtherLinks />

--- a/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
+++ b/context/app/static/js/components/Header/HeaderContent/HeaderContent.jsx
@@ -12,7 +12,7 @@ import Dropdown from '../Dropdown';
 import UserLinks from '../UserLinks';
 import AtlasToolsLinks from '../AtlasToolsLinks';
 import OtherLinks from '../OtherLinks';
-import { Spacer, HeaderButton, FlexNoWrap, StyledSvgIcon, HeaderType } from './style';
+import { Spacer, HeaderButton, FlexNoWrap, StyledSvgIcon } from './style';
 import HubmapLogo from '../HubmapLogo';
 
 function HeaderContent({ anchorRef }) {
@@ -30,12 +30,14 @@ function HeaderContent({ anchorRef }) {
         <>
           <FlexNoWrap>
             {['Donor', 'Sample', 'Dataset'].map((type) => (
-              <HeaderType>
-                <StyledSvgIcon component={entityIconMap[type]} />
-                <HeaderButton key={type} href={`/search?entity_type[0]=${type}`} component={Link}>
-                  {`${type}s`}
-                </HeaderButton>
-              </HeaderType>
+              <HeaderButton
+                key={type}
+                href={`/search?entity_type[0]=${type}`}
+                component={Link}
+                startIcon={<StyledSvgIcon component={entityIconMap[type]} />}
+              >
+                {`${type}s`}
+              </HeaderButton>
             ))}
             <Dropdown title="Other">
               <OtherLinks />

--- a/context/app/static/js/components/Header/HeaderContent/style.js
+++ b/context/app/static/js/components/Header/HeaderContent/style.js
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
+import SvgIcon from '@material-ui/core/SvgIcon';
 
 const Spacer = styled.div`
   flex-grow: 1;
 `;
 
 const HeaderButton = styled(Button)`
-  margin-left: 10px;
   color: ${(props) => props.theme.palette.white.main};
 `;
 
@@ -20,4 +20,14 @@ const StyledDivider = styled(Divider)`
   margin: ${(props) => props.theme.spacing(0.5)}px 0px;
 `;
 
-export { Spacer, HeaderButton, FlexNoWrap, StyledDivider };
+const HeaderType = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 0 ${(props) => props.theme.spacing(1)}px;
+`;
+
+const StyledSvgIcon = styled(SvgIcon)`
+  font-size: 1.25rem;
+`;
+
+export { Spacer, HeaderButton, FlexNoWrap, StyledDivider, StyledSvgIcon, HeaderType };

--- a/context/app/static/js/components/Header/HeaderContent/style.js
+++ b/context/app/static/js/components/Header/HeaderContent/style.js
@@ -20,14 +20,8 @@ const StyledDivider = styled(Divider)`
   margin: ${(props) => props.theme.spacing(0.5)}px 0px;
 `;
 
-const HeaderType = styled.div`
-  display: flex;
-  align-items: center;
-  padding: 0 ${(props) => props.theme.spacing(1)}px;
-`;
-
 const StyledSvgIcon = styled(SvgIcon)`
   font-size: 1.25rem;
 `;
 
-export { Spacer, HeaderButton, FlexNoWrap, StyledDivider, StyledSvgIcon, HeaderType };
+export { Spacer, HeaderButton, FlexNoWrap, StyledDivider, StyledSvgIcon };

--- a/context/app/static/js/components/detailPage/provenance/ProvTable/ProvTable.jsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvTable/ProvTable.jsx
@@ -1,7 +1,10 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react';
+import Typography from '@material-ui/core/Typography';
+
 import { useFlaskDataContext } from 'js/components/Contexts';
-import { FlexContainer, FlexColumn, TableColumn, EntityColumnTitle } from './style';
+import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
+import { FlexContainer, FlexColumn, TableColumn, StyledSvgIcon, ProvTableEntityHeader } from './style';
 import ProvTableTile from '../ProvTableTile';
 import ProvTableDerivedLink from '../ProvTableDerivedLink';
 
@@ -27,7 +30,10 @@ function ProvTable() {
     <FlexContainer>
       {Object.entries(ancestorsAndSelfByType).map(([type, entities]) => (
         <TableColumn key={`provenance-list-${type.toLowerCase()}`}>
-          <EntityColumnTitle variant="h5">{type}s</EntityColumnTitle>
+          <ProvTableEntityHeader>
+            <StyledSvgIcon component={entityIconMap[type]} color="primary" />
+            <Typography variant="h5">{type}s</Typography>
+          </ProvTableEntityHeader>
           <FlexColumn>
             {entities.length > 0 &&
               entities
@@ -53,7 +59,5 @@ function ProvTable() {
     </FlexContainer>
   );
 }
-
-// ProvTable.propTypes = {}
 
 export default ProvTable;

--- a/context/app/static/js/components/detailPage/provenance/ProvTable/style.js
+++ b/context/app/static/js/components/detailPage/provenance/ProvTable/style.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import Typography from '@material-ui/core/Typography';
+import SvgIcon from '@material-ui/core/SvgIcon';
 
 const FlexContainer = styled.div`
   display: flex;
@@ -11,11 +11,6 @@ const FlexContainer = styled.div`
 const FlexColumn = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-`;
-
-const EntityColumnTitle = styled(Typography)`
-  margin-bottom: ${(props) => props.theme.spacing(1)}px;
 `;
 
 // 300 = size of tile
@@ -23,4 +18,15 @@ const TableColumn = styled.div`
   min-width: 300px;
 `;
 
-export { FlexContainer, FlexColumn, TableColumn, EntityColumnTitle };
+const StyledSvgIcon = styled(SvgIcon)`
+  font-size: 1.25rem;
+  margin-right: ${(props) => props.theme.spacing(1)}px;
+`;
+
+const ProvTableEntityHeader = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: ${(props) => props.theme.spacing(1)}px;
+`;
+
+export { FlexContainer, FlexColumn, TableColumn, StyledSvgIcon, ProvTableEntityHeader };

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Tab } from 'js/shared-styles/tabs';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
-import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon } from './style';
+import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon, StyledIconTab } from './style';
 
 function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, renderWarningMessage }) {
   const handleChange = (event, newIndex) => {
@@ -12,22 +12,24 @@ function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, ren
 
   return (
     <>
-      <StyledTabs value={openIndex} onChange={handleChange} aria-label={ariaLabel}>
-        {entities.map((entity, i) => (
-          <Tab
-            label={`${entity.tabLabel} (${entity.data.length})`}
-            index={i}
-            key={entity.tabLabel}
-            data-testid={`${entity.tabLabel.toLowerCase()}-tab`}
-            icon={
-              <StyledSvgIcon
-                component={entityIconMap[`${entity.tabLabel.slice(0, entity.tabLabel.length - 1)}`]}
-                color="white"
-              />
-            }
-          />
-        ))}
-      </StyledTabs>
+      <StyledIconTab>
+        <StyledTabs value={openIndex} onChange={handleChange} aria-label={ariaLabel}>
+          {entities.map((entity, i) => (
+            <Tab
+              label={`${entity.tabLabel} (${entity.data.length})`}
+              index={i}
+              key={entity.tabLabel}
+              data-testid={`${entity.tabLabel.toLowerCase()}-tab`}
+              icon={
+                <StyledSvgIcon
+                  component={entityIconMap[`${entity.tabLabel.slice(0, entity.tabLabel.length - 1)}`]}
+                  color="white"
+                />
+              }
+            />
+          ))}
+        </StyledTabs>
+      </StyledIconTab>
       {entities.map(({ tabLabel, data, entityType: tableEntityType, columns }, i) => (
         <StyledTabPanel value={openIndex} index={i} key={tabLabel} data-testid={`${tabLabel.toLowerCase()}-panel`}>
           {data.length > 0 ? (
@@ -40,7 +42,5 @@ function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, ren
     </>
   );
 }
-
-// RelatedEntitiesTabs.propTypes = {};
 
 export default RelatedEntitiesTabs;

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { Tab } from 'js/shared-styles/tabs';
+import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
-import { StyledTabs, StyledTabPanel, StyledAlert } from './style';
+import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon } from './style';
 
 function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, renderWarningMessage }) {
   const handleChange = (event, newIndex) => {
@@ -18,6 +19,12 @@ function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, ren
             index={i}
             key={entity.tabLabel}
             data-testid={`${entity.tabLabel.toLowerCase()}-tab`}
+            icon={
+              <StyledSvgIcon
+                component={entityIconMap[`${entity.tabLabel.slice(0, entity.tabLabel.length - 1)}`]}
+                color="white"
+              />
+            }
           />
         ))}
       </StyledTabs>

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
@@ -20,12 +20,7 @@ function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, ren
               index={i}
               key={entity.tabLabel}
               data-testid={`${entity.tabLabel.toLowerCase()}-tab`}
-              icon={
-                <StyledSvgIcon
-                  component={entityIconMap[`${entity.tabLabel.slice(0, entity.tabLabel.length - 1)}`]}
-                  color="white"
-                />
-              }
+              icon={<StyledSvgIcon component={entityIconMap[entity.entityType]} color="white" />}
             />
           ))}
         </StyledTabs>

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Tab } from 'js/shared-styles/tabs';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
-import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon, StyledIconTab } from './style';
+import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon } from './style';
 
 function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, renderWarningMessage }) {
   const handleChange = (event, newIndex) => {
@@ -12,19 +12,17 @@ function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, ren
 
   return (
     <>
-      <StyledIconTab>
-        <StyledTabs value={openIndex} onChange={handleChange} aria-label={ariaLabel}>
-          {entities.map((entity, i) => (
-            <Tab
-              label={`${entity.tabLabel} (${entity.data.length})`}
-              index={i}
-              key={entity.tabLabel}
-              data-testid={`${entity.tabLabel.toLowerCase()}-tab`}
-              icon={<StyledSvgIcon component={entityIconMap[entity.entityType]} color="white" />}
-            />
-          ))}
-        </StyledTabs>
-      </StyledIconTab>
+      <StyledTabs value={openIndex} onChange={handleChange} aria-label={ariaLabel}>
+        {entities.map((entity, i) => (
+          <Tab
+            label={`${entity.tabLabel} (${entity.data.length})`}
+            index={i}
+            key={entity.tabLabel}
+            data-testid={`${entity.tabLabel.toLowerCase()}-tab`}
+            icon={<StyledSvgIcon component={entityIconMap[entity.entityType]} color="white" />}
+          />
+        ))}
+      </StyledTabs>
       {entities.map(({ tabLabel, data, entityType: tableEntityType, columns }, i) => (
         <StyledTabPanel value={openIndex} index={i} key={tabLabel} data-testid={`${tabLabel.toLowerCase()}-panel`}>
           {data.length > 0 ? (

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
-import { Tab } from 'js/shared-styles/tabs';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
-import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon } from './style';
+import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon, StyledTab } from './style';
 
 function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, renderWarningMessage }) {
   const handleChange = (event, newIndex) => {
@@ -14,7 +13,7 @@ function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, ren
     <>
       <StyledTabs value={openIndex} onChange={handleChange} aria-label={ariaLabel}>
         {entities.map((entity, i) => (
-          <Tab
+          <StyledTab
             label={`${entity.tabLabel} (${entity.data.length})`}
             index={i}
             key={entity.tabLabel}

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import SvgIcon from '@material-ui/core/SvgIcon';
+
 import { TabPanel, Tabs } from 'js/shared-styles/tabs';
 import { Alert } from 'js/shared-styles/alerts';
 
@@ -12,6 +13,14 @@ const StyledTabPanel = styled(TabPanel)`
 
 const StyledTabs = styled(Tabs)`
   flex: none;
+
+  span {
+    display: contents;
+  }
+
+  &&& svg {
+    margin-bottom: 0;
+  }
 `;
 
 const StyledAlert = styled(Alert)`
@@ -24,14 +33,4 @@ const StyledSvgIcon = styled(SvgIcon)`
   margin-right: ${(props) => props.theme.spacing(1)}px;
 `;
 
-const StyledIconTab = styled.span`
-  span {
-    display: contents;
-  }
-
-  svg {
-    margin-bottom: 0 !important;
-  }
-`;
-
-export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon, StyledIconTab };
+export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon };

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import SvgIcon from '@material-ui/core/SvgIcon';
 import { TabPanel, Tabs } from 'js/shared-styles/tabs';
 import { Alert } from 'js/shared-styles/alerts';
 
@@ -18,4 +19,9 @@ const StyledAlert = styled(Alert)`
   flex-grow: 1;
 `;
 
-export { StyledTabPanel, StyledTabs, StyledAlert };
+const StyledSvgIcon = styled(SvgIcon)`
+  font-size: 1.25rem;
+  margin-right: ${(props) => props.theme.spacing(1)}px;
+`;
+
+export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon };

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
-import { TabPanel, Tabs } from 'js/shared-styles/tabs';
+import { Tab, TabPanel, Tabs } from 'js/shared-styles/tabs';
 import { Alert } from 'js/shared-styles/alerts';
 
 const StyledTabPanel = styled(TabPanel)`
@@ -13,14 +13,6 @@ const StyledTabPanel = styled(TabPanel)`
 
 const StyledTabs = styled(Tabs)`
   flex: none;
-
-  span {
-    display: contents;
-  }
-
-  &&& svg {
-    margin-bottom: 0;
-  }
 `;
 
 const StyledAlert = styled(Alert)`
@@ -33,4 +25,14 @@ const StyledSvgIcon = styled(SvgIcon)`
   margin-right: ${(props) => props.theme.spacing(1)}px;
 `;
 
-export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon };
+const StyledTab = styled(Tab)`
+  span {
+    display: contents;
+  }
+
+  &&& svg {
+    margin-bottom: 0;
+  }
+`;
+
+export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon, StyledTab };

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.js
@@ -24,4 +24,14 @@ const StyledSvgIcon = styled(SvgIcon)`
   margin-right: ${(props) => props.theme.spacing(1)}px;
 `;
 
-export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon };
+const StyledIconTab = styled.span`
+  span {
+    display: contents;
+  }
+
+  svg {
+    margin-bottom: 0 !important;
+  }
+`;
+
+export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon, StyledIconTab };


### PR DESCRIPTION
The following tasks were in the story for this PR:

1. Add icon to entity header
 
  This task had already been completed in the past so there is no additional code added. 
  ![image](https://github.com/hubmapconsortium/portal-ui/assets/45410262/585a6f0c-e288-4a2c-979e-c4b7d35121e7)


2. Add entity icons to header links to search pages
  
  As mentioned in the previous pull request (https://github.com/hubmapconsortium/portal-ui/pull/3195) Tiffany requested that the entire space be clickable so padding is used for the div around the icon and text instead of margin. 

  ![image](https://github.com/hubmapconsortium/portal-ui/assets/45410262/33ae958d-7a90-4bdf-8e9b-1f7e66b1a832)

3. Add entity icons to provenance table tab for entity headers
  ![image](https://github.com/hubmapconsortium/portal-ui/assets/45410262/4da01335-669d-4224-809c-8562dd862f80)

4. Add sample and dataset icon to tabs in "Derived Sample and Datasets"

I added additional comment at the bottom in response to Nik's suggestion. 

I understand that it is not ideal to use !important, but the custom styling I was giving was getting overwritten by MUI. If there is a better way to handle this please let me know!

![image](https://github.com/hubmapconsortium/portal-ui/assets/45410262/5fe225f1-f8dd-4be8-9787-13ca47edc0e4)
![image](https://github.com/hubmapconsortium/portal-ui/assets/45410262/387c0d6b-c877-4e8f-ba14-a667311bdea8)


Before:

![image](https://github.com/hubmapconsortium/portal-ui/assets/45410262/983fb5d3-d11b-4fba-a91e-5ee929eb75a5)


After: 

![image](https://github.com/hubmapconsortium/portal-ui/assets/45410262/322dfd87-89ba-4120-9fc4-3528dc4baca3)