### PR TITLE
John conroy/fix matomo events

### DIFF
--- a/CHANGELOG-fix-matomo-events.md
+++ b/CHANGELOG-fix-matomo-events.md
@@ -1,0 +1,2 @@
+- Fix matomo event tracking to provide name field where applicable.
+- Track entity page visits by HuBMAP ID not UUID.

--- a/CHANGELOG-github-action-node-version
+++ b/CHANGELOG-github-action-node-version
@@ -1,1 +1,0 @@
-- Update Node version used in GitHub Actions workflow.

--- a/context/app/markdown/CHANGELOG.md
+++ b/context/app/markdown/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Remove vitessce conf generation usage of TypeClient.
 - Improve approach to embedding HRA Organ UI.
 - Add support for dynamic maintenance messages.
+- Update Node version used in GitHub Actions workflow.
+- Update Node version used in GitHub Actions workflow.
 
 
 ## v0.85.3 - 2023-12-14

--- a/context/app/markdown/CHANGELOG.md
+++ b/context/app/markdown/CHANGELOG.md
@@ -19,7 +19,6 @@
 - Improve approach to embedding HRA Organ UI.
 - Add support for dynamic maintenance messages.
 - Update Node version used in GitHub Actions workflow.
-- Update Node version used in GitHub Actions workflow.
 
 
 ## v0.85.3 - 2023-12-14

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -85,7 +85,8 @@ const makeFaroSafe = (obj) =>
   Object.fromEntries(Object.entries(obj).map(([key, value]) => [key, `${JSON.stringify(value)}`]));
 
 function trackEvent(event) {
-  tracker.trackEvent(event);
+  const name = event?.label ?? {};
+  tracker.trackEvent({ ...event, ...name });
   ReactGA.event(event);
   // Convert all event values to strings to avoid errors in faro.
   // https://github.com/grafana/faro-web-sdk/issues/269

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -85,7 +85,7 @@ const makeFaroSafe = (obj) =>
   Object.fromEntries(Object.entries(obj).map(([key, value]) => [key, `${JSON.stringify(value)}`]));
 
 function trackEvent(event) {
-  const name = event?.label ?? {};
+  const name = event?.label ? { name: event.label } : {};
   tracker.trackEvent({ ...event, ...name });
   ReactGA.event(event);
   // Convert all event values to strings to avoid errors in faro.

--- a/context/app/static/js/hooks/useTrackID.ts
+++ b/context/app/static/js/hooks/useTrackID.ts
@@ -1,15 +1,21 @@
 import { useEffect } from 'react';
+
 import { trackEvent } from 'js/helpers/trackers';
 
-function useSendUUIDEvent(entity_type, uuid) {
+interface UseTrackIDTypes {
+  entity_type: string;
+  hubmap_id: string;
+}
+
+function useTrackID({ entity_type, hubmap_id }: UseTrackIDTypes) {
   useEffect(() => {
     trackEvent({
       category: entity_type,
       action: 'Visited',
-      label: uuid,
+      label: hubmap_id,
       nonInteraction: true, // not triggered by user interaction
     });
-  }, [entity_type, uuid]);
+  }, [entity_type, hubmap_id]);
 }
 
-export default useSendUUIDEvent;
+export default useTrackID;

--- a/context/app/static/js/pages/Collection/Collection.jsx
+++ b/context/app/static/js/pages/Collection/Collection.jsx
@@ -5,7 +5,7 @@ import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink'
 import Summary from 'js/components/detailPage/summary/Summary';
 import CollectionDatasetsTable from 'js/components/detailPage/CollectionDatasetsTable';
 import ContributorsTable from 'js/components/detailPage/ContributorsTable';
-import useSendUUIDEvent from 'js/components/detailPage/useSendUUIDEvent';
+import useTrackID from 'js/hooks/useTrackID';
 
 function Collection({ collection: collectionData }) {
   const {
@@ -24,7 +24,7 @@ function Collection({ collection: collectionData }) {
 
   const doi = new URL(doi_url).pathname.slice(1);
 
-  useSendUUIDEvent(entity_type, collectionData);
+  useTrackID({ entity_type, hubmap_id });
 
   return (
     <div>

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -14,7 +14,6 @@ import VisualizationWrapper from 'js/components/detailPage/visualization/Visuali
 import DetailLayout from 'js/components/detailPage/DetailLayout';
 import SummaryItem from 'js/components/detailPage/summary/SummaryItem';
 import ContributorsTable from 'js/components/detailPage/ContributorsTable';
-import useSendUUIDEvent from 'js/components/detailPage/useSendUUIDEvent';
 import useEntityStore from 'js/stores/useEntityStore';
 import CollectionsSection from 'js/components/detailPage/CollectionsSection';
 import SupportAlert from 'js/components/detailPage/SupportAlert';
@@ -32,6 +31,7 @@ import CreateWorkspaceDialog from 'js/components/workspaces/CreateWorkspaceDialo
 import { combineMetadata } from 'js/pages/utils/entity-utils';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import { useDatasetsCollections } from 'js/hooks/useDatasetsCollections';
+import useTrackID from 'js/hooks/useTrackID';
 import { useDatasetWorkspace } from './hooks';
 
 function NotebookButton(props) {
@@ -155,7 +155,7 @@ function DatasetDetail({ assayMetadata, vitData, hasNotebook, visLiftedUUID }) {
     shouldDisplaySection,
   );
 
-  useSendUUIDEvent(entity_type, uuid);
+  useTrackID({ entity_type, hubmap_id });
 
   const setAssayMetadata = useEntityStore(entityStoreSelector);
 

--- a/context/app/static/js/pages/Donor/Donor.jsx
+++ b/context/app/static/js/pages/Donor/Donor.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
+
 import { useFlaskDataContext } from 'js/components/Contexts';
 import MetadataTable from 'js/components/detailPage/MetadataTable';
 import ProvSection from 'js/components/detailPage/provenance/ProvSection';
@@ -6,11 +7,11 @@ import Summary from 'js/components/detailPage/summary/Summary';
 import Attribution from 'js/components/detailPage/Attribution';
 import Protocol from 'js/components/detailPage/Protocol';
 import DetailLayout from 'js/components/detailPage/DetailLayout';
-import useSendUUIDEvent from 'js/components/detailPage/useSendUUIDEvent';
 import useEntityStore from 'js/stores/useEntityStore';
 import { DetailContext } from 'js/components/detailPage/DetailContext';
 import { getSectionOrder } from 'js/components/detailPage/utils';
 import DerivedEntitiesSection from 'js/components/detailPage/derivedEntities/DerivedEntitiesSection';
+import useTrackID from 'js/hooks/useTrackID';
 
 const entityStoreSelector = (state) => state.setAssayMetadata;
 
@@ -54,7 +55,7 @@ function DonorDetail() {
     });
   }, [hubmap_id, entity_type, sex, race, age_value, age_unit, setAssayMetadata, group_name]);
 
-  useSendUUIDEvent(entity_type, uuid);
+  useTrackID({ entity_type, hubmap_id });
 
   const detailContext = useMemo(() => ({ hubmap_id, uuid }), [hubmap_id, uuid]);
 

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -11,6 +11,7 @@ import Files from 'js/components/detailPage/files/Files';
 import useEntityStore from 'js/stores/useEntityStore';
 import BulkDataTransfer from 'js/components/detailPage/BulkDataTransfer';
 import { DetailContext } from 'js/components/detailPage/DetailContext';
+import useTrackID from 'js/hooks/useTrackID';
 
 const entityStoreSelector = (state) => state.setAssayMetadata;
 
@@ -34,6 +35,8 @@ function Publication({ publication, vignette_json }) {
   useEffect(() => {
     setAssayMetadata({ hubmap_id, entity_type, title, publication_venue });
   }, [hubmap_id, entity_type, title, publication_venue, setAssayMetadata]);
+
+  useTrackID({ entity_type, hubmap_id });
 
   const associatedCollectionUUID = associated_collection?.uuid;
 

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -11,7 +11,6 @@ import SummaryItem from 'js/components/detailPage/summary/SummaryItem';
 import DetailLayout from 'js/components/detailPage/DetailLayout';
 import MetadataTable from 'js/components/detailPage/MetadataTable';
 import SampleTissue from 'js/components/detailPage/SampleTissue';
-import useSendUUIDEvent from 'js/components/detailPage/useSendUUIDEvent';
 import useEntityStore from 'js/stores/useEntityStore';
 import { DetailContext } from 'js/components/detailPage/DetailContext';
 import { getSectionOrder } from 'js/components/detailPage/utils';
@@ -19,6 +18,7 @@ import { getSectionOrder } from 'js/components/detailPage/utils';
 import DerivedDatasetsSection from 'js/components/detailPage/derivedEntities/DerivedDatasetsSection';
 
 import { combineMetadata } from 'js/pages/utils/entity-utils';
+import useTrackID from 'js/hooks/useTrackID';
 
 const entityStoreSelector = (state) => state.setAssayMetadata;
 
@@ -60,7 +60,7 @@ function SampleDetail() {
     setAssayMetadata({ hubmap_id, entity_type, mapped_organ, sample_category });
   }, [hubmap_id, entity_type, mapped_organ, sample_category, setAssayMetadata]);
 
-  useSendUUIDEvent(entity_type, uuid);
+  useTrackID({ entity_type, hubmap_id });
 
   const detailContext = useMemo(() => ({ hubmap_id, uuid }), [hubmap_id, uuid]);
 


### PR DESCRIPTION
- Fix matomo event tracking to provide name field where applicable.
- Track entity page visits by HuBMAP ID not UUID.

I also added tracking for publication pages and cleaned up an old changelog file that wasn't compiled as it was missing a `.md` extension.