### PR TITLE
NickAkhmetov/Update UBKG endpoints for gene lookups

### DIFF
--- a/CHANGELOG-gene-endpoints.md
+++ b/CHANGELOG-gene-endpoints.md
@@ -1,0 +1,1 @@
+- Updated UBKG endpoints to point to `genes` and `genes-info`.

--- a/context/app/static/js/components/genes/hooks.ts
+++ b/context/app/static/js/components/genes/hooks.ts
@@ -22,12 +22,10 @@ const useGeneApiURLs = () => {
   return useMemo(
     () => ({
       detailURL(geneId: string) {
-        // return `${ubkgEndpoint}/genes/${geneId.toUpperCase()}`;
-        return `${ubkgEndpoint}/gene/${geneId.toUpperCase()}`;
+        return `${ubkgEndpoint}/genes/${geneId.toUpperCase()}`;
       },
       get list() {
-        // return `${ubkgEndpoint}/genes-info`;
-        return `${ubkgEndpoint}/genes`;
+        return `${ubkgEndpoint}/genes-info`;
       },
       organDetails(organName: string) {
         return `/organ/${organName}.json`;


### PR DESCRIPTION
This PR adjusts the gene API endpoints:

- Gene Detail is now coming from `/genes/GENE_IDENTIFIER`
- Gene List is now coming from `/genes-info`