### PR TITLE
NickAkhmetov/CAT-574 Remove stale previews from atlas & tools, improve outbound link handling

### DIFF
--- a/CHANGELOG-cat-574.md
+++ b/CHANGELOG-cat-574.md
@@ -1,0 +1,1 @@
+- Remove stale previews from tools.

--- a/context/app/static/js/components/Header/DropdownLink/DropdownLink.tsx
+++ b/context/app/static/js/components/Header/DropdownLink/DropdownLink.tsx
@@ -1,6 +1,7 @@
 import React, { PropsWithChildren } from 'react';
 import MenuItem, { MenuItemProps } from '@mui/material/MenuItem';
 import { useTrackOutboundLink } from 'js/hooks/useTrackOutboundLink';
+import { useExternalUrlProps } from 'js/hooks/useIsExternalUrl';
 
 interface DropdownLinkProps extends MenuItemProps {
   href: string;
@@ -9,6 +10,7 @@ interface DropdownLinkProps extends MenuItemProps {
 
 function DropdownLink({ href, isIndented, children, onClick, ...rest }: PropsWithChildren<DropdownLinkProps>) {
   const handleClick = useTrackOutboundLink(onClick);
+  const outboundProps = useExternalUrlProps(href);
   return (
     <MenuItem
       sx={({ spacing, palette }) => ({
@@ -18,6 +20,7 @@ function DropdownLink({ href, isIndented, children, onClick, ...rest }: PropsWit
       component="a"
       href={href}
       onClick={handleClick}
+      {...outboundProps}
       {...rest}
     >
       {children}

--- a/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
+++ b/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
@@ -39,24 +39,12 @@ const atlasGroups = {
   ],
   hra: [
     {
-      href: 'https://hubmapconsortium.github.io/hra-previews/pilots/pilot1.html',
-      label: 'HRA Preview: ASCT+B Reporter Comparison',
-    },
-    {
       href: 'https://hubmapconsortium.github.io/hra-previews/pilots/pilot2.html',
       label: 'HRA Preview: Vasculature CCF Visualization',
     },
     {
       href: 'https://hubmapconsortium.github.io/hra-previews/pilots/pilot3.html',
       label: 'HRA Preview: HRA vs. Experimental Data',
-    },
-    {
-      href: 'https://hubmapconsortium.github.io/hra-previews/pilots/pilot4.html',
-      label: 'HRA Preview: Scrollytelling Series',
-    },
-    {
-      href: 'https://hubmapconsortium.github.io/hra-previews/pilots/pilot5.html',
-      label: 'HRA Preview: Tabula Sapiens Comparisons',
     },
     {
       href: 'https://hubmapconsortium.github.io/hra-previews/pilots/pilot6.html',

--- a/context/app/static/js/components/home/ImageCarouselButton/ImageCarouselButton.jsx
+++ b/context/app/static/js/components/home/ImageCarouselButton/ImageCarouselButton.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import Button from '@mui/material/Button';
+import { useExternalUrlProps } from 'js/hooks/useIsExternalUrl';
 
 function ImageCarouselButton({ href }) {
+  const outboundProps = useExternalUrlProps(href);
   return (
-    <Button variant="outlined" color="primary" component="a" href={href}>
+    <Button variant="outlined" color="primary" component="a" href={href} {...outboundProps}>
       Get Started
     </Button>
   );

--- a/context/app/static/js/hooks/useIsExternalUrl.ts
+++ b/context/app/static/js/hooks/useIsExternalUrl.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+/**
+ * Creates and removes a temporary `a` tag to check if a URL is external to the current site
+ *
+ * @see https://www.designcise.com/web/tutorial/how-to-check-if-a-string-url-refers-to-an-external-link-using-javascript
+ * @param url
+ * @returns true if the URL is external, false otherwise
+ */
+function isExternalURL(url: string) {
+  const tmpLink = document.createElement('a');
+  tmpLink.href = url;
+  const tmpLinkHost = tmpLink.host;
+  const windowHost = window.location.host;
+  tmpLink.remove();
+  return tmpLinkHost !== windowHost;
+}
+
+/**
+ * Custom hook to check if a URL is external to the current site
+ *
+ * @param href
+ * @returns true if the URL is external, false otherwise
+ */
+export function useIsExternalUrl(href: string) {
+  return useMemo(() => isExternalURL(href), [href]);
+}
+
+const outboundProps = {
+  rel: 'noopener noreferrer',
+  target: '_blank',
+} as const;
+
+export function useExternalUrlProps(href: string) {
+  const isExternal = useIsExternalUrl(href);
+  return isExternal ? outboundProps : {};
+}


### PR DESCRIPTION
This PR:
- Removes the crossed out elements from the original issue description (see below for comparison)
- Adds a hook to dynamically handle internal vs. external links and demonstrates its usage with carousel CTA links and dropdown links
  - Future improvement: we should be able to start using this hook elsewhere to apply outbound link props where appropriate with minimal effort - the InternalLink vs. OutboundLink dichotomy might be possible to simplify to a single component

Requirement:
![Untitled](https://github.com/hubmapconsortium/portal-ui/assets/19957804/d59efc70-b33a-4218-ba97-d372e7ad3569)

Result:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/4eacbbfd-666e-46bf-80b8-dfcf37dfb42a)
