### PR TITLE
NickAkhmetov/HMP-473 Prevent multiple workspaces from being launched at once

### DIFF
--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -12,6 +12,7 @@ import Header from './Header';
 import { StyledAlert, FlexContainer } from './style';
 // Importing Search styles here so the CSS import order is correct.
 import 'js/components/searchPage/Search.scss';
+import LaunchWorkspaceDialog from './workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog';
 
 // TODO: Delete this when workspaces are publicly released.
 // If we stay in limbo for a long time, this configuration could be moved out of code.
@@ -69,6 +70,10 @@ function App(props) {
         <Routes flaskData={flaskData} />
         <Footer />
         <StyledSnackbar />
+        {/* This dialog is placed at the root of the application because 
+            it is launchable from many places. In the future, this should be
+            improved on by using a global modal stack with portals. */}
+        <LaunchWorkspaceDialog />
       </Providers>
     </StrictMode>
   );

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import DialogModal from 'js/shared-styles/DialogModal';
+import { Button, Stack } from '@mui/material';
+import { useSnackbarActions } from 'js/shared-styles/snackbars';
+import { useLaunchWorkspace, useRunningWorkspace, useWorkspacesList } from '../hooks';
+import { useLaunchWorkspaceStore } from './store';
+
+function LaunchWorkspaceDialog() {
+  const runningWorkspace = useRunningWorkspace();
+  const runningWorkspaceName = runningWorkspace?.name;
+  const { handleStopWorkspace } = useWorkspacesList();
+  const { startAndOpenWorkspace } = useLaunchWorkspace();
+
+  const { isOpen, close, reset, workspace } = useLaunchWorkspaceStore();
+  const workspaceName = workspace?.name;
+
+  const { toastError } = useSnackbarActions();
+  const handleLaunch = () => {
+    if (!runningWorkspace) {
+      console.error('No running workspace found');
+      return;
+    }
+    if (!workspace) {
+      console.error('No workspace to run found');
+      return;
+    }
+    handleStopWorkspace(runningWorkspace.id)
+      .then(() => {
+        // Close to avoid flash of blank launch dialog
+        close();
+        startAndOpenWorkspace(workspace)
+          .catch((e) => {
+            toastError('Failed to launch workspace. Please try again.');
+            reset();
+            console.error(e);
+          })
+          .finally(() => {
+            // reset the dialog even if the launch fails
+            // since the running workspace has stopped
+            reset();
+          });
+      })
+      .catch((e) => {
+        toastError('Failed to stop workspace. Please try again.');
+        console.error(e);
+      });
+  };
+  return (
+    <DialogModal
+      title={`Launch ${workspaceName}`}
+      content={
+        <Stack direction="column" gap={4}>
+          <div>{runningWorkspaceName} is currently running. You can only run one workspace at a time.</div>
+          <div>
+            To launch this workspace, jobs in {runningWorkspaceName} will be stopped. Make sure to save all progress
+            before launching this workspace.
+          </div>
+        </Stack>
+      }
+      isOpen={isOpen}
+      handleClose={close}
+      actions={
+        <Stack direction="row" spacing={2} alignItems="end">
+          <Button type="button" onClick={close}>
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleLaunch}>
+            Launch
+          </Button>
+        </Stack>
+      }
+      withCloseButton
+    />
+  );
+}
+
+export default LaunchWorkspaceDialog;

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/index.ts
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/index.ts
@@ -1,0 +1,1 @@
+export * from './LaunchWorkspaceDialog';

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/store.ts
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/store.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import { Workspace } from '../types';
+
+interface LaunchWorkspaceStore {
+  isOpen: boolean;
+  workspace: Workspace | null;
+  open: () => void;
+  close: () => void;
+  setWorkspace: (workspace: Workspace) => void;
+  reset: () => void;
+}
+
+const launchWorkspaceStore = create<LaunchWorkspaceStore>((set) => ({
+  isOpen: false,
+  workspace: null,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+  setWorkspace: (workspace: Workspace) => set({ workspace }),
+  reset: () => set({ isOpen: false, workspace: null }),
+}));
+
+export const useLaunchWorkspaceStore = launchWorkspaceStore;

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
@@ -21,6 +21,7 @@ import TemplateGrid from '../TemplateGrid';
 import { useWorkspaceTemplates, useWorkspaceTemplateTags } from './hooks';
 import { CreateWorkspaceFormTypes } from './useCreateWorkspaceForm';
 import { CreateTemplateNotebooksTypes } from '../types';
+import { useLaunchWorkspaceStore } from '../LaunchWorkspaceDialog/store';
 
 function ContactPrompt() {
   return (
@@ -101,6 +102,8 @@ function NewWorkspaceDialog({
   const { selectedItems: selectedRecommendedTags, toggleItem: toggleTag } = useSelectItems([]);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
+  const { isOpen: isLaunchWorkspaceDialogOpen } = useLaunchWorkspaceStore();
+
   const { templates } = useWorkspaceTemplates([...selectedTags, ...selectedRecommendedTags]);
 
   const { tags } = useWorkspaceTemplateTags();
@@ -118,7 +121,7 @@ function NewWorkspaceDialog({
 
   return (
     <Dialog
-      open={dialogIsOpen}
+      open={dialogIsOpen && !isLaunchWorkspaceDialogOpen}
       onClose={handleClose}
       scroll="paper"
       aria-labelledby="create-workspace-dialog-title"

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/hooks.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/hooks.ts
@@ -11,7 +11,7 @@ import {
   CreateTemplateNotebooksTypes,
   TemplateTagsResponse,
 } from '../types';
-import { useCreateAndLaunchWorkspace } from '../api';
+import { useCreateAndLaunchWorkspace } from '../hooks';
 
 interface UserTemplatesTypes {
   templatesURL: string;

--- a/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
@@ -4,19 +4,35 @@ import Stack from '@mui/material/Stack';
 
 import JobStatus from 'js/components/workspaces/JobStatus';
 import { condenseJobs, getWorkspaceLink } from 'js/components/workspaces/utils';
-import OutboundLink from 'js/shared-styles/Links/OutboundLink';
+import InternalLink from 'js/shared-styles/Links/InternalLink';
+import { useSnackbarActions } from 'js/shared-styles/snackbars';
+import { useLaunchWorkspace } from '../hooks';
 
 const typographyVariant = 'subtitle1';
 
-function WorkspaceDetails({ workspace, handleStartWorkspace }) {
+function WorkspaceDetails({ workspace }) {
   const job = condenseJobs(workspace.jobs);
-  const link = getWorkspaceLink(workspace);
+  const { handleLaunchWorkspace } = useLaunchWorkspace(workspace);
+  const { toastError } = useSnackbarActions();
+
+  const clickHandler = React.useCallback(
+    (e) => {
+      e.preventDefault();
+      try {
+        handleLaunchWorkspace();
+      } catch (err) {
+        toastError('Error launching workspace');
+        console.error(err);
+      }
+    },
+    [handleLaunchWorkspace, toastError],
+  );
 
   return (
     <Stack direction="column">
-      <OutboundLink href={link} variant={typographyVariant} onClick={() => handleStartWorkspace(workspace.id)}>
+      <InternalLink href={getWorkspaceLink(workspace)} variant={typographyVariant} onClick={clickHandler}>
         {workspace.name}
-      </OutboundLink>
+      </InternalLink>
       <Typography variant="body2">
         <JobStatus job={job} />
         &nbsp;|&nbsp; Created {workspace.datetime_created.slice(0, 10)}

--- a/context/app/static/js/components/workspaces/utils.ts
+++ b/context/app/static/js/components/workspaces/utils.ts
@@ -197,8 +197,8 @@ async function locationIfJobRunning({
   return null;
 }
 
-function getWorkspaceLink(workspace: Workspace) {
-  return `/workspaces/${workspace.id}?notebook_path=${encodeURIComponent(workspace.path)}`;
+function getWorkspaceLink(workspace: Workspace, templatePath?: string) {
+  return `/workspaces/${workspace.id}?notebook_path=${encodeURIComponent(templatePath ?? workspace.path)}`;
 }
 
 function isRunningWorkspace(workspace: MergedWorkspace) {

--- a/context/app/static/js/components/workspaces/utils.ts
+++ b/context/app/static/js/components/workspaces/utils.ts
@@ -201,6 +201,14 @@ function getWorkspaceLink(workspace: Workspace) {
   return `/workspaces/${workspace.id}?notebook_path=${encodeURIComponent(workspace.path)}`;
 }
 
+function isRunningWorkspace(workspace: MergedWorkspace) {
+  return workspace.jobs.some((job) => job.status === 'running' || job.status === 'pending');
+}
+
+function isRunningJob(job: WorkspaceJob) {
+  return job.status === 'running' || job.status === 'pending';
+}
+
 export {
   mergeJobsIntoWorkspaces,
   condenseJobs,
@@ -208,4 +216,6 @@ export {
   getWorkspaceLink,
   getWorkspaceHeaders,
   getWorkspaceJob,
+  isRunningWorkspace,
+  isRunningJob,
 };

--- a/context/app/static/js/pages/Dataset/hooks.js
+++ b/context/app/static/js/pages/Dataset/hooks.js
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { useCreateAndLaunchWorkspace } from 'js/components/workspaces/api';
+import { useCreateAndLaunchWorkspace } from 'js/components/workspaces/hooks';
 
 function useDatasetWorkspace({ entity_type, uuid }) {
   const { createAndLaunchWorkspace } = useCreateAndLaunchWorkspace();

--- a/context/app/static/js/shared-styles/DialogModal/DialogModal.tsx
+++ b/context/app/static/js/shared-styles/DialogModal/DialogModal.tsx
@@ -41,14 +41,14 @@ function DialogModal({
 
   return (
     <Dialog {...props} open={isOpen} onClose={handleClose} fullWidth>
-      <Stack direction="row" alignItems="center" justifyContent="space-between" flexGrow={1}>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" flexGrow={1} pt={2} pl={3} pr={2}>
         <StyledDialogTitle variant="h3" component="h2">
           {title}
         </StyledDialogTitle>
 
         {withCloseButton && (
-          <IconButton onClick={handleClose} color="primary" sx={{ width: '36px', height: '36px' }}>
-            <CloseIcon />
+          <IconButton onClick={handleClose} color="primary" size="large">
+            <CloseIcon sx={{ width: '36px', height: '36px' }} />
           </IconButton>
         )}
       </Stack>

--- a/context/app/static/js/shared-styles/DialogModal/DialogModal.tsx
+++ b/context/app/static/js/shared-styles/DialogModal/DialogModal.tsx
@@ -47,8 +47,8 @@ function DialogModal({
         </StyledDialogTitle>
 
         {withCloseButton && (
-          <IconButton onClick={handleClose} color="primary">
-            <CloseIcon sx={{ width: '36px', height: '36px' }} />
+          <IconButton onClick={handleClose} color="primary" sx={{ width: '36px', height: '36px' }}>
+            <CloseIcon />
           </IconButton>
         )}
       </Stack>

--- a/context/app/static/js/shared-styles/DialogModal/DialogModal.tsx
+++ b/context/app/static/js/shared-styles/DialogModal/DialogModal.tsx
@@ -1,13 +1,28 @@
 import React from 'react';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
-import MUIDialogContent from '@mui/material/DialogContent';
+import MUIDialogContent, { DialogContentProps } from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
-import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 
 import { Alert } from 'js/shared-styles/alerts';
+import { IconButton } from '@mui/material';
+import Stack from '@mui/system/Stack';
 import { StyledDivider, StyledDialogTitle } from './style';
+import { CloseIcon } from '../icons';
+
+interface DialogModalProps extends Omit<React.ComponentProps<typeof Dialog>, 'content' | 'open'> {
+  title: string;
+  errorMessages?: string[];
+  warning?: React.ReactNode;
+  secondaryText?: React.ReactNode;
+  actions?: React.ReactNode;
+  isOpen: boolean;
+  content?: React.ReactNode;
+  handleClose: () => void;
+  DialogContentComponent?: React.ComponentType<DialogContentProps>;
+  withCloseButton?: boolean;
+}
 
 function DialogModal({
   title,
@@ -18,20 +33,27 @@ function DialogModal({
   isOpen,
   handleClose,
   DialogContentComponent,
-  errorMessages,
+  errorMessages = [],
+  withCloseButton,
   ...props
-}) {
-  const DialogContent = DialogContentComponent || MUIDialogContent;
+}: DialogModalProps) {
+  const DialogContent = DialogContentComponent ?? MUIDialogContent;
 
   return (
-    <Dialog open={isOpen} onClose={handleClose} fullWidth {...props}>
-      <StyledDialogTitle disableTypography>
-        <Typography variant="h3" component="h2">
+    <Dialog {...props} open={isOpen} onClose={handleClose} fullWidth>
+      <Stack direction="row" alignItems="center" justifyContent="space-between" flexGrow={1}>
+        <StyledDialogTitle variant="h3" component="h2">
           {title}
-        </Typography>
-      </StyledDialogTitle>
+        </StyledDialogTitle>
+
+        {withCloseButton && (
+          <IconButton onClick={handleClose} color="primary">
+            <CloseIcon sx={{ width: '36px', height: '36px' }} />
+          </IconButton>
+        )}
+      </Stack>
       <DialogContent>
-        {errorMessages?.length > 0 && (
+        {errorMessages.length > 0 && (
           <Box sx={{ display: 'grid', gap: 1, marginBottom: 3 }}>
             {errorMessages.map((errorMessage) => {
               return (

--- a/context/app/static/js/shared-styles/DialogModal/index.js
+++ b/context/app/static/js/shared-styles/DialogModal/index.js
@@ -1,3 +1,0 @@
-import DialogModal from './DialogModal';
-
-export default DialogModal;

--- a/context/app/static/js/shared-styles/DialogModal/index.ts
+++ b/context/app/static/js/shared-styles/DialogModal/index.ts
@@ -1,0 +1,3 @@
+import DialogModal from './DialogModal';
+
+export default DialogModal;

--- a/context/app/static/js/shared-styles/DialogModal/style.ts
+++ b/context/app/static/js/shared-styles/DialogModal/style.ts
@@ -4,7 +4,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 
 const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
   marginBottom: theme.spacing(1),
-  padding: theme.spacing(2, 3, 0, 3),
+  padding: 0,
 })) as typeof DialogTitle;
 
 const StyledDivider = styled(Divider)(({ theme }) => ({

--- a/context/app/static/js/shared-styles/DialogModal/style.ts
+++ b/context/app/static/js/shared-styles/DialogModal/style.ts
@@ -4,13 +4,13 @@ import DialogTitle from '@mui/material/DialogTitle';
 
 const StyledDialogTitle = styled(DialogTitle)(({ theme }) => ({
   marginBottom: theme.spacing(1),
-  padding: theme.spacing(2, 3, 0, 2),
-}));
+  padding: theme.spacing(2, 3, 0, 3),
+})) as typeof DialogTitle;
 
 const StyledDivider = styled(Divider)(({ theme }) => ({
   backgroundColor: theme.palette.primary.main,
   height: '1.5px',
   mt: theme.spacing(1),
-}));
+})) as typeof Divider;
 
 export { StyledDivider, StyledDialogTitle };


### PR DESCRIPTION
This PR adds a modal which pops up if the user attempts to launch a workspace while another workspace is running. 

The modal is global-scoped in order to handle the variety of sources where new workspaces can be created/launched. The function to launch the workspace is hooked into the modal logic, so all future launching points will be automatically verified.

There are also some other minor improvements:

- Opening already-launched workspaces no longer hits the `launch workspace` API
- Stopping workspaces now only hits the API to stop the running/pending jobs instead of all jobs
- The logic for opening a new tab with the workspace is now part of the launch workspace hook so a new tab is only opened when the workspace is successfully launched
- `getWorkspaceLink` logic now allows definition of custom template URLs to use instead of the default workspace.path
- The `CreateWorkspace` dialog is hidden when this dialog is triggered

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/cc0a7ba4-6248-44a7-bcf0-6cf93642a2b9)

