### PR TITLE
NickAkhmetov/CAT-704 Restore donor diversity chart legends

### DIFF
--- a/CHANGELOG-cat-704.md
+++ b/CHANGELOG-cat-704.md
@@ -1,0 +1,1 @@
+- Restore Donor Diversity chart legends.

--- a/context/app/static/js/pages/Diversity/DonorChart.jsx
+++ b/context/app/static/js/pages/Diversity/DonorChart.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Chart as ChartJS, defaults, LinearScale, CategoryScale, BarElement } from 'chart.js';
+import { Chart as ChartJS, defaults, LinearScale, CategoryScale, BarElement, Legend } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
 import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
@@ -95,7 +95,7 @@ function LowLevelDonorChart({ title, donorQuery, xKey, yKey, colorKeys, descript
         </DescriptionPaper>
       )}
       <ChartPaper>
-        <Bar data={graphdata} options={options} />
+        <Bar data={graphdata} options={options} plugins={[Legend]} />
       </ChartPaper>
     </>
   );


### PR DESCRIPTION
This PR restores the legends to the diversity charts by providing the `Legend` plugin to the bar chart component. 

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/348a6564-2904-4f36-8cd8-11569cfda469)
