### PR TITLE
Austenem/CAT-816 identify contacts

### DIFF
--- a/CHANGELOG-identify-contacts.md
+++ b/CHANGELOG-identify-contacts.md
@@ -1,0 +1,1 @@
+- Add a check for "Contacts" data to display in the Contributors table of the detail pages of datasets, collections, and publications.

--- a/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.tsx
+++ b/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.tsx
@@ -19,7 +19,7 @@ import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import { OutlinedAlert } from 'js/shared-styles/alerts/OutlinedAlert.stories';
 import { isValidEmail } from 'js/helpers/functions';
 
-import { useNormalizedContributors } from './hooks';
+import { useNormalizedContacts, useNormalizedContributors } from './hooks';
 import { ContributorAPIResponse, sortContributors, contributorIsContact, ContactAPIResponse } from './utils';
 
 const contributorsInfoAlertText =
@@ -71,7 +71,7 @@ function ContributorsTable({
   ];
 
   const normalizedContributors = useNormalizedContributors(contributors);
-  const normalizedContacts = useNormalizedContributors(contacts);
+  const normalizedContacts = useNormalizedContacts(contacts);
 
   const sortedContributors = sortContributors(normalizedContributors, normalizedContacts);
 

--- a/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.tsx
+++ b/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.tsx
@@ -20,7 +20,7 @@ import { OutlinedAlert } from 'js/shared-styles/alerts/OutlinedAlert.stories';
 import { isValidEmail } from 'js/helpers/functions';
 
 import { useNormalizedContributors } from './hooks';
-import { ContributorAPIResponse, sortContributors, contributorIsContact } from './utils';
+import { ContributorAPIResponse, sortContributors, contributorIsContact, ContactAPIResponse } from './utils';
 
 const contributorsInfoAlertText =
   'Below is the information for the individuals who provided this dataset. For questions for this dataset, reach out to the individuals listed as contacts, either via the email address listed in the table or contact information provided on their ORCID profile page.';
@@ -52,7 +52,7 @@ function ContactCell({ isContact, email }: ContactCellProps) {
 interface ContributorsTableProps {
   title: string;
   contributors: ContributorAPIResponse[];
-  contacts?: ContributorAPIResponse[];
+  contacts?: ContactAPIResponse[];
   iconTooltipText?: string;
   showInfoAlert?: boolean;
 }

--- a/context/app/static/js/components/detailPage/ContributorsTable/hooks.tsx
+++ b/context/app/static/js/components/detailPage/ContributorsTable/hooks.tsx
@@ -3,13 +3,20 @@ import React, { useMemo } from 'react';
 import { Stack } from '@mui/material';
 import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
 import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
-import { ContributorAPIResponse, normalizeContributor } from './utils';
+import { ContributorAPIResponse, ContactAPIResponse, normalizeContributor, normalizeContact } from './utils';
 
 export function useNormalizedContributors(contributors: ContributorAPIResponse[]) {
   const normalizedContributors = useMemo(() => {
     return contributors.map(normalizeContributor);
   }, [contributors]);
   return normalizedContributors;
+}
+
+export function useNormalizedContacts(contacts: ContactAPIResponse[]) {
+  const normalizedContacts = useMemo(() => {
+    return contacts.map(normalizeContact);
+  }, [contacts]);
+  return normalizedContacts;
 }
 
 export function useAttributionSections(

--- a/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
+++ b/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
@@ -33,6 +33,7 @@ export interface CEDARContributor {
 }
 
 export type ContributorAPIResponse = LegacyContributor | CEDARContributor;
+export type ContactAPIResponse = ContributorAPIResponse & { is_contact: 'Yes' | 'TRUE' };
 
 export interface Contributor {
   affiliation: string;
@@ -86,9 +87,12 @@ export const normalizeContributor = (contributor: ContributorAPIResponse): Contr
 
 /**
  * Given a contributor, determine if they are a contact. Necessary to account
- *  for different versions of contributors schemas.
+ * for different versions of contributors schemas - some versions include the
+ * isContact field in contributors, and some have a separate contacts array that
+ * must be checked.
  * @author Austen Money
  * @param contributor a contributor to be checked.
+ * @param contacts an array of contacts to search for the contributor.
  * @returns true if the contributor is a contact, false otherwise.
  */
 export const contributorIsContact = (contributor: Contributor, contacts: Contributor[]): boolean => {

--- a/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
+++ b/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
@@ -100,7 +100,7 @@ export const normalizeContact = (contact: ContactAPIResponse): Contact => ({
  * @param contacts an array of contacts to search for the contributor.
  * @returns true if the contributor is a contact, false otherwise.
  */
-export const contributorIsContact = (contributor: Contributor, contacts: Contributor[]): boolean => {
+export const contributorIsContact = (contributor: Contributor, contacts: Contact[]): boolean => {
   switch (true) {
     case contributor.isContact:
       return true;
@@ -119,7 +119,7 @@ export const contributorIsContact = (contributor: Contributor, contacts: Contrib
  * @param contacts an array of contacts to be used for sorting.
  * @returns a sorted array.
  */
-export const sortContributors = (contributors: Contributor[], contacts: Contributor[]): Contributor[] =>
+export const sortContributors = (contributors: Contributor[], contacts: Contact[]): Contributor[] =>
   contributors.sort((a, b) => {
     const aIsContact = contributorIsContact(a, contacts);
     const bIsContact = contributorIsContact(b, contacts);

--- a/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
+++ b/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
@@ -39,8 +39,6 @@ export interface CEDARContributor extends ContributorBase {
 
 export type ContributorAPIResponse = V0Contributor | LegacyContributor | CEDARContributor;
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface V0Contact extends V0Contributor {}
 export interface LegacyContact extends LegacyContributor {
   is_contact: 'TRUE';
 }
@@ -48,7 +46,7 @@ export interface CEDARContact extends CEDARContributor {
   is_contact: 'Yes';
 }
 
-export type ContactAPIResponse = V0Contact | LegacyContact | CEDARContact;
+export type ContactAPIResponse = V0Contributor | LegacyContact | CEDARContact;
 
 export interface Contributor {
   affiliation: string;

--- a/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
+++ b/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
@@ -39,9 +39,8 @@ export interface CEDARContributor extends ContributorBase {
 
 export type ContributorAPIResponse = V0Contributor | LegacyContributor | CEDARContributor;
 
-export interface v0Contact extends V0Contributor {
-  is_contact: true;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface V0Contact extends V0Contributor {}
 export interface LegacyContact extends LegacyContributor {
   is_contact: 'TRUE';
 }
@@ -49,7 +48,7 @@ export interface CEDARContact extends CEDARContributor {
   is_contact: 'Yes';
 }
 
-export type ContactAPIResponse = v0Contact | LegacyContact | CEDARContact;
+export type ContactAPIResponse = V0Contact | LegacyContact | CEDARContact;
 
 export interface Contributor {
   affiliation: string;

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -100,10 +100,14 @@ export interface Dataset extends Entity {
 
 export interface Collection extends Entity {
   entity_type: 'Collection';
+  contributors: ContributorAPIResponse[];
+  contacts?: ContributorAPIResponse[];
 }
 
 export interface Publication extends Entity {
   entity_type: 'Publication';
+  contributors: ContributorAPIResponse[];
+  contacts?: ContributorAPIResponse[];
 }
 
 export interface Support extends Entity {

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -89,6 +89,7 @@ export interface Dataset extends Entity {
   dbgap_sra_experiment_url: string;
   files: UnprocessedFile[];
   contributors: ContributorAPIResponse[];
+  contacts?: ContributorAPIResponse[];
   sub_status: string;
   protocol_url: string;
   registered_doi: string;
@@ -110,6 +111,7 @@ export interface Support extends Entity {
   origin_samples: Sample[];
   files: UnprocessedFile[];
   contributors: ContributorAPIResponse[];
+  contacts?: ContributorAPIResponse[];
   published_timestamp: number;
   assay_modality: 'single' | 'multiple';
   created_timestamp: number;

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -1,4 +1,4 @@
-import { ContributorAPIResponse } from './detailPage/ContributorsTable/utils';
+import { ContributorAPIResponse, ContactAPIResponse } from './detailPage/ContributorsTable/utils';
 import { UnprocessedFile } from './detailPage/files/types';
 
 export type DonorEntityType = 'Donor';
@@ -89,7 +89,7 @@ export interface Dataset extends Entity {
   dbgap_sra_experiment_url: string;
   files: UnprocessedFile[];
   contributors: ContributorAPIResponse[];
-  contacts?: ContributorAPIResponse[];
+  contacts?: ContactAPIResponse[];
   sub_status: string;
   protocol_url: string;
   registered_doi: string;
@@ -101,13 +101,13 @@ export interface Dataset extends Entity {
 export interface Collection extends Entity {
   entity_type: 'Collection';
   contributors: ContributorAPIResponse[];
-  contacts?: ContributorAPIResponse[];
+  contacts?: ContactAPIResponse[];
 }
 
 export interface Publication extends Entity {
   entity_type: 'Publication';
   contributors: ContributorAPIResponse[];
-  contacts?: ContributorAPIResponse[];
+  contacts?: ContactAPIResponse[];
 }
 
 export interface Support extends Entity {
@@ -115,7 +115,7 @@ export interface Support extends Entity {
   origin_samples: Sample[];
   files: UnprocessedFile[];
   contributors: ContributorAPIResponse[];
-  contacts?: ContributorAPIResponse[];
+  contacts?: ContactAPIResponse[];
   published_timestamp: number;
   assay_modality: 'single' | 'multiple';
   created_timestamp: number;

--- a/context/app/static/js/pages/Collection/Collection.jsx
+++ b/context/app/static/js/pages/Collection/Collection.jsx
@@ -19,6 +19,7 @@ function Collection({ collection: collectionData }) {
     last_modified_timestamp,
     datasets,
     creators,
+    contacts,
   } = collectionData;
 
   const doi = new URL(doi_url).pathname.slice(1);
@@ -50,7 +51,9 @@ function Collection({ collection: collectionData }) {
             )}
           </Summary>
           {'datasets' in collectionData && <CollectionDatasetsTable datasets={datasets} />}
-          {'creators' in collectionData && <ContributorsTable contributors={creators} title="Contributors" />}
+          {'creators' in collectionData && (
+            <ContributorsTable contributors={creators} contacts={contacts} title="Contributors" />
+          )}
         </>
       )}
     </div>

--- a/context/app/static/js/pages/Dataset/Dataset.tsx
+++ b/context/app/static/js/pages/Dataset/Dataset.tsx
@@ -162,6 +162,7 @@ function SupportDetail({ assayMetadata }: EntityDetailProps<Support>) {
     mapped_data_access_level,
     mapped_external_group_name,
     contributors,
+    contacts,
     is_component,
     assay_modality,
   } = assayMetadata;
@@ -233,7 +234,7 @@ function SupportDetail({ assayMetadata }: EntityDetailProps<Support>) {
         {shouldDisplaySection.files && <Files files={files} />}
         {shouldDisplaySection.bulkDataTransfer && <BulkDataTransfer />}
         {shouldDisplaySection.contributors && (
-          <ContributorsTable contributors={contributors} title="Contributors" showInfoAlert />
+          <ContributorsTable contributors={contributors} contacts={contacts} title="Contributors" showInfoAlert />
         )}
 
         <Attribution />
@@ -262,6 +263,7 @@ function DatasetDetail({ assayMetadata, vitData, hasNotebook }: EntityDetailProp
     registered_doi,
     doi_url,
     contributors,
+    contacts,
     is_component,
     assay_modality,
   } = assayMetadata;
@@ -359,7 +361,7 @@ function DatasetDetail({ assayMetadata, vitData, hasNotebook }: EntityDetailProp
         {shouldDisplaySection.bulkDataTransfer && <BulkDataTransfer />}
         {shouldDisplaySection.collections && <CollectionsSection collectionsData={collectionsData} />}
         {shouldDisplaySection.contributors && (
-          <ContributorsTable contributors={contributors} title="Contributors" showInfoAlert />
+          <ContributorsTable contributors={contributors} contacts={contacts} title="Contributors" showInfoAlert />
         )}
         <Attribution />
       </DetailLayout>

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -25,7 +25,7 @@ function Publication({ publication, vignette_json }) {
     sub_status,
     doi_url,
     contributors = [],
-    contacts = [],
+    contacts,
     ancestor_ids,
     publication_venue,
     files,

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -25,6 +25,7 @@ function Publication({ publication, vignette_json }) {
     sub_status,
     doi_url,
     contributors = [],
+    contacts = [],
     ancestor_ids,
     publication_venue,
     files,
@@ -85,7 +86,7 @@ function Publication({ publication, vignette_json }) {
         )}
         {shouldDisplaySection.files && <Files files={files} uuid={uuid} hubmap_id={hubmap_id} />}
         {shouldDisplaySection.bulkDataTransfer && <BulkDataTransfer files={files} uuid={uuid} hubmap_id={hubmap_id} />}
-        <ContributorsTable contributors={contributors} title="Authors" />
+        <ContributorsTable contributors={contributors} contacts={contacts} title="Authors" />
         {shouldDisplaySection.provenance && (
           <ProvSection
             uuid={uuid}


### PR DESCRIPTION
## Summary

Updates the Contributors table in Dataset, Collection, and Publication detail pages to include contact information from `contacts` array present in v1 of the Contributors schema. (v2 added an `is_contact` boolean to objects in the `contributors`/`creators` array). This update accounts for both versions.  

## Design Documentation/Original Tickets

[CAT-815 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-815?atlOrigin=eyJpIjoiOWNiZjQ0MDUyMGNiNDI2Njk3MjJkOTBkMTJlOGY3NWUiLCJwIjoiaiJ9)
[CAT-816 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-816?atlOrigin=eyJpIjoiZDcwMDdhMTNlZGQ0NGY2OWE2M2ZhOTViODc1YjFhMGUiLCJwIjoiaiJ9) (resolved in this update)

## Testing

Manually tested by checking that impacted detail pages list any contacts that exist in their JSON format in the Contributors table. v1 does not include the `is_contact` field, v2 does.

Example of v1 dataset page: http://localhost:5001/browse/dataset/9f37a9b1f6073e6e588ff7e0dd9493b5#contributors
Example of v2 dataset page: http://localhost:5001/browse/dataset/77c4620cac87b7b943402744899270b8#contributors

Example of v1 collection page: http://localhost:5001/browse/collection/3ae4ddfc175d768af5526a010bfe95aa 
Example of v2 collection page: http://localhost:5001/browse/collection/4b87c7596e1f4b4443612862fc562ff1

Example of v1 publication page: not found
Example of v2 publication page: https://portal.hubmapconsortium.org/browse/publication/72cbeb8ff605fd5017cb2666cd19dfb7

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Some minor modifications to the `Dataset` and `Collection` interfaces were made to account for the `creators` field.
