### PR TITLE
John conroy/fix storybook typescript

### DIFF
--- a/CHANGELOG-fix-storybook-typescript.md
+++ b/CHANGELOG-fix-storybook-typescript.md
@@ -1,0 +1,1 @@
+- Configure storybook to build with swc instead of babel and compile typescript.

--- a/context/.storybook/main.js
+++ b/context/.storybook/main.js
@@ -4,7 +4,7 @@ const {
 } = require('../build-utils/alias');
 module.exports = {
   "stories": ['../app/static/js/shared-styles/**/*.stories.js', '../app/static/js/components/**/*.stories.js'],
-  "addons": ["@storybook/addon-links", "@storybook/addon-essentials"],
+  "addons": ["@storybook/addon-links", "@storybook/addon-essentials", 'storybook-addon-swc'],
   "webpackFinal": async config => {
     config.resolve.alias = {
       // extend alias with our own

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -135,6 +135,7 @@
         "sass-loader": "^8.0.2",
         "source-map-loader": "^0.2.4",
         "storybook": "^7.0.26",
+        "storybook-addon-swc": "^1.2.0",
         "style-loader": "^1.1.3",
         "typescript": "^5.1.3",
         "url-loader": "^3.0.0",
@@ -36585,6 +36586,43 @@
         "url": "https://opencollective.com/storybook"
       }
     },
+    "node_modules/storybook-addon-swc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-swc/-/storybook-addon-swc-1.2.0.tgz",
+      "integrity": "sha512-PEpxhAH+407KTcVDC7uUH4S26qtuBDC/JlZI3NqFYu0Tm2uCBf56On+13lK4iE3Iz8FORl4aSXo2RricJ/UhPQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.17.2",
+        "deepmerge": "^4.2.2",
+        "swc-loader": "^0.1.15"
+      },
+      "peerDependencies": {
+        "@swc/core": "^1.2.152",
+        "terser-webpack-plugin": "^4.0.0 || ^5.0.0",
+        "webpack": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": false
+        },
+        "terser-webpack-plugin": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook-addon-swc/node_modules/swc-loader": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.1.16.tgz",
+      "integrity": "sha512-NKIm8aJjK/z/yfzk+v7YGwJMjBKaLaUs9ZKI2zoaIGKAjtkwjO92ZLI0fiTZuwzRqVLQl/29fBdSgFCBzquR0w==",
+      "dev": true,
+      "peerDependencies": {
+        "@swc/core": "^1.2.147",
+        "webpack": ">=2"
+      }
+    },
     "node_modules/stream-browserify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-3.0.0.tgz",
@@ -68956,6 +68994,25 @@
       "dev": true,
       "requires": {
         "@storybook/cli": "7.0.26"
+      }
+    },
+    "storybook-addon-swc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/storybook-addon-swc/-/storybook-addon-swc-1.2.0.tgz",
+      "integrity": "sha512-PEpxhAH+407KTcVDC7uUH4S26qtuBDC/JlZI3NqFYu0Tm2uCBf56On+13lK4iE3Iz8FORl4aSXo2RricJ/UhPQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.17.2",
+        "deepmerge": "^4.2.2",
+        "swc-loader": "^0.1.15"
+      },
+      "dependencies": {
+        "swc-loader": {
+          "version": "0.1.16",
+          "resolved": "https://registry.npmjs.org/swc-loader/-/swc-loader-0.1.16.tgz",
+          "integrity": "sha512-NKIm8aJjK/z/yfzk+v7YGwJMjBKaLaUs9ZKI2zoaIGKAjtkwjO92ZLI0fiTZuwzRqVLQl/29fBdSgFCBzquR0w==",
+          "dev": true
+        }
       }
     },
     "stream-browserify": {

--- a/context/package.json
+++ b/context/package.json
@@ -128,6 +128,7 @@
     "sass-loader": "^8.0.2",
     "source-map-loader": "^0.2.4",
     "storybook": "^7.0.26",
+    "storybook-addon-swc": "^1.2.0",
     "style-loader": "^1.1.3",
     "typescript": "^5.1.3",
     "url-loader": "^3.0.0",


### PR DESCRIPTION
Storybook was failing to load as it was treating typescript files as javascript since it compiles with babel by default. Configuring storybook to use `swc` with `storybook-addon-swc` seems to fix it.