### PR TITLE
NickAkhmetov/CAT-298 Implement profile page

### DIFF
--- a/CHANGELOG-cat-298.md
+++ b/CHANGELOG-cat-298.md
@@ -1,0 +1,1 @@
+- Add user profile page.

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -22,6 +22,8 @@ class DefaultConfig(object):
 
     PORTAL_INDEX_PATH = f'/{version}/portal/search'
     CCF_INDEX_PATH = f'{version}/entities/search'
+    GLOBUS_GROUPS_URL = 'https://raw.githubusercontent.com' + \
+        '/hubmapconsortium/commons/main/hubmap_commons/21f293b0-globus-groups.json'
     SOFT_ASSAY_ENDPOINT_PATH = 'assaytype'
 
     # Everything else should be overridden in app.conf:

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -1,8 +1,10 @@
+from functools import cache
 from io import StringIO
 from csv import DictWriter
 from pathlib import Path
 from datetime import datetime
 
+import requests
 from yaml import safe_load
 
 from flask import Response, abort, request, render_template, jsonify
@@ -188,3 +190,12 @@ def _dicts_to_tsv(data_dicts, first_fields, descriptions_dict):
     tsv_lines = tsv.split('\n')
     tsv_lines[1] = '#' + tsv_lines[1]
     return '\n'.join(tsv_lines)
+
+
+@cache
+@blueprint.route('/api/globus-groups.json')
+def get_globus_groups():
+    # The globus auth helper from hubmap_commons omits the group descriptions, so we need to fetch the full list of groups from the repo.
+    globus_url = 'https://raw.githubusercontent.com/hubmapconsortium/commons/main/hubmap_commons/21f293b0-globus-groups.json'
+    groups = requests.get(globus_url).json()
+    return groups

--- a/context/app/routes_api.py
+++ b/context/app/routes_api.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import requests
 from yaml import safe_load
 
-from flask import Response, abort, request, render_template, jsonify
+from flask import Response, abort, request, render_template, jsonify, current_app
 
 from .utils import make_blueprint, get_client, get_default_flask_data
 
@@ -195,7 +195,7 @@ def _dicts_to_tsv(data_dicts, first_fields, descriptions_dict):
 @cache
 @blueprint.route('/api/globus-groups.json')
 def get_globus_groups():
-    # The globus auth helper from hubmap_commons omits the group descriptions, so we need to fetch the full list of groups from the repo.
-    globus_url = 'https://raw.githubusercontent.com/hubmapconsortium/commons/main/hubmap_commons/21f293b0-globus-groups.json'
-    groups = requests.get(globus_url).json()
+    # The globus auth helper from hubmap_commons omits the group descriptions,
+    # so we need to fetch the full list of groups from the repo.
+    groups = requests.get(current_app.config['GLOBUS_GROUPS_URL']).json()
     return groups

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -181,3 +181,15 @@ def tutorial_detail(tutorial_name):
         title=tutorial_name,
         flask_data=flask_data
     )
+
+
+@blueprint.route('/profile')
+def profile():
+    # We could fetch the globus groups info here, but
+    # the auth helper doesn't currently provide group descriptions
+    flask_data = {**get_default_flask_data()}
+    return render_template(
+        'base-pages/react-content.html',
+        title='Profile',
+        flask_data=flask_data
+    )

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -185,8 +185,6 @@ def tutorial_detail(tutorial_name):
 
 @blueprint.route('/profile')
 def profile():
-    # We could fetch the globus groups info here, but
-    # the auth helper doesn't currently provide group descriptions
     flask_data = {**get_default_flask_data()}
     return render_template(
         'base-pages/react-content.html',

--- a/context/app/static/js/components/Contexts.tsx
+++ b/context/app/static/js/components/Contexts.tsx
@@ -73,6 +73,10 @@ interface AppContextType {
   userTemplatesEndpoint: string;
   ubkgEndpoint: string;
   protocolsClientToken: string;
+  isAuthenticated: boolean;
+  isWorkspacesUser: boolean;
+  isHubmapUser: boolean;
+  userEmail: string;
   [key: string]: unknown;
 }
 

--- a/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
+++ b/context/app/static/js/components/Header/UserLinks/UserLinks.jsx
@@ -19,6 +19,7 @@ function UserLinks({ isAuthenticated, userEmail }) {
       title={<TruncatedSpan>{isAuthenticated ? userEmail || 'User' : 'User Profile'}</TruncatedSpan>}
       data-testid="user-profile-dropdown"
     >
+      {isAuthenticated && <DropdownLink href="/profile">My Profile</DropdownLink>}
       <DropdownLink href="/my-lists">My Lists</DropdownLink>
       {isOnboardableToWorkspaces && <DropdownLink href="/workspaces">My Workspaces</DropdownLink>}
       <StyledDivider />

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -38,6 +38,7 @@ const Biomarkers = lazy(() => import('js/pages/Biomarkers'));
 const CellTypes = lazy(() => import('js/pages/CellTypes'));
 const Tutorials = lazy(() => import('js/pages/Tutorials'));
 const Tutorial = lazy(() => import('js/pages/Tutorial'));
+const Profile = lazy(() => import('js/pages/Profile'));
 
 function Routes({ flaskData }) {
   const {
@@ -276,6 +277,14 @@ function Routes({ flaskData }) {
     );
   }
 
+  if (urlPath === '/profile') {
+    return (
+      <Route>
+        <Profile />
+      </Route>
+    );
+  }
+
   if (urlPath.startsWith('/lineup/')) {
     return (
       <Route>
@@ -358,6 +367,7 @@ Routes.propTypes = {
     geneSymbol: PropTypes.string,
     redirected_from: PropTypes.string,
     cell_type: PropTypes.string,
+    globusGroups: PropTypes.object,
   }),
 };
 

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
@@ -10,7 +10,7 @@ import { StyledSvgIcon, FlexContainer, RightDiv } from './style';
 import EntityHeaderItem from '../EntityHeaderItem';
 import VisualizationShareButtonWrapper from '../VisualizationShareButtonWrapper';
 
-type EntityType = Exclude<keyof typeof entityIconMap, 'Support' | 'Collection' | 'Workspace'>;
+type EntityType = Exclude<keyof typeof entityIconMap, 'Support' | 'Collection' | 'Workspace' | 'VerifiedUser'>;
 
 interface AssayMetadata {
   sex: string;

--- a/context/app/static/js/components/detailPage/summary/SummaryTitle/SummaryTitle.tsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryTitle/SummaryTitle.tsx
@@ -32,7 +32,7 @@ function SummaryTitle({ children, iconTooltipText, entityIcon }: SummaryTitlePro
   }, [setSummaryComponentObserver, entry, inView]);
 
   return (
-    <Stack direction="row" alignItems="center">
+    <Stack direction="row" alignItems="center" gap={1}>
       {Icon && <Icon color="primary" />}
       <Typography variant="subtitle1" component="h1" color="primary" ref={ref}>
         {children}

--- a/context/app/static/js/components/detailPage/utils.js
+++ b/context/app/static/js/components/detailPage/utils.js
@@ -1,9 +1,0 @@
-export function getSectionOrder(possibleSections, optionalSectionsToInclude) {
-  return possibleSections.filter(
-    (section) => !(section in optionalSectionsToInclude) || optionalSectionsToInclude[section],
-  );
-}
-
-export function getCombinedDatasetStatus({ sub_status, status }) {
-  return sub_status || status;
-}

--- a/context/app/static/js/components/detailPage/utils.ts
+++ b/context/app/static/js/components/detailPage/utils.ts
@@ -1,0 +1,12 @@
+export function getSectionOrder(
+  possibleSections: string[],
+  optionalSectionsToInclude: Record<string, boolean>,
+): string[] {
+  return possibleSections.filter(
+    (section) => !(section in optionalSectionsToInclude) || optionalSectionsToInclude[section],
+  );
+}
+
+export function getCombinedDatasetStatus({ sub_status, status }: { sub_status: unknown; status: unknown }) {
+  return sub_status || status;
+}

--- a/context/app/static/js/components/profile/MyLists.tsx
+++ b/context/app/static/js/components/profile/MyLists.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+import SectionPaper from 'js/shared-styles/sections/SectionPaper';
+import { InternalLink } from 'js/shared-styles/Links';
+import useSavedEntitiesStore from 'js/stores/useSavedEntitiesStore';
+import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
+import { DetailPageSection } from '../detailPage/style';
+
+export function MyLists() {
+  const savedListCount = useSavedEntitiesStore((s) => Object.keys(s.savedLists).length);
+  const buttonText = savedListCount === 0 ? 'Create a List' : `Manage Lists (${savedListCount})`;
+  return (
+    <DetailPageSection id="my-lists">
+      <Typography variant="h2">My Lists</Typography>
+      <SectionPaper>
+        <Stack spacing={1} alignItems="start">
+          <Typography variant="body1">
+            Your lists are currently stored on local storage and are not transferable between devices. To manage your
+            lists, navigate to your <InternalLink href="/my-lists">lists</InternalLink>.
+          </Typography>
+          <Button variant="contained" color="primary" component={InternalLink} href="/my-lists">
+            {buttonText}
+          </Button>
+        </Stack>
+      </SectionPaper>
+    </DetailPageSection>
+  );
+}

--- a/context/app/static/js/components/profile/MyLists.tsx
+++ b/context/app/static/js/components/profile/MyLists.tsx
@@ -19,7 +19,7 @@ export function MyLists() {
             Your lists are currently stored on local storage and are not transferable between devices. To manage your
             lists, navigate to your <InternalLink href="/my-lists">lists</InternalLink>.
           </Typography>
-          <Button variant="contained" color="primary" component={InternalLink} href="/my-lists">
+          <Button variant="contained" color="primary" href="/my-lists">
             {buttonText}
           </Button>
         </Stack>

--- a/context/app/static/js/components/profile/MyLists.tsx
+++ b/context/app/static/js/components/profile/MyLists.tsx
@@ -9,7 +9,7 @@ import { DetailPageSection } from '../detailPage/style';
 
 export function MyLists() {
   const savedListCount = useSavedEntitiesStore((s) => Object.keys(s.savedLists).length);
-  const buttonText = savedListCount === 0 ? 'Create a List' : `Manage Lists (${savedListCount})`;
+  const buttonText = savedListCount === 0 ? 'Create List' : `Manage Lists (${savedListCount})`;
   return (
     <DetailPageSection id="my-lists">
       <Typography variant="h2">My Lists</Typography>

--- a/context/app/static/js/components/profile/MyWorkspaces.tsx
+++ b/context/app/static/js/components/profile/MyWorkspaces.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+import LoadingButton from '@mui/lab/LoadingButton';
+import Stack from '@mui/material/Stack';
+import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
+import { Alert } from 'js/shared-styles/alerts';
+import SectionPaper from 'js/shared-styles/sections/SectionPaper';
+import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
+import { DetailPageSection } from '../detailPage/style';
+import { useAppContext } from '../Contexts';
+import { useWorkspaces } from '../workspaces/api';
+
+function NonWorkspacesUserView() {
+  return (
+    <Alert severity="error">
+      Workspaces are currently in beta testing. You must have access to the beta testing group in order to access this
+      feature. <ContactUsLink>Contact us</ContactUsLink> for additional information about accessing this feature.
+    </Alert>
+  );
+}
+
+function MainView() {
+  const { workspaces, isLoading } = useWorkspaces();
+
+  const numberOfWorkspaces = workspaces?.length || 0;
+  const buttonText = numberOfWorkspaces === 0 ? 'Get Started' : `Manage Workspaces (${numberOfWorkspaces})`;
+
+  return (
+    <SectionPaper>
+      <Stack spacing={1} alignItems="start">
+        <LabelledSectionText label="Workspaces Beta Testing Group">
+          You currently have access to the workspace feature as part of the Workspace Beta Testing Group. Navigate to
+          your workspaces to create new workspaces or manage existing workspaces. For additional information about
+          accessing this feature, <ContactUsLink />.
+        </LabelledSectionText>
+        <LoadingButton variant="contained" color="primary" href="/workspaces" loading={isLoading} fullWidth={false}>
+          {buttonText}
+        </LoadingButton>
+      </Stack>
+    </SectionPaper>
+  );
+}
+
+export function MyWorkspaces() {
+  const { isWorkspacesUser } = useAppContext();
+  return (
+    <DetailPageSection id="workspaces">
+      <Typography variant="h2">My Workspaces</Typography>
+      {isWorkspacesUser ? <MainView /> : <NonWorkspacesUserView />}
+    </DetailPageSection>
+  );
+}

--- a/context/app/static/js/components/profile/MyWorkspaces.tsx
+++ b/context/app/static/js/components/profile/MyWorkspaces.tsx
@@ -12,7 +12,7 @@ import { useWorkspaces } from '../workspaces/api';
 
 function NonWorkspacesUserView() {
   return (
-    <Alert severity="error">
+    <Alert severity="warning">
       Workspaces are currently in beta testing. You must have access to the beta testing group in order to access this
       feature. <ContactUsLink>Contact us</ContactUsLink> for additional information about accessing this feature.
     </Alert>
@@ -45,8 +45,10 @@ export function MyWorkspaces() {
   const { isWorkspacesUser } = useAppContext();
   return (
     <DetailPageSection id="workspaces">
-      <Typography variant="h2">My Workspaces</Typography>
-      {isWorkspacesUser ? <MainView /> : <NonWorkspacesUserView />}
+      <Stack spacing={1}>
+        <Typography variant="h2">My Workspaces</Typography>
+        {isWorkspacesUser ? <MainView /> : <NonWorkspacesUserView />}
+      </Stack>
     </DetailPageSection>
   );
 }

--- a/context/app/static/js/components/profile/Summary/Description.tsx
+++ b/context/app/static/js/components/profile/Summary/Description.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Alert } from 'js/shared-styles/alerts';
+import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
+import { useAppContext } from 'js/components/Contexts';
+
+export function ProfileDescription() {
+  const { userEmail } = useAppContext();
+  // ensure that the user only sees this message once per account per device
+  const localStorageKey = `${userEmail}-has-seen-profile-description`;
+
+  const hasSeenProfileDescriptionCookie = Boolean(localStorage.getItem(localStorageKey));
+  const [hasSeenProfileDescription, setHasSeenProfileDescription] = React.useState(hasSeenProfileDescriptionCookie);
+  if (hasSeenProfileDescription) {
+    return null;
+  }
+  const onClose = () => {
+    localStorage.setItem(localStorageKey, 'true');
+    setHasSeenProfileDescription(true);
+  };
+  return (
+    <Alert severity="info" onClose={onClose}>
+      Your access levels are listed below describing your level of access regarding HuBMAP data and features.&nbsp;
+      <ContactUsLink>Contact us</ContactUsLink> for additional information about your access groups.
+    </Alert>
+  );
+}

--- a/context/app/static/js/components/profile/Summary/Groups.tsx
+++ b/context/app/static/js/components/profile/Summary/Groups.tsx
@@ -1,31 +1,11 @@
 import React from 'react';
-import { readCookie } from 'js/helpers/functions';
 import SectionPaper from 'js/shared-styles/sections/SectionPaper';
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
-import { Stack } from '@mui/material';
-import { useAppContext } from '../../Contexts';
-import { useGlobusGroups } from './hooks';
+import Stack from '@mui/material/Stack';
+import { useCurrentUserGlobusGroups } from './hooks';
 
 export function ProfileGroups() {
-  const { isAuthenticated } = useAppContext();
-  const groupsCookie = readCookie('user_groups');
-  const { data: allGlobusGroups = [] } = useGlobusGroups();
-  if (!groupsCookie || !isAuthenticated) {
-    return null;
-  }
-
-  const groups = groupsCookie.split('|');
-
-  const currentUserGroups = allGlobusGroups
-    ?.filter((group) => groups.includes(group.name))
-    .map((g) => ({
-      key: g.name,
-      name: g.displayname,
-      description: g.description,
-    }));
-
-  const nonHubmapGroups = groups.filter((group) => !currentUserGroups.find((g) => g.key === group));
-
+  const currentUserGroups = useCurrentUserGlobusGroups();
   return (
     <SectionPaper>
       <Stack direction="column" spacing={1}>
@@ -34,9 +14,6 @@ export function ProfileGroups() {
             {description}
           </LabelledSectionText>
         ))}
-        {nonHubmapGroups.length > 0 && (
-          <LabelledSectionText label="Other Groups">{nonHubmapGroups.join(', ')}</LabelledSectionText>
-        )}
       </Stack>
     </SectionPaper>
   );

--- a/context/app/static/js/components/profile/Summary/Groups.tsx
+++ b/context/app/static/js/components/profile/Summary/Groups.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { readCookie } from 'js/helpers/functions';
+import SectionPaper from 'js/shared-styles/sections/SectionPaper';
+import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
+import { Stack } from '@mui/material';
+import { useAppContext } from '../../Contexts';
+import { useGlobusGroups } from './hooks';
+
+export function ProfileGroups() {
+  const { isAuthenticated } = useAppContext();
+  const groupsCookie = readCookie('user_groups');
+  const { data: allGlobusGroups = [] } = useGlobusGroups();
+  if (!groupsCookie || !isAuthenticated) {
+    return null;
+  }
+
+  const groups = groupsCookie.split('|');
+
+  const currentUserGroups = allGlobusGroups
+    ?.filter((group) => groups.includes(group.name))
+    .map((g) => ({
+      key: g.name,
+      name: g.displayname,
+      description: g.description,
+    }));
+
+  const nonHubmapGroups = groups.filter((group) => !currentUserGroups.find((g) => g.key === group));
+
+  return (
+    <SectionPaper>
+      <Stack direction="column" spacing={1}>
+        {currentUserGroups.map(({ name, description }) => (
+          <LabelledSectionText key={name} label={name}>
+            {description}
+          </LabelledSectionText>
+        ))}
+        {nonHubmapGroups.length > 0 && (
+          <LabelledSectionText label="Other Groups">{nonHubmapGroups.join(', ')}</LabelledSectionText>
+        )}
+      </Stack>
+    </SectionPaper>
+  );
+}

--- a/context/app/static/js/components/profile/Summary/Summary.tsx
+++ b/context/app/static/js/components/profile/Summary/Summary.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import { useAppContext } from '../../Contexts';
+import { DetailPageSection } from '../../detailPage/style';
+import { ProfileGroups } from './Groups';
+import { ProfileTitle } from './Title';
+import { ProfileDescription } from './Description';
+
+export function ProfileSummary() {
+  const { userEmail } = useAppContext();
+
+  return (
+    <DetailPageSection id="summary">
+      <Stack spacing={1}>
+        <ProfileTitle />
+        <Typography variant="h2">{userEmail}</Typography>
+        <ProfileDescription />
+        <ProfileGroups />
+      </Stack>
+    </DetailPageSection>
+  );
+}

--- a/context/app/static/js/components/profile/Summary/Title.tsx
+++ b/context/app/static/js/components/profile/Summary/Title.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import SummaryTitle from '../../detailPage/summary/SummaryTitle';
+import { useAppContext } from '../../Contexts';
+
+const hubmapUserHeader = {
+  text: 'HuBMAP Consortium Member',
+  icon: 'VerifiedUser' as const,
+};
+
+const nonHubmapUserHeader = {
+  text: 'External User',
+  icon: undefined,
+};
+
+export function ProfileTitle() {
+  const { isHubmapUser } = useAppContext();
+  const { text, icon } = isHubmapUser ? hubmapUserHeader : nonHubmapUserHeader;
+  return <SummaryTitle entityIcon={icon}>{text}</SummaryTitle>;
+}

--- a/context/app/static/js/components/profile/Summary/hooks.ts
+++ b/context/app/static/js/components/profile/Summary/hooks.ts
@@ -4,8 +4,7 @@ import { SWRError } from 'js/helpers/swr/errors';
 import useSWRImmutable from 'swr/immutable';
 
 // The globus auth helper from hubmap_commons omits the group descriptions, so we need to fetch the full list of groups from the repo.
-const globusGroupsURL =
-  'https://raw.githubusercontent.com/hubmapconsortium/commons/main/hubmap_commons/21f293b0-globus-groups.json';
+const globusGroupsURL = '/api/globus-groups.json';
 
 interface GlobusGroupInfo {
   description: string;

--- a/context/app/static/js/components/profile/Summary/hooks.ts
+++ b/context/app/static/js/components/profile/Summary/hooks.ts
@@ -1,0 +1,33 @@
+import { fetcher } from 'js/helpers/swr';
+import { SWRError } from 'js/helpers/swr/errors';
+import useSWRImmutable from 'swr/immutable';
+
+// The globus auth helper from hubmap_commons omits the group descriptions, so we need to fetch the full list of groups from the repo.
+const globusGroupsURL =
+  'https://raw.githubusercontent.com/hubmapconsortium/commons/main/hubmap_commons/21f293b0-globus-groups.json';
+
+interface GlobusGroupInfo {
+  description: string;
+  data_provider: boolean;
+  has_subgroups: boolean;
+  identity_set_properties: null; // This is always null in the data.
+  uuid: string;
+  group_type: 'regular' | 'data-read' | 'protected-data' | 'data-admin';
+  name: string;
+  displayname: string;
+  shortname: string;
+  generateuuid: boolean;
+  tmc_prefix: string;
+}
+
+export function useGlobusGroups() {
+  const { data, error } = useSWRImmutable<GlobusGroupInfo[], SWRError>(globusGroupsURL, (url: string) =>
+    fetcher<GlobusGroupInfo[]>({ url }),
+  );
+
+  return {
+    data,
+    error,
+    isLoading: !data && !error,
+  };
+}

--- a/context/app/static/js/components/profile/Summary/index.ts
+++ b/context/app/static/js/components/profile/Summary/index.ts
@@ -1,0 +1,1 @@
+export * from './Summary';

--- a/context/app/static/js/components/profile/index.ts
+++ b/context/app/static/js/components/profile/index.ts
@@ -1,0 +1,3 @@
+export * from './MyLists';
+export * from './MyWorkspaces';
+export * from './Summary';

--- a/context/app/static/js/components/workspaces/workspaceMessaging.tsx
+++ b/context/app/static/js/components/workspaces/workspaceMessaging.tsx
@@ -1,11 +1,11 @@
 import React, { PropsWithChildren } from 'react';
 import Stack from '@mui/material/Stack';
-import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
 
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
 import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
 import { Alert } from 'js/shared-styles/alerts';
+import LoginAlert from 'js/shared-styles/alerts/LoginAlert';
 import { InternalLink } from 'js/shared-styles/Links';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 
@@ -73,11 +73,7 @@ const text = {
 };
 
 function LogInAlert() {
-  return (
-    <Alert severity="info" action={<Button href="/login">Log in</Button>}>
-      You must be logged in to access workspaces. Access to workspaces is restricted to HuBMAP members at present.
-    </Alert>
-  );
+  return <LoginAlert featureName="workspaces" />;
 }
 
 function AccessAlert() {

--- a/context/app/static/js/pages/Profile/Profile.tsx
+++ b/context/app/static/js/pages/Profile/Profile.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { useAppContext } from 'js/components/Contexts';
+import DetailLayout from 'js/components/detailPage/DetailLayout';
+import { getSectionOrder } from 'js/components/detailPage/utils';
+import { MyLists, MyWorkspaces, ProfileSummary } from 'js/components/profile';
+import LoginAlert from 'js/shared-styles/alerts/LoginAlert';
+
+const sectionOrder = getSectionOrder(['summary', 'my-lists', 'workspaces'], {});
+
+function ProfilePage() {
+  const { isAuthenticated } = useAppContext();
+
+  if (!isAuthenticated) {
+    return <LoginAlert featureName="profile pages" />;
+  }
+
+  return (
+    <DetailLayout sectionOrder={sectionOrder}>
+      <ProfileSummary />
+      <MyLists />
+      <MyWorkspaces />
+    </DetailLayout>
+  );
+}
+
+export default ProfilePage;

--- a/context/app/static/js/pages/Profile/index.ts
+++ b/context/app/static/js/pages/Profile/index.ts
@@ -1,0 +1,3 @@
+import Profile from './Profile';
+
+export default Profile;

--- a/context/app/static/js/shared-styles/alerts/LoginAlert.tsx
+++ b/context/app/static/js/shared-styles/alerts/LoginAlert.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import Button from '@mui/material/Button';
+import { Alert } from './Alert';
+
+interface LoginAlertProps {
+  featureName: string;
+}
+export default function LoginAlert({ featureName }: LoginAlertProps) {
+  return (
+    <Alert severity="info" action={<Button href="/login">Log in</Button>}>
+      You must be logged in to access {featureName}. Access to {featureName} is restricted to HuBMAP members at present.
+    </Alert>
+  );
+}

--- a/context/app/static/js/shared-styles/icons/entityIconMap.ts
+++ b/context/app/static/js/shared-styles/icons/entityIconMap.ts
@@ -1,7 +1,7 @@
 import { ReactComponent as WorkspacesIcon } from 'assets/svg/workspaces.svg';
 import ScatterPlot from '@mui/icons-material/ScatterPlot';
 import { ReactComponent as GeneIcon } from 'assets/svg/gene.svg';
-import { DatasetIcon, SampleIcon, DonorIcon, PublicationIcon, CollectionIcon } from './icons';
+import { DatasetIcon, SampleIcon, DonorIcon, PublicationIcon, CollectionIcon, VerifiedIcon } from './icons';
 
 export const entityIconMap = {
   Donor: DonorIcon,
@@ -13,4 +13,5 @@ export const entityIconMap = {
   Workspace: WorkspacesIcon,
   CellType: ScatterPlot,
   Gene: GeneIcon,
+  VerifiedUser: VerifiedIcon,
 };

--- a/context/app/static/js/shared-styles/icons/icons.ts
+++ b/context/app/static/js/shared-styles/icons/icons.ts
@@ -20,6 +20,7 @@ import ArrowDropUpRoundedIcon from '@mui/icons-material/ArrowDropUpRounded';
 import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import DescriptionOutlinedIcon from '@mui/icons-material/DescriptionOutlined';
 import ContactSupportIcon from '@mui/icons-material/ContactSupportRounded';
+import VerifiedUserRounded from '@mui/icons-material/VerifiedUserRounded';
 import { styled } from '@mui/material/styles';
 import SvgIcon, { SvgIconProps } from '@mui/material/SvgIcon';
 import { ElementType } from 'react';
@@ -77,6 +78,8 @@ const AddIcon = withIconStyles(AddRoundedIcon);
 
 const SupportIcon = withIconStyles(ContactSupportIcon);
 
+const VerifiedIcon = withIconStyles(VerifiedUserRounded);
+
 export {
   CloseIcon,
   CollectionIcon,
@@ -99,4 +102,5 @@ export {
   UpIcon,
   AddIcon,
   SupportIcon,
+  VerifiedIcon,
 };

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -9,7 +9,7 @@ pyyaml>=5.4
 python-datauri>=0.2.8
 python-frontmatter>=0.5.0
 hubmap-api-py-client>=0.0.11
-hubmap-commons>=2.1.10
+hubmap-commons>=2.1.14
 # As of 2023-08-24, this is the version of boto3 which is compatible with both the 
 # portal-visualization->vitessce->ome-zarr dependency on aiobotocore~=2.5
 # and the hubmap-commons dependency on boto3>=1.24.47

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -468,9 +468,9 @@ h5py==3.9.0 \
 hubmap-api-py-client==0.0.11 \
     --hash=sha256:65576f80fb449688027cabd43cd7f130e52fa8f43c4e823a579b6111085203e1
     # via -r context/requirements.in
-hubmap-commons==2.1.10 \
-    --hash=sha256:38c83d9d05457a22ba0a5ccad2001887917d9729ffcfb605395b59c46bfafdba \
-    --hash=sha256:571d8dbd881982453bb36e1b88de9f5bf52d7c9345e5689cc3a625c64241e0f6
+hubmap-commons==2.1.14 \
+    --hash=sha256:4a4f90d40946f735618a323a491dabce1188bc26877669d2067ed636528dff9b \
+    --hash=sha256:be988a12f1e9a932b62b4dd129595557f02ff51d8a0763a2304aa893ec217732
     # via
     #   -r context/requirements.in
     #   portal-visualization


### PR DESCRIPTION
This PR implements the user profile page.


<details><summary>Logged in HuBMAP user with access to workspaces</summary>
<p>

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/18f5bac1-32f0-4b5b-b945-70fa7292693a)

</p>
</details> 

<details><summary>Logged in HuBMAP user with no access to workspaces</summary>
<p>

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/b6ec7a87-0a57-46ca-85ff-aa7d176ddea4)

</p>
</details> 


<details><summary>Logged in external user</summary>
<p>


![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/2a817ac7-b5cd-43c5-a69e-e912142809d1)

</p>
</details>


<details><summary>Unauthenticated user</summary>
<p>

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/ea5403e5-70cc-472e-b309-8d8945a8d21d)


</p>
</details> 

<details><summary>Minor Details</summary>
<p>

I made the buttons more "call to action"-y if there are no existing lists or workspaces. 

If no lists are available:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/a08e0748-1b7a-460a-bde8-152cfe690612)

If no workspaces have been created but user has access to workspaces:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/3271c472-f349-475a-8d7f-b74d9a291ae5)

</p>
</details> 