### PR TITLE
NickAkhmetov/HMP-333 Persist selections on dataset test-search page

### DIFF
--- a/context/app/static/js/components/entity-search/Search/Search.jsx
+++ b/context/app/static/js/components/entity-search/Search/Search.jsx
@@ -20,7 +20,7 @@ const createSkClient = () =>
   });
 
 function Search() {
-  const { results, allResultsUUIDs, entityType } = useSearch();
+  const { results, allResultsUUIDs, entityType } = useSearch({ isTestSearch: true });
 
   return (
     <>

--- a/context/app/static/js/components/entity-search/Search/hooks.js
+++ b/context/app/static/js/components/entity-search/Search/hooks.js
@@ -40,10 +40,12 @@ const query = new CustomQuery({
   },
 });
 
-function useSearch() {
+function useSearch({ isTestSearch }) {
   const { elasticsearchEndpoint, groupsToken } = useAppContext();
   const authHeader = getAuthHeader(groupsToken);
   const { fields, tileFields, facets, defaultFilters, entityType, numericFacetsProps, availableFields } = useStore();
+  // Persist selections on test search page for datasets only
+  const persistSelections = entityType === 'dataset' && isTestSearch;
 
   const defaultFilterValues = Object.values(defaultFilters);
 
@@ -96,6 +98,7 @@ function useSearch() {
     queryBody,
     elasticsearchEndpoint,
     groupsToken,
+    persistSelections,
   });
 
   return { results, entityType, allResultsUUIDs };

--- a/context/app/static/js/components/entity-search/searchkit-modifications/useSearchkitSDK.js
+++ b/context/app/static/js/components/entity-search/searchkit-modifications/useSearchkitSDK.js
@@ -16,6 +16,7 @@ const useSearchkitSDK = ({
   elasticsearchEndpoint,
   groupsToken,
   queryBody,
+  persistSelections,
 }) => {
   const [results, setResponse] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -53,12 +54,14 @@ const useSearchkitSDK = ({
         // eslint-disable-next-line no-underscore-dangle
         const currentResultsUUIDS = allResults.hits.hits.map((hit) => hit._id);
 
-        // if the number of new results is larger, reset selections
-        if (currentResultsUUIDS.length > allResultsUUIDs.length) {
-          deselectHeaderAndRows();
-        } else {
-          // retain selections included in the new results
-          setSelectedRows(...[currentResultsUUIDS.filter((result) => selectedRows.has(result))]);
+        if (!persistSelections) {
+          // if the number of new results is larger, reset selections
+          if (currentResultsUUIDS.length > allResultsUUIDs.length) {
+            deselectHeaderAndRows();
+          } else {
+            // retain selections included in the new results
+            setSelectedRows(...[currentResultsUUIDS.filter((result) => selectedRows.has(result))]);
+          }
         }
 
         setAllResultsUUIDS(currentResultsUUIDS);


### PR DESCRIPTION
This PR adds an escape hatch to the current behavior of resetting selections when the results change to specifically allow users to make selections across multiple search pages on the test-search datasets page. 

Since this selection reset is defined as part of the SearchKit behavior and we're planning a revamp of it in the near future, this seemed like a good way to avoid introducing potentially unwanted behavior on the other search pages by removing the deselection logic outright. If that would be preferable, I can adjust this accordingly.


https://github.com/hubmapconsortium/portal-ui/assets/19957804/45fab5cd-2b30-4619-9ec1-3b958d08793d

