### PR TITLE
Austenem/CAT-570 add workspace ids

### DIFF
--- a/CHANGELOG-add-workspace-ids.md
+++ b/CHANGELOG-add-workspace-ids.md
@@ -1,0 +1,1 @@
+- Show IDs of workspaces in the workspaces list to differentiate between workspaces with the same name.

--- a/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
+++ b/context/app/static/js/components/workspaces/WorkspaceDetails/WorkspaceDetails.jsx
@@ -18,6 +18,7 @@ function WorkspaceDetails({ workspace }) {
       </InternalLink>
       <Typography variant="body2">
         <JobStatus job={job} />
+        &nbsp;|&nbsp; ID: {workspace.id}
         &nbsp;|&nbsp; Created {workspace.datetime_created.slice(0, 10)}
       </Typography>
     </Stack>


### PR DESCRIPTION
## Summary

Tiny update that adds IDs to subheadings in the workspaces list to differentiate between workspaces with the same name.

## Design Documentation/Original Tickets

[CAT-570 JIRA ticket ](https://hms-dbmi.atlassian.net/browse/CAT-570?atlOrigin=eyJpIjoiYmE5ODdjYTQzNmQ0NGIxYTg4M2Q3ZWQ3Y2ZkNGQ1NDciLCJwIjoiaiJ9)

## Screenshots/Video

<img width="1228" alt="Screenshot 2024-07-24 at 4 21 41 PM" src="https://github.com/user-attachments/assets/c9396efe-f9f0-43d9-8ca6-b324c1b0ffbb">

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added
