### PR TITLE
NickAkhmetov/CAT-757 Fix incorrect URL structure in gene search results

### DIFF
--- a/CHANGELOG-cat-757.md
+++ b/CHANGELOG-cat-757.md
@@ -1,0 +1,1 @@
+- Fix incorrect URL structure in gene search results.

--- a/context/app/static/js/components/cells/DatasetTableRow/DatasetTableRow.tsx
+++ b/context/app/static/js/components/cells/DatasetTableRow/DatasetTableRow.tsx
@@ -51,7 +51,7 @@ function useDatasetURL(uuid: string) {
   if (queryType !== 'gene') {
     return `/browse/dataset/${uuid}`;
   }
-  return `/cells/${uuid}?marker=${cellVariableName}`;
+  return `/browse/dataset/${uuid}?marker=${cellVariableName}`;
 }
 
 function DatasetTableRow({


### PR DESCRIPTION
This PR corrects the URL structure in the dataset table row component.