### PR TITLE
Austenem/CAT-807 fix launch workspace button

### DIFF
--- a/CHANGELOG-fix-launch-button.md
+++ b/CHANGELOG-fix-launch-button.md
@@ -1,0 +1,1 @@
+Fix issue of "Launch Workspace" button not appearing in workspace detail pages. 

--- a/CHANGELOG-fix-launch-button.md
+++ b/CHANGELOG-fix-launch-button.md
@@ -1,1 +1,1 @@
-Fix issue of "Launch Workspace" button not appearing in workspace detail pages. 
+- Fix issue of "Launch Workspace" button not appearing in workspace detail pages. 

--- a/context/app/static/js/pages/Workspace/Workspace.tsx
+++ b/context/app/static/js/pages/Workspace/Workspace.tsx
@@ -81,6 +81,8 @@ function WorkspaceContent({ workspaceId }: WorkspacePageProps) {
                 button={LaunchStopButton}
                 handleStopWorkspace={handleStopWorkspace}
                 isStoppingWorkspace={isStoppingWorkspace}
+                showLaunch
+                showStop
               />
             </>
           }


### PR DESCRIPTION
## Summary

This update fixes the bug introduced by CAT-711 that hid the "Launch Workspace" and "Stop Jobs" buttons in workspace detail pages. 

## Design Documentation/Original Tickets

[CAT-807 JIRA ticket](https://hms-dbmi.atlassian.net/browse/CAT-807?atlOrigin=eyJpIjoiZDg5YTNlMzRiYTRkNDIwYWFkZTczODU2NDAzMGZlZjciLCJwIjoiaiJ9)

## Testing

Workspace detail page was manually checked to ensure that both buttons appear when expected. There are no other instances of this button component that might have missing props. 

## Screenshots/Video

<img width="800" alt="Screenshot 2024-08-01 at 10 45 07 AM" src="https://github.com/user-attachments/assets/931c8a47-3348-4b6b-b424-cbcef032cc70">

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
