### PR TITLE
Fixed overflow into main page upon view expansion or dragging

### DIFF
--- a/CHANGELOG-fix-viz-view-expansion.md
+++ b/CHANGELOG-fix-viz-view-expansion.md
@@ -1,0 +1,1 @@
+- Fixed view expansion in the visualization section to overflow within the container and not outside it.

--- a/context/app/static/js/components/detailPage/visualization/Visualization/style.ts
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/style.ts
@@ -42,7 +42,7 @@ const ExpandableDiv = styled('div')<ExpandableDivProps>(({ $isExpanded, theme, $
   height: $isExpanded ? `calc(100vh - ${totalHeightOffset}px)` : `${vitessceFixedHeight}px`,
   backgroundColor: $theme === 'dark' ? '#333333' : theme.palette.white.main,
   width: '100%',
-  overflow: 'visible',
+  overflow: 'scroll',
   '.vitessce-container': {
     display: 'block',
     height: $isExpanded ? `calc(100vh - ${totalHeightOffset}px)` : 'auto',


### PR DESCRIPTION
## Summary

The views in the visualization panel would overflow to the main page when dragged or expanded. This PR avoids that behavior and adds scrolling to the visualization panel when expanded.

## Design Documentation/Original Tickets
[CAT-818](https://hms-dbmi.atlassian.net/browse/CAT-818)

## Testing

Manually tested by dragging and expanding the views.

## Screenshots/Video



## Checklist

- [ ] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.


[CAT-818]: https://hms-dbmi.atlassian.net/browse/CAT-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ