### PR TITLE
NickAkhmetov/Hotfix - Uppercase biomarkers search input

### DIFF
--- a/CHANGELOG-biomarker-search.md
+++ b/CHANGELOG-biomarker-search.md
@@ -1,0 +1,1 @@
+- Adjust biomarker search input to ensure gene symbols are matched against.

--- a/context/app/static/js/components/biomarkers/hooks.ts
+++ b/context/app/static/js/components/biomarkers/hooks.ts
@@ -4,7 +4,7 @@ import { useBiomarkersSearchState } from './BiomarkersSearchContext';
 
 function useCurrentGenesList() {
   const { search } = useBiomarkersSearchState();
-  return useGeneList(search);
+  return useGeneList(search.toUpperCase());
 }
 
 export function useResultsList() {


### PR DESCRIPTION
This PR adjusts the biomarkers landing page search functionality so the input is automatically uppercased when sent to the server; this is a workaround for the `genes-info` endpoint currently being case sensitive and only matching against gene symbols.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/e2929d58-9564-405a-a6ac-d8d06fa4366d)
