### PR TITLE
Nickakhmetov/HMP-358 Readme cleanup/housekeeping

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -160,9 +160,6 @@
             "label": "Storybook",
             "type": "npm",
             "script": "storybook",
-            "dependsOn": [
-                "npm install"
-            ],
             "options": {
                 "cwd": "${workspaceFolder}/context"
             },
@@ -189,6 +186,9 @@
                 "Storybook"
             ],
             "dependsOrder": "parallel",
+            "problemMatcher": [
+                "$eslint-stylish"
+            ]
         },
         {
             "label": "dev-start",

--- a/CHANGELOG-hmp-359-housekeeping.md
+++ b/CHANGELOG-hmp-359-housekeeping.md
@@ -1,0 +1,1 @@
+- Update READMEs to reflect current practices.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,12 @@ All designs are in [Figma](https://www.figma.com/files/team/834568130405102661/H
   - ```nvm use `cat .nvmrc` ```
 
 Optional:
-- `VSCode`, with `eslint` and `prettier` plugins
+- `VS Code`, with [recommended extensions](./.vscode/extensions.json).
+  - While this is optional, it is worth noting that it is in use by the whole development team
+  - Using VS Code lets us share [default configuration settings](./.vscode/default.settings.json) and easily run scripts using [VS Code tasks](./.vscode/tasks.json).
 - `docker`
+  - Docker is necessary in order to create images for the [deploy process](https://hms-dbmi.atlassian.net/wiki/spaces/GL/pages/3009282049/Deployment)
+  - It is also used to run a local instance of the application when using the test scripts in the `./etc` directory
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 
 <details><summary>For React</summary>
 
-> :information_source: **Any mentions of `.js`/`.jsx` in the following guidelines are interchangeable with `.ts`/`.tsx`. New features should ideally be developed in TypeScript.**
+> **Note**  
+> **Any mentions of `.js`/`.jsx` in the following guidelines are interchangeable with `.ts`/`.tsx`. New features should ideally be developed in TypeScript.**
 
 - Components with tests or styles should be placed in to their own directory.
 - Styles should follow the `style.*` pattern where the extension is `js` for styled components or `css` for stylesheets.

--- a/README.md
+++ b/README.md
@@ -187,8 +187,9 @@ Load tests [are available](end-to-end/artillery/), but they are not run as part 
 
 ### Running tests locally without docker
 - **Jest**: `cd context; npm run test`
-- **Cypress**: `cd end-to-end; npm run cypress:open` 
+- **Cypress**: With the application running, `cd end-to-end; npm run cypress:open` 
   - If using WSL2, see the WSL2-specific steps in the [end to end readme](./end-to-end/README.md).
+  - Note that the cypress tests (particularly for the publication page) are expected to be run with the `test` environment enabled in app.conf
 - **Pytest**: `cd context; pytest app --ignore app/api/vitessce_conf_builder`  
 
 ### Linting and pre-commit hooks

--- a/README.md
+++ b/README.md
@@ -142,8 +142,11 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 
 <details><summary>For React</summary>
 
+> :information_source: **Any mentions of `.js`/`.jsx` in the following guidelines are interchangeable with `.ts`/`.tsx`. New features should ideally be developed in TypeScript.**
+
 - Components with tests or styles should be placed in to their own directory.
-- Styles should follow the `style.*` pattern where the extension is js for styled components or css for stylesheets.
+- Styles should follow the `style.*` pattern where the extension is `js` for styled components or `css` for stylesheets.
+  - New styled components should use `styled` from `@mui/styles`.
 - Tests should follow the `*.spec.js` pattern...
 - and stories should follow the `*.stories.js` pattern. For both, the prefix is the name of the component.
 - Each component directory should have an `index.js` which exports the component as default.

--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ SVG files smaller than 5KB can be included in the repository in `context/app/sta
 The CDN responds with a `cache-control: max-age=1555200` header for all items,
 but can be overridden on a per image basis by setting the `cache-control` header for the object in S3.
 
+If an uploaded file replaces an existing one and uses the same file name, a CloudFront cache invalidation should be run, targeting the specific file(s) that have been updated.
+ - Log in to the AWS console and go to [distributions](https://us-east-1.console.aws.amazon.com/cloudfront/v3/home?region=us-east-1#/distributions)
+ - Select the distribution corresponding to the S3 server.
+ - Go to the `Invalidations` tab and click `Create Invalidation`.
+ - Enter the file names which should be invalidated in cache, with the full path; you can target multiple similar file names by using wildcards
+   - e.g. to invalidate all files in `/` starting with `publication-slide`, you would enter `/publication-slide*`, which would select all the different sizes of that image.
+ - After confirming that you are targeting only the intended files, click `Create Invalidation` again.
+
 For the homepage carousel, images should have a 16:9 aspect ratio, a width of at least 1400px, a title, a description, and, if desired, a url to be used for the 'Get Started' button.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ After checking out the project, cd-ing into it, and setting up a Python 3.9 virt
 The webpack dev server serves all files within the public directory and provides hot module replacement for the react application;
 The webpack dev server proxies all requests outside of those for files in the public directory to the flask server.
 
-Note: Searchkit, our interface to Elasticsearch, has changed significantly in the lastest release. Documentation for version 2.0 can be found [here](https://github.com/searchkit/searchkit/tree/6f3786657c8afa6990a41acb9f2371c28b2e0986/packages/searchkit-docs).
+Note: Searchkit, our interface to Elasticsearch, has changed significantly in the latest release. Documentation for version 2.0 can be found [here](https://github.com/searchkit/searchkit/tree/6f3786657c8afa6990a41acb9f2371c28b2e0986/packages/searchkit-docs).
 
 ### Changelog files
 Every PR should be reviewed, and every PR should include a new `CHANGELOG-something.md` at the root of the repository. These are concatenated by `etc/build/push.sh` during deploy.

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 
 ### File and directory structure conventions
 
-<details><summary>For React</summary>
+<details><summary>![React.js Icon](https://skills.thijs.gg/icons?i=react&theme=light) React</summary>
 
 > **Note**  
 > **Any mentions of `.js`/`.jsx` in the following guidelines are interchangeable with `.ts`/`.tsx`. New features should ideally be developed in TypeScript.**

--- a/README.md
+++ b/README.md
@@ -133,8 +133,6 @@ After checking out the project, cd-ing into it, and setting up a Python 3.9 virt
 - Run `etc/dev/dev-start.sh` to start the webpack dev and flask servers and then visit [localhost:5001](http://localhost:5001).
   - If using VS Code, you can also use the `dev-start` task, which will launch these services in separate terminal windows.
 
-You will see an warning about `Cannot find source file '../src/index.ts'`, but just ignore it; [Issue filed](https://github.com/hubmapconsortium/portal-ui/issues/1489).
-
 The webpack dev server serves all files within the public directory and provides hot module replacement for the react application;
 The webpack dev server proxies all requests outside of those for files in the public directory to the flask server.
 

--- a/README.md
+++ b/README.md
@@ -155,9 +155,10 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 
 </details>
 
-<details><summary>:framed_picture Images</summary>
+<details><summary>:framed_picture: Images</summary>
 
-Images should displayed using the `source srcset` attribute. You should prepare four versions of the image starting at its original size and at 75%, 50% and 25% the original image's size preserving its aspect ratio. If available, you should also provide a 2x resolution for higher density screens. For example, to resize images using Mac's Preview you can visit the 'Tools' menu and select 'Adjust Size', from there you can change the image's width while making sure 'Scale Proportionally' and 'Resample Image' are checked. Once ready, each version of the image should be processed with an image optimizer such as ImgOptim.
+Images should displayed using the `source srcset` attribute. You should prepare four versions of the image starting at its original size and at 75%, 50% and 25% the original image's size preserving its aspect ratio. If available, you should also provide a 2x resolution for higher density screens. 
+- For example, to resize images using Mac's Preview you can visit the 'Tools' menu and select 'Adjust Size', from there you can change the image's width while making sure 'Scale Proportionally' and 'Resample Image' are checked. Once ready, each version of the image should be processed with an image optimizer such as [ImgOptim](https://imageoptim.com/mac).
 
 Finally after processing, the images should be added to the S3 bucket, `portal-ui-images-s3-origin`,
 to be delivered by the cloudfront CDN.

--- a/README.md
+++ b/README.md
@@ -197,8 +197,11 @@ If you want to bypass the hook, set `HUSKY_SKIP_HOOKS=1`.
 
 You can also lint and auto-correct from the command-line:
 ```
+cd context
 npm run lint
 npm run lint:fix
+EXCLUDE=node_modules,ingest-validation-tools,etc/dev/organ-utils
+autopep8 --in-place --aggressive -r . --exclude $EXCLUDE
 ```
 
 ### Storybook

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 
 ### File and directory structure conventions
 
-<details><summary>![React.js Icon](https://skills.thijs.gg/icons?i=react&theme=light) React</summary>
+<details><summary>:atom_symbol: React</summary>
 
 > **Note**  
 > **Any mentions of `.js`/`.jsx` in the following guidelines are interchangeable with `.ts`/`.tsx`. New features should ideally be developed in TypeScript.**

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Optional:
 After checking out the project, cd-ing into it, and setting up a Python 3.9 virtual environment,
 - Get `app.conf` from [Confluence](https://hms-dbmi.atlassian.net/wiki/spaces/GL/pages/3045457929/app.conf) or from another developer and place it at `context/instance/app.conf`.
 - Run `etc/dev/dev-start.sh` to start the webpack dev and flask servers and then visit [localhost:5001](http://localhost:5001).
+  - If using VS Code, you can also use the `dev-start` task, which will launch these services in separate terminal windows.
 
 You will see an warning about `Cannot find source file '../src/index.ts'`, but just ignore it; [Issue filed](https://github.com/hubmapconsortium/portal-ui/issues/1489).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Flask app, using React on the front end and primarily Elasticsearch on
 wrapped in a Docker container for deployment using Docker Compose. The front end depends on AWS S3 and CloudFront for the hosting and delivery of images.
 It is deployed at [portal.hubmapconsortium.org](https://portal.hubmapconsortium.org/)
 
-The Data Portal depends on many [APIs](portal.hubmapconsortium.org/services),
+The Data Portal depends on many [APIs](https://portal.hubmapconsortium.org/services),
 and directly or indirectly, on many other HuBMAP repos.
 
 ```mermaid
@@ -18,7 +18,7 @@ graph LR
     top --> ccf-ui
     click ccf-ui href "https://github.com/hubmapconsortium/ccf-ui"
     top --> vitessce --> viv
-    click vitessce href "https://github.com/hubmapconsortium/vitessce"
+    click vitessce href "https://github.com/vitessce/vitessce"
     click viv href "https://github.com/hms-dbmi/viv"
     top --> portal-visualization --> vitessce-python
     click portal-visualization href "https://github.com/hubmapconsortium/portal-visualization"
@@ -125,7 +125,7 @@ Optional:
 ### Development
 
 After checking out the project, cd-ing into it, and setting up a Python 3.9 virtual environment,
-- Get `app.conf` from another developer and place it at `context/instance/app.conf`.
+- Get `app.conf` from [Confluence](https://hms-dbmi.atlassian.net/wiki/spaces/GL/pages/3045457929/app.conf) or from another developer and place it at `context/instance/app.conf`.
 - Run `etc/dev/dev-start.sh` to start the webpack dev and flask servers and then visit [localhost:5001](http://localhost:5001).
 
 You will see an warning about `Cannot find source file '../src/index.ts'`, but just ignore it; [Issue filed](https://github.com/hubmapconsortium/portal-ui/issues/1489).
@@ -133,11 +133,10 @@ You will see an warning about `Cannot find source file '../src/index.ts'`, but j
 The webpack dev server serves all files within the public directory and provides hot module replacement for the react application;
 The webpack dev server proxies all requests outside of those for files in the public directory to the flask server.
 
-Note: Searchkit, our interface to Elasticsearch, has changed significantly in the lastest release. Documentation for version 2.0 can be found [here](http://searchkit.github.io/searchkit/stable/).
+Note: Searchkit, our interface to Elasticsearch, has changed significantly in the lastest release. Documentation for version 2.0 can be found [here](https://github.com/searchkit/searchkit/tree/6f3786657c8afa6990a41acb9f2371c28b2e0986/packages/searchkit-docs).
 
 ### Changelog files
-Every PR should be reviewed, and every PR should include a new `CHANGELOG-something.md`:
-These are concatenated by `etc/build/push.sh`.
+Every PR should be reviewed, and every PR should include a new `CHANGELOG-something.md` at the root of the repository. These are concatenated by `etc/build/push.sh`.
 
 ### File and directory structure conventions
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The webpack dev server proxies all requests outside of those for files in the pu
 Note: Searchkit, our interface to Elasticsearch, has changed significantly in the lastest release. Documentation for version 2.0 can be found [here](https://github.com/searchkit/searchkit/tree/6f3786657c8afa6990a41acb9f2371c28b2e0986/packages/searchkit-docs).
 
 ### Changelog files
-Every PR should be reviewed, and every PR should include a new `CHANGELOG-something.md` at the root of the repository. These are concatenated by `etc/build/push.sh`.
+Every PR should be reviewed, and every PR should include a new `CHANGELOG-something.md` at the root of the repository. These are concatenated by `etc/build/push.sh` during deploy.
 
 ### File and directory structure conventions
 
@@ -153,8 +153,11 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 - Components with tests or styles should be placed in to their own directory.
 - Styles should follow the `style.*` pattern where the extension is `js` for styled components or `css` for stylesheets.
   - New styled components should use `styled` from `@mui/styles`.
-- Tests should follow the `*.spec.js` pattern...
-- and stories should follow the `*.stories.js` pattern. For both, the prefix is the name of the component.
+- Supporting test files have specific naming conventions:
+  - Jest Tests should follow the `*.spec.js` pattern.
+  - Stories should follow the `*.stories.js` pattern.
+  - Cypress tests should follow the `*.cy.js` pattern.
+  - For all test files, the prefix is the name of the component.
 - Each component directory should have an `index.js` which exports the component as default.
 - Components which share a common domain can be placed in a directory within components named after the domain.
 
@@ -163,7 +166,7 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 <details><summary>:framed_picture: Images</summary>
 
 Images should displayed using the `source srcset` attribute. You should prepare four versions of the image starting at its original size and at 75%, 50% and 25% the original image's size preserving its aspect ratio. If available, you should also provide a 2x resolution for higher density screens. 
-- For example, to resize images using Mac's Preview you can visit the 'Tools' menu and select 'Adjust Size', from there you can change the image's width while making sure 'Scale Proportionally' and 'Resample Image' are checked. Once ready, each version of the image should be processed with an image optimizer such as [ImgOptim](https://imageoptim.com/mac).
+- For example, to resize images using Mac's Preview you can visit the 'Tools' menu and select 'Adjust Size', from there you can change the image's width while making sure 'Scale Proportionally' and 'Resample Image' are checked. Once ready, each version of the image should be processed with an image optimizer such as [ImgOptim](https://imageoptim.com/mac) or [Online Image Compressor](https://imagecompressor.com/).
 
 Finally after processing, the images should be added to the S3 bucket, `portal-ui-images-s3-origin`,
 to be delivered by the cloudfront CDN.
@@ -177,10 +180,16 @@ For the homepage carousel, images should have a 16:9 aspect ratio, a width of at
 </details>
 
 ## Testing
-Python unit tests use Pytest, front end tests use Jest, an end-to-end tests use Cypress.
-Each suite is run separately on Gihub CI.
+Python unit tests use Pytest, front end tests use Jest, and end-to-end tests use Cypress.
+Each suite is run separately on GitHub CI.
 
 Load tests [are available](end-to-end/artillery/), but they are not run as part of CI.
+
+### Running tests locally without docker
+- **Jest**: `cd context; npm run test`
+- **Cypress**: `cd end-to-end; npm run cypress:open` 
+  - If using WSL2, see the WSL2-specific steps in the [end to end readme](./end-to-end/README.md).
+- **Pytest**: `cd context; pytest app --ignore app/api/vitessce_conf_builder`  
 
 ### Linting and pre-commit hooks
 CI lints the codebase, and to save time, we also lint in a pre-commit hook.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Every PR should be reviewed, and every PR should include a new `CHANGELOG-someth
 
 </details>
 
-<details><summary>For images</summary>
+<details><summary>:framed_picture Images</summary>
 
 Images should displayed using the `source srcset` attribute. You should prepare four versions of the image starting at its original size and at 75%, 50% and 25% the original image's size preserving its aspect ratio. If available, you should also provide a 2x resolution for higher density screens. For example, to resize images using Mac's Preview you can visit the 'Tools' menu and select 'Adjust Size', from there you can change the image's width while making sure 'Scale Proportionally' and 'Resample Image' are checked. Once ready, each version of the image should be processed with an image optimizer such as ImgOptim.
 

--- a/context/app/static/js/components/home/ImageCarouselControlButtons/ImageCarouselControlButtons.jsx
+++ b/context/app/static/js/components/home/ImageCarouselControlButtons/ImageCarouselControlButtons.jsx
@@ -7,7 +7,7 @@ import { FlexList, StyledIconButton } from './style';
 
 function SelectImageButton({ isSelectedImageIndex, onClick }) {
   return (
-    <StyledIconButton tabIndex="-1" onClick={onClick} disabled={isSelectedImageIndex}>
+    <StyledIconButton tabIndex={-1} onClick={onClick} disabled={isSelectedImageIndex}>
       {isSelectedImageIndex ? (
         <Brightness1RoundedIcon fontSize="small" />
       ) : (
@@ -29,7 +29,7 @@ function ImageCarouselControlButtons({ numImages, selectedImageIndex, setSelecte
   return (
     <FlexList aria-hidden="true">
       <li>
-        <StyledIconButton tabIndex="-1" color="primary" onClick={setPreviousSelectedImageIndex}>
+        <StyledIconButton tabIndex={-1} color="primary" onClick={setPreviousSelectedImageIndex}>
           <ChevronLeftRoundedIcon />
         </StyledIconButton>
       </li>
@@ -46,7 +46,7 @@ function ImageCarouselControlButtons({ numImages, selectedImageIndex, setSelecte
         ))}
 
       <li>
-        <StyledIconButton tabIndex="-1" color="primary" onClick={setNextSelectedImageIndex}>
+        <StyledIconButton tabIndex={-1} color="primary" onClick={setNextSelectedImageIndex}>
           <ChevronRightRoundedIcon />
         </StyledIconButton>
       </li>

--- a/end-to-end/README.md
+++ b/end-to-end/README.md
@@ -1,3 +1,21 @@
 There isn't a good mechanism in npm to distinguish test-only dependencies from those necessary for the build.
 - Cypress is pretty big, so to speed up the build, Cypress and its tests will be in this separate directory.
 - Artillery is not large, but it also is not needed for the build, so it's here, too.
+
+## WSL2-specific Cypress setup steps
+
+Some additional steps are necessary in order to run GUI applications (such as Cypress) for anyone using WSL2.
+
+1. Verify you are running WSL2 by opening `cmd.exe` and running `wsl -l -v`; you should have version 2. If you are currently running version 1, it needs to be updated.
+2. Install a Windows X server such as [VcXsrv](https://sourceforge.net/projects/vcxsrv/); this can be done in the background while we edit the configuration in the next two steps.
+3. Open your `.bashrc` or `.zshrc` file and add the following lines to the top:
+   1. `export DISPLAY=$(cat /etc/resolv.conf | grep nameserver | awk '{print $2; exit;}'):0.0` (to properly set the display server's URL)
+   2. `sudo /etc/init.d/dbus start &> /dev/null` (to autostart dbus on startup)
+4. Edit the sudoers file for dbus to avoid being prompted for a sudo password each time you open WSL/a new terminal window:
+   1. Confirm your username with `whoami` if you're not sure what it is set to.
+   2. Use `sudo visudo -f /etc/sudoers.d/dbus`; this will open a blank file in nano.
+   3. Add the following line: `<your_username> ALL = (root) NOPASSWD: /etc/init.d/dbus`, replacing `<your_username>` with your actual username and omitting the angle brackets.
+   4. Save and exit nano with `Ctrl + O`, `Enter`, `Ctrl + X`.
+5. Launch the X server (if using VcXsrv, look for XLaunch). Client/startup settings can be left default, but under Extra settings make sure to check the "Disable access control" checkbox. Allow public AND private networks when Windows prompts for permissions on first launch.
+6. Make sure you've used `source ~/.bashrc` to add the DISPLAY environment variable to your shell's environment or have launched another terminal since adding those lines.
+7. Launch Cypress by running `npm run cypress` in this directory.


### PR DESCRIPTION
This PR is an effort to improve our READMEs by updating any outdated/dead links, documenting changes to our best practices, and providing instructions for various common tasks in our development process.

I also made some other minor adjustments:
- I adjusted the `Storybook` task not to depend on `npm install`; this makes the `dev-start (no install)` task function as expected.
- I fixed the `dev-start (no install)` task not having a problem matcher set, which made it prompt for a problem matcher each time it was run
- I adjusted the tabIndex for the homepage carousel controls to be passed in as a number (`{-1}` instead of `"-1"`) to remove a large warning that popped up in the dev console on the homepage