### PR TITLE
NickAkhmetov/HMP-566 Make footer link icons consistent

### DIFF
--- a/CHANGELOG-HMP-566.md
+++ b/CHANGELOG-HMP-566.md
@@ -1,0 +1,2 @@
+- Add portal analytics link to maintenance page footer.
+- Fix consistency of external link icon logic.

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -40,9 +40,9 @@ function Footer({ isMaintenancePage }) {
             </FlexColumn>
             <FlexColumn $mr={1}>
               <Typography variant="subtitle2">Software</Typography>
-              <OutboundLink variant="body2" href="https://github.com/hubmapconsortium">
+              <OutboundIconLink variant="body2" href="https://github.com/hubmapconsortium">
                 GitHub
-              </OutboundLink>
+              </OutboundIconLink>
               {!isMaintenancePage && (
                 <>
                   <InternalLink variant="body2" href="/services">
@@ -51,11 +51,14 @@ function Footer({ isMaintenancePage }) {
                   <InternalLink variant="body2" href="/apis">
                     APIs
                   </InternalLink>
-                  <OutboundLink variant="body2" href="https://lookerstudio.google.com/u/0/reporting/bceef6eb-c727-4b6f-ac00-364b280ae8c2/page/p_o7z46wg18c">
-                    Portal Usage Analytics
-                  </OutboundLink>
                 </>
               )}
+              <OutboundIconLink
+                variant="body2"
+                href="https://lookerstudio.google.com/u/0/reporting/bceef6eb-c727-4b6f-ac00-364b280ae8c2/page/p_o7z46wg18c"
+              >
+                Portal Usage Analytics
+              </OutboundIconLink>
             </FlexColumn>
             <FlexColumn $mr={1}>
               <Typography variant="subtitle2">Policies</Typography>


### PR DESCRIPTION
This PR:
- Adds an external link icon to the GitHub link
- Makes the portal analytics link available while in maintenance and adds an external link icon

Non-maintenance footer:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/a4557de8-7e3f-47d1-a144-a9b1acdacb64)

Maintenance footer:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/a0f822bb-5f27-43e4-9f96-e6fa7bc044f2)
