### PR TITLE
NickAkhmetov/HMP-314 QA Fixes after MUI 5 upgrade

### DIFF
--- a/CHANGELOG-mui-qa-fixes-1.md
+++ b/CHANGELOG-mui-qa-fixes-1.md
@@ -1,0 +1,2 @@
+- Fix various styles broken during MUI 5 upgrade.
+- Update desktop dropdown popper to use Popper v2 offset API.

--- a/context/app/static/js/components/Footer/style.js
+++ b/context/app/static/js/components/Footer/style.js
@@ -20,7 +20,7 @@ const Flex = styled.div`
 const FlexColumn = styled.div`
   display: flex;
   flex-direction: column;
-  margin-right: ${(props) => (props.$mr ? props.theme.spacing(10) : '0')}px;
+  margin-right: ${(props) => (props.$mr ? props.theme.spacing(10) : '0')};
 `;
 
 const HubmapLogo = styled(Logo)`

--- a/context/app/static/js/components/Header/Dropdown/Dropdown.jsx
+++ b/context/app/static/js/components/Header/Dropdown/Dropdown.jsx
@@ -19,7 +19,19 @@ function Dropdown({ title, children, menuListId, ...rest }) {
         {title}
         {open ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />}
       </Button>
-      <OffsetPopper open={open} anchorEl={anchorRef.current} placement="bottom-start">
+      <OffsetPopper
+        open={open}
+        anchorEl={anchorRef.current}
+        placement="bottom-start"
+        modifiers={[
+          {
+            name: 'offset',
+            options: {
+              offset: [0, 14],
+            },
+          },
+        ]}
+      >
         <Paper>
           <ClickAwayListener onClickAway={toggle}>
             <MenuList id={menuListId}>{children}</MenuList>

--- a/context/app/static/js/components/Header/Dropdown/style.js
+++ b/context/app/static/js/components/Header/Dropdown/style.js
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 import Popper from '@mui/material/Popper';
 
 const OffsetPopper = styled(Popper)`
-  margin-top: 14px;
   z-index: ${(props) => props.theme.zIndex.dropdownOffset};
 `;
 

--- a/context/app/static/js/components/detailPage/provenance/ProvTable/style.js
+++ b/context/app/static/js/components/detailPage/provenance/ProvTable/style.js
@@ -21,13 +21,13 @@ const TableColumn = styled.div`
 
 const StyledSvgIcon = styled(SvgIcon)`
   font-size: 1.25rem;
-  margin-right: ${(props) => props.theme.spacing(1)}px;
+  margin-right: ${(props) => props.theme.spacing(1.5)};
 `;
 
 const ProvTableEntityHeader = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: ${(props) => props.theme.spacing(1)}px;
+  margin-bottom: ${(props) => props.theme.spacing(1)};
 `;
 
 export { FlexContainer, FlexColumn, TableColumn, StyledSvgIcon, ProvTableEntityHeader };

--- a/context/app/static/js/pages/search/style.js
+++ b/context/app/static/js/pages/search/style.js
@@ -8,13 +8,13 @@ const SearchHeader = styled(Typography)`
 
 const StyledSvgIcon = styled(SvgIcon)`
   font-size: 2.5rem;
-  margin-right: ${(props) => props.theme.spacing(0.5)}px;
+  margin-right: ${(props) => props.theme.spacing(0.5)};
 `;
 
 const SearchEntityHeader = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: ${(props) => props.theme.spacing(1)}px;
+  margin-bottom: ${(props) => props.theme.spacing(1)};
 `;
 
 export { SearchHeader, StyledSvgIcon, SearchEntityHeader };


### PR DESCRIPTION
- Removes unnecessary `px` suffixes missed during upgrade/merge process to fix broken spacing
- Adjusts popover positioning on desktop to use the `modifiers` API from Popover v2 since margin is no longer usable for popover positioning

Prov table headers before/after:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/2f25ff7a-18a3-4ed7-9b43-1b6e1a82719d)
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/01623ada-5434-4904-a590-eb44dddaf872)

Header dropdowns before/after:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/f16eabfc-8ee2-47d7-86ce-cebc8bcf323c)
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/a683ad9c-749b-4a98-85f6-fb7e02a1f6cf)

Search headers before/after:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/42082b21-0b44-44b9-827d-e12fb27a6365)
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/519f38a2-c433-401a-81b3-d228c510756d)

Footer before/after:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/55b46afd-a629-44c3-a9a4-f0483d6eeaa9)
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/32a4f291-fd53-42d6-94c3-4e5df591b2f2)