### PR TITLE
Austenem/CAT-821 disable job dialog

### DIFF
--- a/CHANGELOG-disable-job-dialog.md
+++ b/CHANGELOG-disable-job-dialog.md
@@ -1,0 +1,1 @@
+- Prevent already running workspaces from prompting the user to choose a job type.

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
@@ -41,6 +41,7 @@ function LaunchWorkspaceDialog() {
     },
     [submit, handleClose, toastError],
   );
+
   return (
     <DialogModal
       title={`Launch ${workspaceName}`}
@@ -76,7 +77,7 @@ function LaunchWorkspaceDialog() {
           </Stack>
         </form>
       }
-      isOpen={isOpen}
+      isOpen={isOpen && !runningWorkspaceIsCurrentWorkpace}
       handleClose={handleClose}
       actions={
         <Stack direction="row" spacing={2} alignItems="end">

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
@@ -77,7 +77,7 @@ function LaunchWorkspaceDialog() {
           </Stack>
         </form>
       }
-      isOpen={isOpen && !runningWorkspaceIsCurrentWorkpace}
+      isOpen={isOpen}
       handleClose={handleClose}
       actions={
         <Stack direction="row" spacing={2} alignItems="end">

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
@@ -41,7 +41,6 @@ function LaunchWorkspaceDialog() {
     },
     [submit, handleClose, toastError],
   );
-
   return (
     <DialogModal
       title={`Launch ${workspaceName}`}

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/hooks.ts
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/hooks.ts
@@ -8,6 +8,7 @@ import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import { workspaceJobTypeIdField } from '../workspaceFormFields';
 import { useLaunchWorkspace, useRunningWorkspace, useWorkspacesList } from '../hooks';
 import { DEFAULT_JOB_TYPE } from '../constants';
+import { MergedWorkspace } from '../types';
 
 export interface LaunchWorkspaceFormTypes {
   workspaceJobTypeId: string;
@@ -51,7 +52,8 @@ function useLaunchWorkspaceDialog() {
 
   const { handleStopWorkspace } = useWorkspacesList();
   const { startAndOpenWorkspace } = useLaunchWorkspace();
-  const { isOpen, close, workspace } = useLaunchWorkspaceStore();
+  const { isOpen, open, close, workspace, setWorkspace } = useLaunchWorkspaceStore();
+
   const runningWorkspaceIsCurrentWorkpace = runningWorkspace?.id === workspace?.id;
 
   const { toastError } = useSnackbarActions();
@@ -111,6 +113,22 @@ function useLaunchWorkspaceDialog() {
     ],
   );
 
+  const handleLaunch = useCallback(
+    (currentWorkspace: MergedWorkspace) => {
+      setWorkspace(currentWorkspace);
+
+      if (currentWorkspace.jobs.length > 0) {
+        submit({ workspaceJobTypeId: currentWorkspace.jobs[0].job_type }).catch((e) => {
+          toastError('Failed to launch workspace. Please try again.');
+          console.error(e);
+        });
+      } else {
+        open();
+      }
+    },
+    [submit, toastError, setWorkspace, open],
+  );
+
   return {
     isRunningWorkspace,
     runningWorkspaceName: runningWorkspaceName.current,
@@ -125,6 +143,7 @@ function useLaunchWorkspaceDialog() {
     handleSubmit,
     isSubmitting,
     handleClose,
+    handleLaunch,
   };
 }
 

--- a/context/app/static/js/components/workspaces/WorkspaceLaunchStopButtons/WorkspaceLaunchStopButtons.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceLaunchStopButtons/WorkspaceLaunchStopButtons.tsx
@@ -91,7 +91,7 @@ function StopWorkspaceAlert() {
 
 function WorkspaceLaunchStopButtons(props: WorkspaceButtonProps) {
   const { workspace, button: ButtonComponent, showLaunch = false, showStop = false } = props;
-  const { handleLaunch } = useLaunchWorkspaceDialog();
+  const { launchOrOpenDialog } = useLaunchWorkspaceDialog();
 
   if (workspace.status === 'deleting') {
     return (
@@ -105,7 +105,7 @@ function WorkspaceLaunchStopButtons(props: WorkspaceButtonProps) {
     <Stack direction="row" spacing={2}>
       {showStop && <StopWorkspaceButton {...props} />}
       {showLaunch && (
-        <Button type="button" variant="contained" color="primary" onClick={() => handleLaunch(workspace)}>
+        <Button type="button" variant="contained" color="primary" onClick={() => launchOrOpenDialog(workspace)}>
           Launch Workspace
         </Button>
       )}

--- a/context/app/static/js/components/workspaces/WorkspaceLaunchStopButtons/WorkspaceLaunchStopButtons.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceLaunchStopButtons/WorkspaceLaunchStopButtons.tsx
@@ -109,7 +109,9 @@ function WorkspaceLaunchStopButtons(props: WorkspaceButtonProps) {
           color="primary"
           onClick={() => {
             setWorkspace(workspace);
-            open();
+            if (workspace.jobs.length === 0) {
+              open();
+            }
           }}
         >
           Launch Workspace

--- a/context/app/static/js/components/workspaces/WorkspaceLaunchStopButtons/WorkspaceLaunchStopButtons.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceLaunchStopButtons/WorkspaceLaunchStopButtons.tsx
@@ -5,11 +5,11 @@ import Typography from '@mui/material/Typography';
 
 import { useWorkspacesList } from 'js/components/workspaces/hooks';
 import { isRunningWorkspace, findRunningWorkspace } from 'js/components/workspaces/utils';
-import { useLaunchWorkspaceStore } from 'js/stores/useWorkspaceModalStore';
 import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import { Alert } from 'js/shared-styles/alerts';
 import { isWorkspaceAtDatasetLimit } from 'js/helpers/functions';
 import { MergedWorkspace } from '../types';
+import { useLaunchWorkspaceDialog } from '../LaunchWorkspaceDialog/hooks';
 
 interface WorkspaceButtonProps {
   workspace: MergedWorkspace;
@@ -91,7 +91,8 @@ function StopWorkspaceAlert() {
 
 function WorkspaceLaunchStopButtons(props: WorkspaceButtonProps) {
   const { workspace, button: ButtonComponent, showLaunch = false, showStop = false } = props;
-  const { open, setWorkspace } = useLaunchWorkspaceStore();
+  const { handleLaunch } = useLaunchWorkspaceDialog();
+
   if (workspace.status === 'deleting') {
     return (
       <ButtonComponent type="button" disabled size="small">
@@ -99,21 +100,12 @@ function WorkspaceLaunchStopButtons(props: WorkspaceButtonProps) {
       </ButtonComponent>
     );
   }
+
   return (
     <Stack direction="row" spacing={2}>
       {showStop && <StopWorkspaceButton {...props} />}
       {showLaunch && (
-        <Button
-          type="button"
-          variant="contained"
-          color="primary"
-          onClick={() => {
-            setWorkspace(workspace);
-            if (workspace.jobs.length === 0) {
-              open();
-            }
-          }}
-        >
+        <Button type="button" variant="contained" color="primary" onClick={() => handleLaunch(workspace)}>
           Launch Workspace
         </Button>
       )}

--- a/context/app/static/js/components/workspaces/utils.ts
+++ b/context/app/static/js/components/workspaces/utils.ts
@@ -193,6 +193,16 @@ function findBestJob(jobs: WorkspaceJob[]) {
 }
 
 /**
+ * Return the type of the job with the highest status.
+ * @param jobs A list of jobs to extract the best job type from.
+ * @returns The type of the job with the highest status.
+ */
+function findBestJobType(jobs: WorkspaceJob[]) {
+  const bestJob = findBestJob(jobs);
+  return bestJob?.job_type ?? DEFAULT_JOB_TYPE;
+}
+
+/**
  * Finds the job with the highest status and returns a digest.
  * @param jobs A list of jobs to extract the best job from.
  * @returns A digest of the best job to use for a workspace which includes the status, whether a new job can be created, and the URL and message if the job is active/activating
@@ -325,6 +335,7 @@ function sortTemplates(templates: TemplatesTypes, disabledTemplates?: TemplatesT
 export {
   mergeJobsIntoWorkspaces,
   findBestJob,
+  findBestJobType,
   condenseJobs,
   locationIfJobRunning,
   getWorkspaceFileName,

--- a/context/app/static/js/components/workspaces/utils.ts
+++ b/context/app/static/js/components/workspaces/utils.ts
@@ -195,7 +195,7 @@ function findBestJob(jobs: WorkspaceJob[]) {
 /**
  * Return the type of the job with the highest status.
  * @param jobs A list of jobs to extract the best job type from.
- * @returns The type of the job with the highest status.
+ * @returns The type of the job with the highest status if it exists, else the default job type.
  */
 function findBestJobType(jobs: WorkspaceJob[]) {
   const bestJob = findBestJob(jobs);


### PR DESCRIPTION
## Summary

This update prevents already running workspaces from prompting the user to choose a job type.

## Design Documentation/Original Tickets

[CAT-821 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-821?atlOrigin=eyJpIjoiNWIzNzU5OGMxYmJlNGI5Nzg5MmY4Y2Y4YWZkM2E1NjkiLCJwIjoiaiJ9)

## Testing

Manually tested by attempting to launch, relaunch, and stop workspaces from various points of entry.

## Screenshots/Video

https://github.com/user-attachments/assets/204a440b-ffee-42e5-a6c0-0aa5e583686b

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
