### PR TITLE
NickAkhmetov/HMP-505 Add handling for workspace API 404's

### DIFF
--- a/CHANGELOG-HMP-505.md
+++ b/CHANGELOG-HMP-505.md
@@ -1,0 +1,1 @@
+- Add handling for workspace API requests with no results.


### PR DESCRIPTION
This PR causes an error page to be displayed when a workspace detail request fails.

Note that a webpack overlay is initially displayed if this error is thrown while in development; this overlay will not appear in production.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/00c0607d-3c6d-4137-a9d7-5296c7f71598)
