### PR TITLE
NickAkhmetov/HMP-323 Remove underline on Visualize link

### DIFF
--- a/CHANGELOG-hmp-323.md
+++ b/CHANGELOG-hmp-323.md
@@ -1,0 +1,1 @@
+- Remove underline from Visualize link.

--- a/context/app/static/js/components/searchPage/MetadataMenu/MetadataMenu.jsx
+++ b/context/app/static/js/components/searchPage/MetadataMenu/MetadataMenu.jsx
@@ -8,7 +8,8 @@ import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import withDropdownMenuProvider from 'js/shared-styles/dropdowns/DropdownMenuProvider/withDropdownMenuProvider';
 import { useStore } from 'js/shared-styles/dropdowns/DropdownMenuProvider/store';
 import DropdownMenu from 'js/shared-styles/dropdowns/DropdownMenu';
-import { StyledDropdownMenuButton, StyledLink, StyledInfoIcon } from './style';
+import { Link } from '@mui/material';
+import { StyledDropdownMenuButton, StyledInfoIcon } from './style';
 
 async function fetchAndDownload({ urlPath, allResultsUUIDs, closeMenu, analyticsCategory }) {
   await postAndDownloadFile({ url: urlPath, body: { uuids: allResultsUUIDs } });
@@ -39,7 +40,9 @@ function MetadataMenu({ type, analyticsCategory }) {
       <StyledDropdownMenuButton menuID={menuID}>Metadata</StyledDropdownMenuButton>
       <DropdownMenu id={menuID}>
         <MenuItem>
-          <StyledLink href={`/lineup/${lcPluralType}`}>Visualize</StyledLink>
+          <Link underline="none" href={`/lineup/${lcPluralType}`}>
+            Visualize
+          </Link>
           <SecondaryBackgroundTooltip title="Visualize all available metadata in Lineup." placement="bottom-start">
             <StyledInfoIcon color="primary" />
           </SecondaryBackgroundTooltip>

--- a/context/app/static/js/components/searchPage/MetadataMenu/style.js
+++ b/context/app/static/js/components/searchPage/MetadataMenu/style.js
@@ -10,9 +10,7 @@ const StyledDropdownMenuButton = styled(DropdownMenuButton)`
 `;
 
 const StyledLink = styled(Link)`
-  &:hover {
-    text-decoration: none;
-  }
+  text-decoration: none;
 `;
 
 const StyledInfoIcon = styled(InfoIcon)`

--- a/context/app/static/js/components/searchPage/MetadataMenu/style.js
+++ b/context/app/static/js/components/searchPage/MetadataMenu/style.js
@@ -13,4 +13,4 @@ const StyledInfoIcon = styled(InfoIcon)`
   margin-left: ${(props) => props.theme.spacing(0.5)};
 `;
 
-export { StyledDropdownMenuButton, StyledLink, StyledInfoIcon };
+export { StyledDropdownMenuButton, StyledInfoIcon };

--- a/context/app/static/js/components/searchPage/MetadataMenu/style.js
+++ b/context/app/static/js/components/searchPage/MetadataMenu/style.js
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import Link from '@mui/material/Link';
 
 import { InfoIcon } from 'js/shared-styles/icons';
 import DropdownMenuButton from 'js/shared-styles/dropdowns/DropdownMenuButton';
@@ -7,10 +6,6 @@ import DropdownMenuButton from 'js/shared-styles/dropdowns/DropdownMenuButton';
 const StyledDropdownMenuButton = styled(DropdownMenuButton)`
   margin: 0 ${(props) => props.theme.spacing(1)};
   height: 100%;
-`;
-
-const StyledLink = styled(Link)`
-  text-decoration: none;
 `;
 
 const StyledInfoIcon = styled(InfoIcon)`


### PR DESCRIPTION
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/513a2ac1-a04a-4590-9dbb-bfaed6603cb2)

The default `underline` prop for MUI links was changed from `hover` to `always` in MUI 5. I changed the prop to `underline="none"` and removed the unnecessary extra style.