### PR TITLE
NickAkhmetov/bump portal-vis to 0.2.2

### DIFF
--- a/CHANGELOG-portal-vis.md
+++ b/CHANGELOG-portal-vis.md
@@ -1,0 +1,1 @@
+- Bump portal-visualization to v0.2.2 to support revised 10X columns.

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -16,7 +16,7 @@ hubmap-commons>=2.1.10
 boto3==1.28.17
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.1.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.2.2.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.


### PR DESCRIPTION
This PR updates the portal-visualization version to support the new columns in the 10X multiome datasets.