### PR TITLE
Austenem/cat 756 add navigation tooltips

### DIFF
--- a/CHANGELOG-add-navigation-tooltips.md
+++ b/CHANGELOG-add-navigation-tooltips.md
@@ -1,1 +1,1 @@
-Add tooltips to the apps and profile icons in the navigation bar.
+- Add tooltips to the apps and profile icons in the navigation bar.

--- a/CHANGELOG-add-navigation-tooltips.md
+++ b/CHANGELOG-add-navigation-tooltips.md
@@ -1,0 +1,1 @@
+Add tooltips to the apps and profile icons in the navigation bar.

--- a/context/app/static/js/components/Header/HeaderNavigationDrawer/HeaderNavigationDrawer.tsx
+++ b/context/app/static/js/components/Header/HeaderNavigationDrawer/HeaderNavigationDrawer.tsx
@@ -9,6 +9,7 @@ interface HeaderNavigationDrawerProps {
   sections: DrawerSection[];
   direction: 'left' | 'right';
   altOnlyTitle?: boolean;
+  tooltipText?: string;
 }
 
 export default function HeaderNavigationDrawer({
@@ -17,6 +18,7 @@ export default function HeaderNavigationDrawer({
   sections,
   direction,
   altOnlyTitle,
+  tooltipText,
 }: HeaderNavigationDrawerProps) {
   const { open, toggle, onClose } = useDrawerState();
   return (
@@ -27,6 +29,7 @@ export default function HeaderNavigationDrawer({
         altOnlyTitle={altOnlyTitle}
         onClick={toggle}
         icon={open ? <CloseIcon fontSize="1.5rem" /> : icon}
+        tooltip={tooltipText}
       />
       <NavigationDrawer title={title} direction={direction} sections={sections} onClose={onClose} open={open} />
     </>

--- a/context/app/static/js/components/Header/HeaderNavigationDrawer/instances.tsx
+++ b/context/app/static/js/components/Header/HeaderNavigationDrawer/instances.tsx
@@ -25,6 +25,7 @@ export function ToolsAndApplicationLinks() {
       icon={<AppsRounded />}
       direction="right"
       altOnlyTitle
+      tooltipText="HuBMAP Tools & Applications"
     />
   );
 }
@@ -38,6 +39,7 @@ export function UserLinks() {
       icon={<UserIcon />}
       direction="right"
       altOnlyTitle
+      tooltipText={isAuthenticated ? userEmail : 'Your Profile'}
     />
   );
 }


### PR DESCRIPTION
This PR adds tooltips to the apps and profile icons in the navigation bar.

<img width="700" alt="Screenshot 2024-07-22 at 10 49 11 AM" src="https://github.com/user-attachments/assets/1266aeb4-6c0d-4c0c-82fe-9655d00945f2">
<img width="700" alt="Screenshot 2024-07-22 at 10 49 00 AM" src="https://github.com/user-attachments/assets/a25a2e19-32f6-4600-a699-5f5b7eca739c">
<img width="700" alt="Screenshot 2024-07-22 at 10 48 53 AM" src="https://github.com/user-attachments/assets/e14ddad6-9b65-4d06-80b7-950b9a4d9c83">
