### PR TITLE
NickAkhmetov/HMP-322 Fix table of contents link to derived samples and datasets section

### DIFF
--- a/CHANGELOG-hmp-322-fix-donor-toc.md
+++ b/CHANGELOG-hmp-322-fix-donor-toc.md
@@ -1,0 +1,1 @@
+- Fix Donor page table of contents link to derived samples and datasets section.

--- a/context/.eslintrc.yml
+++ b/context/.eslintrc.yml
@@ -71,6 +71,7 @@ overrides:
     rules:
       import/no-extraneous-dependencies: [0]
       '@typescript-eslint/no-var-requires': [0] # allow use of require in jest tests
+      jest/no-standalone-expect: ['error', { 'additionalTestBlockFunctions': ['test.each'] }] # Detect test.each as a test block function
       jest/expect-expect: ['error', { 'assertFunctionNames': ['expect*'] }] # allow expect calls to be contained within helper functions that start with expect
       '@typescript-eslint/no-empty-function': [0] # allow empty function placeholders in jest tests
   - files: ['**/*.stories.{js,jsx,ts,tsx}']

--- a/context/app/static/js/components/detailPage/derivedEntities/DerivedEntitiesSection/DerivedEntitiesSection.jsx
+++ b/context/app/static/js/components/detailPage/derivedEntities/DerivedEntitiesSection/DerivedEntitiesSection.jsx
@@ -15,7 +15,7 @@ function DerivedEntitiesSection() {
   return (
     <RelatedEntitiesSectionWrapper
       isLoading={isLoading}
-      sectionId="derived-entities"
+      sectionId="derived-samples-and-datasets"
       headerComponent={
         <RelatedEntitiesSectionHeader
           header="Derived Samples and Datasets"

--- a/context/app/static/js/helpers/functions.js
+++ b/context/app/static/js/helpers/functions.js
@@ -12,10 +12,20 @@ export function capitalizeString(s) {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+export const NOT_CAPITALIZED_WORDS = ['of', 'to', 'and', 'the', 'a'];
+
+export function shouldCapitalizeString(s, idx = 1) {
+  const lowerCase = s.toLowerCase();
+  if (idx === 0) {
+    return true;
+  }
+  return NOT_CAPITALIZED_WORDS.indexOf(lowerCase) === -1;
+}
+
 export function capitalizeAndReplaceDashes(s) {
   return s
     .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .map((word, idx) => (shouldCapitalizeString(word, idx) ? capitalizeString(word) : word))
     .join(' ');
 }
 

--- a/context/app/static/js/helpers/functions.spec.js
+++ b/context/app/static/js/helpers/functions.spec.js
@@ -7,7 +7,9 @@ import {
   getDonorAgeString,
   filterObjectByKeys,
   getOriginSamplesOrgan,
-} from './functions'; // replace 'yourModule' with your actual module name
+  NOT_CAPITALIZED_WORDS,
+  shouldCapitalizeString,
+} from './functions';
 
 test('isEmptyArrayOrObject', () => {
   expect(isEmptyArrayOrObject([])).toBeTruthy();
@@ -24,7 +26,26 @@ test('capitalizeString', () => {
 test('capitalizeAndReplaceDashes', () => {
   expect(capitalizeAndReplaceDashes('hello-world')).toEqual('Hello World');
   expect(capitalizeAndReplaceDashes('my-new-dog')).toEqual('My New Dog');
+  expect(
+    capitalizeAndReplaceDashes(
+      'a-very-long-string-to-test-capitalization-and-make-sure-the-title-case-works-correctly',
+    ),
+  ).toEqual('A Very Long String to Test Capitalization and Make Sure the Title Case Works Correctly');
 });
+
+test.each(NOT_CAPITALIZED_WORDS, 'capitalizeAndReplaceDashes capitalizes "%s" if it is the first word', (word) => {
+  expect(shouldCapitalizeString(word, 0)).toBeTruthy();
+  expect(capitalizeAndReplaceDashes(word)).toEqual(capitalizeString(word));
+});
+
+test.each(
+  NOT_CAPITALIZED_WORDS,
+  'capitalizeAndReplaceDashes does not capitalize "%s" if it is not the first word',
+  (word) => {
+    expect(shouldCapitalizeString(word, 1)).toBeFalsy();
+    expect(capitalizeAndReplaceDashes(`first-${word}`)).toEqual(`First ${word}`);
+  },
+);
 
 test('replaceUnderscore', () => {
   expect(replaceUnderscore('hello_world')).toEqual('hello world');

--- a/context/app/static/js/pages/Donor/Donor.jsx
+++ b/context/app/static/js/pages/Donor/Donor.jsx
@@ -38,7 +38,7 @@ function DonorDetail() {
   };
 
   const sectionOrder = getSectionOrder(
-    ['summary', 'metadata', 'derived', 'provenance', 'protocols', 'attribution'],
+    ['summary', 'metadata', 'derived-samples-and-datasets', 'provenance', 'protocols', 'attribution'],
     shouldDisplaySection,
   );
 
@@ -71,7 +71,7 @@ function DonorDetail() {
           group_name={group_name}
         />
         {shouldDisplaySection.metadata && <MetadataTable metadata={mapped_metadata} hubmap_id={hubmap_id} />}
-        <DerivedEntitiesSection sectionId="derived" />
+        <DerivedEntitiesSection />
         <ProvSection />
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} />}
         <Attribution


### PR DESCRIPTION
This PR adjusts the ID used to reference the Derived Samples and Datasets section on the donor page so that it is properly translated by the ID -> title translation function for the table of contents. 

This PR also extends the logic for this function to no longer capitalize `['of', 'to', 'and', 'the', 'a']` if they are not the first word in the title and adds test cases to document this functionality.


https://github.com/hubmapconsortium/portal-ui/assets/19957804/0dc55a5c-7f2f-428f-8ff3-645081b70867

