### PR TITLE
NickAkhmetov/HMP-271 Tear down publication time gate

### DIFF
--- a/CHANGELOG-hmp-271.md
+++ b/CHANGELOG-hmp-271.md
@@ -1,0 +1,1 @@
+- Remove extra logic to determine whether to display publication slide.

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -1,7 +1,7 @@
 from flask import (render_template, current_app, abort,
                    session, request)
 
-from .utils import get_default_flask_data, make_blueprint, get_organs, get_enable_publications
+from .utils import get_default_flask_data, make_blueprint, get_organs
 
 
 blueprint = make_blueprint(__name__)
@@ -9,8 +9,7 @@ blueprint = make_blueprint(__name__)
 
 @blueprint.route('/')
 def index():
-    flask_data = {**get_default_flask_data(), 'organs_count': len(get_organs()),
-                  'enable_publications': get_enable_publications()}
+    flask_data = {**get_default_flask_data(), 'organs_count': len(get_organs())}
     return render_template(
         'base-pages/react-content.html',
         flask_data=flask_data,

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -308,7 +308,6 @@ Routes.propTypes = {
     organs_count: PropTypes.number,
     vignette_json: PropTypes.object,
     geneSymbol: PropTypes.string,
-    enable_publications: PropTypes.bool,
   }),
 };
 

--- a/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
+++ b/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
@@ -41,8 +41,7 @@ const slides = [
 const disableRandomImage = true;
 
 function ImageCarouselContainer() {
-  // Set random intial image index if publications are not yet enabled
-  // If publications are enabled, use publication slide first
+  // In order to keep highlighting publications, the shuffle functionality is currently disabled.
   const [selectedImageIndex, setSelectedImageIndex] = useState(
     disableRandomImage ? 0 : Math.floor(Math.random() * slides.length),
   );

--- a/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
+++ b/context/app/static/js/components/home/ImageCarouselContainer/ImageCarouselContainer.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 
 import CarouselImage from 'js/components/home/CarouselImage';
 
-import { useFlaskDataContext } from 'js/components/Contexts';
 import ImageCarousel from '../ImageCarousel';
 import ImageCarouselControlButtons from '../ImageCarouselControlButtons';
 import ImageCarouselCallToAction from '../ImageCarouselCallToAction';
@@ -12,6 +11,12 @@ import { getCarouselImageSrcSet } from './utils';
 const getCDNCarouselImageSrcSet = (key) => getCarouselImageSrcSet(key, CDN_URL);
 
 const slides = [
+  {
+    title: 'Discover the publications reporting the breakthroughs of  mapping the human body with HuBMAP data',
+    body: 'Explore publications authored by scientists in the consortium involving HuBMAP data. Additional publications will be coming in the future as the consortium continue to create mappings of the human body. View the press release reporting on these publications.',
+    image: <CarouselImage {...getCDNCarouselImageSrcSet('publication')} alt="HuBMAP Publications" key="Publications" />,
+    buttonHref: '/publications',
+  },
   {
     title: 'Explore spatial single-cell data with Vitessce visualizations',
     body: 'View multi-modal single-cell resolution measurements with reusable interactive components such as a scatterplot, spatial+imaging plot, genome browser tracks, statistical plots, and controller components.',
@@ -33,25 +38,16 @@ const slides = [
   },
 ];
 
-const publicationSlide = {
-  title: 'Discover the publications reporting the breakthroughs of  mapping the human body with HuBMAP data',
-  body: 'Explore publications authored by scientists in the consortium involving HuBMAP data. Additional publications will be coming in the future as the consortium continue to create mappings of the human body. View the press release reporting on these publications.',
-  image: <CarouselImage {...getCDNCarouselImageSrcSet('publication')} alt="HuBMAP Publications" key="Publications" />,
-  buttonHref: '/publications',
-};
-
-const slidesWithPublications = [publicationSlide, ...slides];
+const disableRandomImage = true;
 
 function ImageCarouselContainer() {
-  const { enable_publications: enablePublications } = useFlaskDataContext();
-  const slidesToUse = enablePublications ? slidesWithPublications : slides;
   // Set random intial image index if publications are not yet enabled
   // If publications are enabled, use publication slide first
   const [selectedImageIndex, setSelectedImageIndex] = useState(
-    enablePublications ? 0 : Math.floor(Math.random() * slidesToUse.length),
+    disableRandomImage ? 0 : Math.floor(Math.random() * slides.length),
   );
 
-  const { title, body, buttonHref } = slidesToUse[selectedImageIndex];
+  const { title, body, buttonHref } = slides[selectedImageIndex];
   return (
     <Flex>
       <CallToActionWrapper>
@@ -59,13 +55,13 @@ function ImageCarouselContainer() {
         <ImageCarouselControlButtons
           selectedImageIndex={selectedImageIndex}
           setSelectedImageIndex={setSelectedImageIndex}
-          numImages={slidesToUse.length}
+          numImages={slides.length}
         />
       </CallToActionWrapper>
       <ImageCarousel
         selectedImageIndex={selectedImageIndex}
         setSelectedImageIndex={setSelectedImageIndex}
-        images={slidesToUse.map((slide) => slide.image)}
+        images={slides.map((slide) => slide.image)}
       />
     </Flex>
   );

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -1,6 +1,5 @@
 from urllib.parse import urlparse
 from flask import (current_app, request, session, Blueprint)
-from datetime import datetime
 
 from .api.client import ApiClient
 from .api.mock_client import MockApiClient
@@ -56,11 +55,3 @@ def get_organs():
     dir_path = Path(dirname(__file__) + '/organ')
     organs = {p.stem: safe_load(p.read_text()) for p in dir_path.glob('*.yaml')}
     return organs
-
-
-def get_enable_publications():
-    current_timestamp = datetime.now().timestamp()
-    # 2023-07-19 at 15:00:00 UTC
-    publication_embargo_end_timestamp = 1689778800
-    return current_app.config.get('ENABLE_PUBLICATIONS') or \
-        current_timestamp > publication_embargo_end_timestamp


### PR DESCRIPTION
This PR removes the `enable_publications` flag from the flask data. The homepage is still set to display the publication slide by default, but the extra logic to determine whether the launch date/time has passed has been removed.