### PR TITLE
John conroy/fix entity page tracker CAT-553

### DIFF
--- a/CHANGELOG-fix-entity-page-tracker.md
+++ b/CHANGELOG-fix-entity-page-tracker.md
@@ -1,0 +1,1 @@
+- Fix entity page event tracker to handle undefined entity in flask context.

--- a/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.jsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/SummaryData.jsx
@@ -3,15 +3,13 @@ import PropTypes from 'prop-types';
 import SaveEditEntityButton from 'js/components/detailPage/SaveEditEntityButton';
 
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
-import { FileIcon } from 'js/shared-styles/icons';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
-import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import VersionSelect from 'js/components/detailPage/VersionSelect';
 import SummaryTitle from 'js/components/detailPage/summary/SummaryTitle';
 import SummaryItem from 'js/components/detailPage/summary/SummaryItem';
 import StatusIcon from 'js/components/detailPage/StatusIcon';
-import { FlexEnd, JsonButton, StyledTypography, StyledSvgIcon, SummaryDataHeader } from './style';
-import { useTrackEntityPageEvent } from '../../useTrackEntityPageEvent';
+import { FlexEnd, StyledTypography, StyledSvgIcon, SummaryDataHeader } from './style';
+import SummaryJSONButton from '../SummaryJSONButton';
 
 const datasetEntityTypes = ['Dataset', 'Support', 'Publication', 'Preprint'];
 const publicationEntityTypes = ['Publication', 'Preprint'];
@@ -33,8 +31,6 @@ function SummaryData({
 }) {
   const isPublication = publicationEntityTypes.includes(entity_type);
   const LeftTextContainer = isPublication ? React.Fragment : 'div';
-
-  const trackEntityPageEvent = useTrackEntityPageEvent();
 
   return (
     <>
@@ -63,18 +59,7 @@ function SummaryData({
               </>
             )}
             <FlexEnd>
-              {showJsonButton && (
-                <SecondaryBackgroundTooltip title="View JSON">
-                  <JsonButton
-                    href={`/browse/${entity_type.toLowerCase()}/${uuid}.json`}
-                    target="_blank"
-                    component="a"
-                    onClick={() => trackEntityPageEvent({ action: 'View JSON' })}
-                  >
-                    <FileIcon color="primary" />
-                  </JsonButton>
-                </SecondaryBackgroundTooltip>
-              )}
+              {showJsonButton && <SummaryJSONButton entity_type={entity_type} uuid={uuid} />}
               {entityCanBeSaved && <SaveEditEntityButton uuid={uuid} entity_type={entity_type} />}
               {datasetEntityTypes.includes(entity_type) && <VersionSelect uuid={uuid} />}
             </FlexEnd>

--- a/context/app/static/js/components/detailPage/summary/SummaryData/style.js
+++ b/context/app/static/js/components/detailPage/summary/SummaryData/style.js
@@ -2,16 +2,10 @@ import styled from 'styled-components';
 import Typography from '@mui/material/Typography';
 import SvgIcon from '@mui/material/SvgIcon';
 
-import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
-
 const FlexEnd = styled.div`
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-`;
-
-const JsonButton = styled(WhiteBackgroundIconButton)`
-  height: 36px;
 `;
 
 const StyledTypography = styled(Typography)`
@@ -29,4 +23,4 @@ const SummaryDataHeader = styled.div`
   margin-bottom: ${(props) => props.theme.spacing(1)};
 `;
 
-export { FlexEnd, JsonButton, StyledTypography, StyledSvgIcon, SummaryDataHeader };
+export { FlexEnd, StyledTypography, StyledSvgIcon, SummaryDataHeader };

--- a/context/app/static/js/components/detailPage/summary/SummaryJSONButton/SummaryJSONButton.tsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryJSONButton/SummaryJSONButton.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { WhiteRectangularTooltipIconButton } from 'js/shared-styles/buttons/TooltipButton';
+import { FileIcon } from 'js/shared-styles/icons';
+import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
+
+interface Props {
+  entity_type: string;
+  uuid: string;
+}
+
+function SummaryJSONButton({ entity_type, uuid }: Props) {
+  const trackEntityPageEvent = useTrackEntityPageEvent();
+
+  return (
+    <WhiteRectangularTooltipIconButton
+      tooltip="View JSON"
+      sx={{ height: '36px', display: 'flex' }}
+      href={`/browse/${entity_type.toLowerCase()}/${uuid}.json`}
+      target="_blank"
+      onClick={() => trackEntityPageEvent({ action: 'View JSON' })}
+    >
+      <FileIcon color="primary" />
+    </WhiteRectangularTooltipIconButton>
+  );
+}
+
+export default SummaryJSONButton;

--- a/context/app/static/js/components/detailPage/summary/SummaryJSONButton/index.ts
+++ b/context/app/static/js/components/detailPage/summary/SummaryJSONButton/index.ts
@@ -1,0 +1,3 @@
+import SummaryJSONButton from './SummaryJSONButton';
+
+export default SummaryJSONButton;

--- a/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
+++ b/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
@@ -10,10 +10,8 @@ interface TrackingEventType {
 }
 
 function useTrackEntityPageEvent() {
-  const {
-    entity: { hubmap_id, entity_type },
-  } = useFlaskDataContext();
-
+  const { entity = { hubmap_id: undefined, entity_type: undefined } } = useFlaskDataContext();
+  const { hubmap_id, entity_type } = entity;
   return useCallback(
     (event: TrackingEventType) => {
       if (!(hubmap_id || entity_type)) {

--- a/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
+++ b/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
@@ -14,12 +14,10 @@ function useTrackEntityPageEvent() {
   const { hubmap_id, entity_type } = entity;
   return useCallback(
     (event: TrackingEventType) => {
-      if (!(hubmap_id || entity_type)) {
-        trackEvent(event);
-      }
+      const category = entity_type ? `${entity_type} Page` : 'Detail Page';
       trackEvent(
         {
-          category: `${entity_type} Page`,
+          category,
           ...event,
         },
         hubmap_id,

--- a/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
+++ b/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
@@ -16,6 +16,9 @@ function useTrackEntityPageEvent() {
 
   return useCallback(
     (event: TrackingEventType) => {
+      if (!(hubmap_id || entity_type)) {
+        trackEvent(event);
+      }
       trackEvent(
         {
           category: `${entity_type} Page`,

--- a/context/app/static/js/shared-styles/buttons/TooltipButton/TooltipIconButton.tsx
+++ b/context/app/static/js/shared-styles/buttons/TooltipButton/TooltipIconButton.tsx
@@ -1,13 +1,17 @@
-import React from 'react';
-import { IconButtonProps } from '@mui/material/IconButton';
+import React, { ElementType } from 'react';
+import { IconButtonProps, IconButtonTypeMap } from '@mui/material/IconButton';
+import { styled } from '@mui/material/styles';
 
 import TooltipButtonBase from './TooltipButtonBase';
 
-export interface TooltipButtonProps extends IconButtonProps {
+export type TooltipButtonProps<E extends ElementType = IconButtonTypeMap['defaultComponent']> = {
   tooltip: React.ReactNode;
-}
+} & IconButtonProps<E>;
 
-function TooltipIconButton({ children, ...props }: TooltipButtonProps, ref: React.Ref<HTMLButtonElement>) {
+function TooltipIconButton<E extends ElementType = IconButtonTypeMap['defaultComponent']>(
+  { children, ...props }: TooltipButtonProps<E>,
+  ref: React.Ref<HTMLButtonElement>,
+) {
   return (
     <TooltipButtonBase {...props} ref={ref} isIconButton>
       {children}
@@ -15,4 +19,18 @@ function TooltipIconButton({ children, ...props }: TooltipButtonProps, ref: Reac
   );
 }
 
-export default React.forwardRef(TooltipIconButton);
+const ForwardedTooltipIconButton = React.forwardRef(TooltipIconButton);
+
+const RectangularTooltipIconButton = styled(ForwardedTooltipIconButton)(() => ({
+  borderRadius: '0px',
+}));
+
+const WhiteRectangularTooltipIconButton = styled(RectangularTooltipIconButton)(({ theme }) => ({
+  backgroundColor: theme.palette.white.main,
+  color: theme.palette.primary.main,
+  border: `1px solid ${theme.palette.divider}`,
+  borderRadius: theme.spacing(0.5),
+}));
+
+export { RectangularTooltipIconButton, WhiteRectangularTooltipIconButton };
+export default ForwardedTooltipIconButton;

--- a/context/app/static/js/shared-styles/buttons/TooltipButton/index.ts
+++ b/context/app/static/js/shared-styles/buttons/TooltipButton/index.ts
@@ -1,5 +1,15 @@
 import TooltipButton from './TooltipButton';
 
-import TooltipIconButton, { TooltipButtonProps } from './TooltipIconButton';
+import TooltipIconButton, {
+  TooltipButtonProps,
+  RectangularTooltipIconButton,
+  WhiteRectangularTooltipIconButton,
+} from './TooltipIconButton';
 
-export { TooltipButton, TooltipIconButton, type TooltipButtonProps };
+export {
+  TooltipButton,
+  TooltipIconButton,
+  type TooltipButtonProps,
+  RectangularTooltipIconButton,
+  WhiteRectangularTooltipIconButton,
+};


### PR DESCRIPTION
Fixes `useTrackEntityPageEvent` to handle undefined `entity_type` and `hubmap_id` inside the flask data context. We could consider defining a new field in the flask data for detail pages which would be the `entity_type` for search-api dependent detail pages and manually set for other pages like workspaces.

I also went on a little bit of a tangent to pull the tracker out of `SummaryData`.