### PR TITLE
NickAkhmetov/CAT-712 Fix "explore datasets" link

### DIFF
--- a/CHANGELOG-cat-712.md
+++ b/CHANGELOG-cat-712.md
@@ -1,0 +1,1 @@
+- Fix "explore datasets" link on updated homepage.

--- a/context/app/static/js/components/home/Hero/Hero.tsx
+++ b/context/app/static/js/components/home/Hero/Hero.tsx
@@ -19,7 +19,7 @@ const heroTabs = [
       {
         title: 'Explore datasets',
         icon: <entityIconMap.Dataset fontSize="1.5rem" />,
-        href: '/organ',
+        href: '/search?entity_type[0]=Dataset',
       },
       {
         title: 'Explore molecules/cell types',


### PR DESCRIPTION
This PR fixes the "explore datasets" link on the updated homepage to direct to the dataset search page; it was previously an "explore organs" link until a last minute change, so the URL got missed.