### PR TITLE
John conroy/fix protocols errors HMP-306

### DIFF
--- a/CHANGELOG-fix-protocols-errors.md
+++ b/CHANGELOG-fix-protocols-errors.md
@@ -1,0 +1,1 @@
+- Display message when protocols.io requests fail in protocols section.

--- a/context/app/static/js/components/Providers.jsx
+++ b/context/app/static/js/components/Providers.jsx
@@ -40,7 +40,7 @@ function Providers({
   );
 
   const protocolsContext = useMemo(
-    () => ({ protocolsClientId: flaskData?.protocolsClientId, clientAuthToken: flaskData?.protocolsClientToken }),
+    () => ({ clientId: flaskData?.protocolsClientId, clientAuthToken: flaskData?.protocolsClientToken }),
     [flaskData],
   );
 

--- a/context/app/static/js/components/detailPage/Protocol/Protocol.jsx
+++ b/context/app/static/js/components/detailPage/Protocol/Protocol.jsx
@@ -3,31 +3,43 @@ import PropTypes from 'prop-types';
 import Divider from '@material-ui/core/Divider';
 
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import useProtocolData, { useFormattedProtocolUrls } from 'js/hooks/useProtocolData';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
+import HelpLink from 'js/shared-styles/Links/HelpLink';
 import { DetailPageSection } from 'js/components/detailPage/style';
 import { StyledPaper } from './style';
 import SectionItem from '../SectionItem';
 
+function ProtocolMessage({ precedingText }) {
+  return (
+    <SectionItem>
+      <div>
+        {precedingText}
+        <HelpLink /> about this issue and mention the HuBMAP ID.
+      </div>
+    </SectionItem>
+  );
+}
+
 function ProtocolLink({ url, index }) {
-  const { loading, data, error } = useProtocolData(url);
-  if (error || loading || !data) {
+  const { isLoading, data, error } = useProtocolData(url);
+
+  if (error || isLoading || !data) {
     if (index !== 0) {
       // Only show loading message for first protocol link
       return null;
     }
-    // Extra `div` wrapper is necessary to prevent the email icon link from taking up the full width and breaking text
-    return (
-      <SectionItem>
-        <div>
-          Protocols are loading. If protocols take a significant time to load, please contact{' '}
-          <EmailIconLink email="help@hubmapconsortium.org">help@hubmapconsortium.org</EmailIconLink> about this issue
-          and mention the HuBMAP ID.
-        </div>
-      </SectionItem>
-    );
+
+    if (isLoading && !error) {
+      // Extra `div` wrapper is necessary to prevent the email icon link from taking up the full width and breaking text
+      return (
+        <ProtocolMessage precedingText="Protocols are loading. If protocols take a significant time to load, please contact " />
+      );
+    }
+
+    return <ProtocolMessage precedingText="Failed to retrieve protocols. Please contact " />;
   }
+
   return (
     <SectionItem label={data?.payload?.title}>
       <OutboundIconLink href={data?.payload?.url}>{data?.payload?.url}</OutboundIconLink>

--- a/context/app/static/js/components/detailPage/Protocol/Protocol.jsx
+++ b/context/app/static/js/components/detailPage/Protocol/Protocol.jsx
@@ -14,6 +14,7 @@ import SectionItem from '../SectionItem';
 function ProtocolMessage({ precedingText }) {
   return (
     <SectionItem>
+      {/* Extra `div` wrapper is necessary to prevent the email icon link from taking up the full width and breaking text. */}
       <div>
         {precedingText}
         <HelpLink /> about this issue and mention the HuBMAP ID.
@@ -32,7 +33,6 @@ function ProtocolLink({ url, index }) {
     }
 
     if (isLoading && !error) {
-      // Extra `div` wrapper is necessary to prevent the email icon link from taking up the full width and breaking text
       return (
         <ProtocolMessage precedingText="Protocols are loading. If protocols take a significant time to load, please contact " />
       );

--- a/context/app/static/js/helpers/swr.ts
+++ b/context/app/static/js/helpers/swr.ts
@@ -1,16 +1,34 @@
+type fetchOptionsType = {
+  urls: string;
+  requestInit: RequestInit;
+  expectedStatusCodes: number[];
+};
+
 /**
  * SWR fetcher which accepts an array of URLs and returns the responses as JSON
  * A custom requestInit object can be passed to fetch as well.
  * @example // without requestInit
- * const { data } = useSWR(urls, multiFetcher);
+ * const { data } = useSWR({ urls, multiFetcher });
  * @example // with requestInit
- * const { data } = useSWR({ urls, token }, ({ urls, token }) => multiFetcher(urls, { headers: { Authorization: `Bearer ${token}` } })
- * @param urls - Array of URLs to fetch
- * @param requestInit - Optional RequestInit object to pass to fetch
+ * const { data } = useSWR({ urls, token }, ({ urls, token }) => multiFetcher({ urls, { headers: { Authorization: `Bearer ${token}` } } })
+ * @param fetchOptions
+ * @param fetchOptions.urls - Array of URLs to fetch
+ * @param fetchOptions.requestInit - Optional RequestInit object to pass to fetch
+ * @param fetchOptions.expectedStatusCodes - Optional array of status codes which reflect a succesful request
  */
 
-export async function multiFetcher<T>(urls: string[], requestInit: RequestInit = {}) {
-  const f = (url: string) => fetch(url, requestInit).then((response) => response.json());
+export async function multiFetcher<T>({ urls, requestInit = {}, expectedStatusCodes = [200] }: fetchOptionsType) {
+  const f = (url: string) =>
+    fetch(url, requestInit).then((response) => {
+      if (!expectedStatusCodes.includes(response.status)) {
+        const error = new Error(`The request to ${urls.join(', ')} failed.`);
+        error.info = response.json();
+        error.status = response.status;
+        throw error;
+      }
+      return response.json();
+    });
+
   if (urls.length === 0) {
     return Promise.resolve([] as T[]);
   }
@@ -21,12 +39,14 @@ export async function multiFetcher<T>(urls: string[], requestInit: RequestInit =
  * SWR fetcher which accepts a single URL and returns the response as JSON.
  * A custom requestInit object can be passed to fetch as well.
  * @example // without requestInit
- * const { data } = useSWR(urls, multiFetcher);
+ * const { data } = useSWR({ urls, multiFetcher });
  * @example // with requestInit
- * const { data } = useSWR({ urls, token }, ({ urls, token }) => multiFetcher(urls, { headers: { Authorization: `Bearer ${token}` } })
- * @param urls - Array of URLs to fetch
- * @param requestInit - Optional RequestInit object to pass to fetch
+ * const { data } = useSWR({ urls, token }, ({ urls, token }) => multiFetcher({ urls, { headers: { Authorization: `Bearer ${token}` } } })
+ * @param fetchOptions
+ * @param fetchOptions.urls - Array of URLs to fetch
+ * @param fetchOptions.requestInit - Optional RequestInit object to pass to fetch
+ * @param fetchOptions.expectedStatusCodes - Optional array of status codes which reflect a succesful request
  */
-export async function fetcher<T>(url: string, requestInit: RequestInit = {}) {
-  return multiFetcher([url], requestInit).then((data) => data[0]) as Promise<T>;
+export async function fetcher<T>({ url, requestInit = {}, expectedStatusCodes = [200] }: fetchOptionsType) {
+  return multiFetcher({ urls: [url], requestInit, expectedStatusCodes }).then((data) => data[0]) as Promise<T>;
 }

--- a/context/app/static/js/helpers/swr.ts
+++ b/context/app/static/js/helpers/swr.ts
@@ -1,7 +1,7 @@
 type fetchOptionsType = {
   urls: string;
-  requestInit: RequestInit;
-  expectedStatusCodes: number[];
+  requestInit?: RequestInit;
+  expectedStatusCodes?: number[];
 };
 
 /**

--- a/context/app/static/js/hooks/useProtocolData.js
+++ b/context/app/static/js/hooks/useProtocolData.js
@@ -35,7 +35,7 @@ export function useFormattedProtocolUrls(protocolUrls, lastVersion) {
 function useProtocolData(protocolUrl) {
   const { protocolsClientToken } = useAppContext();
   const result = useSWR([protocolUrl, protocolsClientToken], ([url, token]) =>
-    fetcher(url, { headers: { Authorization: `Bearer ${token}` } }),
+    fetcher({ url, requestInit: { headers: { Authorization: `Bearer ${token}` } } }),
   );
   return result;
 }

--- a/context/app/static/js/shared-styles/Links/HelpLink.tsx
+++ b/context/app/static/js/shared-styles/Links/HelpLink.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
+
+function HelpLink(props) {
+  return (
+    <EmailIconLink email="help@hubmapconsortium.org" {...props}>
+      help@hubmapconsortium.org
+    </EmailIconLink>
+  );
+}
+
+export default HelpLink;


### PR DESCRIPTION
Fixes the handling of loading and errors for protocols.io requests in protocols section. Previously the non-200s were not being treated as errors and the resulting display matches what is shown in https://hms-dbmi.atlassian.net/browse/HMP-306. That being said, the requests were only failing locally due to our out of date `app.conf` files. Requests on PROD should work.

I'm not sure if the mismatched key passed to `protocolsContext` in `Providers` would have caused any issues ( it does not seem like we're using this context anywhere?), but I fixed it to match the types defined in `ProctocolAPIContext`. Should typescript have picked this up?

I've also added `HelpLink` to be used throughout the application. I've filed https://hms-dbmi.atlassian.net/browse/HMP-307.

200

<img width="1131" alt="Screen Shot 2023-07-26 at 11 21 26 AM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/52a36643-53e5-4c01-9997-7742fcbe7c14">

Non-200

<img width="1112" alt="Screen Shot 2023-07-26 at 11 21 52 AM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/b10a2105-f384-49e1-860c-b7f6350f7768">
