### PR TITLE
HMP-475 Fix changelog version and exit build if Docker is not running

### DIFF
--- a/CHANGELOG-update-release-tag.md
+++ b/CHANGELOG-update-release-tag.md
@@ -1,0 +1,2 @@
+- Update CHANGELOG entry to match Docker tag for v0.82.3.
+- Update push.sh to exit early if prerequisite is not met.

--- a/context/app/markdown/CHANGELOG.md
+++ b/context/app/markdown/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.82.2 - 2023-10-31
+## v0.82.3 - 2023-10-31
 
 - Implement workspace usability metric tracking.
 - Add hook to check if user has any running workspaces.

--- a/context/app/markdown/CHANGELOG.md
+++ b/context/app/markdown/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Further constrain collections on landing page to only show collections with both a registered doi and doi url.
 - Add dialog to launch workspaces from user templates.
 
+## v0.82.2
+
+- Version number skipped.
 
 ## v0.82.1 - 2023-10-25
 

--- a/etc/build/push.sh
+++ b/etc/build/push.sh
@@ -3,6 +3,8 @@ set -o errexit
 
 die() { set +v; echo "$*" 1>&2 ; exit 1; }
 
+docker info >/dev/null 2>&1 || die 'Docker daemon is not running.'
+
 git diff --quiet || die 'Uncommitted changes: Stash or commit'
 git checkout main
 git pull


### PR DESCRIPTION
Adds a check at the start of the push.sh script to check if Docker is running. The push should exit early to avoid the changelog version getting out of sync with the docker tag.

Updates erroneous tag in last CHANGELOG entry.