### PR TITLE
Tkakar/cat 749 map icons and colors

### DIFF
--- a/CHANGELOG-mapped-status-icons.md
+++ b/CHANGELOG-mapped-status-icons.md
@@ -1,0 +1,1 @@
+- Updated the status icons and colors with the provided mui icons

--- a/context/app/static/js/components/detailPage/StatusIcon/ColoredStatusIcon.tsx
+++ b/context/app/static/js/components/detailPage/StatusIcon/ColoredStatusIcon.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { ColoredStatusIconProps, getStyledIcon, iconSymbolStatusMap } from './style';
+
+function ColoredStatusIcon({ $iconStatus, ...props }: ColoredStatusIconProps) {
+  const IconComponent = iconSymbolStatusMap[$iconStatus];
+  const StyledIcon = getStyledIcon(IconComponent, $iconStatus);
+  return <StyledIcon {...props} />;
+}
+
+export { ColoredStatusIcon };

--- a/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.tsx
+++ b/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ColoredStatusIcon } from './style';
+import { ColoredStatusIcon } from './ColoredStatusIcon';
 
 function getColor(status: string) {
   if (['NEW', 'REOPENED', 'QA', 'LOCKED', 'PROCESSING', 'HOLD', 'SUBMITTED'].includes(status)) {
@@ -30,7 +30,7 @@ function StatusIcon({ status: irregularCaseStatus }: StatusIconProps) {
   const status = irregularCaseStatus.toUpperCase();
   const color = getColor(status);
 
-  return <ColoredStatusIcon $iconColor={color} data-testid="status-svg-icon" />;
+  return <ColoredStatusIcon $iconStatus={color} data-testid="status-svg-icon" />;
 }
 
 export default StatusIcon;

--- a/context/app/static/js/components/detailPage/StatusIcon/style.ts
+++ b/context/app/static/js/components/detailPage/StatusIcon/style.ts
@@ -1,15 +1,27 @@
 import { styled } from '@mui/material/styles';
-import LensIcon from '@mui/icons-material/LensRounded';
+import { InfoRounded, ErrorRounded, WarningRounded, CheckCircleRounded } from '@mui/icons-material';
+import { SvgIconProps } from '@mui/material/SvgIcon';
 
-interface ColoredStatusIconProps {
-  $iconColor: 'info' | 'success' | 'warning' | 'error';
+export interface ColoredStatusIconProps extends SvgIconProps {
+  $iconStatus: 'info' | 'success' | 'warning' | 'error';
 }
 
-const ColoredStatusIcon = styled(LensIcon)<ColoredStatusIconProps>(({ theme, $iconColor }) => ({
-  color: theme.palette[$iconColor].main,
-  fontSize: 16,
-  marginRight: 3,
-  alignSelf: 'center',
-}));
+export const iconSymbolStatusMap: {
+  [key in ColoredStatusIconProps['$iconStatus']]: React.ComponentType<SvgIconProps>;
+} = {
+  info: InfoRounded,
+  success: CheckCircleRounded,
+  warning: WarningRounded,
+  error: ErrorRounded,
+};
 
-export { ColoredStatusIcon };
+export const getStyledIcon = (
+  IconComponent: React.ComponentType<SvgIconProps>,
+  $iconStatus: ColoredStatusIconProps['$iconStatus'],
+) =>
+  styled(IconComponent)(({ theme }) => ({
+    color: theme.palette[$iconStatus].main,
+    fontSize: 16,
+    marginRight: 3,
+    alignSelf: 'center',
+  }));


### PR DESCRIPTION
Mapped the icons and colors provided [here](https://hms-dbmi.atlassian.net/wiki/spaces/GL/pages/3497164909/Dataset+Statuses) in the code.
Current blue color for info (based on Figma) is the right one to use, the confluence needs to be updated for that. 