### PR TITLE
update HuBMAP doc site url

### DIFF
--- a/CHANGELOG-update-hubmap-doc-site-url.md
+++ b/CHANGELOG-update-hubmap-doc-site-url.md
@@ -1,0 +1,2 @@
+- HuBMAP documentation site URL changed from https://software.docs.hubmapconsortium.org to https://docs.hubmapconsortium.org.
+

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ graph LR
 
 Issues with the Portal can be reported [via email](mailto:help@hubmapconsortium.org).
 More information on how issues are tracked across HuBMAP is available
-[here](https://software.docs.hubmapconsortium.org/feedback).
+[here](https://docs.hubmapconsortium.org/feedback).
 
 ## Design
 

--- a/context/app/markdown/docs.redirect
+++ b/context/app/markdown/docs.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/
+https://docs.hubmapconsortium.org/

--- a/context/app/markdown/docs/about.redirect
+++ b/context/app/markdown/docs/about.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/about
+https://docs.hubmapconsortium.org/about

--- a/context/app/markdown/docs/apis.redirect
+++ b/context/app/markdown/docs/apis.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/apis
+https://docs.hubmapconsortium.org/apis

--- a/context/app/markdown/docs/assays.redirect
+++ b/context/app/markdown/docs/assays.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays
+https://docs.hubmapconsortium.org/assays

--- a/context/app/markdown/docs/assays/af.redirect
+++ b/context/app/markdown/docs/assays/af.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/af
+https://docs.hubmapconsortium.org/assays/af

--- a/context/app/markdown/docs/assays/atacseq.redirect
+++ b/context/app/markdown/docs/assays/atacseq.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/atacseq
+https://docs.hubmapconsortium.org/assays/atacseq

--- a/context/app/markdown/docs/assays/celldive.redirect
+++ b/context/app/markdown/docs/assays/celldive.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/celldive
+https://docs.hubmapconsortium.org/assays/celldive

--- a/context/app/markdown/docs/assays/codex.redirect
+++ b/context/app/markdown/docs/assays/codex.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/codex
+https://docs.hubmapconsortium.org/assays/codex

--- a/context/app/markdown/docs/assays/imc.redirect
+++ b/context/app/markdown/docs/assays/imc.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/imc
+https://docs.hubmapconsortium.org/assays/imc

--- a/context/app/markdown/docs/assays/lcms.redirect
+++ b/context/app/markdown/docs/assays/lcms.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/lcms
+https://docs.hubmapconsortium.org/assays/lcms

--- a/context/app/markdown/docs/assays/lightsheet.redirect
+++ b/context/app/markdown/docs/assays/lightsheet.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/lightsheet
+https://docs.hubmapconsortium.org/assays/lightsheet

--- a/context/app/markdown/docs/assays/maldi-ims.redirect
+++ b/context/app/markdown/docs/assays/maldi-ims.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/maldi-ims
+https://docs.hubmapconsortium.org/assays/maldi-ims

--- a/context/app/markdown/docs/assays/mxif.redirect
+++ b/context/app/markdown/docs/assays/mxif.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/mxif
+https://docs.hubmapconsortium.org/assays/mxif

--- a/context/app/markdown/docs/assays/nano.redirect
+++ b/context/app/markdown/docs/assays/nano.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/nano
+https://docs.hubmapconsortium.org/assays/nano

--- a/context/app/markdown/docs/assays/pas.redirect
+++ b/context/app/markdown/docs/assays/pas.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/pas
+https://docs.hubmapconsortium.org/assays/pas

--- a/context/app/markdown/docs/assays/rnaseq.redirect
+++ b/context/app/markdown/docs/assays/rnaseq.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/rnaseq
+https://docs.hubmapconsortium.org/assays/rnaseq

--- a/context/app/markdown/docs/assays/seqfish.redirect
+++ b/context/app/markdown/docs/assays/seqfish.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/seqfish
+https://docs.hubmapconsortium.org/assays/seqfish

--- a/context/app/markdown/docs/assays/wgs.redirect
+++ b/context/app/markdown/docs/assays/wgs.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/assays/wgs
+https://docs.hubmapconsortium.org/assays/wgs

--- a/context/app/markdown/docs/consent.redirect
+++ b/context/app/markdown/docs/consent.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/consent
+https://docs.hubmapconsortium.org/consent

--- a/context/app/markdown/docs/data-states.redirect
+++ b/context/app/markdown/docs/data-states.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/data-states
+https://docs.hubmapconsortium.org/data-states

--- a/context/app/markdown/docs/datasets.redirect
+++ b/context/app/markdown/docs/datasets.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/datasets
+https://docs.hubmapconsortium.org/datasets

--- a/context/app/markdown/docs/donor.redirect
+++ b/context/app/markdown/docs/donor.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/donor
+https://docs.hubmapconsortium.org/donor

--- a/context/app/markdown/docs/faq.redirect
+++ b/context/app/markdown/docs/faq.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/faq
+https://docs.hubmapconsortium.org/faq

--- a/context/app/markdown/docs/feedback.redirect
+++ b/context/app/markdown/docs/feedback.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/feedback
+https://docs.hubmapconsortium.org/feedback

--- a/context/app/markdown/docs/infrastructure.redirect
+++ b/context/app/markdown/docs/infrastructure.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/infrastructure
+https://docs.hubmapconsortium.org/infrastructure

--- a/context/app/markdown/docs/metadata.redirect
+++ b/context/app/markdown/docs/metadata.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/metadata
+https://docs.hubmapconsortium.org/metadata

--- a/context/app/markdown/docs/pipelines.redirect
+++ b/context/app/markdown/docs/pipelines.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/pipelines
+https://docs.hubmapconsortium.org/pipelines

--- a/context/app/markdown/docs/release-summer-2020.redirect
+++ b/context/app/markdown/docs/release-summer-2020.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/release-summer-2020
+https://docs.hubmapconsortium.org/release-summer-2020

--- a/context/app/markdown/docs/software.redirect
+++ b/context/app/markdown/docs/software.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/software
+https://docs.hubmapconsortium.org/software

--- a/context/app/markdown/docs/technical.redirect
+++ b/context/app/markdown/docs/technical.redirect
@@ -1,1 +1,1 @@
-https://software.docs.hubmapconsortium.org/technical
+https://docs.hubmapconsortium.org/technical

--- a/context/app/static/js/components/Footer/Footer.jsx
+++ b/context/app/static/js/components/Footer/Footer.jsx
@@ -69,7 +69,7 @@ function Footer({ isMaintenancePage }) {
                 Data Sharing Policy
               </OutboundLink>
               {!isMaintenancePage && (
-                <OutboundLink href="https://software.docs.hubmapconsortium.org/about#citation" variant="body2">
+                  <OutboundLink href="https://docs.hubmapconsortium.org/about#citation" variant="body2">
                   Citing HuBMAP
                 </OutboundLink>
               )}

--- a/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
+++ b/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
@@ -104,9 +104,9 @@ const previewLinks = [
 
 const resourceGroups = {
   docs: [
-    { href: 'https://software.docs.hubmapconsortium.org/technical', label: 'Technical Documentation' },
-    { href: 'https://software.docs.hubmapconsortium.org/faq', label: 'FAQ' },
-    { href: 'https://software.docs.hubmapconsortium.org/about', label: 'About' },
+    { href: 'https://docs.hubmapconsortium.org/technical', label: 'Technical Documentation' },
+    { href: 'https://docs.hubmapconsortium.org/faq', label: 'FAQ' },
+    { href: 'https://docs.hubmapconsortium.org/about', label: 'About' },
   ],
   previews: previewLinks,
 };

--- a/context/app/static/js/pages/Dataset/Dataset.jsx
+++ b/context/app/static/js/pages/Dataset/Dataset.jsx
@@ -67,7 +67,7 @@ function SummaryDataChildren({
       <SummaryItem>
         <InternalLink
           variant="h6"
-          href="https://software.docs.hubmapconsortium.org/assays"
+          href="https://docs.hubmapconsortium.org/assays"
           underline="none"
           onClick={() => trackEntityPageEvent({ action: 'Assay Documentation Navigation', label: mapped_data_types })}
         >

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -165,7 +165,7 @@ paths = ['/organ', '/publications', '/collections', '/cells']
     'path_status',
     [
         ('/', '200 OK'),
-        ('/docs', '302 FOUND', 'https://software.docs.hubmapconsortium.org/'),
+        ('/docs', '302 FOUND', 'https://docs.hubmapconsortium.org/'),
 
         *[(path, '200 OK') for path in paths],
         *[(path + '/', '302 FOUND', path) for path in paths],


### PR DESCRIPTION
The main HuBMAP documentation site URL changed from https://software.docs.hubmapconsortium.org to https://docs.hubmapconsortium.org