### PR TITLE
NickAkhmetov/HMP-514 Link to workspace details page from session time alert

### DIFF
--- a/CHANGELOG-hmp-514.md
+++ b/CHANGELOG-hmp-514.md
@@ -1,0 +1,1 @@
+- Add link to currently running workspace from session time notification if not currently on the workspace's page.

--- a/context/app/static/js/components/workspaces/WorkspaceSessionWarning.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceSessionWarning.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Alert } from 'js/shared-styles/alerts';
 import Button from '@mui/material/Button';
 import { useSnackbarActions } from 'js/shared-styles/snackbars';
+import { InternalLink } from 'js/shared-styles/Links';
 import { useRefreshSession, useSessionWarning, useWorkspacesList } from './hooks';
 import { MergedWorkspace } from './types';
 
@@ -28,8 +29,9 @@ function RefreshSession({ workspace }: RefreshSessionProps) {
 
 interface WorkspaceSessionWarningProps {
   workspaces?: MergedWorkspace[];
+  link?: boolean;
 }
-export default function WorkspaceSessionWarning({ workspaces }: WorkspaceSessionWarningProps) {
+export default function WorkspaceSessionWarning({ workspaces, link }: WorkspaceSessionWarningProps) {
   const { workspacesList } = useWorkspacesList();
   const sessionWarning = useSessionWarning(workspaces ?? workspacesList);
 
@@ -37,9 +39,15 @@ export default function WorkspaceSessionWarning({ workspaces }: WorkspaceSession
 
   const { warning, matchedWorkspace } = sessionWarning;
 
+  const formattedWorkspaceName = link ? (
+    <InternalLink href={`/workspaces/${matchedWorkspace.id}`}>{matchedWorkspace.name}</InternalLink>
+  ) : (
+    matchedWorkspace.name
+  );
+
   return (
     <Alert severity="info" action={<RefreshSession workspace={matchedWorkspace} />}>
-      {warning}
+      {formattedWorkspaceName} {warning}
     </Alert>
   );
 }

--- a/context/app/static/js/components/workspaces/hooks.ts
+++ b/context/app/static/js/components/workspaces/hooks.ts
@@ -206,7 +206,7 @@ function useSessionWarning(workspaces: MergedWorkspace[]) {
 
   const [matchedWorkspace, timeLeft] = result;
 
-  const warning = `${matchedWorkspace.name} is currently running. You have ${Math.floor(
+  const warning = `is currently running. You have ${Math.floor(
     timeLeft / 60,
   )} minutes left in your session. Renewing your session time will stop all jobs running in your workspace.`;
 

--- a/context/app/static/js/pages/Workspaces/Workspaces.tsx
+++ b/context/app/static/js/pages/Workspaces/Workspaces.tsx
@@ -9,7 +9,7 @@ import WorkspaceSessionWarning from 'js/components/workspaces/WorkspaceSessionWa
 function Workspaces() {
   return (
     <Stack spacing={2} direction="column">
-      <WorkspaceSessionWarning />
+      <WorkspaceSessionWarning link />
       <WorkspacesTitle />
       <WorkspacesAuthGuard>
         <WorkspacesAuthenticated />

--- a/context/package.json
+++ b/context/package.json
@@ -159,7 +159,8 @@
     "lint:fix": "eslint -c .eslintrc.yml ./app/static/js/ --fix",
     "storybook": "storybook dev -p 6006 -s app/static/storybook-public/",
     "build-storybook": "storybook build",
-    "tsc": "tsc --noEmit"
+    "tsc": "tsc --noEmit",
+    "clean": "rm -rf ./app/static/public"
   },
   "lint-staged": {
     "app/static/js/**/*.{js,jsx,ts,tsx,y*ml,json,md}": [


### PR DESCRIPTION
This PR adds a link to a workspace's details page from the workspaces list to ease navigation/provide clarity.

Workspace list view:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/647e3e17-4b69-4428-ba78-68987e5cb926)

Workspace detail page view:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/712bd95f-80d3-4fab-8ef7-b24d436da7c4)

I also added an `npm run clean` script to let us clean up the `public` folder generated after build to troubleshoot issues with module updates not working as expected.