### PR TITLE
Set platform environment variable.

### DIFF
--- a/CHANGELOG-container-arch.md
+++ b/CHANGELOG-container-arch.md
@@ -1,0 +1,12 @@
+- Remove stale previews from tools.
+- Add tracking for various donor and sample page events.
+- Remove unused import.
+- Update GitHub action checkout from v2 to v4.
+- Update GitHub action setup-node from v3 to v4 .
+- Update GitHub action codeql from v2 to v4 .
+- Update GitHub action setup-python from v4 to v5 .
+- Fix broken publication cypress test.
+- Update dataset detail page for multi-assay datasets.
+- Add multi-assay provenance display on dataset detail pages.
+- Use cython<3 at build time to address: "AttributeError: cython_sources".
+- Explicitly set container architecture to amd64.

--- a/context/app/markdown/CHANGELOG.md
+++ b/context/app/markdown/CHANGELOG.md
@@ -1,19 +1,3 @@
-## v0.93.0 - 2024-03-22
-
-- Explicitly set container architecture to amd64.
-- Remove stale previews from tools.
-- Add tracking for various donor and sample page events.
-- Remove unused import.
-- Update GitHub action checkout from v2 to v4.
-- Update GitHub action setup-node from v3 to v4 .
-- Update GitHub action codeql from v2 to v4 .
-- Update GitHub action setup-python from v4 to v5 .
-- Fix broken publication cypress test.
-- Update dataset detail page for multi-assay datasets.
-- Add multi-assay provenance display on dataset detail pages.
-- Use cython<3 at build time to address: "AttributeError: cython_sources".
-
-
 ## v0.92.0 - 2024-03-08
 
 - Fix tile view of search pages.

--- a/etc/build/build.sh
+++ b/etc/build/build.sh
@@ -10,7 +10,8 @@ IMAGE_NAME=$1
 
 NODE_V=$(perl -pne 's/v//' .nvmrc )
 PYTHON_MINOR_V=$(perl -pne 's/\.\d+$//' .python-version)
-echo "Building $IMAGE_NAME with Node $NODE_V and Python $PYTHON_MINOR_V..."
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+echo "Building $IMAGE_NAME with Node $NODE_V and Python $PYTHON_MINOR_V using platform $DOCKER_DEFAULT_PLATFORM..."
 
 # Docker BuildKit supports parallelizing multi-stage builds.
 # https://medium.com/@tonistiigi/advanced-multi-stage-build-patterns-6f741b852fae

--- a/etc/dev/docker.sh
+++ b/etc/dev/docker.sh
@@ -3,7 +3,7 @@ set -o errexit
 
 die() { set +v; echo "$*" 1>&2 ; exit 1; }
 
-IMAGE_NAME=hubmap/portal-ui
+IMAGE_NAME=portal-ui:amd64
 CONTAINER_NAME=hubmap-portal-ui
 CONF_PATH=context/instance/app.conf
 PORT=$1


### PR DESCRIPTION
Docker will automatically select an image variant which matches your OS and architecture. To instruct docker to pass the --platform flag to build our Docker image for an x86/amd64 platform, we set the environment variable `DOCKER_DEFAULT_PLATFORM` in the build script.