### PR TITLE
NickAkhmetov/HMP-430 Fix Faro SWR logs

### DIFF
--- a/CHANGELOG-HMP-430.md
+++ b/CHANGELOG-HMP-430.md
@@ -1,0 +1,1 @@
+- Fix Faro logging function calls for query errors and slow loading warnings.

--- a/context/app/static/js/components/Providers.jsx
+++ b/context/app/static/js/components/Providers.jsx
@@ -21,12 +21,16 @@ const generateClassName = createGenerateClassName({
 
 const swrConfig = {
   revalidateOnFocus: false,
-  onError: (error) => {
-    faro.api.pushError(error);
+  onError: (error, key) => {
+    faro.api.pushError(error, {
+      context: { key, type: 'SWR Error' },
+    });
   },
-  onLoadingSlow: (key, config) => {
+  onLoadingSlow: (key) => {
     // By default, this is triggered if a request takes longer than 3000ms.
-    faro.api.pushEvent(`Slow-loading query: ${key}`, { key, ...config });
+    faro.api.pushError(new Error(`Slow-loading query: ${key}`), {
+      context: { key, type: 'SWR Slow Loading' },
+    });
   },
 };
 

--- a/context/app/static/js/components/Providers.jsx
+++ b/context/app/static/js/components/Providers.jsx
@@ -22,11 +22,11 @@ const generateClassName = createGenerateClassName({
 const swrConfig = {
   revalidateOnFocus: false,
   onError: (error) => {
-    faro.logError(error);
+    faro.api.pushError(error);
   },
   onLoadingSlow: (key, config) => {
     // By default, this is triggered if a request takes longer than 3000ms.
-    faro.logWarning(`Loading slow: ${key}`, { key, ...config });
+    faro.api.pushEvent(`Slow-loading query: ${key}`, { key, ...config });
   },
 };
 


### PR DESCRIPTION
This PR fixes the calls to `faro.logError` and `faro.logWarning` - these functions don't exist and I didn't catch this in my initial implementation because `Providers` is a `.jsx` file (and thus ESLint does not throw errors when a non-existing property is referenced).

I've revised these calls to `faro.api.pushError` and `faro.api.pushEvent`, respectively.