### PR TITLE
Austenem/CAT-386 add confirmation window

### DIFF
--- a/CHANGELOG-add-confirmation-window.md
+++ b/CHANGELOG-add-confirmation-window.md
@@ -1,0 +1,1 @@
+- Add confirmation modal to the 'delete workspaces' button.

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
@@ -39,21 +39,23 @@ export default function ConfirmDeleteWorkspacesDialog({
     return workspace ? workspace.name : '';
   });
 
+  const selectedWorkspaceNamesList = generateCommaList(selectedWorkspaceNames);
+
   const handleDeleteAndClose = useCallback(() => {
     const workspaceIds = [...selectedWorkspaceIds];
 
     Promise.all(workspaceIds.map((workspaceId) => handleDeleteWorkspace(Number(workspaceId))))
       .then(() => {
-        toastSuccess(`Successfully deleted workspaces: ${generateCommaList(selectedWorkspaceNames)}`);
+        toastSuccess(`Successfully deleted workspaces: ${selectedWorkspaceNamesList}`);
         selectedWorkspaceIds.clear();
       })
       .catch((e) => {
-        toastError(`Error deleting workspaces: ${generateCommaList(selectedWorkspaceNames)}`);
+        toastError(`Error deleting workspaces: ${selectedWorkspaceNamesList}`);
         console.error(e);
       });
 
     handleClose();
-  }, [handleDeleteWorkspace, selectedWorkspaceIds, selectedWorkspaceNames, handleClose, toastError, toastSuccess]);
+  }, [handleDeleteWorkspace, selectedWorkspaceIds, selectedWorkspaceNamesList, handleClose, toastError, toastSuccess]);
 
   return (
     <Dialog
@@ -75,7 +77,7 @@ export default function ConfirmDeleteWorkspacesDialog({
         </Box>
       </Stack>
       <DialogContent>
-        You have selected to delete {generateCommaList(selectedWorkspaceNames)}. You cannot undo this action.
+        You have selected to delete {selectedWorkspaceNamesList}. You cannot undo this action.
       </DialogContent>
       <Divider />
       <DialogActions>

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
@@ -1,24 +1,24 @@
 import React from 'react';
 
-import { Box, Button, DialogActions, DialogContent, Divider, Stack } from '@mui/material';
-import Dialog from '@mui/material/Dialog/Dialog';
-import DialogTitle from '@mui/material/DialogTitle/DialogTitle';
-import IconButton from '@mui/material/IconButton/IconButton';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  IconButton,
+  Stack,
+} from '@mui/material';
 import CloseRounded from '@mui/icons-material/CloseRounded';
 
 import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import { SelectedItems } from 'js/hooks/useSelectItems';
+import { generateCommaList } from 'js/helpers/functions';
 
 import { useWorkspacesList } from '../hooks';
 import { MergedWorkspace } from '../types';
-
-const genCommaList = (list: string[]): string => {
-  const { length } = list;
-
-  return length < 2
-    ? list.join('')
-    : `${list.slice(0, length - 1).join(', ')}${length < 3 ? ' and ' : ', and '}${list[length - 1]}`;
-};
 
 interface ConfirmDeleteWorkspacesDialogProps {
   dialogIsOpen: boolean;
@@ -39,7 +39,7 @@ export default function ConfirmDeleteWorkspacesDialog({
     const workspaceIds = [...selectedWorkspaceIds];
 
     Promise.all(workspaceIds.map((workspaceId) => handleDeleteWorkspace(Number(workspaceId)))).catch((e) => {
-      toastError(`Error deleting workspaces: ${workspaceIds.join(', ')}`);
+      toastError(`Error deleting workspaces: ${generateCommaList(workspaceIds)}`);
       console.error(e);
     });
 
@@ -72,7 +72,7 @@ export default function ConfirmDeleteWorkspacesDialog({
       </Stack>
       <DialogContent>
         You have selected to delete
-        {` ${genCommaList(selectedWorkspaceNames)}`}. You cannot undo this action.
+        {` ${generateCommaList(selectedWorkspaceNames)}`}. You cannot undo this action.
       </DialogContent>
       <Divider />
       <DialogActions>

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
@@ -72,7 +72,7 @@ export default function ConfirmDeleteWorkspacesDialog({
         </Box>
       </Stack>
       <DialogContent>
-        You have selected to delete {`${generateCommaList(selectedWorkspaceNames)}`}. You cannot undo this action.
+        You have selected to delete {generateCommaList(selectedWorkspaceNames)}. You cannot undo this action.
       </DialogContent>
       <Divider />
       <DialogActions>

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import { Box, Button, DialogActions, DialogContent, Divider, Stack } from '@mui/material';
+import Dialog from '@mui/material/Dialog/Dialog';
+import DialogTitle from '@mui/material/DialogTitle/DialogTitle';
+import IconButton from '@mui/material/IconButton/IconButton';
+import CloseRounded from '@mui/icons-material/CloseRounded';
+
+import { useSnackbarActions } from 'js/shared-styles/snackbars';
+import { SelectedItems } from 'js/hooks/useSelectItems';
+
+import { useWorkspacesList } from '../hooks';
+import { MergedWorkspace } from '../types';
+
+const genCommaList = (list: string[]): string => {
+  const { length } = list;
+
+  return length < 2
+    ? list.join('')
+    : `${list.slice(0, length - 1).join(', ')}${length < 3 ? ' and ' : ', and '}${list[length - 1]}`;
+};
+
+interface ConfirmDeleteWorkspacesDialogProps {
+  dialogIsOpen: boolean;
+  handleClose: () => void;
+  selectedWorkspaceIds: SelectedItems;
+  workspacesList: MergedWorkspace[];
+}
+export default function ConfirmDeleteWorkspacesDialog({
+  dialogIsOpen,
+  handleClose,
+  selectedWorkspaceIds,
+  workspacesList,
+}: ConfirmDeleteWorkspacesDialogProps) {
+  const { handleDeleteWorkspace } = useWorkspacesList();
+  const { toastError } = useSnackbarActions();
+
+  const handleDeleteAndClose = () => {
+    const workspaceIds = [...selectedWorkspaceIds];
+
+    Promise.all(workspaceIds.map((workspaceId) => handleDeleteWorkspace(Number(workspaceId)))).catch((e) => {
+      toastError(`Error deleting workspaces: ${workspaceIds.join(', ')}`);
+      console.error(e);
+    });
+
+    selectedWorkspaceIds.clear();
+    handleClose();
+  };
+
+  const selectedWorkspaceNames = Array.from(selectedWorkspaceIds).map((id) => {
+    const workspace = workspacesList.find((w) => w.id === Number(id));
+    return workspace ? workspace.name : '';
+  });
+
+  return (
+    <Dialog
+      open={dialogIsOpen}
+      onClose={handleClose}
+      scroll="paper"
+      aria-labelledby="create-workspace-dialog-title"
+      maxWidth="lg"
+    >
+      <Stack display="flex" flexDirection="row" justifyContent="space-between" marginRight={1}>
+        <DialogTitle id="delete-workspace-dialog-title" variant="h3">
+          Delete Workspace
+        </DialogTitle>
+        <Box alignContent="center">
+          <IconButton aria-label="Close" onClick={handleClose} size="large">
+            <CloseRounded />
+          </IconButton>
+        </Box>
+      </Stack>
+      <DialogContent>
+        You have selected to delete
+        {` ${genCommaList(selectedWorkspaceNames)}`}. You cannot undo this action.
+      </DialogContent>
+      <Divider />
+      <DialogActions>
+        <Button onClick={handleClose}>Cancel</Button>
+        <Button onClick={handleDeleteAndClose} variant="contained" color="warning">
+          Delete
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
@@ -17,22 +17,22 @@ import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import { SelectedItems } from 'js/hooks/useSelectItems';
 import { generateCommaList } from 'js/helpers/functions';
 
-import { useWorkspacesList } from '../hooks';
 import { MergedWorkspace } from '../types';
 
 interface ConfirmDeleteWorkspacesDialogProps {
   dialogIsOpen: boolean;
   handleClose: () => void;
+  handleDeleteWorkspace: (workspaceId: number) => Promise<void>;
   selectedWorkspaceIds: SelectedItems;
   workspacesList: MergedWorkspace[];
 }
 export default function ConfirmDeleteWorkspacesDialog({
   dialogIsOpen,
   handleClose,
+  handleDeleteWorkspace,
   selectedWorkspaceIds,
   workspacesList,
 }: ConfirmDeleteWorkspacesDialogProps) {
-  const { handleDeleteWorkspace } = useWorkspacesList();
   const { toastError } = useSnackbarActions();
 
   const handleDeleteAndClose = () => {

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
@@ -1,16 +1,15 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
-import {
-  Box,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  Divider,
-  IconButton,
-  Stack,
-} from '@mui/material';
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+import Divider from '@mui/material/Divider';
+import IconButton from '@mui/material/IconButton';
+
 import CloseRounded from '@mui/icons-material/CloseRounded';
 
 import { useSnackbarActions } from 'js/shared-styles/snackbars';
@@ -33,24 +32,28 @@ export default function ConfirmDeleteWorkspacesDialog({
   selectedWorkspaceIds,
   workspacesList,
 }: ConfirmDeleteWorkspacesDialogProps) {
-  const { toastError } = useSnackbarActions();
-
-  const handleDeleteAndClose = () => {
-    const workspaceIds = [...selectedWorkspaceIds];
-
-    Promise.all(workspaceIds.map((workspaceId) => handleDeleteWorkspace(Number(workspaceId)))).catch((e) => {
-      toastError(`Error deleting workspaces: ${generateCommaList(workspaceIds)}`);
-      console.error(e);
-    });
-
-    selectedWorkspaceIds.clear();
-    handleClose();
-  };
+  const { toastError, toastSuccess } = useSnackbarActions();
 
   const selectedWorkspaceNames = Array.from(selectedWorkspaceIds).map((id) => {
     const workspace = workspacesList.find((w) => w.id === Number(id));
     return workspace ? workspace.name : '';
   });
+
+  const handleDeleteAndClose = useCallback(() => {
+    const workspaceIds = [...selectedWorkspaceIds];
+
+    Promise.all(workspaceIds.map((workspaceId) => handleDeleteWorkspace(Number(workspaceId))))
+      .then(() => {
+        toastSuccess(`Successfully deleted workspaces: ${generateCommaList(selectedWorkspaceNames)}`);
+        selectedWorkspaceIds.clear();
+      })
+      .catch((e) => {
+        toastError(`Error deleting workspaces: ${generateCommaList(selectedWorkspaceNames)}`);
+        console.error(e);
+      });
+
+    handleClose();
+  }, [handleDeleteWorkspace, selectedWorkspaceIds, selectedWorkspaceNames, handleClose, toastError, toastSuccess]);
 
   return (
     <Dialog

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/ConfirmDeleteWorkspacesDialog.tsx
@@ -57,12 +57,13 @@ export default function ConfirmDeleteWorkspacesDialog({
       open={dialogIsOpen}
       onClose={handleClose}
       scroll="paper"
-      aria-labelledby="create-workspace-dialog-title"
+      aria-labelledby="delete-workspace-dialog"
       maxWidth="lg"
     >
       <Stack display="flex" flexDirection="row" justifyContent="space-between" marginRight={1}>
         <DialogTitle id="delete-workspace-dialog-title" variant="h3">
           Delete Workspace
+          {selectedWorkspaceIds.size > 1 ? 's' : ''}
         </DialogTitle>
         <Box alignContent="center">
           <IconButton aria-label="Close" onClick={handleClose} size="large">
@@ -71,8 +72,7 @@ export default function ConfirmDeleteWorkspacesDialog({
         </Box>
       </Stack>
       <DialogContent>
-        You have selected to delete
-        {` ${generateCommaList(selectedWorkspaceNames)}`}. You cannot undo this action.
+        You have selected to delete {`${generateCommaList(selectedWorkspaceNames)}`}. You cannot undo this action.
       </DialogContent>
       <Divider />
       <DialogActions>

--- a/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/index.ts
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteWorkspacesDialog/index.ts
@@ -1,0 +1,3 @@
+import ConfirmDeleteWorkspacesDialog from './ConfirmDeleteWorkspacesDialog';
+
+export default ConfirmDeleteWorkspacesDialog;

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
@@ -9,27 +10,26 @@ import Description from 'js/shared-styles/sections/Description';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 import WorkspaceListItem from 'js/components/workspaces/WorkspaceListItem';
 import { useSelectItems } from 'js/hooks/useSelectItems';
-import { useSnackbarActions } from 'js/shared-styles/snackbars';
+
 import { useWorkspacesList } from './hooks';
 import WorkspaceButton from './WorkspaceButton';
 import NewWorkspaceDialogFromWorkspaceList from './NewWorkspaceDialog/NewWorkspaceDialogFromWorkspaceList';
+import ConfirmDeleteWorkspacesDialog from './ConfirmDeleteWorkspacesDialog';
 
 function WorkspacesList() {
-  const { workspacesList, handleDeleteWorkspace, isDeleting } = useWorkspacesList();
-
+  const { workspacesList, isDeleting } = useWorkspacesList();
   const { selectedItems, toggleItem } = useSelectItems();
-  const { toastError } = useSnackbarActions();
 
-  const handleDeleteSelected = () => {
-    const workspaceIds = [...selectedItems];
-    Promise.all(workspaceIds.map((workspaceId) => handleDeleteWorkspace(workspaceId))).catch((e) => {
-      toastError(`Error deleting workspace: ${e.message}`);
-      console.error(e);
-    });
-  };
+  const [dialogIsOpen, setDialogIsOpen] = useState(false);
 
   return (
     <>
+      <ConfirmDeleteWorkspacesDialog
+        dialogIsOpen={dialogIsOpen}
+        handleClose={() => setDialogIsOpen(false)}
+        selectedWorkspaceIds={selectedItems}
+        workspacesList={workspacesList}
+      />
       <SpacedSectionButtonRow
         leftText={
           <Typography variant="subtitle1">
@@ -39,7 +39,7 @@ function WorkspacesList() {
         buttons={
           <Stack direction="row" gap={1}>
             <WorkspaceButton
-              onClick={handleDeleteSelected}
+              onClick={() => setDialogIsOpen(true)}
               disabled={selectedItems.size === 0 || isDeleting}
               tooltip="Delete selected workspaces"
             >

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -1,15 +1,12 @@
 import React, { useState } from 'react';
 
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
-import Stack from '@mui/material/Stack';
+import { Checkbox, Paper, Stack, Typography } from '@mui/material';
 import DeleteRounded from '@mui/icons-material/DeleteRounded';
-import Checkbox from '@mui/material/Checkbox';
 
 import Description from 'js/shared-styles/sections/Description';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
-import WorkspaceListItem from 'js/components/workspaces/WorkspaceListItem';
 import { useSelectItems } from 'js/hooks/useSelectItems';
+import WorkspaceListItem from 'js/components/workspaces/WorkspaceListItem';
 
 import { useWorkspacesList } from './hooks';
 import WorkspaceButton from './WorkspaceButton';

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -14,7 +14,7 @@ import NewWorkspaceDialogFromWorkspaceList from './NewWorkspaceDialog/NewWorkspa
 import ConfirmDeleteWorkspacesDialog from './ConfirmDeleteWorkspacesDialog';
 
 function WorkspacesList() {
-  const { workspacesList, isDeleting } = useWorkspacesList();
+  const { workspacesList, handleDeleteWorkspace, isDeleting } = useWorkspacesList();
   const { selectedItems, toggleItem } = useSelectItems();
 
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
@@ -24,6 +24,7 @@ function WorkspacesList() {
       <ConfirmDeleteWorkspacesDialog
         dialogIsOpen={dialogIsOpen}
         handleClose={() => setDialogIsOpen(false)}
+        handleDeleteWorkspace={handleDeleteWorkspace}
         selectedWorkspaceIds={selectedItems}
         workspacesList={workspacesList}
       />

--- a/context/app/static/js/components/workspaces/WorkspacesList.jsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.jsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react';
 
-import { Checkbox, Paper, Stack, Typography } from '@mui/material';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import DeleteRounded from '@mui/icons-material/DeleteRounded';
+import Checkbox from '@mui/material/Checkbox';
 
 import Description from 'js/shared-styles/sections/Description';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';

--- a/context/app/static/js/helpers/functions.spec.js
+++ b/context/app/static/js/helpers/functions.spec.js
@@ -9,6 +9,7 @@ import {
   getOriginSamplesOrgan,
   NOT_CAPITALIZED_WORDS,
   shouldCapitalizeString,
+  generateCommaList,
 } from './functions';
 
 test('isEmptyArrayOrObject', () => {
@@ -73,4 +74,14 @@ test('getOriginSamplesOrgan', () => {
   expect(getOriginSamplesOrgan(entity)).toEqual('heart, liver');
   entity.origin_samples_unique_mapped_organs = [];
   expect(getOriginSamplesOrgan(entity)).toEqual('');
+});
+
+test('generateCommaList', () => {
+  expect(generateCommaList([])).toStrictEqual('');
+  expect(generateCommaList(['apples'])).toStrictEqual('apples');
+  expect(generateCommaList(['apples', 'bananas'])).toStrictEqual('apples and bananas');
+  expect(generateCommaList(['apples', 'bananas', 'oranges'])).toStrictEqual('apples, bananas, and oranges');
+  expect(generateCommaList(['apples', 'bananas', 'oranges', 'grapes'])).toStrictEqual(
+    'apples, bananas, oranges, and grapes',
+  );
 });

--- a/context/app/static/js/helpers/functions.ts
+++ b/context/app/static/js/helpers/functions.ts
@@ -176,3 +176,11 @@ export function filterObjectByKeys<O extends object, K extends keyof O>(obj: O, 
 export function getOriginSamplesOrgan(entity: { origin_samples_unique_mapped_organs: string[] }) {
   return entity.origin_samples_unique_mapped_organs.join(', ');
 }
+
+export function generateCommaList(list: string[]): string {
+  const { length } = list;
+
+  return length < 2
+    ? list.join('')
+    : `${list.slice(0, length - 1).join(', ')}${length < 3 ? ' and ' : ', and '}${list[length - 1]}`;
+}

--- a/context/app/static/js/helpers/functions.ts
+++ b/context/app/static/js/helpers/functions.ts
@@ -177,6 +177,16 @@ export function getOriginSamplesOrgan(entity: { origin_samples_unique_mapped_org
   return entity.origin_samples_unique_mapped_organs.join(', ');
 }
 
+/**
+ * Given an array of strings, create a single comma-separated string that includes
+ * 'and' as well as an oxford comma.
+ *   Ex: ['apples'] => 'apples'
+ *   Ex: ['apples', 'bananas'] => 'apples and bananas'
+ *   Ex: ['apples', 'bananas', 'grapes'] => 'apples, bananas, and grapes'
+ * @author Austen Money
+ * @param list an array of elements to be made into a single comma-separated string.
+ * @returns a comma-separated string.
+ */
 export function generateCommaList(list: string[]): string {
   const { length } = list;
 


### PR DESCRIPTION
## Summary

This update adds a confirmation modal to the 'Delete Workspace' button to avoid accidental deletions. 

## Design Documentation/Original Tickets

[CAT-386 JIRA ticket (dev)](https://hms-dbmi.atlassian.net/browse/CAT-386?atlOrigin=eyJpIjoiZjY4OGNjYjBmN2E2NGZmNzllZDJkYTY3NzllZDI0MWQiLCJwIjoiaiJ9)

[CAT-780 JIRA ticket (design)](https://hms-dbmi.atlassian.net/browse/CAT-780?atlOrigin=eyJpIjoiNWQ5YTQxYjlkMDEwNDYwYWIyYzg5MmM3NWNiNDA5OTEiLCJwIjoiaiJ9)

[Figma mockup](https://www.figma.com/design/NgBjvs0jRbDHhiyn5nicDm/Workspace?node-id=2671-30185&m=dev)

## Testing

Functionalities of this feature that have been tested manually:
* "Delete workspaces" button is disabled while no workspaces are selected
* Dialog opens when 1+ workspaces are selected and "Delete workspaces" button is clicked
* Dialog can be exited without deletion three ways:
  * Clicking anywhere outside of the modal 
  * Clicking the top right "X" button
  * Clicking the "Cancel" button
* When "Delete" button in modal is clicked, the selected workspace(s) are deleted and the modal closes
* The text inside the modal appropriately adjusts syntax based on how many workspaces are selected (ie "workspace 1", "workspace 1 and workspace 2", and "workspace 1, workspace 2, and workspace 3")

## Screenshots/Video


https://github.com/user-attachments/assets/f4a0723b-6347-443e-b144-5786aa202096


## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added
