### PR TITLE
Austenem/CAT-824 fix spacing

### DIFF
--- a/CHANGELOG-fix-banner-spacing.md
+++ b/CHANGELOG-fix-banner-spacing.md
@@ -1,0 +1,1 @@
+Fix spacing issue for alert banners that show in datasets section of the "Create New Workspace" dialog.

--- a/CHANGELOG-fix-banner-spacing.md
+++ b/CHANGELOG-fix-banner-spacing.md
@@ -1,1 +1,1 @@
-Fix spacing issue for alert banners that show in datasets section of the "Create New Workspace" dialog.
+- Fix spacing issue for alert banners that show in datasets section of the "Create New Workspace" dialog.

--- a/context/app/static/js/shared-styles/alerts/ErrorOrWarningMessages/ErrorOrWarningMessages.tsx
+++ b/context/app/static/js/shared-styles/alerts/ErrorOrWarningMessages/ErrorOrWarningMessages.tsx
@@ -28,7 +28,7 @@ function ErrorOrWarningMessages({ errorMessages = [], warningMessages = [] }: Er
         };
 
   return (
-    <Stack spacing={3}>
+    <Stack spacing={2} marginBottom={2}>
       {content.messages.map((message) => {
         return (
           <Alert key={message} severity={content.severity}>


### PR DESCRIPTION
## Summary

Fixes margin issue for alert banners in the datasets section of the "Create New Workspace" dialog.

## Design Documentation/Original Tickets

[CAT-824 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-824?atlOrigin=eyJpIjoiZTZlOGIxMjkxOWNkNDE0Zjg5YmQ4ZTExZWQxNzI2NWIiLCJwIjoiaiJ9)

## Testing

Manually tested by visually inspecting workspace dialogs that have none, one, or two alert banners.

## Screenshots/Video

**Previous issue:**

<img width="800" alt="Screenshot 2024-08-08 at 10 14 19 AM" src="https://github.com/user-attachments/assets/61b6cf8a-c9c4-433d-bc73-5cd3dc99cf87">

**Updated banners:**

<img width="800" alt="Screenshot 2024-08-12 at 11 57 55 AM" src="https://github.com/user-attachments/assets/d7e7b484-4cb6-4782-b7f0-f8567d92e363">
<img width="800" alt="Screenshot 2024-08-12 at 11 57 39 AM" src="https://github.com/user-attachments/assets/bde15661-bae3-4242-9e9d-935b4b1032e6">

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
