### PR TITLE
Updated query for recent datasets

### DIFF
--- a/CHANGELOG-update-recent-dataset-query.md
+++ b/CHANGELOG-update-recent-dataset-query.md
@@ -1,0 +1,1 @@
+- Updated query for recent datasets to avoid filtering based on presence of visualization.

--- a/context/app/static/js/components/home/RecentEntities/queries.ts
+++ b/context/app/static/js/components/home/RecentEntities/queries.ts
@@ -1,4 +1,5 @@
 import { SearchRequest } from '@elastic/elasticsearch/lib/api/types';
+import { includeOnlyDatasetsClause } from 'js/helpers/queries';
 
 export const recentPublicationsQuery: SearchRequest = {
   query: {
@@ -61,15 +62,7 @@ export const recentPublicationsQuery: SearchRequest = {
 // Fetches the most recent datasets with a visualization
 export const recentDatasetsQuery: SearchRequest = {
   size: 0,
-  query: {
-    bool: {
-      filter: {
-        term: {
-          visualization: 'true',
-        },
-      },
-    },
-  },
+  query: includeOnlyDatasetsClause,
   sort: [
     {
       last_modified_timestamp: 'desc',


### PR DESCRIPTION
## Summary
The recent datasets section on homepage had a query clause for showing only datasets that had visualizations. The clause is removed in this PR.

## Design Documentation/Original Tickets

Jira ticket: [CAT-773](https://hms-dbmi.atlassian.net/browse/CAT-773)

## Testing
Tested manually.

## Screenshots/Video
updated recent datasets list
<img width="616" alt="Screenshot 2024-07-31 at 10 32 31 AM" src="https://github.com/user-attachments/assets/626ef82b-3002-4efc-81c0-07a79cb66b85">


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.


[CAT-773]: https://hms-dbmi.atlassian.net/browse/CAT-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ