### PR TITLE
NickAkhmetov/HOTFIX Fix workspace launch error message display logic

### DIFF
--- a/CHANGELOG-fix-workspace-launch-error-message.md
+++ b/CHANGELOG-fix-workspace-launch-error-message.md
@@ -1,0 +1,1 @@
+- Fix workspace launch error message display logic.

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -33,31 +33,33 @@ function NewWorkspaceDialogFromSelections() {
         removeDatasets={deselectRows}
         {...rest}
       >
-        <ErrorMessages errorMessages={errorMessages} />
-        {protectedHubmapIds.length > 0 && (
-          <Box>
-            <WorkspaceField
-              control={control}
-              name="protected-datasets"
-              label="Protected Datasets"
-              value={protectedHubmapIds}
-              error
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton onClick={() => handleCopyClick(protectedHubmapIds)}>
-                      <ContentCopyIcon />
-                    </IconButton>
-                  </InputAdornment>
-                ),
-                readOnly: true,
-              }}
-            />
-            <Button sx={{ mt: 1 }} variant="contained" color="primary" onClick={removeProtectedDatasets}>
-              Remove Protected Datasets ({protectedRows.length})
-            </Button>
-          </Box>
-        )}
+        <Box>
+          <ErrorMessages errorMessages={errorMessages} />
+          {protectedHubmapIds.length > 0 && (
+            <>
+              <WorkspaceField
+                control={control}
+                name="protected-datasets"
+                label="Protected Datasets"
+                value={protectedHubmapIds}
+                error
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton onClick={() => handleCopyClick(protectedHubmapIds)}>
+                        <ContentCopyIcon />
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                  readOnly: true,
+                }}
+              />
+              <Button sx={{ mt: 1 }} variant="contained" color="primary" onClick={removeProtectedDatasets}>
+                Remove Protected Datasets ({protectedRows.length})
+              </Button>
+            </>
+          )}
+        </Box>
       </NewWorkspaceDialog>
     </>
   );

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -33,9 +33,9 @@ function NewWorkspaceDialogFromSelections() {
         removeDatasets={deselectRows}
         {...rest}
       >
+        <ErrorMessages errorMessages={errorMessages} />
         {protectedHubmapIds.length > 0 && (
           <Box>
-            <ErrorMessages errorMessages={errorMessages} />
             <WorkspaceField
               control={control}
               name="protected-datasets"


### PR DESCRIPTION
This PR pulls the workspace error message rendering logic outside of the condition that checks whether to display the protected datasets field in order to make other errors appear as expected.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/b509b71c-c6cc-4ab4-8864-a80fda74f6af)
