### PR TITLE
John conroy/fix missing viz CAT-566

### DIFF
--- a/CHANGELOG-fix-missing-viz.md
+++ b/CHANGELOG-fix-missing-viz.md
@@ -1,0 +1,1 @@
+- Fix bug in which new datasets without deprecated `data_types` field were not displaying visualizations correctly.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -202,7 +202,7 @@ class ApiClient():
                         {entity["uuid"]}: {error}')
                 vitessce_conf = _create_vitessce_error(error)
 
-        elif not entity.get('files') or not entity.get('data_types'):
+        elif not entity.get('files'):
             vitessce_conf = ConfCells(None, None)
 
         # Otherwise, just try to visualize the data for the entity itself:


### PR DESCRIPTION
Fix bug in which new datasets without deprecated `data_types` field were not displaying visualizations correctly.