### PR TITLE
NickAkhmetov/HOTFIX - Fix matomo user group tracking

### DIFF
--- a/CHANGELOG-matomo-groups.md
+++ b/CHANGELOG-matomo-groups.md
@@ -1,0 +1,1 @@
+- Fix matomo user group tracking.

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -38,7 +38,10 @@ export function getUserGroups() {
 function getCustomDimensions() {
   const userType = getUserType();
   const userGroups = getUserGroups();
-  return [1 /* user_type */, userType, 2 /* user_groups */, userGroups];
+  return [
+    [1 /* user_type */, userType],
+    [2 /* user_groups */, userGroups],
+  ];
 }
 
 const tracker = new MatomoTracker({


### PR DESCRIPTION
This PR fixes tracking for user groups. I consulted the types for the matomo tracker and discovered that when multiple custom dimensions are defined in the instantiation of the tracker, they need to be provided as an array of arrays. The groups are now included as part of the tracking request.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/3462fd41-d85b-4576-8e0c-3edf14b82c06)
