### PR TITLE
NickAkhmetov/HOTFIX - Metadata section typo

### DIFF
--- a/CHANGELOG-hotfix-metadata.md
+++ b/CHANGELOG-hotfix-metadata.md
@@ -1,0 +1,1 @@
+- Correct a typo which caused the metadata table to not display.

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -235,7 +235,7 @@ function DatasetDetail({ assayMetadata, vitData, hasNotebook, visLiftedUUID }) {
         {shouldDisplaySection.provenance && <ProvSection uuid={uuid} assayMetadata={assayMetadata} />}
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} />}
         {shouldDisplaySection.metadata && (
-          <MetadataSection metadata={combineMetadata} assay_modality={assay_modality} />
+          <MetadataSection metadata={combinedMetadata} assay_modality={assay_modality} />
         )}
         {shouldDisplaySection.files && (
           <Files files={files} uuid={uuid} hubmap_id={hubmap_id} visLiftedUUID={visLiftedUUID} />


### PR DESCRIPTION
This PR is a hotfix which corrects a typo that causes the metadata section to not appear as expected in dataset pages.

This was not caught during development due to the culmination of a few factors:
- both `combineMetadata` and `combinedMetadata` were in the file
- the file was not yet converted to TypeScript, so the type difference was not caught

Due to the time-crunch we were in at the time of the merge (shortly before demo days) we missed this detail during QA as well; I've updated the QA notes to include confirming the metadata section is populated.

Metadata section after applying fix:

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/da2e8d22-d53b-4c62-85c1-8aa4382fd3be)
