### PR TITLE
John conroy/workspace tutorial HMP-425

### DIFF
--- a/CHANGELOG-workspace-tutorial.md
+++ b/CHANGELOG-workspace-tutorial.md
@@ -1,0 +1,2 @@
+- Add tutorials landing page.
+- Add workspaces tutorial.

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -169,3 +169,28 @@ def genes(gene_symbol):
         title=gene_symbol,
         flask_data=flask_data
     )
+
+
+@blueprint.route('/tutorials')
+def tutorials():
+    flask_data = {
+        **get_default_flask_data(),
+    }
+    return render_template(
+        'base-pages/react-content.html',
+        title='Tutorials',
+        flask_data=flask_data
+    )
+
+
+@blueprint.route('/tutorials/<tutorial_name>')
+def tutorial_detail(tutorial_name):
+    flask_data = {
+        **get_default_flask_data(),
+        'tutorialName': tutorial_name
+    }
+    return render_template(
+        'base-pages/react-content.html',
+        title=tutorial_name,
+        flask_data=flask_data
+    )

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -36,6 +36,7 @@ const WorkspacePleaseWait = lazy(() => import('js/pages/WorkspacePleaseWait'));
 const GeneDetails = lazy(() => import('js/pages/Genes'));
 const Biomarkers = lazy(() => import('js/pages/Biomarkers'));
 const Tutorials = lazy(() => import('js/pages/Tutorials'));
+const Tutorial = lazy(() => import('js/pages/Tutorial'));
 
 function Routes({ flaskData }) {
   const {
@@ -53,6 +54,7 @@ function Routes({ flaskData }) {
     organ,
     vignette_json,
     geneSymbol,
+    tutorialName,
   } = flaskData;
   const urlPath = window.location.pathname;
   const url = window.location.href;
@@ -301,7 +303,6 @@ function Routes({ flaskData }) {
   }
 
   if (urlPath.startsWith('/tutorials')) {
-    /*
     if (tutorialName) {
       return (
         <Route>
@@ -309,7 +310,6 @@ function Routes({ flaskData }) {
         </Route>
       );
     }
-    */
 
     return (
       <Route>

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -35,6 +35,8 @@ const Workspace = lazy(() => import('js/pages/Workspace'));
 const WorkspacePleaseWait = lazy(() => import('js/pages/WorkspacePleaseWait'));
 const GeneDetails = lazy(() => import('js/pages/Genes'));
 const Biomarkers = lazy(() => import('js/pages/Biomarkers'));
+const Tutorials = lazy(() => import('js/pages/Tutorials'));
+
 function Routes({ flaskData }) {
   const {
     entity,
@@ -294,6 +296,24 @@ function Routes({ flaskData }) {
     return (
       <Route>
         <Biomarkers />
+      </Route>
+    );
+  }
+
+  if (urlPath.startsWith('/tutorials')) {
+    /*
+    if (tutorialName) {
+      return (
+        <Route>
+          <Tutorial tutorialName={tutorialName} />
+        </Route>
+      );
+    }
+    */
+
+    return (
+      <Route>
+        <Tutorials />
       </Route>
     );
   }

--- a/context/app/static/js/components/workspaces/WorkspacesAuthenticated.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesAuthenticated.jsx
@@ -4,6 +4,7 @@ import Typography from '@mui/material/Typography';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import { useAppContext } from 'js/components/Contexts';
 import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
+import { LinkPrompt } from 'js/shared-styles/tutorials/Prompt';
 import WorkspacesList from './WorkspacesList';
 
 import { StyledDescription } from './style';
@@ -17,6 +18,12 @@ function WorkspacesAuthenticated() {
 
   return (
     <>
+      <LinkPrompt
+        headerText="Getting Started"
+        descriptionText="Get a tutorial of how to explore workspaces to analyze HuBMAP data."
+        buttonText="Navigate to the Workspace Tutorial"
+        buttonHref="/tutorials/workspaces"
+      />
       <StyledDescription>
         <Typography gutterBottom>
           HuBMAP Workspaces are in{' '}

--- a/context/app/static/js/pages/Tutorial/Tutorial.tsx
+++ b/context/app/static/js/pages/Tutorial/Tutorial.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
 
 import PageTitle from 'js/shared-styles/pages/PageTitle';
 import SectionPaper from 'js/shared-styles/sections/SectionPaper';
@@ -18,13 +19,19 @@ const tutorials = {
   },
 };
 
+const StyledIframe = styled('iframe')({
+  border: 'none',
+  width: '100%',
+  aspectRatio: '3 / 1.75',
+});
+
 function Tutorial({ tutorialName }: TutorialProps) {
   const { title, description, iframeLink } = tutorials[tutorialName];
   return (
     <Stack spacing={2}>
       <PageTitle>{title}</PageTitle>
       <SectionPaper>{description}</SectionPaper>
-      <iframe src={iframeLink} title={title} style={{ border: 'none', width: '100%', aspectRatio: '3 / 2' }} />
+      <StyledIframe src={iframeLink} title={title} />
     </Stack>
   );
 }

--- a/context/app/static/js/pages/Tutorial/Tutorial.tsx
+++ b/context/app/static/js/pages/Tutorial/Tutorial.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Stack from '@mui/material/Stack';
+
+import PageTitle from 'js/shared-styles/pages/PageTitle';
+import SectionPaper from 'js/shared-styles/sections/SectionPaper';
+
+interface TutorialProps {
+  tutorialName: 'workspaces';
+}
+
+const tutorials = {
+  workspaces: {
+    title: 'Navigating Workspaces',
+    description:
+      'Learn how to use workspaces to analyze HuBMAP data by initiating Jupyter notebooks and choosing from a variety of pre-established templates.',
+    iframeLink:
+      'https://app.tango.us/app/embed/bcece94f-ba05-4acb-b05b-a7d333afc583?skipCover=false&defaultListView=true&skipBranding=false',
+  },
+};
+
+function Tutorial({ tutorialName }: TutorialProps) {
+  const { title, description, iframeLink } = tutorials[tutorialName];
+  return (
+    <Stack spacing={2}>
+      <PageTitle>{title}</PageTitle>
+      <SectionPaper>{description}</SectionPaper>
+      <iframe src={iframeLink} title={title} style={{ border: 'none', width: '100%', aspectRatio: '3 / 2' }} />
+    </Stack>
+  );
+}
+
+export default Tutorial;

--- a/context/app/static/js/pages/Tutorial/index.tsx
+++ b/context/app/static/js/pages/Tutorial/index.tsx
@@ -1,0 +1,3 @@
+import Tutorial from './Tutorial';
+
+export default Tutorial;

--- a/context/app/static/js/pages/Tutorials/Tutorials.tsx
+++ b/context/app/static/js/pages/Tutorials/Tutorials.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import { styled } from '@mui/material/styles';
+
+import PageTitle from 'js/shared-styles/pages/PageTitle';
+import SectionPaper from 'js/shared-styles/sections/SectionPaper';
+import SelectableCard from 'js/shared-styles/cards/SelectableCard';
+
+const tutorials = {
+  workspaces: {
+    title: 'Workspaces',
+    route: 'workspaces',
+    description:
+      'Learn how to set up workspaces that allows you to run analysis on HuBMAP data with Jupyter notebooks.',
+    tags: ['Workspaces', 'Data Analysis'],
+  },
+};
+
+const StyledLink = styled('a')(({ theme }) => ({
+  h6: {
+    color: theme.palette.common.link,
+  },
+}));
+
+function Tutorials() {
+  return (
+    <Stack spacing={2}>
+      <PageTitle>Tutorials</PageTitle>
+      <SectionPaper>Browse tutorials of how to navigate the HuBMAP Data Portal for your specific needs.</SectionPaper>
+      <Grid container alignItems="stretch">
+        {Object.values(tutorials).map(({ title, description, tags, route }) => (
+          <Grid item xs={4} key={title} aria-label={`${title} tutorial`}>
+            <StyledLink href={`/tutorials/${route}`}>
+              <SelectableCard title={title} description={description} cardKey={title} tags={tags} />
+            </StyledLink>
+          </Grid>
+        ))}
+      </Grid>
+    </Stack>
+  );
+}
+
+export default Tutorials;

--- a/context/app/static/js/pages/Tutorials/index.tsx
+++ b/context/app/static/js/pages/Tutorials/index.tsx
@@ -1,0 +1,3 @@
+import Tutorials from './Tutorials';
+
+export default Tutorials;

--- a/context/app/static/js/shared-styles/tutorials/Prompt/Prompt.jsx
+++ b/context/app/static/js/shared-styles/tutorials/Prompt/Prompt.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Typography from '@mui/material/Typography';
 import IconButton from '@mui/material/IconButton';
 import PropTypes from 'prop-types';
@@ -43,6 +43,33 @@ function Prompt({ headerText, descriptionText, buttonText, buttonIsDisabled }) {
   );
 }
 
+function LinkPrompt({ headerText, descriptionText, buttonText, buttonHref }) {
+  const [isPromptOpen, setIsPromptOpen] = useState(true);
+  return (
+    isPromptOpen && (
+      <StyledPaper>
+        <CenteredDiv>
+          <Flex>
+            <StyledInfoIcon />
+            <Typography variant="subtitle1" color="textPrimary">
+              {headerText}
+            </Typography>
+          </Flex>
+          <StyledTypography>{descriptionText}</StyledTypography>
+          <StyledButton variant="contained" href={buttonHref} component="a">
+            {buttonText}
+          </StyledButton>
+        </CenteredDiv>
+        <div>
+          <IconButton aria-label="close" onClick={() => setIsPromptOpen(false)} size="large">
+            <StyledCloseIcon />
+          </IconButton>
+        </div>
+      </StyledPaper>
+    )
+  );
+}
+
 Prompt.propTypes = {
   headerText: PropTypes.string.isRequired,
   descriptionText: PropTypes.string.isRequired,
@@ -50,4 +77,5 @@ Prompt.propTypes = {
   buttonIsDisabled: PropTypes.bool.isRequired,
 };
 
+export { LinkPrompt };
 export default Prompt;

--- a/context/app/static/js/shared-styles/tutorials/Prompt/index.js
+++ b/context/app/static/js/shared-styles/tutorials/Prompt/index.js
@@ -1,3 +1,4 @@
-import Prompt from './Prompt';
+import Prompt, { LinkPrompt } from './Prompt';
 
+export { LinkPrompt };
 export default Prompt;


### PR DESCRIPTION
We'll need to revisit the styling when there are more tutorials, but this works for now. We should also refactor the tutorial prompt and convert it to ts at a later date.

I imagine we'll want to add the tutorials link to navigation once workspaces is live?

<img width="1792" alt="Screenshot 2023-12-04 at 10 44 19 AM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/d2213e33-3377-4029-9a67-1bc947cd7c40">

<img width="1792" alt="Screenshot 2023-12-04 at 10 44 12 AM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/c0474e6e-7022-488c-a1ec-595656e3b573">

<img width="1792" alt="Screenshot 2023-12-04 at 10 44 01 AM" src="https://github.com/hubmapconsortium/portal-ui/assets/62477388/2b761bc1-72b9-47da-894a-efb385cf5756">
