### PR TITLE
Nickakhmetov/HMP-409 Remove `marked` in favor of `react-markdown`

### DIFF
--- a/CHANGELOG-hmp-409-markdown.md
+++ b/CHANGELOG-hmp-409-markdown.md
@@ -1,0 +1,1 @@
+- Remove `marked` in favor of `react-markdown`.

--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { pdfjs } from 'react-pdf';
-import marked from 'marked';
+import ReactMarkdown from 'react-markdown';
 import Providers from './Providers';
 import Routes from './Routes';
 import Footer from './Footer';
@@ -54,8 +54,7 @@ function App(props) {
       {globalAlertMd && (
         <FlexContainer>
           <StyledAlert severity="warning">
-            {/* eslint-disable-next-line react/no-danger */}
-            <div dangerouslySetInnerHTML={{ __html: marked.parseInline(globalAlertMd) }} />
+            <ReactMarkdown>{globalAlertMd}</ReactMarkdown>
           </StyledAlert>
         </FlexContainer>
       )}

--- a/context/app/static/js/components/Markdown/Markdown.jsx
+++ b/context/app/static/js/components/Markdown/Markdown.jsx
@@ -1,19 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import marked from 'marked';
+import ReactMarkdown from 'react-markdown';
 import Typography from '@mui/material/Typography';
 
 import { StyledPaper } from './style';
 
 function Markdown({ markdown }) {
-  const html = marked(markdown);
-
   return (
     <StyledPaper>
       <Typography variant="body1" component="div">
-        {/* Typography defaults to <p>, which causes invalid element nesting. */}
-        {/* eslint-disable-next-line react/no-danger */}
-        <div dangerouslySetInnerHTML={{ __html: html }} />
+        <ReactMarkdown>{markdown}</ReactMarkdown>
       </Typography>
     </StyledPaper>
   );

--- a/context/app/static/js/components/organ/Azimuth/Azimuth.jsx
+++ b/context/app/static/js/components/organ/Azimuth/Azimuth.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import marked from 'marked';
+import ReactMarkdown from 'react-markdown';
 import Box from '@mui/material/Box';
 
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
@@ -13,8 +13,6 @@ import { Flex, StyledInfoIcon } from '../style';
 import { StyledPaper } from './style';
 
 function Azimuth({ config }) {
-  const dataRefHtml = marked.parseInline(config.dataref);
-
   return (
     <>
       <SpacedSectionButtonRow
@@ -33,11 +31,9 @@ function Azimuth({ config }) {
         <LabelledSectionText label="Nuclei in reference">{config.nunit}</LabelledSectionText>
         {/* eslint-disable react/no-danger */}
         <LabelledSectionText label="Reference dataset">
-          <Box
-            component="span"
-            sx={(theme) => ({ '&>a': { color: theme.palette.info.main } })}
-            dangerouslySetInnerHTML={{ __html: dataRefHtml }}
-          />
+          <Box component="span" sx={(theme) => ({ '&>a': { color: theme.palette.info.main } })}>
+            <ReactMarkdown>{config.dataref}</ReactMarkdown>
+          </Box>
         </LabelledSectionText>
       </StyledPaper>
 

--- a/context/app/static/js/components/style.js
+++ b/context/app/static/js/components/style.js
@@ -7,6 +7,8 @@ const StyledAlert = styled(Alert)`
   width: ${(props) => props.theme.breakpoints.values.lg}px;
   margin-top: ${(props) => props.theme.spacing(3)};
   z-index: 0; // Does not display on preview pages without this; Not sure sure why not.
+  display: flex;
+  align-items: center;
 `;
 
 const FlexContainer = styled(Container)`

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -42,7 +42,6 @@
         "fast-deep-equal": "^3.1.3",
         "immer": "^9.0.6",
         "lineupjsx": "^4.6.0",
-        "marked": "^2.1.3",
         "nuka-carousel": "^6.0.3",
         "pretty-bytes": "^6.1.1",
         "prop-types": "^15.7.2",
@@ -27322,17 +27321,6 @@
       },
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
-    },
-    "node_modules/marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">= 10"
       }
     },
     "node_modules/material-colors": {
@@ -58597,11 +58585,6 @@
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.3.2.tgz",
       "integrity": "sha512-B+28F5ucp83aQm+OxNrPkS8z0tMKaeHiy0lHJs3LqCyDQFtWuenaIrkaVTgAm1pf1AU85LXltva86hlaT17i8Q==",
       "dev": true
-    },
-    "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
     },
     "material-colors": {
       "version": "1.2.6",

--- a/context/package.json
+++ b/context/package.json
@@ -35,7 +35,6 @@
     "fast-deep-equal": "^3.1.3",
     "immer": "^9.0.6",
     "lineupjsx": "^4.6.0",
-    "marked": "^2.1.3",
     "nuka-carousel": "^6.0.3",
     "pretty-bytes": "^6.1.1",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
This PR removes all usages of `marked` in favor of using `react-markdown`, which does not require us to dangerously set inner HTML. I tested the places in the application where this was in use (organ pages' `reference analysis` pane, global alert, and markdown pages such as /changelog) and confirmed functionality is unaffected.

Fixes #3067