### PR TITLE
Austenem/CAT-841 fix notebook download

### DIFF
--- a/CHANGELOG-fix-notebook-download.md
+++ b/CHANGELOG-fix-notebook-download.md
@@ -1,0 +1,1 @@
+- Fix bug preventing visualization notebooks from being downloaded on dataset detail pages.

--- a/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/VisualizationNotebookButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/VisualizationNotebookButton.tsx
@@ -52,7 +52,7 @@ function VisualizationNotebookButton({ uuid, hubmap_id, mapped_data_access_level
     },
     {
       children: 'Download Jupyter Notebook',
-      onClick: downloadNotebook,
+      onClick: downloadNotebook(),
       icon: Download,
     },
   ];

--- a/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/VisualizationNotebookButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/VisualizationNotebookButton.tsx
@@ -30,17 +30,15 @@ function VisualizationNotebookButton({ uuid, hubmap_id, mapped_data_access_level
   });
 
   const downloadNotebook = useCallback(() => {
-    return () => {
-      trackEntityPageEvent({ action: `Vitessce / ${tooltip}` });
-      postAndDownloadFile({
-        url: `/notebooks/entities/dataset/${uuid}.ws.ipynb`,
-        body: {},
-      })
-        .then()
-        .catch(() => {
-          toastError('Failed to download Jupyter Notebook');
-        });
-    };
+    trackEntityPageEvent({ action: `Vitessce / ${tooltip}` });
+    postAndDownloadFile({
+      url: `/notebooks/entities/dataset/${uuid}.ws.ipynb`,
+      body: {},
+    })
+      .then()
+      .catch(() => {
+        toastError('Failed to download Jupyter Notebook');
+      });
   }, [uuid, toastError, trackEntityPageEvent]);
 
   const options = [
@@ -52,7 +50,7 @@ function VisualizationNotebookButton({ uuid, hubmap_id, mapped_data_access_level
     },
     {
       children: 'Download Jupyter Notebook',
-      onClick: downloadNotebook(),
+      onClick: downloadNotebook,
       icon: Download,
     },
   ];


### PR DESCRIPTION
## Summary

Tiny fix for bug preventing visualization notebooks from being downloaded on dataset detail pages.

## Design Documentation/Original Tickets

[CAT-841 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-841?atlOrigin=eyJpIjoiMzFmNTA0YmU4NzBkNDk1M2I5MjVlYzg5MzNhZGJlOTIiLCJwIjoiaiJ9)

## Testing

Manually tested and was able to download several notebooks successfully.

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

