### PR TITLE
NickAkhmetov/Navigation QA fixes

### DIFF
--- a/CHANGELOG-nav-qa.md
+++ b/CHANGELOG-nav-qa.md
@@ -1,0 +1,1 @@
+- Fix minor nav issues found during QA.

--- a/context/app/static/js/components/Header/HeaderButton/HeaderButton.tsx
+++ b/context/app/static/js/components/Header/HeaderButton/HeaderButton.tsx
@@ -1,9 +1,8 @@
 import React, { forwardRef, Ref } from 'react';
 
-import Button from '@mui/material/Button';
-import IconButton from '@mui/material/IconButton';
 import { useIsMobile } from 'js/hooks/media-queries';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import { StyledHeaderButton, StyledHeaderIconButton } from './styles';
 
 interface HeaderButtonProps {
   title: string;
@@ -25,16 +24,15 @@ function HeaderButton(
     'aria-label': title,
     ref,
     onClick,
-    style: { color: 'white' },
     'data-testid': testId,
   };
 
   const button = showTitle ? (
-    <Button startIcon={icon} {...commonProps}>
+    <StyledHeaderButton startIcon={icon} {...commonProps}>
       {title}
-    </Button>
+    </StyledHeaderButton>
   ) : (
-    <IconButton {...commonProps}>{icon}</IconButton>
+    <StyledHeaderIconButton {...commonProps}>{icon}</StyledHeaderIconButton>
   );
 
   if (tooltip) {

--- a/context/app/static/js/components/Header/HeaderButton/styles.ts
+++ b/context/app/static/js/components/Header/HeaderButton/styles.ts
@@ -1,0 +1,15 @@
+import { styled } from '@mui/material/styles';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+
+export const StyledHeaderButton = styled(Button)(({ theme }) => ({
+  color: theme.palette.common.white,
+  '.MuiButton-startIcon': {
+    marginRight: theme.spacing(0.5),
+    color: theme.palette.common.white,
+  },
+}));
+
+export const StyledHeaderIconButton = styled(IconButton)(({ theme }) => ({
+  color: theme.palette.common.white,
+}));

--- a/context/app/static/js/components/Header/HeaderNavigationDrawer/HeaderNavigationDrawer.tsx
+++ b/context/app/static/js/components/Header/HeaderNavigationDrawer/HeaderNavigationDrawer.tsx
@@ -1,5 +1,6 @@
 import NavigationDrawer, { DrawerSection, useDrawerState } from 'js/shared-styles/Drawer';
 import React from 'react';
+import { CloseIcon } from 'js/shared-styles/icons';
 import HeaderButton from '../HeaderButton/HeaderButton';
 
 interface HeaderNavigationDrawerProps {
@@ -25,7 +26,7 @@ export default function HeaderNavigationDrawer({
         title={title}
         altOnlyTitle={altOnlyTitle}
         onClick={toggle}
-        icon={icon}
+        icon={open ? <CloseIcon fontSize="1.5rem" /> : icon}
       />
       <NavigationDrawer title={title} direction={direction} sections={sections} onClose={onClose} open={open} />
     </>

--- a/context/app/static/js/components/Header/HeaderNavigationDrawer/instances.tsx
+++ b/context/app/static/js/components/Header/HeaderNavigationDrawer/instances.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import { DatabaseIcon, InfoIcon } from 'js/shared-styles/icons';
 import AppsRounded from '@mui/icons-material/AppsRounded';
 import MenuRounded from '@mui/icons-material/MenuRounded';
-import PersonRounded from '@mui/icons-material/PersonRounded';
 import { useAppContext } from 'js/components/Contexts';
+
+import UserIcon from '../UserIcon';
 import HeaderNavigationDrawer from './HeaderNavigationDrawer';
 import { dataLinks, resourceLinks, toolsAndAppsLinks, userLinks, mobileMenuLinks } from '../staticLinks';
 
@@ -34,7 +35,7 @@ export function UserLinks() {
     <HeaderNavigationDrawer
       title="Your Profile"
       sections={userLinks(isAuthenticated)}
-      icon={<PersonRounded />}
+      icon={<UserIcon />}
       direction="right"
       altOnlyTitle
     />

--- a/context/app/static/js/components/Header/HeaderNavigationDrawer/instances.tsx
+++ b/context/app/static/js/components/Header/HeaderNavigationDrawer/instances.tsx
@@ -30,11 +30,11 @@ export function ToolsAndApplicationLinks() {
 }
 
 export function UserLinks() {
-  const { isAuthenticated } = useAppContext();
+  const { isAuthenticated, isHubmapUser, userEmail } = useAppContext();
   return (
     <HeaderNavigationDrawer
       title="Your Profile"
-      sections={userLinks(isAuthenticated)}
+      sections={userLinks(isAuthenticated, isHubmapUser, userEmail)}
       icon={<UserIcon />}
       direction="right"
       altOnlyTitle

--- a/context/app/static/js/components/Header/UserIcon/UserIcon.tsx
+++ b/context/app/static/js/components/Header/UserIcon/UserIcon.tsx
@@ -19,8 +19,8 @@ export default function UserIcon() {
   return (
     <Avatar
       sx={{
-        width: '30px',
-        height: '30px',
+        width: '24px',
+        height: '24px',
         bgcolor: '#c5c7cf', // primary-container
         color: (theme) => theme.palette.common.black,
       }}

--- a/context/app/static/js/components/Header/UserIcon/UserIcon.tsx
+++ b/context/app/static/js/components/Header/UserIcon/UserIcon.tsx
@@ -1,0 +1,32 @@
+import { useAppContext } from 'js/components/Contexts';
+import React from 'react';
+import Avatar from '@mui/material/Avatar';
+import PersonRounded from '@mui/icons-material/PersonRounded';
+import { Typography } from '@mui/material';
+
+function Authenticated({ userEmail }: { userEmail: string }) {
+  return <Typography variant="subtitle2">{userEmail[0].toUpperCase()}</Typography>;
+}
+
+function Anonymous() {
+  return <PersonRounded fontSize="1rem" />;
+}
+
+export default function UserIcon() {
+  const { userEmail, isAuthenticated } = useAppContext();
+  const alt = isAuthenticated ? userEmail : 'Anonymous User';
+  const content = isAuthenticated ? <Authenticated userEmail={userEmail} /> : <Anonymous />;
+  return (
+    <Avatar
+      sx={{
+        width: '30px',
+        height: '30px',
+        bgcolor: '#c5c7cf', // primary-container
+        color: (theme) => theme.palette.common.black,
+      }}
+      alt={alt}
+    >
+      {content}
+    </Avatar>
+  );
+}

--- a/context/app/static/js/components/Header/UserIcon/index.ts
+++ b/context/app/static/js/components/Header/UserIcon/index.ts
@@ -1,0 +1,3 @@
+import UserIcon from './UserIcon';
+
+export default UserIcon;

--- a/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
+++ b/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
@@ -13,6 +13,7 @@ import {
   SearchIcon,
   SupportIcon,
   DonorIcon as UserIcon,
+  VerifiedIcon,
 } from 'js/shared-styles/icons';
 import ExternalImageIcon from 'js/shared-styles/icons/ExternalImageIcon';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
@@ -244,18 +245,31 @@ export const toolsAndAppsLinks: DrawerSection[] = [
   },
 ];
 
-export const userLinks: (isAuthenticated: boolean) => DrawerSection[] = (isAuthenticated) => {
+export const userLinks: (isAuthenticated: boolean, isHubmapUser: boolean, userEmail: string) => DrawerSection[] = (
+  isAuthenticated,
+  isHubmapUser,
+  userEmail,
+) => {
+  const profileLabel = isAuthenticated ? userEmail : 'My Profile';
+  const profileDescription = isHubmapUser
+    ? 'Verified HuBMAP member. Find information about your profile.'
+    : 'Find information about your profile.';
+  const ProfileIcon = isHubmapUser ? VerifiedIcon : UserIcon;
   return [
     {
-      title: 'Your Profile',
-      hideTitle: true,
+      title: 'Account',
       items: [
         {
           href: '/profile',
-          label: 'Profile',
-          description: 'Find information about your profile.',
-          icon: <UserIcon color="primary" />,
+          label: profileLabel,
+          description: profileDescription,
+          icon: <ProfileIcon color="primary" />,
         },
+      ],
+    },
+    {
+      title: 'Personal Space',
+      items: [
         {
           href: '/my-lists',
           label: 'My Lists',

--- a/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
+++ b/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
@@ -54,7 +54,7 @@ export const resourceLinks: DrawerSection[] = [
     items: [
       {
         label: 'Technical Documentation',
-        description: 'Learn more about how to explore the data portal',
+        description: 'Learn more about how to explore the data portal.',
         icon: <DeveloperBoardRounded color="primary" />,
         href: 'https://docs.hubmapconsortium.org/faq',
       },

--- a/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
+++ b/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
@@ -54,7 +54,7 @@ export const resourceLinks: DrawerSection[] = [
     items: [
       {
         label: 'Technical Documentation',
-        description: 'Learn more about how to explore the data portal.',
+        description: 'Browse documentation about the development of HuBMAP resources.',
         icon: <DeveloperBoardRounded color="primary" />,
         href: 'https://docs.hubmapconsortium.org/faq',
       },
@@ -205,7 +205,7 @@ export const toolsAndAppsLinks: DrawerSection[] = [
       {
         label: 'Exploration User Interface (EUI)',
         description: 'Explore and validate spatially registered tissue blocks and cell-type populations.',
-        href: '/ccf-eui',
+        href: 'https://apps.humanatlas.io/eui/',
         icon: <EUIIcon />,
       },
       {

--- a/context/app/static/js/shared-styles/Drawer/DrawerItem.tsx
+++ b/context/app/static/js/shared-styles/Drawer/DrawerItem.tsx
@@ -11,7 +11,7 @@ function formatPrimaryText(label: string, href: string): [React.ReactNode, typeo
     label
   ) : (
     <>
-      {label} <ExternalLinkIcon fontSize="1rem" />
+      {label} <ExternalLinkIcon color="info" fontSize="1rem" />
     </>
   );
   return [primaryText, LinkComponent];

--- a/context/app/static/js/shared-styles/Drawer/NavigationDrawer.tsx
+++ b/context/app/static/js/shared-styles/Drawer/NavigationDrawer.tsx
@@ -15,7 +15,7 @@ export default function NavigationDrawer({ title, direction, sections, onClose, 
   }, [] as DrawerSection[]);
   return (
     <StyledDrawer open={open} anchor={direction} onClose={onClose}>
-      <Stack gap={2} useFlexGap>
+      <Stack gap={1} useFlexGap>
         <DrawerTitle>
           {title}
           <IconButton aria-label="Close" onClick={onClose}>

--- a/context/app/static/js/shared-styles/Drawer/styles.tsx
+++ b/context/app/static/js/shared-styles/Drawer/styles.tsx
@@ -8,6 +8,7 @@ import ListSubheader from '@mui/material/ListSubheader';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import React from 'react';
 import Divider, { DividerProps } from '@mui/material/Divider';
+import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 
 export const StyledDrawer = styled(Drawer)(({ theme, anchor }) => ({
   '& .MuiDrawer-paper': {
@@ -18,6 +19,7 @@ export const StyledDrawer = styled(Drawer)(({ theme, anchor }) => ({
     flexDirection: 'column',
     [theme.breakpoints.down('sm')]: {
       width: '100%',
+      top: headerHeight,
     },
   },
 }));


### PR DESCRIPTION
- Fixed technical documentation description
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/771e02e1-5023-4929-8ca1-0c8f04090df3)

- decreased spacing between header icons and text from 8px to 4px
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/3b9dac43-1d80-4e16-852f-76d13d7b7ca0)

- decreased navigation drawer gap between components
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/640489cf-cc5e-4c45-be49-426b54f4e9ee)

- made icons swap to "close" buttons when drawer is expanded, prevented drawer from covering header on mobile, and updated profile drawer options/button icon:
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/3c28bfa1-8619-43c5-ac77-429808cab869)
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/ac444db3-ad6e-425a-9963-a14b20251935)

![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/2948dbb2-2391-4b34-8a25-86f56f017dc3)
![image](https://github.com/hubmapconsortium/portal-ui/assets/19957804/cfb50785-55f4-4473-b6dc-9c32050c8227)
