### PR TITLE
Update vitessce-data s3 bucket urls in preview configs

### DIFF
--- a/CHANGELOG-s3-urls.md
+++ b/CHANGELOG-s3-urls.md
@@ -1,0 +1,1 @@
+- Updated `vitessce-data` and `vitessce-data-v2` S3 bucket URLs to point to `data-1.vitessce.io` and `data-2.vitessce.io` subdomains, respectively.

--- a/context/app/preview/3d-tissue-maps.md
+++ b/context/app/preview/3d-tissue-maps.md
@@ -15,16 +15,16 @@ vitessce_conf:
           'files':
             [
               {
-                'url': 'https://vitessce-data-v2.s3.amazonaws.com/data/washu-kidney/LS_20x_5_Stitched.pyramid.ome.tiff',
+                'url': 'https://data-2.vitessce.io/data/washu-kidney/LS_20x_5_Stitched.pyramid.ome.tiff',
                 'fileType': 'image.ome-tiff',
                 'coordinationValues': { 'fileUid': 'kidney', 'obsType': 'gloms' },
                 'options':
                   {
-                    'offsetsUrl': 'https://vitessce-data-v2.s3.amazonaws.com/data/washu-kidney/LS_20x_5_Stitched.pyramid.offsets.json',
+                    'offsetsUrl': 'https://data-2.vitessce.io/data/washu-kidney/LS_20x_5_Stitched.pyramid.offsets.json',
                   },
               },
               {
-                'url': 'https://vitessce-data-v2.s3.amazonaws.com/data/washu-kidney/decimated.glb',
+                'url': 'https://data-2.vitessce.io/data/washu-kidney/decimated.glb',
                 'fileType': 'obsSegmentations.glb',
                 'coordinationValues': { 'fileUid': 'gloms', 'obsType': 'gloms' },
                 'options':
@@ -43,7 +43,7 @@ vitessce_conf:
                   },
               },
               {
-                'url': 'https://vitessce-data-v2.s3.amazonaws.com/data/washu-kidney/statistics.csv',
+                'url': 'https://data-2.vitessce.io/data/washu-kidney/statistics.csv',
                 'fileType': 'obsFeatureMatrix.csv',
                 'coordinationValues': { 'obsType': 'gloms', 'featureType': 'feature', 'featureValueType': 'value' },
               },

--- a/context/app/preview/cell-type-annotations.md
+++ b/context/app/preview/cell-type-annotations.md
@@ -18,12 +18,12 @@ vitessce_conf:
               [
                 {
                   'fileType': 'cells.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cells.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cells.json',
                   'options': { 'embeddingTypes': ['UMAP'] },
                 },
                 {
                   'fileType': 'cell-sets.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cell-sets.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/2dca1bf5832a4102ba780e9e54f6c350.cell-sets.json',
                 },
                 {
                   'fileType': 'expression-matrix.zarr',
@@ -73,12 +73,12 @@ vitessce_conf:
               [
                 {
                   'fileType': 'cells.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cells.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cells.json',
                   'options': { 'embeddingTypes': ['UMAP'] },
                 },
                 {
                   'fileType': 'cell-sets.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cell-sets.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/7fd04d1aba61c35843dd2eb6a19d2545.cell-sets.json',
                 },
                 {
                   'fileType': 'expression-matrix.zarr',
@@ -128,12 +128,12 @@ vitessce_conf:
               [
                 {
                   'fileType': 'cells.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cells.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cells.json',
                   'options': { 'embeddingTypes': ['UMAP'] },
                 },
                 {
                   'fileType': 'cell-sets.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cell-sets.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/8a238da50c0c0436510b857c21e4e792.cell-sets.json',
                 },
                 {
                   'fileType': 'expression-matrix.zarr',
@@ -183,12 +183,12 @@ vitessce_conf:
               [
                 {
                   'fileType': 'cells.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cells.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cells.json',
                   'options': { 'embeddingTypes': ['UMAP'] },
                 },
                 {
                   'fileType': 'cell-sets.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cell-sets.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/3683b49e27133c064ccbd59ff9723e7c.cell-sets.json',
                 },
                 {
                   'fileType': 'expression-matrix.zarr',
@@ -238,12 +238,12 @@ vitessce_conf:
               [
                 {
                   'fileType': 'cells.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cells.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cells.json',
                   'options': { 'embeddingTypes': ['UMAP'] },
                 },
                 {
                   'fileType': 'cell-sets.json',
-                  'url': 'https://s3.amazonaws.com/vitessce-data/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cell-sets.json',
+                  'url': 'https://data-1.vitessce.io/0.0.31/master_release/satija/ed8a4dbbb1554a5e3227d6dfb2368828.cell-sets.json',
                 },
                 {
                   'fileType': 'expression-matrix.zarr',

--- a/context/app/preview/multimodal-molecular-imaging-data.md
+++ b/context/app/preview/multimodal-molecular-imaging-data.md
@@ -12,7 +12,7 @@ vitessce_conf:
           'name': 'raster',
           'type': 'RASTER',
           'fileType': 'raster.json',
-          'url': 'https://data-1.vitessce.io/0.0.27/master_release/spraggins/spraggins.raster.json',
+          'url': 'https://data-1.vitessce.io/0.0.31/master_release/spraggins/spraggins.raster.json',
         },
       ],
     'name': 'Spraggins',

--- a/context/app/preview/multimodal-molecular-imaging-data.md
+++ b/context/app/preview/multimodal-molecular-imaging-data.md
@@ -12,7 +12,7 @@ vitessce_conf:
           'name': 'raster',
           'type': 'RASTER',
           'fileType': 'raster.json',
-          'url': 'https://s3.amazonaws.com/vitessce-data/0.0.27/master_release/spraggins/spraggins.raster.json',
+          'url': 'https://data-1.vitessce.io/0.0.27/master_release/spraggins/spraggins.raster.json',
         },
       ],
     'name': 'Spraggins',


### PR DESCRIPTION
## Summary

With migration of Vitessce-related AWS resources to the DBMI Landing Zone, I have also moved the data in the vitessce-data S3 buckets behind CloudFront distributions, located at subdomains of `vitessce.io`. This will provide our team with full control over these URLs moving forward instead of being locked into S3 bucket naming and other restrictions.

## Design Documentation/Original Tickets

Fixes #3483 

## Testing

Describe how the feature has been tested, including both automated and manual testing strategies.

## Screenshots/Video

Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
