### PR TITLE
NickAkhmetov/CAT-593 Support display of legacy contact information without `version` field

### DIFF
--- a/CHANGELOG-cat-593.md
+++ b/CHANGELOG-cat-593.md
@@ -1,0 +1,1 @@
+- Support display of legacy contact information which does not have `version` field available.

--- a/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
+++ b/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
@@ -80,4 +80,6 @@ const normalizeCEDARContributor = (contributor: CEDARContributor): Contributor =
 };
 
 export const normalizeContributor = (contributor: ContributorAPIResponse): Contributor =>
-  'version' in contributor ? normalizeLegacyContributor(contributor) : normalizeCEDARContributor(contributor);
+  'metadata_schema_id' in contributor
+    ? normalizeCEDARContributor(contributor)
+    : normalizeLegacyContributor(contributor);


### PR DESCRIPTION
The `contacts` in data collections do not have a `version` field, while `contributors` do. Since the adapter I had built out for this as part of #3391 assumed that all legacy contacts have a `version` field while all CEDAR contacts have the `metadata_schema_id` field, I had used the presence of the `version` field as the discriminator to determine which adapter function to use. As this assumption has been proven incorrect, I have reversed this logic - if the metadata schema ID field is present, we know it's a CEDAR schema contributor, while if the metadata schema ID is missing, we know it's legacy data.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/d177fda3-caa3-4a30-925a-b7bb42ce3b1e)
