### PR TITLE
NickAkhmetov/CAT-610 Remove extra "S" on prov tables

### DIFF
--- a/CHANGELOG-CAT-610.md
+++ b/CHANGELOG-CAT-610.md
@@ -1,0 +1,1 @@
+- Remove extra "s" on provenance tables.

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayProvenance/MultiAssayProvenance.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayProvenance/MultiAssayProvenance.tsx
@@ -44,7 +44,6 @@ function MultiTileStack({ datasets, title }: { datasets: MultiAssayEntity[]; tit
             />
           ),
         )}
-        s
       </Stack>
     </>
   );


### PR DESCRIPTION
This PR removes the extra "S" from the multi-assay provenance component.