### PR TITLE
NickAkhmetov/CAT-698 Remove "other groups" from profile pages

### DIFF
--- a/CHANGELOG-cat-698.md
+++ b/CHANGELOG-cat-698.md
@@ -1,0 +1,1 @@
+- Remove "other groups" from profile pages.

--- a/context/app/static/js/components/profile/Summary/hooks.ts
+++ b/context/app/static/js/components/profile/Summary/hooks.ts
@@ -56,15 +56,5 @@ export function useCurrentUserGlobusGroups() {
       description: g.description,
     }));
 
-  const nonHubmapGroups = groups.filter((group) => !currentUserGroups.find((g) => g.key === group));
-
-  if (nonHubmapGroups.length > 0) {
-    currentUserGroups.push({
-      key: 'Other',
-      name: 'Other Groups',
-      description: `You are also part of the following groups: ${nonHubmapGroups.join(', ')}`,
-    });
-  }
-
   return currentUserGroups;
 }


### PR DESCRIPTION
This PR removes the `other groups` section of the profile page:

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/c27715a8-e6a4-41bf-967d-ab5a3abf749e)
