### PR TITLE
Updated the HRA API endpoint to point to the HuBMAP-only version

### DIFF
--- a/CHANGELOG-update-hra-api-endpoint.md
+++ b/CHANGELOG-update-hra-api-endpoint.md
@@ -1,0 +1,1 @@
+- Updated the HRA API endpoint to point to the HuBMAP-only version

--- a/context/app/static/js/pages/Iframe/Iframe.jsx
+++ b/context/app/static/js/pages/Iframe/Iframe.jsx
@@ -19,8 +19,8 @@ function Switch({ organs_count }) {
       return (
         <ccf-organ-info
           organ-iri={iri}
-          use-remote-api="false"
-          data-sources='["https://ccf-api.hubmapconsortium.org/v1/hubmap/rui_locations.jsonld"]'
+          use-remote-api="true"
+          remote-api-endpoint="https://apps.humanatlas.io/hubmap-hra-api/v1"
         />
       );
     default:

--- a/context/app/templates/special-pages/ccf-eui.html
+++ b/context/app/templates/special-pages/ccf-eui.html
@@ -17,6 +17,7 @@
   <ccf-eui
     hubmap-token="{{ groups_token }}"
     use-remote-api="true"
+    remote-api-endpoint="https://apps.humanatlas.io/hubmap-hra-api/v1"
   ></ccf-eui>
 </body>
 


### PR DESCRIPTION
For both EUI and the organ-info web component, we are switching the API endpoint to a hubmap-only version of the HRA-API (formerly known as the CCF-API). It is exactly the same code as in production, but just limited to HuBMAP data.

This has been a request for a while and should provide good performance now. It can be merged at any time.