### PR TITLE
HMP-330 Fix autocomplete/selects on Molecular Data Query page

### DIFF
--- a/CHANGELOG-HMP-330.md
+++ b/CHANGELOG-HMP-330.md
@@ -1,0 +1,1 @@
+- Fix molecular data queries beta page select and autocomplete components.

--- a/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
+++ b/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
@@ -48,14 +48,14 @@ function AutocompleteEntity({ targetEntity, setter, cellVariableNames, setCellVa
     <Autocomplete
       options={options}
       multiple
-      getOptionLabel={(option) => option}
+      getOptionLabel={(option) => option.full}
       isOptionEqualToValue={(option, value) => option.full === value}
-      renderOption={(option) => (
-        <>
+      renderOption={(props, option) => (
+        <li {...props}>
           {option.pre}
           <b>{option.match}</b>
           {option.post}
-        </>
+        </li>
       )}
       value={cellVariableNames}
       onChange={(event, value) => {

--- a/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
+++ b/context/app/static/js/components/cells/AutocompleteEntity/AutocompleteEntity.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 
 import Autocomplete from '@mui/material/Autocomplete';
 import TextField from '@mui/material/TextField';
@@ -23,6 +23,8 @@ function AutocompleteEntity({ targetEntity, setter, cellVariableNames, setCellVa
     setCellVariableNames([]);
   }, [targetEntity, setCellVariableNames]);
 
+  const loading = useRef(false);
+
   async function handleChange(event) {
     const { target } = event;
     setSubstring(target.value);
@@ -33,13 +35,15 @@ function AutocompleteEntity({ targetEntity, setter, cellVariableNames, setCellVa
     }
 
     try {
-      setOptions(
-        await new CellsService().searchBySubstring({
-          targetEntity,
-          substring: target.value,
-        }),
-      );
+      loading.current = true;
+      const newOptions = await new CellsService().searchBySubstring({
+        targetEntity,
+        substring: target.value,
+      });
+      loading.current = false;
+      setOptions(newOptions);
     } catch (e) {
+      loading.current = false;
       console.warn(e.message);
     }
   }
@@ -50,6 +54,7 @@ function AutocompleteEntity({ targetEntity, setter, cellVariableNames, setCellVa
       multiple
       getOptionLabel={(option) => option.full}
       isOptionEqualToValue={(option, value) => option.full === value}
+      loading={loading.current}
       renderOption={(props, option) => (
         <li {...props}>
           {option.pre}

--- a/context/app/static/js/components/cells/QuerySelect/QuerySelect.jsx
+++ b/context/app/static/js/components/cells/QuerySelect/QuerySelect.jsx
@@ -19,15 +19,6 @@ function QuerySelect({ completeStep, setParametersButtonRef }) {
         variant="outlined"
         select
         fullWidth
-        SelectProps={{
-          MenuProps: {
-            anchorOrigin: {
-              vertical: 'bottom',
-              horizontal: 'left',
-            },
-            getContentAnchorEl: null,
-          },
-        }}
       >
         {Object.values(queryTypes).map((type) => (
           <MenuItem value={type.value} key={type.value}>


### PR DESCRIPTION
This PR
- Fixes the centering of the protein vs. gene select
- Fixes the display of the autocomplete search results

Gene and Protein options are properly centered:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/e5bc3464-b518-45b5-8a87-3f06e2263b0e)

Gene lookup results are displayed as expected:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/520124bb-7a00-4381-b632-bf0e5040c833)

I also added a loading state so that the autocomplete doesn't flash "No results" while there's a pending lookup:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/db9f2077-25bf-4fa3-aeaa-9973c757db50)