### PR TITLE
NickAkhmetov/HMP-501 Link to organ pages from gene detail page

### DIFF
--- a/CHANGELOG-HMP-501.md
+++ b/CHANGELOG-HMP-501.md
@@ -1,0 +1,1 @@
+- Add links to organ pages from gene detail page's cell types list.

--- a/context/app/static/js/components/genes/CellTypes/CellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/CellTypes.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
 import Table from '@mui/material/Table';
 import TableHead from '@mui/material/TableHead';
@@ -14,6 +14,7 @@ import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 import LoadingTableRows from 'js/shared-styles/tables/LoadingTableRows';
 import { StyledTableContainer } from 'js/shared-styles/tables';
 import { LineClamp } from 'js/shared-styles/text';
+import { InternalLink } from 'js/shared-styles/Links';
 import { cellTypes } from '../constants';
 import { useGeneDetails } from '../hooks';
 import ViewDatasets from './ViewDatasets';
@@ -31,6 +32,21 @@ export function TableSkeleton({ numberOfCols = columnLabels.length }: { numberOf
       <LoadingTableRows numberOfRows={3} numberOfCols={numberOfCols} />
     </>
   );
+}
+
+function OrgansCell({ organs }: { organs: { name: string }[] }) {
+  const contents = !organs ? (
+    <>&mdash;</>
+  ) : (
+    organs.map((o, idx) => (
+      <Fragment key={o.name}>
+        <InternalLink href={`/organ/${o.name}`}>{o.name}</InternalLink>
+        {idx < organs.length - 1 && ', '}
+      </Fragment>
+    ))
+  );
+
+  return <TableCell sx={{ whiteSpace: 'nowrap' }}>{contents}</TableCell>;
 }
 
 export default function CellTypes() {
@@ -58,7 +74,7 @@ export default function CellTypes() {
                   <TableCell>
                     <LineClamp lines={2}>{cellType.definition}</LineClamp>
                   </TableCell>
-                  <TableCell>{cellType.organs.map((o) => o.name).join(',\u00A0') || <>&mdash;</>}</TableCell>
+                  <OrgansCell organs={cellType.organs} />
                   <TableCell>
                     <ViewDatasets id={cellType.id} name={cellType.name} />
                   </TableCell>

--- a/context/app/static/js/components/genes/CellTypes/CellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/CellTypes.tsx
@@ -38,10 +38,10 @@ function OrgansCell({ organs }: { organs: { name: string }[] }) {
   const contents = !organs ? (
     <>&mdash;</>
   ) : (
-    organs.map((o, idx) => (
-      <Fragment key={o.name}>
-        <InternalLink href={`/organ/${o.name}`}>{o.name}</InternalLink>
-        {idx < organs.length - 1 && ', '}
+    organs.map(({ name }, i) => (
+      <Fragment key={name}>
+        <InternalLink href={`/organ/${name}`}>{name}</InternalLink>
+        {i < organs.length - 1 && ', '}
       </Fragment>
     ))
   );


### PR DESCRIPTION
This PR adds links from the gene detail page's `cell types` table to the corresponding organ.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/b9ad60ba-e8be-4151-906d-600335ca3aba)

During development, I discovered we don't currently handle the edge case where we don't have any available cell types/organs to display and created https://hms-dbmi.atlassian.net/browse/HMP-512 to track this.