### PR TITLE
NickAkhmetov/HMP-433 Restore magnifying glass icon to search bars

### DIFF
--- a/CHANGELOG-HMP-433-restore-search-icon.md
+++ b/CHANGELOG-HMP-433-restore-search-icon.md
@@ -1,0 +1,1 @@
+- Restore magnifying glass icon to search bars.

--- a/context/app/static/js/components/searchPage/Search.scss
+++ b/context/app/static/js/components/searchPage/Search.scss
@@ -114,7 +114,7 @@ $text-primary: rgba(0, 0, 0, 0.87);
 
 .sk-search-box__icon:before {
   fill: $primary-purple;
-  background: url('~assets/svg/search-icon.svg') no-repeat top left;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 2 20 20' fill='%23444A65' width='20px' height='20px'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M15.5 14h-.79l-.28-.27c1.2-1.4 1.82-3.31 1.48-5.34-.47-2.78-2.79-5-5.59-5.34-4.23-.52-7.79 3.04-7.27 7.27.34 2.8 2.56 5.12 5.34 5.59 2.03.34 3.94-.28 5.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E");
 }
 
 .sk-search-box.is-focused,

--- a/context/app/static/js/components/searchPage/Search.scss
+++ b/context/app/static/js/components/searchPage/Search.scss
@@ -114,7 +114,7 @@ $text-primary: rgba(0, 0, 0, 0.87);
 
 .sk-search-box__icon:before {
   fill: $primary-purple;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 2 20 20' fill='%23444A65' width='20px' height='20px'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M15.5 14h-.79l-.28-.27c1.2-1.4 1.82-3.31 1.48-5.34-.47-2.78-2.79-5-5.59-5.34-4.23-.52-7.79 3.04-7.27 7.27.34 2.8 2.56 5.12 5.34 5.59 2.03.34 3.94-.28 5.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E");
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 2 20 20' fill='%23444A65' width='20px' height='20px'%3E%3Cpath d='M0 0h24v24H0V0z' fill='none'/%3E%3Cpath d='M15.5 14h-.79l-.28-.27c1.2-1.4 1.82-3.31 1.48-5.34-.47-2.78-2.79-5-5.59-5.34-4.23-.52-7.79 3.04-7.27 7.27.34 2.8 2.56 5.12 5.34 5.59 2.03.34 3.94-.28 5.34-1.48l.27.28v.79l4.25 4.25c.41.41 1.08.41 1.49 0 .41-.41.41-1.08 0-1.49L15.5 14zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z'/%3E%3C/svg%3E") no-repeat top left;
 }
 
 .sk-search-box.is-focused,


### PR DESCRIPTION
This PR restores the search icon to the search pages' search bars.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/9dc5b179-0a3b-49cf-b504-649405b08486)

This was likely a result of the upgrade to Webpack 5 a while ago, since the core error appears to be an unreadable SVG reference in the SCSS code.

Since this is the only case where we import our SVG's from SCSS and it's only necessary in order to override default searchkit styles, I've revised the style so it applies the icon via a data URL instead.