### PR TITLE
John conroy/update reference to vitessce version

### DIFF
--- a/CHANGELOG-update-reference-to-vitessce-version.md
+++ b/CHANGELOG-update-reference-to-vitessce-version.md
@@ -1,0 +1,1 @@
+- Fix bug referencing vitessce version when downloading visualization notebooks.

--- a/context/app/routes_notebooks.py
+++ b/context/app/routes_notebooks.py
@@ -9,6 +9,7 @@ from requests import post
 import nbformat
 from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 
+from importlib.metadata import version 
 import vitessce
 
 from .utils import make_blueprint, get_url_base_from_request, entity_types, get_client
@@ -105,7 +106,7 @@ def entity_notebook(entity_type, uuid):
         new_code_cell(
             '!pip uninstall community flask albumentations -y '
             '# Preinstalled on Colab; Causes version conflicts.\n'
-            f'!pip install vitessce[all]=={vitessce.__version__}'),
+            f'!pip install vitessce[all]=={version("vitessce")}'),
         *vitessce_conf.cells
     ]
 

--- a/context/app/routes_notebooks.py
+++ b/context/app/routes_notebooks.py
@@ -9,7 +9,7 @@ from requests import post
 import nbformat
 from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 
-from importlib.metadata import version 
+from importlib.metadata import version
 import vitessce
 
 from .utils import make_blueprint, get_url_base_from_request, entity_types, get_client

--- a/context/app/routes_notebooks.py
+++ b/context/app/routes_notebooks.py
@@ -10,7 +10,6 @@ import nbformat
 from nbformat.v4 import (new_notebook, new_markdown_cell, new_code_cell)
 
 from importlib.metadata import version
-import vitessce
 
 from .utils import make_blueprint, get_url_base_from_request, entity_types, get_client
 


### PR DESCRIPTION
Fix bug relayed by Phil in hive developers where a user had issues downloading the notebook from https://portal.hubmapconsortium.org/notebooks/entities/dataset/ade8d4ca1fd95afbafdc78a2461bab9c.ws. In the `python-vitessce` version included in the recent update of `portal-visualization`, `vitessce` no longer has a `__version__` attribute.