### PR TITLE
NickAkhmetov/HMP-482 Remove spaces from tracked event names

### DIFF
--- a/CHANGELOG-HMP-482.md
+++ b/CHANGELOG-HMP-482.md
@@ -1,0 +1,1 @@
+- Removed spaces from tracked event names.

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -87,7 +87,8 @@ function trackEvent(event) {
   // Convert all event values to strings to avoid errors in faro.
   // https://github.com/grafana/faro-web-sdk/issues/269
   const faroSafeEvent = makeFaroSafe(event);
-  faro.api.pushEvent(event.category, faroSafeEvent);
+  const category = faroSafeEvent.category.replace(/ /g, '_');
+  faro.api.pushEvent(category, faroSafeEvent);
 }
 
 function trackMeasurement(type, values, context = undefined) {


### PR DESCRIPTION
This PR replaces every space in event category names with underscores by applying a regex to the category before sending it via faro. This is only applied to faro events in order to avoid impacting matomo/GA values.