### PR TITLE
Austenem/CAT-766 disable launch button

### DIFF
--- a/CHANGELOG-disable-launch-button.md
+++ b/CHANGELOG-disable-launch-button.md
@@ -1,0 +1,1 @@
+- Disable "Launch Workspace" button when a workspace title is not provided.

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -50,7 +50,7 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate }: UseCreateWorks
       templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
       workspaceJobTypeId: DEFAULT_JOB_TYPE,
     },
-    mode: 'all',
+    mode: 'onChange',
     resolver: zodResolver(schema),
   });
 

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -42,6 +42,7 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate }: UseCreateWorks
     control,
     reset,
     formState: { errors, isSubmitting, isSubmitSuccessful },
+    trigger,
   } = useForm({
     defaultValues: {
       'workspace-name': defaultName ?? '',
@@ -64,6 +65,14 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate }: UseCreateWorks
     reset();
     handleClose();
   }
+
+  useEffect(() => {
+    if (dialogIsOpen) {
+      trigger('workspace-name').catch((e) => {
+        console.error(e);
+      });
+    }
+  }, [dialogIsOpen, trigger]);
 
   return {
     dialogIsOpen,

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -49,7 +49,7 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate }: UseCreateWorks
       templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
       workspaceJobTypeId: DEFAULT_JOB_TYPE,
     },
-    mode: 'onChange',
+    mode: 'all',
     resolver: zodResolver(schema),
   });
 


### PR DESCRIPTION
## Summary

This update disables the "Launch Workspace" button and shows an alert if a workspace title is not given in the "Create New Workspace" dialog. 

## Design Documentation/Original Tickets

[CAT-766 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-766?atlOrigin=eyJpIjoiNzAyODkwMDFmZjk5NDlkOGEzMzk3OTMxMGJiNDVkNGMiLCJwIjoiaiJ9)

## Testing

Manually tested by checking that the alert appears in the "Create New Workspace" dialog, shows appropriately during dialog interactions depending on whether a title has been provided, and persists if the dialog is closed and reopened.

## Screenshots/Video

<img width="900" alt="Screenshot 2024-08-12 at 4 54 03 PM" src="https://github.com/user-attachments/assets/a3445748-d88e-4070-9aa3-cdec4a6a0349">

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
