### PR TITLE
NickAkhmetov/CAT-530 fix entity table icon colors

### DIFF
--- a/CHANGELOG-cat-530.md
+++ b/CHANGELOG-cat-530.md
@@ -1,0 +1,1 @@
+- Fix entity table icon colors.

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.jsx
@@ -19,7 +19,7 @@ function RelatedEntitiesTabs({ entities, openIndex, setOpenIndex, ariaLabel, ren
             index={i}
             key={entity.tabLabel}
             data-testid={`${entity.tabLabel.toLowerCase()}-tab`}
-            icon={<StyledSvgIcon component={entityIconMap[entity.entityType]} color="white" />}
+            icon={<StyledSvgIcon component={entityIconMap[entity.entityType]} color="primary" />}
             iconPosition="start"
           />
         ))}

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
@@ -37,7 +37,7 @@ function EntitiesTables<Doc>({
               label={`${entityType}s (${totalHitsCounts[i] ?? 0})`}
               key={`${entityType}-tab`}
               index={i}
-              icon={Icon ? <Icon sx={{ fontSize: '1.5rem' }} /> : undefined}
+              icon={Icon ? <Icon sx={{ fontSize: '1.5rem', color: 'primary' }} /> : undefined}
               iconPosition="start"
               isSingleTab={entities.length === 0}
             />


### PR DESCRIPTION
This PR adjusts the colors of the entity icons on table tabs so that they use the primary color, matching the intended designs.

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/ba9e6851-b6c9-494e-b660-d665f9cb0910)
