### PR TITLE
Austenem/CAT-784 fix template grid

### DIFF
--- a/CHANGELOG-fix-template-grid.md
+++ b/CHANGELOG-fix-template-grid.md
@@ -1,0 +1,1 @@
+- Prevent header from being clipped when the template selection grid is scrolled.

--- a/context/app/static/js/components/workspaces/SelectableTemplateGrid/SelectableTemplateGrid.tsx
+++ b/context/app/static/js/components/workspaces/SelectableTemplateGrid/SelectableTemplateGrid.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, ChangeEvent } from 'react';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
-import Stack from '@mui/material/Stack';
 import { useController, Control, Path } from 'react-hook-form';
 
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
@@ -70,25 +69,23 @@ function SelectableTemplateGrid<FormType extends FormWithTemplates>({
   return (
     <Box>
       {errorMessage && <ErrorOrWarningMessages errorMessages={[errorMessage]} />}
-      <Stack marginBottom={2}>
-        <SpacedSectionButtonRow
-          leftText={<Typography variant="subtitle1">{selectedTemplates.size} Templates Selected</Typography>}
-          buttons={
-            <>
-              <Button disabled={selectedTemplates.size === 0} sx={{ mr: 1 }} onClick={() => updateTemplates([])}>
-                Deselect All
-              </Button>
-              <Button
-                color="primary"
-                variant="contained"
-                onClick={() => updateTemplates(getActiveTemplates({ templates, disabledTemplates }))}
-              >
-                Select All
-              </Button>
-            </>
-          }
-        />
-      </Stack>
+      <SpacedSectionButtonRow
+        leftText={<Typography variant="subtitle1">{selectedTemplates.size} Templates Selected</Typography>}
+        buttons={
+          <>
+            <Button disabled={selectedTemplates.size === 0} sx={{ mr: 1 }} onClick={() => updateTemplates([])}>
+              Deselect All
+            </Button>
+            <Button
+              color="primary"
+              variant="contained"
+              onClick={() => updateTemplates(getActiveTemplates({ templates, disabledTemplates }))}
+            >
+              Select All
+            </Button>
+          </>
+        }
+      />
       <TemplateGrid
         templates={templates}
         selectItem={selectItem}

--- a/context/app/static/js/components/workspaces/SelectableTemplateGrid/SelectableTemplateGrid.tsx
+++ b/context/app/static/js/components/workspaces/SelectableTemplateGrid/SelectableTemplateGrid.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, ChangeEvent } from 'react';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
 import { useController, Control, Path } from 'react-hook-form';
 
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
@@ -69,23 +70,25 @@ function SelectableTemplateGrid<FormType extends FormWithTemplates>({
   return (
     <Box>
       {errorMessage && <ErrorOrWarningMessages errorMessages={[errorMessage]} />}
-      <SpacedSectionButtonRow
-        leftText={<Typography variant="subtitle1">{selectedTemplates.size} Templates Selected</Typography>}
-        buttons={
-          <>
-            <Button disabled={selectedTemplates.size === 0} sx={{ mr: 1 }} onClick={() => updateTemplates([])}>
-              Deselect All
-            </Button>
-            <Button
-              color="primary"
-              variant="contained"
-              onClick={() => updateTemplates(getActiveTemplates({ templates, disabledTemplates }))}
-            >
-              Select All
-            </Button>
-          </>
-        }
-      />
+      <Stack marginBottom={2}>
+        <SpacedSectionButtonRow
+          leftText={<Typography variant="subtitle1">{selectedTemplates.size} Templates Selected</Typography>}
+          buttons={
+            <>
+              <Button disabled={selectedTemplates.size === 0} sx={{ mr: 1 }} onClick={() => updateTemplates([])}>
+                Deselect All
+              </Button>
+              <Button
+                color="primary"
+                variant="contained"
+                onClick={() => updateTemplates(getActiveTemplates({ templates, disabledTemplates }))}
+              >
+                Select All
+              </Button>
+            </>
+          }
+        />
+      </Stack>
       <TemplateGrid
         templates={templates}
         selectItem={selectItem}

--- a/context/app/static/js/components/workspaces/TemplateGrid/TemplateGrid.tsx
+++ b/context/app/static/js/components/workspaces/TemplateGrid/TemplateGrid.tsx
@@ -18,9 +18,9 @@ function TemplateGrid({
   disabledTemplates = {},
 }: TemplateGridProps) {
   return (
-    <Grid container spacing={2} alignItems="stretch" sx={{ maxHeight: '625px', overflowY: 'auto' }}>
+    <Grid container columnSpacing={2} alignItems="stretch" sx={{ maxHeight: '625px', overflowY: 'auto' }}>
       {Object.entries(templates).map(([templateKey, { title, description, tags }]) => (
-        <Grid item md={4} xs={12} key={templateKey}>
+        <Grid item md={4} xs={12} key={templateKey} paddingBottom={2}>
           <SelectableCard
             title={title}
             description={description}


### PR DESCRIPTION
## Summary

This update prevents the number of templates selected and selection buttons from being clipped when the template grid is scrolled.

## Design Documentation/Original Tickets

[CAT-784 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-784?atlOrigin=eyJpIjoiNDhmNDJkMWE1OWQyNDZlMzhkMTEyOTRiYTA1MWEwYTYiLCJwIjoiaiJ9)

## Testing

This feature was manually tested by checking that the `TemplateGrid` component no longer clips in each page where it is used. 

## Screenshots/Video

https://github.com/user-attachments/assets/9c5546f4-2552-491a-9635-6bc2b1765ce1

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
