### PR TITLE
NickAkhmetov/CAT-641 Fix unexpected visualizations on unprocessed datasets

### DIFF
--- a/CHANGELOG-cat-641.md
+++ b/CHANGELOG-cat-641.md
@@ -1,0 +1,1 @@
+- Fix unexpected visualizations on unprocessed datasets.

--- a/context/app/api/client.py
+++ b/context/app/api/client.py
@@ -269,16 +269,24 @@ class ApiClient():
         returns the doc of the most recent descendant
         that is in QA or Published status.
         '''
-        hints = "is_support" if is_publication else "is_image"
+
+        hints = [{
+            "term": {
+                "vitessce-hints": "is_support"
+            }
+        }]
+        if not is_publication:
+            hints.append({
+                "term": {
+                    "vitessce-hints": "is_image"
+                }
+            })
+
         query = {
             "query": {
                 "bool": {
                     "must": [
-                        {
-                            "term": {
-                                "vitessce-hints": hints
-                            }
-                        },
+                        *hints,
                         {
                             "term": {
                                 "ancestor_ids": uuid


### PR DESCRIPTION
This PR fixes visualizations appearing on primary datasets with image descendants. Instead of only checking for `is_support` or `is_image`, image pyramid cases need to check for the presence of both hints (which is also why we can't use a `terms`	condition here, since that returns if any of the matched terms are met).

AF Dataset:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/a1aece10-aa1b-4836-a906-5044d91c3bd9)

CODEX (non-processed) dataset:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/5197eb94-2e83-4dfc-a121-1d7babb55444)

CODEX (processed) dataset:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/476f1040-539a-4ff8-b252-679ad413b5ec)
