### PR TITLE
NickAkhmetov/HMP-387 add portal usage analytics link to site footer

### DIFF
--- a/CHANGELOG-hmp-387.md
+++ b/CHANGELOG-hmp-387.md
@@ -1,0 +1,1 @@
+- Add portal usage analytics link to site footer.

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -51,6 +51,9 @@ function Footer({ isMaintenancePage }) {
                   <InternalLink variant="body2" href="/apis">
                     APIs
                   </InternalLink>
+                  <OutboundLink variant="body2" href="https://lookerstudio.google.com/u/0/reporting/bceef6eb-c727-4b6f-ac00-364b280ae8c2/page/p_o7z46wg18c">
+                    Portal Usage Analytics
+                  </OutboundLink>
                 </>
               )}
             </FlexColumn>


### PR DESCRIPTION
This PR adds a link to the looker studio instance to the site's footer.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/c49e4636-b07c-441e-b690-bdd45cb6ad57)
