### PR TITLE
NickAkhmetov/Preselect marker genes in azimuth visualizations on gene pages

### DIFF
--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.jsx
@@ -43,7 +43,7 @@ const visualizationStoreSelector = (state) => ({
   setVitessceStateDebounced: state.setVitessceStateDebounced,
 });
 
-function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, shouldMountVitessce = true }) {
+function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, shouldMountVitessce = true, markerGene }) {
   const {
     vizIsFullscreen,
     expandViz,
@@ -83,11 +83,8 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, should
   const { vitessceConfig, vitessceSelection, setVitessceSelection } = useVitessceConfig({
     vitData,
     setVitessceState,
+    markerGene,
   });
-
-  function addError(message) {
-    toastError(message);
-  }
 
   function setSelectionAndClearErrors(itemAndIndex) {
     const { i } = itemAndIndex;
@@ -153,7 +150,7 @@ function Visualization({ vitData, uuid, hasNotebook, shouldDisplayHeader, should
                   theme={vizTheme}
                   onConfigChange={setVitessceStateDebounced}
                   height={vizIsFullscreen ? null : vitessceFixedHeight}
-                  onWarn={addError}
+                  onWarn={toastError}
                 />
               </VisualizationTracker>
             )}

--- a/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
@@ -4,7 +4,7 @@ import { decodeURLParamsToConf, VitessceConfig, CoordinationType as ct } from 'v
 import { useSnackbarStore } from 'js/shared-styles/snackbars';
 
 function handleMarkerGene(vData, markerGene) {
-  if (vData && vData.layout && markerGene) {
+  if (vData?.layout && markerGene) {
     const vc = VitessceConfig.fromJSON(vData);
     const [featureSelection, obsColorEncoding] = vc.addCoordination(ct.FEATURE_SELECTION, ct.OBS_COLOR_ENCODING);
     vc.config.layout.forEach((v) => v.useCoordination(featureSelection, obsColorEncoding));

--- a/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
@@ -1,9 +1,21 @@
 import { useState, useEffect } from 'react';
-import { decodeURLParamsToConf } from 'vitessce';
+import { decodeURLParamsToConf, VitessceConfig, CoordinationType as ct } from 'vitessce';
 
 import { useSnackbarStore } from 'js/shared-styles/snackbars';
 
-export function useVitessceConfig({ vitData, setVitessceState }) {
+function handleMarkerGene(vData, markerGene) {
+  if (vData && vData.layout && markerGene) {
+    const vc = VitessceConfig.fromJSON(vData);
+    const [featureSelection, obsColorEncoding] = vc.addCoordination(ct.FEATURE_SELECTION, ct.OBS_COLOR_ENCODING);
+    vc.config.layout.forEach((v) => v.useCoordination(featureSelection, obsColorEncoding));
+    featureSelection.setValue([markerGene]);
+    obsColorEncoding.setValue('geneSelection');
+    return vc.toJSON();
+  }
+  return vData;
+}
+
+export function useVitessceConfig({ vitData, setVitessceState, markerGene }) {
   const [vitessceSelection, setVitessceSelection] = useState(null);
   const [vitessceConfig, setVitessceConfig] = useState(null);
 
@@ -13,9 +25,11 @@ export function useVitessceConfig({ vitData, setVitessceState }) {
 
   useEffect(() => {
     function setVitessceDefaults(vData) {
-      setVitessceState(Array.isArray(vData) ? vData[0] : vData);
+      const initialVData = Array.isArray(vData) ? vData[0] : vData;
+      const vc = handleMarkerGene(initialVData, markerGene);
+      setVitessceState(vc);
       setVitessceSelection(0);
-      setVitessceConfig(vData);
+      setVitessceConfig(vc);
     }
 
     if (setVitessceState && vitData) {
@@ -47,6 +61,6 @@ export function useVitessceConfig({ vitData, setVitessceState }) {
       setVitessceSelection(initialSelectionFromUrl);
       setVitessceConfig(initializedVitDataFromUrl);
     }
-  }, [setVitessceState, vitData, toastError]);
+  }, [setVitessceState, vitData, toastError, markerGene]);
   return { vitessceConfig, vitessceSelection, setVitessceSelection };
 }

--- a/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/hooks.js
@@ -25,11 +25,12 @@ export function useVitessceConfig({ vitData, setVitessceState, markerGene }) {
 
   useEffect(() => {
     function setVitessceDefaults(vData) {
-      const initialVData = Array.isArray(vData) ? vData[0] : vData;
-      const vc = handleMarkerGene(initialVData, markerGene);
-      setVitessceState(vc);
+      const vDataWithMarkerGene = Array.isArray(vData)
+        ? vData.map((v) => handleMarkerGene(v, markerGene))
+        : handleMarkerGene(vData, markerGene);
+      setVitessceState(Array.isArray(vData) ? vDataWithMarkerGene[0] : vDataWithMarkerGene);
       setVitessceSelection(0);
-      setVitessceConfig(vc);
+      setVitessceConfig(vDataWithMarkerGene);
     }
 
     if (setVitessceState && vitData) {

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.jsx
@@ -6,7 +6,15 @@ import { VisualizationSuspenseFallback } from './VisualizationSuspenseFallback';
 
 const Visualization = React.lazy(() => import('../Visualization'));
 
-function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader, hasBeenMounted, isPublicationPage }) {
+function VisualizationWrapper({
+  vitData,
+  uuid,
+  hasNotebook,
+  shouldDisplayHeader,
+  hasBeenMounted,
+  isPublicationPage,
+  markerGene,
+}) {
   const containerStyles = useMemo(
     () => ({
       shouldDisplayHeader,
@@ -25,6 +33,7 @@ function VisualizationWrapper({ vitData, uuid, hasNotebook, shouldDisplayHeader,
             hasNotebook={hasNotebook}
             shouldDisplayHeader={shouldDisplayHeader}
             shouldMountVitessce={hasBeenMounted}
+            markerGene={markerGene}
           />
         </Suspense>
       </VisualizationErrorBoundary>

--- a/context/app/static/js/components/genes/Organs/Visualization.tsx
+++ b/context/app/static/js/components/genes/Organs/Visualization.tsx
@@ -6,12 +6,14 @@ import { OrganFile } from 'js/components/organ/types';
 import { DetailPageAlert } from 'js/components/detailPage/style';
 import { Typography } from '@mui/material';
 import InfoTooltipIcon from 'js/shared-styles/icons/TooltipIcon';
+import { useGenePageContext } from '../hooks';
 
 interface AzimuthVisualizationProps {
   organ: OrganFile;
 }
 
 export function AzimuthVisualization({ organ }: AzimuthVisualizationProps) {
+  const { geneSymbol } = useGenePageContext();
   if (!organ) return null;
   if (!organ?.azimuth) {
     return <DetailPageAlert severity="info">No Azimuth reference-based analysis available.</DetailPageAlert>;
@@ -33,6 +35,7 @@ export function AzimuthVisualization({ organ }: AzimuthVisualizationProps) {
         hasNotebook={false}
         isPublicationPage={false}
         shouldDisplayHeader={false}
+        markerGene={geneSymbol}
       />
     </Stack>
   );


### PR DESCRIPTION
This PR makes azimuth visualizations on gene pages highlight the current gene by default.

In the future, this approach could potentially supercede the portal-visualization package's handling of marker genes, as a future improvement.

Demo (note that ABCA1 is selected in the visualization):
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/5bf60091-f927-4d07-940a-474123f48499)
