### PR TITLE
Resolve attribute error when installing pyyaml dependency.

### DIFF
--- a/CHANGELOG-pyyaml-cython.md
+++ b/CHANGELOG-pyyaml-cython.md
@@ -1,0 +1,1 @@
+- Use cython<3 at build time to address: "AttributeError: cython_sources" 

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -25,10 +25,18 @@ RUN npm run build
 
 FROM tiangolo/uwsgi-nginx-flask:python${PYTHON_MINOR_V}
 
+# Use a constraints file to force pip to use cython<3 at build time to address:
+# "AttributeError: cython_sources" with Cython 3.0.0a10 #601 (comment)
+# https://stackoverflow.com/questions/77490435/attributeerror-cython-sources
+# May be removed after upgrading to PyYaml 6
+# https://github.com/yaml/pyyaml/issues/724
+ARG PIP_CONSTRAINT="cython<3"
+
 COPY requirements.txt /app
 # Legacy resolver is used to avoid issues with a non-pinned subdependency which causes build failures in CI
 # https://github.com/hubmapconsortium/portal-ui/actions/runs/6087458665/job/16516023950
-RUN pip install -r /app/requirements.txt --use-deprecated=legacy-resolver
+RUN echo "cython<3" > /tmp/constraint.txt
+RUN PIP_CONSTRAINT=/tmp/constraint.txt pip install -r /app/requirements.txt --use-deprecated=legacy-resolver
 
 # NGINX should serve static content directly.
 # https://github.com/tiangolo/uwsgi-nginx-flask-docker#custom-static-path

--- a/context/Dockerfile
+++ b/context/Dockerfile
@@ -30,7 +30,6 @@ FROM tiangolo/uwsgi-nginx-flask:python${PYTHON_MINOR_V}
 # https://stackoverflow.com/questions/77490435/attributeerror-cython-sources
 # May be removed after upgrading to PyYaml 6
 # https://github.com/yaml/pyyaml/issues/724
-ARG PIP_CONSTRAINT="cython<3"
 
 COPY requirements.txt /app
 # Legacy resolver is used to avoid issues with a non-pinned subdependency which causes build failures in CI


### PR DESCRIPTION
Use a constraints file to force pip to use cython<3 at build time to address:
"AttributeError: cython_sources" with Cython 3.0.0a10 #601 (comment)
https://stackoverflow.com/questions/77490435/attributeerror-cython-sources 

We may be able to remove this after upgrading to PyYaml 6. 
https://github.com/yaml/pyyaml/issues/724

```
25.60 Collecting pyyaml==5.4
25.61   Downloading PyYAML-5.4.tar.gz (174 kB)
25.62      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 174.8/174.8 kB 25.9 MB/s eta 0:00:00
25.69   Installing build dependencies: started
27.15   Installing build dependencies: finished with status 'done'
27.15   Getting requirements to build wheel: started
27.26   Getting requirements to build wheel: finished with status 'error'
27.27   error: subprocess-exited-with-error
27.27   
27.27   × Getting requirements to build wheel did not run successfully.
27.27   │ exit code: 1
27.27   ╰─> [48 lines of output]
27.27       running egg_info
27.27       writing lib3/PyYAML.egg-info/PKG-INFO
27.27       writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
27.27       writing top-level names to lib3/PyYAML.egg-info/top_level.txt
27.27       Traceback (most recent call last):
27.27         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
27.27           main()
27.27         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
27.27           json_out['return_val'] = hook(**hook_input['kwargs'])
27.27         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
27.27           return hook(config_settings)
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
27.27           return self._get_build_requires(config_settings, requirements=['wheel'])
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
27.27           self.run_setup()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 311, in run_setup
27.27           exec(code, locals())
27.27         File "<string>", line 271, in <module>
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 104, in setup
27.27           return distutils.core.setup(**attrs)
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 185, in setup
27.27           return run_commands(dist)
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
27.27           dist.run_commands()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
27.27           self.run_command(cmd)
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 967, in run_command
27.27           super().run_command(command)
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
27.27           cmd_obj.run()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 321, in run
27.27           self.find_sources()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 329, in find_sources
27.27           mm.run()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 550, in run
27.27           self.add_defaults()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 588, in add_defaults
27.27           sdist.add_defaults(self)
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/sdist.py", line 102, in add_defaults
27.27           super().add_defaults()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
27.27           self._add_defaults_ext()
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
27.27           self.filelist.extend(build_ext.get_source_files())
27.27         File "<string>", line 201, in get_source_files
27.27         File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
27.27           raise AttributeError(attr)
27.27       AttributeError: cython_sources
27.27       [end of output]
27.27   
27.27   note: This error originates from a subprocess, and is likely not a problem with pip.
27.27 error: subprocess-exited-with-error
27.27 
27.27 × Getting requirements to build wheel did not run successfully.
27.27 │ exit code: 1
27.27 ╰─> [48 lines of output]
27.27     running egg_info
27.27     writing lib3/PyYAML.egg-info/PKG-INFO
27.27     writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
27.27     writing top-level names to lib3/PyYAML.egg-info/top_level.txt
27.27     Traceback (most recent call last):
27.27       File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
27.27         main()
27.27       File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
27.27         json_out['return_val'] = hook(**hook_input['kwargs'])
27.27       File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
27.27         return hook(config_settings)
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
27.27         return self._get_build_requires(config_settings, requirements=['wheel'])
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
27.27         self.run_setup()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 311, in run_setup
27.27         exec(code, locals())
27.27       File "<string>", line 271, in <module>
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 104, in setup
27.27         return distutils.core.setup(**attrs)
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 185, in setup
27.27         return run_commands(dist)
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
27.27         dist.run_commands()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
27.27         self.run_command(cmd)
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 967, in run_command
27.27         super().run_command(command)
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
27.27         cmd_obj.run()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 321, in run
27.27         self.find_sources()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 329, in find_sources
27.27         mm.run()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 550, in run
27.27         self.add_defaults()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/egg_info.py", line 588, in add_defaults
27.27         sdist.add_defaults(self)
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/command/sdist.py", line 102, in add_defaults
27.27         super().add_defaults()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
27.27         self._add_defaults_ext()
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
27.27         self.filelist.extend(build_ext.get_source_files())
27.27       File "<string>", line 201, in get_source_files
27.27       File "/tmp/pip-build-env-8w9o7wxj/overlay/lib/python3.9/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
27.27         raise AttributeError(attr)
27.27     AttributeError: cython_sources
27.27     [end of output]
27.27 
27.27 note: This error originates from a subprocess, and is likely not a problem with pip.
```