### PR TITLE
NickAkhmetov/HMP-503 Prevent creation and launch of duplicate workspaces by spam-clicking submit

### DIFF
--- a/CHANGELOG-HMP-503.md
+++ b/CHANGELOG-HMP-503.md
@@ -1,0 +1,1 @@
+- Prevent duplicate workspace creation via rapid submission of launch new workspace form.

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
@@ -179,7 +179,7 @@ function NewWorkspaceDialog({
             Filter workspace templates by tags
           </Typography>
           <Stack spacing={1}>
-            <MultiAutocomplete<string>
+            <MultiAutocomplete
               value={selectedTags}
               options={Object.keys(tags)
                 .filter((tag) => !recommendedTags.includes(tag))
@@ -216,7 +216,7 @@ function NewWorkspaceDialog({
         <Button
           type="submit"
           form="create-workspace-form"
-          disabled={Object.keys(errors).length > 0 || errorMessages.length > 0 || selectedTags.length === 0}
+          disabled={Object.keys(errors).length > 0 || errorMessages.length > 0}
         >
           Launch Workspace
         </Button>

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
@@ -216,7 +216,7 @@ function NewWorkspaceDialog({
         <Button
           type="submit"
           form="create-workspace-form"
-          disabled={Object.keys(errors).length > 0 || errorMessages.length > 0}
+          disabled={Object.keys(errors).length > 0 || errorMessages.length > 0 || selectedTags.length === 0}
         >
           Launch Workspace
         </Button>

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import Chip, { ChipProps } from '@mui/material/Chip';
 import Button from '@mui/material/Button';
+import LoadingButton from '@mui/lab/LoadingButton';
 
 import Step from 'js/shared-styles/surfaces/Step';
 import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
@@ -87,6 +88,7 @@ interface NewWorkspaceDialogProps {
   handleClose: () => void;
   removeDatasets?: (datasetUUIDs: string[]) => void;
   onSubmit: ({ workspaceName, templateKeys, uuids }: CreateTemplateNotebooksTypes) => void;
+  isSubmitting?: boolean;
 }
 
 const recommendedTags = ['visualization', 'api'];
@@ -102,6 +104,7 @@ function NewWorkspaceDialog({
   onSubmit,
   removeDatasets,
   children,
+  isSubmitting,
 }: PropsWithChildren<NewWorkspaceDialogProps & ReactHookFormProps>) {
   const { selectedItems: selectedRecommendedTags, toggleItem: toggleTag } = useSelectItems([]);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -213,13 +216,14 @@ function NewWorkspaceDialog({
       </DialogContent>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
-        <Button
+        <LoadingButton
+          loading={isSubmitting}
           type="submit"
           form="create-workspace-form"
           disabled={Object.keys(errors).length > 0 || errorMessages.length > 0}
         >
           Launch Workspace
-        </Button>
+        </LoadingButton>
       </DialogActions>
     </Dialog>
   );

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
@@ -161,7 +161,7 @@ function NewWorkspaceDialog({
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onSubmit={handleSubmit(submit)}
           >
-            <WorkspaceField<CreateWorkspaceFormTypes>
+            <WorkspaceField
               control={control}
               name="workspace-name"
               label="Name"

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -12,7 +12,7 @@ import ErrorMessages from 'js/shared-styles/alerts/ErrorMessages';
 import useProtectedDatasetsForm from 'js/components/workspaces/NewWorkspaceDialog/useProtectedDatasetsForm';
 import { useHandleCopyClick } from 'js/hooks/useCopyText';
 import { useSelectableTableStore } from 'js/shared-styles/tables/SelectableTableProvider';
-import { useCreateWorkspaceForm, CreateWorkspaceFormTypes } from './useCreateWorkspaceForm';
+import { useCreateWorkspaceForm } from './useCreateWorkspaceForm';
 
 function NewWorkspaceDialogFromSelections() {
   const { errorMessages, protectedHubmapIds, removeProtectedDatasets, protectedRows, selectedRows } =
@@ -36,7 +36,7 @@ function NewWorkspaceDialogFromSelections() {
         {protectedHubmapIds.length > 0 && (
           <Box>
             <ErrorMessages errorMessages={errorMessages} />
-            <WorkspaceField<CreateWorkspaceFormTypes>
+            <WorkspaceField
               control={control}
               name="protected-datasets"
               label="Protected Datasets"

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -51,7 +51,7 @@ function useCreateWorkspaceForm({ defaultName }: UseCreateWorkspaceTypes) {
     handleSubmit,
     control,
     reset,
-    formState: { errors },
+    formState: { errors, isSubmitting, isSubmitted },
   } = useForm({
     defaultValues: {
       'workspace-name': defaultName ?? '',
@@ -68,6 +68,7 @@ function useCreateWorkspaceForm({ defaultName }: UseCreateWorkspaceTypes) {
   }
 
   async function onSubmit({ templateKeys, uuids, workspaceName }: CreateTemplateNotebooksTypes) {
+    if (isSubmitting || isSubmitted) return;
     await createTemplateNotebooks({ templateKeys, uuids, workspaceName });
     reset();
     handleClose();

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -74,7 +74,16 @@ function useCreateWorkspaceForm({ defaultName }: UseCreateWorkspaceTypes) {
     handleClose();
   }
 
-  return { dialogIsOpen, setDialogIsOpen, handleClose, handleSubmit, control, errors, onSubmit };
+  return {
+    dialogIsOpen,
+    setDialogIsOpen,
+    handleClose,
+    handleSubmit,
+    control,
+    errors,
+    onSubmit,
+    isSubmitting: isSubmitting || isSubmitted,
+  };
 }
 
 interface DatasetAccessLevelHits {


### PR DESCRIPTION
This PR prevents the creation and launching duplicate workspaces on `Create Workspace` form submit by checking to see if the form is already submitting/submitted before firing the API call. This is also graphically conveyed to the user via the `launch workspace` text being replaced with a loading indicator (via the `@mui/lab` component `<LoadingButton />`).


https://github.com/hubmapconsortium/portal-ui/assets/19957804/65839c10-1036-4f75-b720-0fb17a58d573

I also removed some redundant type annotations; TypeScript didn't end raise any issues in response to their removal.