### PR TITLE
Release/v0.76.4

### DIFF
--- a/CHANGELOG-HMP-320-Wrong-blue-for-link-on-organ-page.md
+++ b/CHANGELOG-HMP-320-Wrong-blue-for-link-on-organ-page.md
@@ -1,1 +1,0 @@
-- Fix Reference dataset link color on organ page.

--- a/CHANGELOG-HMP-330.md
+++ b/CHANGELOG-HMP-330.md
@@ -1,1 +1,0 @@
-- Fix molecular data queries beta page select and autocomplete components.

--- a/CHANGELOG-hmp-271.md
+++ b/CHANGELOG-hmp-271.md
@@ -1,1 +1,0 @@
-- Remove extra logic to determine whether to display publication slide.

--- a/CHANGELOG-hmp-309.md
+++ b/CHANGELOG-hmp-309.md
@@ -1,2 +1,0 @@
-- Make individual organs' routes case insensitive
-- Handle spaces and underscores sent as part of organ name

--- a/CHANGELOG-upgrade-portal-vis.md
+++ b/CHANGELOG-upgrade-portal-vis.md
@@ -1,1 +1,0 @@
-- Upgrade portal-visualization to 0.0.13.

--- a/context/app/markdown/CHANGELOG.md
+++ b/context/app/markdown/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.76.4 - 2023-08-14
+
+- Remove extra logic to determine whether to display publication slide.
+- Make individual organs' routes case insensitive
+- Handle spaces and underscores sent as part of organ name
+- Fix Reference dataset link color on organ page.
+- Fix molecular data queries beta page select and autocomplete components.
+- Upgrade portal-visualization to 0.0.13.
+
+
 ## v0.76.3 - 2023-08-10
 
 - Implemented new panel design when entity api for globus link returns an error. 

--- a/context/app/markdown/dependencies.md
+++ b/context/app/markdown/dependencies.md
@@ -7,7 +7,7 @@ The services the portal relies on are [listed separately](/services).
 ## Git submodules
 
 ```
- 79cab515ee56184a824c6755ff25fc6e2d1a3a65 context/ingest-validation-tools (v0.0.13-23-g79cab51)
+ 79cab515ee56184a824c6755ff25fc6e2d1a3a65 context/ingest-validation-tools (v0.0.13-23-g79cab515)
 ```
 
 ## Python packages
@@ -27,7 +27,7 @@ hubmap-api-py-client>=0.0.9
 hubmap-commons>=2.0.12
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.12.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.0.13.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portal-ui",
-  "version": "0.76.3",
+  "version": "0.76.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "portal-ui",
-      "version": "0.76.3",
+      "version": "0.76.4",
       "license": "MIT",
       "dependencies": {
         "@datapunt/matomo-tracker-js": "^0.5.1",

--- a/context/package.json
+++ b/context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portal-ui",
-  "version": "0.76.3",
+  "version": "0.76.4",
   "dependencies": {
     "@datapunt/matomo-tracker-js": "^0.5.1",
     "@elastic/datemath": "^5.0.3",


### PR DESCRIPTION
This branch contains the version bumps/changelogs necessary to release v.0.76.4; the `push` script would not allow me to push these commits directly to main, so I'm trying it as a separate PR.