### PR TITLE
HMP-321 Add sort headers to samples tables on organ pages

### DIFF
--- a/CHANGELOG-organ-sample-table-sort.md
+++ b/CHANGELOG-organ-sample-table-sort.md
@@ -1,0 +1,1 @@
+- Add sort headers to samples tables on organ pages.

--- a/context/app/static/js/components/searchPage/SortingTableHead/SortingTableHead.jsx
+++ b/context/app/static/js/components/searchPage/SortingTableHead/SortingTableHead.jsx
@@ -16,7 +16,7 @@ function getOrder(orderPair, selectedItems) {
   return match.length ? match[0].order : undefined;
 }
 
-function OrderIcon({ order }) {
+export function OrderIcon({ order }) {
   if (order === 'asc') return <ArrowUpOn />;
   if (order === 'desc') return <ArrowDownOn />;
   return <ArrowDownOff />;

--- a/context/app/static/js/hooks/useSortState.ts
+++ b/context/app/static/js/hooks/useSortState.ts
@@ -1,0 +1,55 @@
+import { useCallback, useReducer } from 'react';
+
+type SortState = {
+  columnId?: string;
+  direction?: 'asc' | 'desc';
+};
+
+type SortAction =
+  | {
+      type: 'sort';
+      payload: string;
+    }
+  | {
+      type: 'reset';
+    };
+
+const initialSortState: SortState = {
+  columnId: undefined,
+  direction: undefined,
+} as SortState;
+
+function sortReducer(state: SortState, action: SortAction): SortState {
+  switch (action.type) {
+    case 'sort':
+      if (state.columnId === action.payload) {
+        return {
+          columnId: action.payload,
+          direction: state.direction === 'asc' ? 'desc' : 'asc',
+        };
+      }
+      return {
+        columnId: action.payload,
+        direction: 'desc',
+      } as SortState;
+    case 'reset':
+      return initialSortState;
+    default:
+      console.warn('Unrecognized action type', action);
+      return state;
+  }
+}
+
+export const useSortState = () => {
+  const [sortState, dispatch] = useReducer(sortReducer, initialSortState);
+
+  const sort = useCallback((columnId: string) => {
+    dispatch({ type: 'sort', payload: columnId });
+  }, []);
+
+  const reset = useCallback(() => {
+    dispatch({ type: 'reset' });
+  }, []);
+
+  return { sortState, sort, reset };
+};

--- a/context/app/static/js/shared-styles/tables/index.js
+++ b/context/app/static/js/shared-styles/tables/index.js
@@ -1,18 +1,18 @@
-import styled from 'styled-components';
+import { styled } from '@mui/styles';
 import TableContainer from '@mui/material/TableContainer';
 import TableCell from '@mui/material/TableCell';
 
-const StyledTableContainer = styled(TableContainer)`
-  max-height: 340px; // Height lands in the middle of a row, to show that div can scroll.
+const StyledTableContainer = styled(TableContainer)(({ theme }) => ({
+  maxHeight: 340,
+  overflowY: 'auto',
+  '& .MuiTableCell-root': {
+    backgroundColor: theme.palette.white,
+  },
+}));
 
-  th {
-    background-color: #ffffff;
-  }
-`;
-
-const HeaderCell = styled(TableCell)`
-  font-size: ${(props) => props.theme.typography.subtitle2.fontSize};
-  font-weight: ${(props) => props.theme.typography.subtitle2.fontWeight};
-`;
+const HeaderCell = styled(TableCell)(({ theme }) => ({
+  fontSize: theme.typography.subtitle2.fontSize,
+  fontWeight: theme.typography.subtitle2.fontWeight,
+}));
 
 export { StyledTableContainer, HeaderCell };


### PR DESCRIPTION
This PR adds sorting to headers on the organ table.

Existing sort-related logic used searchkit, so I implemented my own little sort management hook; I am open to reimplementing this some other way if need be!

In order to prevent the table from flashing "0 samples" and no results whenever the sort changes, I'm using a ref to store the previous value and displaying the ref value whenever results are pending.

I also noticed some serious lag on organ pages whenever the HRA visualization would load in; the entire rest of the page was unresponsive for ~10 seconds each time I loaded it. This may be remediated by the React 18 createRoot upgrade since we'd be able to isolate the HRA visualization inside another root.

https://github.com/hubmapconsortium/portal-ui/assets/19957804/6ee34a72-b654-4655-a7bf-22a4d4438df6