### PR TITLE
NickAkhmetov/CAT-591 Fix tile search view

### DIFF
--- a/CHANGELOG-cat-591.md
+++ b/CHANGELOG-cat-591.md
@@ -1,0 +1,1 @@
+- Fix tile view of search pages.

--- a/context/app/static/js/components/searchPage/config.js
+++ b/context/app/static/js/components/searchPage/config.js
@@ -72,7 +72,7 @@ const sampleConfig = {
       field('origin_samples.mapped_organ', 'Organ'),
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],
-    tile: sharedTileFields,
+    tile: [...sharedTileFields, field('origin_samples_unique_mapped_organs', 'Organ')],
     ccf: [],
   },
 };

--- a/context/app/static/js/components/searchPage/config.js
+++ b/context/app/static/js/components/searchPage/config.js
@@ -117,7 +117,7 @@ const datasetConfig = {
       field('mapped_status', 'Status'),
       field('mapped_last_modified_timestamp', 'Last Modified'),
     ],
-    tile: [...sharedTileFields, field('thumbnail_file.file_uuid', 'Thumbnail UUID')],
+    tile: [...sharedTileFields, field('origin_samples_unique_mapped_organs', 'Organ'), field('thumbnail_file.file_uuid', 'Thumbnail UUID')],
     ccf: [],
   },
 };


### PR DESCRIPTION
This PR adds the missing field that was causing the tile view of search pages to crash if viewing any query but the default.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/da3f5fae-2118-4681-baba-12f8b56ca003)
