### PR TITLE
NickAkhmetov/HMP-537 Update publication ID in cypress test

### DIFF
--- a/CHANGELOG-hmp-537.md
+++ b/CHANGELOG-hmp-537.md
@@ -1,0 +1,1 @@
+- Updated target publication for cypress tests.

--- a/end-to-end/cypress/e2e/portal/publication-page.cy.js
+++ b/end-to-end/cypress/e2e/portal/publication-page.cy.js
@@ -1,5 +1,4 @@
-// TODO: This will need to be updated when TEST is overwritten with prod data.
-const publicationId = "0bac279e054856ca1b98a2bfb28bb011";
+const publicationId = "2ced91fd6d543e79af90313e52ada57d";
 const title =
   "Vitessce: integrative visualization of multimodal and spatially-resolved single-cell data";
 
@@ -9,7 +8,7 @@ describe("Publication page", () => {
       cy.viewport("macbook-15");
       cy.intercept(
         {
-          hostname: "hubmapconsortium.org",
+          hostname: "assets.hubmapconsortium.org",
           url: new RegExp(`.*${publicationId}\/data.*`),
         },
         (res) => res.destroy()

--- a/end-to-end/cypress/e2e/portal/publication-page.cy.js
+++ b/end-to-end/cypress/e2e/portal/publication-page.cy.js
@@ -8,7 +8,7 @@ describe("Publication page", () => {
       cy.viewport("macbook-15");
       cy.intercept(
         {
-          hostname: "assets.hubmapconsortium.org",
+          hostname: "hubmapconsortium.org",
           url: new RegExp(`.*${publicationId}\/data.*`),
         },
         (res) => res.destroy()


### PR DESCRIPTION
This PR updates the publication page cypress tests to use the synced production publication UUID for the Vitessce preprint, as the test/dev db's were synced with prod on Friday.