### PR TITLE
Austenem/CAT-820 update homepage news

### DIFF
--- a/CHANGELOG-update-homepage-news.md
+++ b/CHANGELOG-update-homepage-news.md
@@ -1,0 +1,1 @@
+- Update "What's New?" homepage listing with June 2024 user facing updates.

--- a/context/app/static/js/components/home/Hero/const.tsx
+++ b/context/app/static/js/components/home/Hero/const.tsx
@@ -1,5 +1,5 @@
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
-import { SearchIcon } from 'js/shared-styles/icons';
+import { SearchIcon, DonorIcon } from 'js/shared-styles/icons';
 import { TimelineData } from 'js/shared-styles/Timeline/types';
 import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
 import React from 'react';
@@ -10,6 +10,21 @@ const timelineIconProps = {
 } as const;
 
 export const HOME_TIMELINE_ITEMS: TimelineData[] = [
+  {
+    title: 'Profile Page Now Available',
+    titleHref: '/profile',
+    description:
+      'Profile pages are now available to allow logged in users to view their profile information including permission groups, saved lists and saved workspaces.',
+    date: 'June 2024',
+    img: <DonorIcon {...timelineIconProps} />,
+  },
+  {
+    title: 'Homepage Redesign Updated',
+    titleHref: '/',
+    description: 'Homepage design updated to highlight portal features and improve navigation to essential locations.',
+    date: 'June 2024',
+    img: <entityIconMap.CellType {...timelineIconProps} />,
+  },
   {
     title: 'Molecular & Cellular Query Updated',
     titleHref: '/cells',

--- a/context/app/static/js/components/home/Hero/const.tsx
+++ b/context/app/static/js/components/home/Hero/const.tsx
@@ -1,12 +1,15 @@
+import React from 'react';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import { SearchIcon, DonorIcon } from 'js/shared-styles/icons';
 import { TimelineData } from 'js/shared-styles/Timeline/types';
 import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
-import React from 'react';
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+import ExternalImageIcon from 'js/shared-styles/icons/ExternalImageIcon';
 
 const timelineIconProps = {
   fontSize: '1.5rem',
+  height: '1.5rem',
+  width: '1.5rem',
 } as const;
 
 export const HOME_TIMELINE_ITEMS: TimelineData[] = [
@@ -23,7 +26,7 @@ export const HOME_TIMELINE_ITEMS: TimelineData[] = [
     titleHref: '/',
     description: 'Homepage design updated to highlight portal features and improve navigation to essential locations.',
     date: 'June 2024',
-    img: <entityIconMap.CellType {...timelineIconProps} />,
+    img: <ExternalImageIcon icon="dataPortal" style={timelineIconProps} />,
   },
   {
     title: 'Molecular & Cellular Query Updated',

--- a/context/app/static/js/shared-styles/icons/ExternalImageIcon.tsx
+++ b/context/app/static/js/shared-styles/icons/ExternalImageIcon.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+import { CSSProperties } from 'styled-components';
 import * as externalIcons from './externalImageIcons';
 
 interface ExternalImageIconProps {
   icon: keyof typeof externalIcons;
+  style?: CSSProperties;
 }
 
-export default function ExternalImageIcon({ icon }: ExternalImageIconProps) {
+export default function ExternalImageIcon({ icon, style }: ExternalImageIconProps) {
   const { src, alt } = externalIcons[icon];
-  return <img src={src} alt={alt} />;
+  return <img src={src} alt={alt} style={style} />;
 }


### PR DESCRIPTION
## Summary

Update "What's New?" homepage listing with June 2024 user-facing updates.

## Design Documentation/Original Tickets

[CAT-820 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-820?atlOrigin=eyJpIjoiM2RjYTg4N2FhNmRhNDExOTgwZWY3YzMyOWJlM2Y5YjQiLCJwIjoiaiJ9)

[Homepage Latest Changes Entries](https://hms-dbmi.atlassian.net/wiki/x/AYDO0g)

## Testing

Visually compared homepage to listing.

## Screenshots/Video

<img width="1289" alt="Screenshot 2024-08-14 at 2 59 38 PM" src="https://github.com/user-attachments/assets/36ce10e9-0526-4aa4-9b21-841d1f52b424">

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

