### PR TITLE
NickAkhmetov/HMP-231 Add React Strict Mode/make adjustments to hide warnings

### DIFF
--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { StrictMode } from 'react';
 import { pdfjs } from 'react-pdf';
 import ReactMarkdown from 'react-markdown';
 import { enableMapSet } from 'immer';
@@ -47,28 +47,30 @@ function App(props) {
   const isHubmapUser = userGroups?.includes('HuBMAP');
 
   return (
-    <Providers
-      endpoints={endpoints}
-      groupsToken={groupsToken}
-      isAuthenticated={isAuthenticated}
-      userEmail={userEmail}
-      workspacesToken={workspacesToken}
-      isWorkspacesUser={isWorkspacesUser}
-      isHubmapUser={isHubmapUser}
-      flaskData={flaskData}
-    >
-      <Header />
-      {globalAlertMd && (
-        <FlexContainer>
-          <StyledAlert severity="warning">
-            <ReactMarkdown>{globalAlertMd}</ReactMarkdown>
-          </StyledAlert>
-        </FlexContainer>
-      )}
-      <Routes flaskData={flaskData} />
-      <Footer />
-      <StyledSnackbar />
-    </Providers>
+    <StrictMode>
+      <Providers
+        endpoints={endpoints}
+        groupsToken={groupsToken}
+        isAuthenticated={isAuthenticated}
+        userEmail={userEmail}
+        workspacesToken={workspacesToken}
+        isWorkspacesUser={isWorkspacesUser}
+        isHubmapUser={isHubmapUser}
+        flaskData={flaskData}
+      >
+        <Header />
+        {globalAlertMd && (
+          <FlexContainer>
+            <StyledAlert severity="warning">
+              <ReactMarkdown>{globalAlertMd}</ReactMarkdown>
+            </StyledAlert>
+          </FlexContainer>
+        )}
+        <Routes flaskData={flaskData} />
+        <Footer />
+        <StyledSnackbar />
+      </Providers>
+    </StrictMode>
   );
 }
 export default App;

--- a/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
+++ b/context/app/static/js/components/cells/DatasetsSelectedByExpression/DatasetsSelectedByExpression.jsx
@@ -48,7 +48,6 @@ function DatasetsSelectedByExpression({ completeStep, runQueryButtonRef }) {
                 vertical: 'bottom',
                 horizontal: 'center',
               },
-              getContentAnchorEl: null,
             },
           }}
           helperText="Genomic modality refers to Gene Expression (RNA) or DNA Accessibility (ATAC)."

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/GlobusLink.jsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/GlobusLink.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Divider from '@mui/material/Divider';
 import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 
 import { DetailSectionPaper } from 'js/shared-styles/surfaces';
 import { useFlaskDataContext } from 'js/components/Contexts';
@@ -42,23 +43,20 @@ function GlobusLink({ uuid, isSupport = false }) {
   }
 
   return (
-    <>
-      <Divider />
-      <LinkContainer>
-        <WrapperComponent isSupport={isSupport}>
-          <FilesConditionalLink
-            href={responseUrl}
-            hasAgreedToDUA={hasAgreedToDUA}
-            openDUA={() => openDUA(responseUrl)}
-            variant="subtitle2"
-            hasIcon
-          >
-            {hubmap_id}
-            {' Globus'}
-          </FilesConditionalLink>
-        </WrapperComponent>
-      </LinkContainer>
-    </>
+    <LinkContainer>
+      <WrapperComponent isSupport={isSupport}>
+        <FilesConditionalLink
+          href={responseUrl}
+          hasAgreedToDUA={hasAgreedToDUA}
+          openDUA={() => openDUA(responseUrl)}
+          variant="subtitle2"
+          hasIcon
+        >
+          {hubmap_id}
+          {' Globus'}
+        </FilesConditionalLink>
+      </WrapperComponent>
+    </LinkContainer>
   );
 }
 
@@ -69,10 +67,10 @@ function GlobusLinkContainer() {
   } = useFlaskDataContext();
 
   return (
-    <>
-      <GlobusLink uuid={uuid} />
-      {vis_lifted_uuid && <GlobusLink uuid={vis_lifted_uuid} isSupport />}
-    </>
+    <Stack key={uuid} divider={<Divider />}>
+      <GlobusLink uuid={uuid} key={uuid} />
+      {vis_lifted_uuid && <GlobusLink uuid={vis_lifted_uuid} key={vis_lifted_uuid} isSupport />}
+    </Stack>
   );
 }
 

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/usePanelSet.jsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/usePanelSet.jsx
@@ -107,7 +107,7 @@ const PUBLIC_DATA = {
       ),
     },
   ],
-  links: [<GlobusLink />],
+  links: [<GlobusLink key="globus-public" />],
 };
 
 const ACCESS_TO_PROTECTED_DATA = {
@@ -126,7 +126,7 @@ const ACCESS_TO_PROTECTED_DATA = {
       ),
     },
   ],
-  links: [<GlobusLink />],
+  links: [<GlobusLink key="globus-protected" />],
 };
 
 const NO_ACCESS_TO_PROTECTED_DATA = {

--- a/context/app/static/js/components/detailPage/Citation/Citation.jsx
+++ b/context/app/static/js/components/detailPage/Citation/Citation.jsx
@@ -22,6 +22,7 @@ function Citation({ contributors, citationTitle, created_timestamp, doi_url, doi
       iconTooltipText="Citation is provided in NLM format. If DataCite page is available, click button to view alternate ways to cite."
       className={className}
       bottomSpacing={1}
+      childContainerComponent="div"
     >
       <Typography variant="body1">
         {citation} Available from: <OutboundIconLink href={doi_url}>{doi_url}</OutboundIconLink>

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTable/RelatedEntitiesTable.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTable/RelatedEntitiesTable.jsx
@@ -31,8 +31,8 @@ function RelatedEntitiesTable({ columns, entities, entityType }) {
       ))}
       tableRows={entities.map(({ _source }) => (
         <TableRow key={_source.hubmap_id} data-testid={`${entityType}-row`}>
-          {allColumns.map(({ renderColumnCell }) => (
-            <TableCell>{renderColumnCell(_source)}</TableCell>
+          {allColumns.map(({ id, renderColumnCell }) => (
+            <TableCell key={id}>{renderColumnCell(_source)}</TableCell>
           ))}
         </TableRow>
       ))}

--- a/context/app/static/js/shared-styles/dropdowns/DropdownMenu/DropdownMenu.jsx
+++ b/context/app/static/js/shared-styles/dropdowns/DropdownMenu/DropdownMenu.jsx
@@ -11,7 +11,6 @@ function DropdownMenu({ children, id, ...rest }) {
       anchorEl={menuRef.current}
       open={menuIsOpen}
       onClose={closeMenu}
-      getContentAnchorEl={null}
       anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
       id={id}
       {...rest}

--- a/context/app/static/js/shared-styles/icons/URLSvgIcon/URLSvgIcon.tsx
+++ b/context/app/static/js/shared-styles/icons/URLSvgIcon/URLSvgIcon.tsx
@@ -16,7 +16,6 @@ function URLSvgIcon({ iconURL, ariaLabel, ...rest }: URLSvgIconProps) {
         width: theme.spacing(3),
         height: theme.spacing(3),
       })}
-      iconURL={iconURL}
       role="img"
       aria-label={ariaLabel}
       {...rest}


### PR DESCRIPTION
This PR makes a few minor adjustments to address React warnings surfaced by React Strict Mode.

Remaining concerns related to dependencies:
- `searchkit` throws warnings due to use of string refs and legacy context API usage
- `vitessce` throws warnings due to a key uniqueness issue in a subcomponent, usage of `findDOMNode` in place of a node ref, and legacy context API usage
- `@hms-dbmi/react-workflow-viz` uses `findDOMNode` as well

I kept StrictMode enabled for now, but it can be toggled back off if requested. It [applies some changes to behavior only](https://react.dev/reference/react/StrictMode) to make it easier to spot bugs during development.