### PR TITLE
NickAkhmetov/HMP-316 Add missing collections icon to header

### DIFF
--- a/CHANGELOG-fix-collections-header.md
+++ b/CHANGELOG-fix-collections-header.md
@@ -1,0 +1,1 @@
+- Add missing Collections icon to header.

--- a/context/app/static/js/components/detailPage/summary/SummaryData/style.js
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/style.js
@@ -20,13 +20,13 @@ const StyledTypography = styled(Typography)`
 
 const StyledSvgIcon = styled(SvgIcon)`
   font-size: 1.25rem;
-  margin-right: ${(props) => props.theme.spacing(0.5)}px;
+  margin-right: ${(props) => props.theme.spacing(0.5)};
 `;
 
 const SummaryDataHeader = styled.div`
   display: flex;
   align-items: center;
-  margin-bottom: ${(props) => props.theme.spacing(1)}px;
+  margin-bottom: ${(props) => props.theme.spacing(1)};
 `;
 
 export { FlexEnd, JsonButton, StyledTypography, StyledSvgIcon, SummaryDataHeader };

--- a/context/app/static/js/shared-styles/icons/entityIconMap.js
+++ b/context/app/static/js/shared-styles/icons/entityIconMap.js
@@ -1,4 +1,4 @@
-import { DatasetIcon, SampleIcon, DonorIcon, PublicationIcon } from 'js/shared-styles/icons';
+import { DatasetIcon, SampleIcon, DonorIcon, PublicationIcon, CollectionIcon } from 'js/shared-styles/icons';
 
 export const entityIconMap = {
   Donor: DonorIcon,
@@ -6,4 +6,5 @@ export const entityIconMap = {
   Dataset: DatasetIcon,
   Support: DatasetIcon,
   Publication: PublicationIcon,
+  Collection: CollectionIcon,
 };


### PR DESCRIPTION
This PR adds the Collections icon to the `entityIconMap` used for detail page headers; this was previously not present, which led to a weird spacing issue. I also fixed the margins by removing the `px` suffix.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/5ad73741-a21a-4b0e-b328-8876c078dfd1)
