### PR TITLE
Nickakhmetov/HMP-317 HMP-318 fix font sizes

### DIFF
--- a/CHANGELOG-mui-qa-fixes-1.md
+++ b/CHANGELOG-mui-qa-fixes-1.md
@@ -1,1 +1,0 @@
-- Restore MUI v4 font size.

--- a/CHANGELOG-mui-qa-fixes-1.md
+++ b/CHANGELOG-mui-qa-fixes-1.md
@@ -1,0 +1,1 @@
+- Restore MUI v4 font size.

--- a/CHANGELOG-mui-qa-fixes-2.md
+++ b/CHANGELOG-mui-qa-fixes-2.md
@@ -1,0 +1,2 @@
+- Restore MUI v4 font size.
+- Fix Diversity page title size.

--- a/context/app/static/js/pages/Diversity/style.js
+++ b/context/app/static/js/pages/Diversity/style.js
@@ -2,12 +2,13 @@ import styled from 'styled-components';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import SectionPaper from 'js/shared-styles/sections/SectionPaper';
+import Title from 'js/shared-styles/pages/PageTitle';
 
 const PageTitleWrapper = styled.div`
   margin-bottom: 20px;
 `;
 
-const PageTitle = styled(Typography)`
+const PageTitle = styled(Title)`
   margin-bottom: 10px;
 `;
 

--- a/context/app/static/js/theme.jsx
+++ b/context/app/static/js/theme.jsx
@@ -140,6 +140,18 @@ const theme = createTheme({
       xl: 1920, // v5 default = 1536
     },
   },
+  components: {
+    MuiCssBaseline: {
+      // use body2 style like v4 instead of body1
+      styleOverrides: {
+        body: {
+          fontSize: '0.8rem',
+          lineHeight: 1.43,
+          letterSpacing: '0.01071em',
+        },
+      },
+    },
+  },
 });
 
 export default theme;


### PR DESCRIPTION
This PR restores the previous global default font sizes to address sizing issues on components which were previously using these default styles. It also updates the Diversity page to use the global PageTitle component

Fixed SRA experiment sizes: 
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/45869054-8594-4418-9a64-d5254d38cfa5)

Fixed diversity header:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/797d994f-fc09-4f01-b23b-8a616163041e)
