### PR TITLE
Austenem/cat 740 fix table tabs

### DIFF
--- a/CHANGELOG-fix-table-tabs.md
+++ b/CHANGELOG-fix-table-tabs.md
@@ -1,0 +1,1 @@
+Fix styling on related entities table tabs.

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.tsx
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/RelatedEntitiesTabs.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import RelatedEntitiesTable from 'js/components/detailPage/related-entities/RelatedEntitiesTable';
-import { Tab } from 'js/shared-styles/tabs';
+import { Tab, Tabs } from 'js/shared-styles/tabs';
 import { ESEntityType, PartialEntity } from 'js/components/types';
-import { StyledTabs, StyledTabPanel, StyledAlert, StyledSvgIcon } from './style';
+import { StyledTabPanel, StyledAlert, StyledSvgIcon } from './style';
 import { RelatedEntitiesColumn } from '../RelatedEntitiesTable/RelatedEntitiesTable';
 
 interface RelatedEntitiesTabProps {
@@ -33,7 +33,7 @@ function RelatedEntitiesTabs({
 
   return (
     <>
-      <StyledTabs value={openIndex} onChange={handleChange} aria-label={ariaLabel}>
+      <Tabs value={openIndex} onChange={handleChange} aria-label={ariaLabel}>
         {entities.map((entity, i) => (
           <Tab
             label={`${entity.tabLabel} (${entity.data.length})`}
@@ -44,7 +44,7 @@ function RelatedEntitiesTabs({
             iconPosition="start"
           />
         ))}
-      </StyledTabs>
+      </Tabs>
       {entities.map(({ tabLabel, data, entityType: tableEntityType, columns }, i) => (
         <StyledTabPanel value={openIndex} index={i} key={tabLabel} data-testid={`${tabLabel.toLowerCase()}-panel`}>
           {data.length > 0 ? (

--- a/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.ts
+++ b/context/app/static/js/components/detailPage/related-entities/RelatedEntitiesTabs/style.ts
@@ -1,7 +1,7 @@
 import { styled } from '@mui/material/styles';
 import SvgIcon from '@mui/material/SvgIcon';
 
-import { TabPanel, Tabs } from 'js/shared-styles/tabs';
+import { TabPanel } from 'js/shared-styles/tabs';
 import { Alert } from 'js/shared-styles/alerts';
 import { ComponentProps } from 'react';
 
@@ -11,10 +11,6 @@ const StyledTabPanel = styled(TabPanel)(({ index, value }: ComponentProps<typeof
   minHeight: 0, // flex overflow fix
   alignItems: 'center',
 }));
-
-const StyledTabs = styled(Tabs)({
-  flex: 0,
-});
 
 const StyledAlert = styled(Alert)({
   margin: 10,
@@ -26,4 +22,4 @@ const StyledSvgIcon = styled(SvgIcon)(({ theme }) => ({
   marginRight: theme.spacing(1),
 }));
 
-export { StyledTabPanel, StyledTabs, StyledAlert, StyledSvgIcon };
+export { StyledTabPanel, StyledAlert, StyledSvgIcon };


### PR DESCRIPTION
This PR removes flex styling from related entities table tabs so that they match intended designs. 
<img width="1057" alt="Screenshot 2024-07-11 at 2 23 02 PM" src="https://github.com/user-attachments/assets/05290846-0d84-44dd-93ac-c09ab79e1ad1">
<img width="1087" alt="Screenshot 2024-07-11 at 2 23 08 PM" src="https://github.com/user-attachments/assets/7e2dc12d-be56-49d3-9fd7-10cc667731d8">
