### PR TITLE
NickAkhmetov/HMP-307 Use `HelpLink` component

### DIFF
--- a/CHANGELOG-hmp-307-help-links.md
+++ b/CHANGELOG-hmp-307-help-links.md
@@ -1,0 +1,1 @@
+- Use reusable HelpLink component where the hubmap support email is referenced.

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -6,7 +6,7 @@ import { InternalLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
+import HelpLink from 'js/shared-styles/Links/HelpLink';
 import { FlexContainer, Flex, FlexColumn, HubmapLogo, LogoWrapper, Background } from './style';
 
 function Footer({ isMaintenancePage }) {
@@ -33,9 +33,7 @@ function Footer({ isMaintenancePage }) {
                   </InternalLink>
                 </>
               )}
-              <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-                Submit Feedback
-              </EmailIconLink>
+              <HelpLink variant="body2">Submit Feedback</HelpLink>
               <OutboundIconLink variant="body2" href="https://twitter.com/_hubmap">
                 HuBMAP on Twitter
               </OutboundIconLink>

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/usePanelSet.jsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/usePanelSet.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 import { InternalLink } from 'js/shared-styles/Links';
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import { useAppContext, useFlaskDataContext } from 'js/components/Contexts';
+import HelpLink variant="body2" from 'js/shared-styles/Links/HelpLink variant="body2"';
 import GlobusLink from './GlobusLink';
 import { useFetchProtectedFile } from './hooks';
 import { LoginButton } from './style';
@@ -43,11 +43,8 @@ const loginPanel = {
   status: 'error',
   children: (
     <>
-      Please <InternalLink href="/login">log in</InternalLink> for Globus access or email{' '}
-      <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-        help@hubmapconsortium.org
-      </EmailIconLink>{' '}
-      with the dataset ID about the files you are trying to access.
+      Please <InternalLink href="/login">log in</InternalLink> for Globus access or email <HelpLink variant="body2" /> with the dataset
+      ID about the files you are trying to access.
     </>
   ),
   addOns: (
@@ -63,11 +60,7 @@ const noDbGaPPanel = {
   children: (
     <>
       This dataset contains protected-access human sequence data. Data is not yet available through dbGaP, but will be
-      available soon. Please contact{' '}
-      <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-        help@hubmapconsortium.org
-      </EmailIconLink>{' '}
-      with any questions regarding this data.
+      available soon. Please contact <HelpLink variant="body2" /> with any questions regarding this data.
     </>
   ),
 };
@@ -108,10 +101,7 @@ const PUBLIC_DATA = {
       children: (
         <>
           Files are available through the Globus Research Data Management System. If you require additional help, email{' '}
-          <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-            help@hubmapconsortium.org
-          </EmailIconLink>{' '}
-          with the dataset ID and information about the files you are trying to access.
+          <HelpLink variant="body2" /> with the dataset ID and information about the files you are trying to access.
         </>
       ),
     },
@@ -129,11 +119,8 @@ const ACCESS_TO_PROTECTED_DATA = {
           You are authorized to access protected-access human sequence data through the Globus Research Data Management
           System. Please review and follow all{' '}
           <OutboundLink href="https://hubmapconsortium.org/policies/">policies</OutboundLink> related to the use of
-          these protected data. If you require additional help, email{' '}
-          <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-            help@hubmapconsortium.org
-          </EmailIconLink>{' '}
-          with the dataset ID and information about the files you are trying to access.
+          these protected data. If you require additional help, email <HelpLink variant="body2" /> with the dataset ID and information
+          about the files you are trying to access.
         </>
       ),
     },
@@ -148,10 +135,7 @@ const NO_ACCESS_TO_PROTECTED_DATA = {
       <div>
         These data are still being prepared, processed, or curated and will only be available to members of the team who
         submitted the data. For additional help, email
-        <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-          help@hubmapconsortium.org
-        </EmailIconLink>
-        .
+        <HelpLink variant="body2" />.
       </div>
     ),
   },
@@ -167,10 +151,7 @@ const NON_CONSORTIUM_MEMBERS = {
           This dataset contains protected-access human sequence data. If you are not a Consortium member, you must
           access these data through dbGaP if available. dbGaP authentication is required for downloading through these
           links. View documentation on how to attain dbGaP access. For additional help, email
-          <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-            help@hubmapconsortium.org
-          </EmailIconLink>{' '}
-          with the dataset ID and information about the files you are trying to access.
+          <HelpLink variant="body2" /> with the dataset ID and information about the files you are trying to access.
         </>
       ),
     },
@@ -190,10 +171,7 @@ const DATASET_NOT_FINALIZED = {
       <div>
         These data are still being prepared, processed, or curated and will only be available to members of the team who
         submitted the data. For additional help, email
-        <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-          help@hubmapconsortium.org
-        </EmailIconLink>
-        .
+        <HelpLink variant="body2" />.
       </div>
     ),
   },
@@ -206,11 +184,8 @@ const ENTITY_API_ERROR = {
     tooltip: globusText.tooltip,
     children: (
       <>
-        The API failed to retrieve the link to Globus. Please report this issue to{' '}
-        <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-          help@hubmapconsortium.org
-        </EmailIconLink>{' '}
-        with the dataset ID and information about the files you are trying to access.
+        The API failed to retrieve the link to Globus. Please report this issue to <HelpLink variant="body2" /> with the dataset ID and
+        information about the files you are trying to access.
       </>
     ),
   },

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/usePanelSet.jsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/usePanelSet.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 import { InternalLink } from 'js/shared-styles/Links';
 import { useAppContext, useFlaskDataContext } from 'js/components/Contexts';
-import HelpLink variant="body2" from 'js/shared-styles/Links/HelpLink variant="body2"';
+import HelpLink from 'js/shared-styles/Links/HelpLink';
 import GlobusLink from './GlobusLink';
 import { useFetchProtectedFile } from './hooks';
 import { LoginButton } from './style';
@@ -43,8 +43,8 @@ const loginPanel = {
   status: 'error',
   children: (
     <>
-      Please <InternalLink href="/login">log in</InternalLink> for Globus access or email <HelpLink variant="body2" /> with the dataset
-      ID about the files you are trying to access.
+      Please <InternalLink href="/login">log in</InternalLink> for Globus access or email <HelpLink variant="body2" />{' '}
+      with the dataset ID about the files you are trying to access.
     </>
   ),
   addOns: (
@@ -119,8 +119,8 @@ const ACCESS_TO_PROTECTED_DATA = {
           You are authorized to access protected-access human sequence data through the Globus Research Data Management
           System. Please review and follow all{' '}
           <OutboundLink href="https://hubmapconsortium.org/policies/">policies</OutboundLink> related to the use of
-          these protected data. If you require additional help, email <HelpLink variant="body2" /> with the dataset ID and information
-          about the files you are trying to access.
+          these protected data. If you require additional help, email <HelpLink variant="body2" /> with the dataset ID
+          and information about the files you are trying to access.
         </>
       ),
     },
@@ -184,8 +184,8 @@ const ENTITY_API_ERROR = {
     tooltip: globusText.tooltip,
     children: (
       <>
-        The API failed to retrieve the link to Globus. Please report this issue to <HelpLink variant="body2" /> with the dataset ID and
-        information about the files you are trying to access.
+        The API failed to retrieve the link to Globus. Please report this issue to <HelpLink variant="body2" /> with the
+        dataset ID and information about the files you are trying to access.
       </>
     ),
   },

--- a/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
+++ b/context/app/static/js/components/error/ErrorBody/ErrorBody.jsx
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types';
 import { InternalLink } from 'js/shared-styles/Links';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
+import HelpLink from 'js/shared-styles/Links/HelpLink';
 
 function LoginLink() {
   return <InternalLink href="/login">login</InternalLink>;
 }
 function HelpEmailLink() {
-  return <EmailIconLink email="help@hubmapconsortium.org">help@hubmapconsortium.org</EmailIconLink>;
+  return <HelpLink />;
 }
 
 function ErrorBody({ errorCode, urlPath, isAuthenticated, isGlobus401, isMaintenancePage }) {

--- a/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
+++ b/context/app/static/js/components/home/DataUseGuidelines/DataUseGuidelines.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+import HelpLink from 'js/shared-styles/Links/HelpLink';
 import { StyledPaper, StyledTypography } from './style';
 
 const paragraphs = [
@@ -60,10 +60,7 @@ const paragraphs = [
     key: 'help',
     component: (
       <>
-        Please direct any questions to{' '}
-        <EmailIconLink email="help@hubmapconsortium.org" iconFontSize="1.1rem">
-          help@hubmapconsortium.org
-        </EmailIconLink>
+        Please direct any questions to <HelpLink iconFontSize="1.1rem" />.
       </>
     ),
   },

--- a/context/app/static/js/components/workspaces/WorkspacesAuthenticated.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesAuthenticated.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Typography from '@mui/material/Typography';
 
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import { useAppContext } from 'js/components/Contexts';
+import HelpLink from 'js/shared-styles/Links/HelpLink';
 import WorkspacesList from './WorkspacesList';
 
 import { StyledDescription } from './style';
@@ -28,9 +28,8 @@ function WorkspacesAuthenticated() {
           can be launched directly from this page.
         </Typography>
         <Typography>
-          Workspaces should not be used for long-running batch processes. Contact{' '}
-          <EmailIconLink email="help@hubmapconsortium.org">help@hubmapconsortium.org</EmailIconLink> for information
-          about accessing HuBMAP compute resources.
+          Workspaces should not be used for long-running batch processes. Contact <HelpLink /> for information about
+          accessing HuBMAP compute resources.
         </Typography>
       </StyledDescription>
       <WorkspacesList />

--- a/context/app/static/js/pages/Workspaces/Workspaces.jsx
+++ b/context/app/static/js/pages/Workspaces/Workspaces.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import { useAppContext } from 'js/components/Contexts';
 import WorkspacesTitle from 'js/components/workspaces/WorkspacesTitle';
 import { InternalLink } from 'js/shared-styles/Links';
 import WorkspacesAuthenticated from 'js/components/workspaces/WorkspacesAuthenticated';
+import HelpLink from 'js/shared-styles/Links/HelpLink';
 import { StyledDescription } from './style';
 
 function WorkspacesContent() {
@@ -22,11 +22,8 @@ function WorkspacesContent() {
   if (!isWorkspacesUser) {
     return (
       <StyledDescription>
-        You must be a member of the allowed Globus group to access this feature. Email{' '}
-        <EmailIconLink variant="body2" email="help@hubmapconsortium.org">
-          help@hubmapconsortium.org
-        </EmailIconLink>{' '}
-        to gain access.
+        You must be a member of the allowed Globus group to access this feature. Email <HelpLink variant="body2" /> to
+        gain access.
       </StyledDescription>
     );
   }

--- a/context/app/static/js/shared-styles/Links/HelpLink.tsx
+++ b/context/app/static/js/shared-styles/Links/HelpLink.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
-import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
+import React, { ComponentProps, PropsWithChildren } from 'react';
+import EmailIconLink from './iconLinks/EmailIconLink';
 
-function HelpLink(props) {
+type HelpLinkProps = PropsWithChildren<ComponentProps<typeof EmailIconLink>>;
+
+const helpEmail = 'help@hubmapconsortium.org';
+
+function HelpLink({ children, ...props }: HelpLinkProps) {
   return (
-    <EmailIconLink email="help@hubmapconsortium.org" {...props}>
-      help@hubmapconsortium.org
+    <EmailIconLink {...props} email={helpEmail}>
+      {children ?? helpEmail}
     </EmailIconLink>
   );
 }


### PR DESCRIPTION
This PR:
- Replaces all references to emailiconlinks with an email of `help@hubmapconsortium.org` with the `HelpLink` component
- Adjusts the HelpLink component to allow overrides of the text in the link to handle an edge case where the text is "contact support"