### PR TITLE
Austenem/cat 774 fix workspaces text

### DIFF
--- a/CHANGELOG-fix-workspace-text.md
+++ b/CHANGELOG-fix-workspace-text.md
@@ -1,1 +1,1 @@
-Update login alert text on the workspaces landing page.
+- Update login alert text on the workspaces landing page.

--- a/CHANGELOG-fix-workspace-text.md
+++ b/CHANGELOG-fix-workspace-text.md
@@ -1,0 +1,1 @@
+Update login alert text on the workspaces landing page.

--- a/context/app/static/js/shared-styles/alerts/LoginAlert.tsx
+++ b/context/app/static/js/shared-styles/alerts/LoginAlert.tsx
@@ -11,7 +11,7 @@ export default function LoginAlert({ featureName }: LoginAlertProps) {
     <Alert severity="info" action={<Button href="/login">Log in</Button>}>
       You must be logged in to access {featureName}.
       {featureName === 'workspaces'
-        ? ` At present, access to ${featureName} is restricted to HuBMAP members and invited community members.`
+        ? ' At present, access to workspaces is restricted to HuBMAP members and invited community members.'
         : ` Access to ${featureName} is restricted to HuBMAP members at present.`}
     </Alert>
   );

--- a/context/app/static/js/shared-styles/alerts/LoginAlert.tsx
+++ b/context/app/static/js/shared-styles/alerts/LoginAlert.tsx
@@ -9,7 +9,10 @@ interface LoginAlertProps {
 export default function LoginAlert({ featureName }: LoginAlertProps) {
   return (
     <Alert severity="info" action={<Button href="/login">Log in</Button>}>
-      You must be logged in to access {featureName}. Access to {featureName} is restricted to HuBMAP members at present.
+      You must be logged in to access {featureName}.
+      {featureName === 'workspaces'
+        ? ` At present, access to ${featureName} is restricted to HuBMAP members and invited community members.`
+        : ` Access to ${featureName} is restricted to HuBMAP members at present.`}
     </Alert>
   );
 }


### PR DESCRIPTION
This PR updates the login alert text on the workspaces landing page in order to match intended designs.