### PR TITLE
NickAkhmetov/HMP-496 Prevent launch of additional workspaces while a launch is already in progress

### DIFF
--- a/CHANGELOG-hmp-496.md
+++ b/CHANGELOG-hmp-496.md
@@ -1,0 +1,1 @@
+- Prevent launch of additional workspaces while a launch is already in progress.

--- a/context/app/static/js/components/workspaces/hooks.ts
+++ b/context/app/static/js/components/workspaces/hooks.ts
@@ -58,7 +58,9 @@ function useWorkspacesList() {
 
 function useRunningWorkspace() {
   const { workspacesList } = useWorkspacesList();
-  return workspacesList.find((workspace) => workspace.jobs.some((job) => job.status === 'running'));
+  return workspacesList.find((workspace) =>
+    workspace.jobs.some((job) => job.status === 'running' || job.status === 'pending'),
+  );
 }
 
 function useHasRunningWorkspace() {


### PR DESCRIPTION
This PR adjusts the `useRunningWorkspace` functionality to properly identify when there is an activating workspace job in order to prevent users from launching an additional job while one is already starting up.