### PR TITLE
Austenem/CAT-840 fix protected dataset ids

### DIFF
--- a/CHANGELOG-fix-protected-dataset-ids.md
+++ b/CHANGELOG-fix-protected-dataset-ids.md
@@ -1,0 +1,1 @@
+- Fix bug that prevented protected dataset ids from being displayed in "Launch New Workspace" dialog.

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -16,7 +16,7 @@ function NewWorkspaceDialogFromSelections() {
   const { deselectRows } = useSelectableTableStore();
 
   const { control, errors, setDialogIsOpen, ...rest } = useCreateWorkspaceForm({
-    defaultProtectedDatasets: protectedHubmapIds,
+    initialProtectedDatasets: protectedHubmapIds,
   });
 
   return (

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -11,10 +11,13 @@ import { useCreateWorkspaceDatasets, useCreateWorkspaceForm } from './useCreateW
 import RemoveProtectedDatasetsFormField from '../RemoveProtectedDatasetsFormField';
 
 function NewWorkspaceDialogFromSelections() {
-  const { errorMessages, warningMessages, selectedRows, ...restWorkspaceDatasets } = useCreateWorkspaceDatasets();
+  const { errorMessages, warningMessages, selectedRows, protectedHubmapIds, ...restWorkspaceDatasets } =
+    useCreateWorkspaceDatasets();
   const { deselectRows } = useSelectableTableStore();
 
-  const { control, errors, setDialogIsOpen, ...rest } = useCreateWorkspaceForm({});
+  const { control, errors, setDialogIsOpen, ...rest } = useCreateWorkspaceForm({
+    defaultProtectedDatasets: protectedHubmapIds,
+  });
 
   return (
     <>
@@ -32,7 +35,11 @@ function NewWorkspaceDialogFromSelections() {
       >
         <Box>
           <ErrorOrWarningMessages errorMessages={errorMessages} warningMessages={warningMessages} />
-          <RemoveProtectedDatasetsFormField control={control} {...restWorkspaceDatasets} />
+          <RemoveProtectedDatasetsFormField
+            control={control}
+            protectedHubmapIds={protectedHubmapIds}
+            {...restWorkspaceDatasets}
+          />
         </Box>
       </NewWorkspaceDialog>
     </>

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -26,7 +26,7 @@ interface CreateWorkspaceFormTypes extends FormWithTemplates {
 interface UseCreateWorkspaceTypes {
   defaultName?: string;
   defaultTemplate?: string;
-  defaultProtectedDatasets?: string;
+  initialProtectedDatasets?: string;
 }
 
 const schema = z
@@ -34,9 +34,13 @@ const schema = z
   .partial()
   .required({ 'workspace-name': true, templates: true });
 
-function useCreateWorkspaceForm({ defaultName, defaultTemplate, defaultProtectedDatasets }: UseCreateWorkspaceTypes) {
+function useCreateWorkspaceForm({ defaultName, defaultTemplate, initialProtectedDatasets }: UseCreateWorkspaceTypes) {
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
   const createTemplateNotebooks = useTemplateNotebooks();
+
+  const checkedWorkspaceName = defaultName ?? '';
+  const checkedProtectedDatasets = initialProtectedDatasets ?? '';
+  const checkedTemplates = [defaultTemplate ?? DEFAULT_TEMPLATE_KEY];
 
   const {
     handleSubmit,
@@ -46,9 +50,9 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate, defaultProtected
     trigger,
   } = useForm({
     defaultValues: {
-      'workspace-name': defaultName ?? '',
-      'protected-datasets': defaultProtectedDatasets ?? '',
-      templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
+      'workspace-name': checkedWorkspaceName,
+      'protected-datasets': checkedProtectedDatasets,
+      templates: checkedTemplates,
       workspaceJobTypeId: DEFAULT_JOB_TYPE,
     },
     mode: 'onChange',
@@ -68,15 +72,16 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate, defaultProtected
   }
 
   useEffect(() => {
-    if (defaultProtectedDatasets && defaultProtectedDatasets !== '') {
+    if (initialProtectedDatasets && initialProtectedDatasets !== '') {
       reset({
-        'workspace-name': defaultName ?? '',
-        'protected-datasets': defaultProtectedDatasets ?? '',
-        templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
+        'workspace-name': checkedWorkspaceName,
+        'protected-datasets': checkedProtectedDatasets,
+        templates: checkedTemplates,
         workspaceJobTypeId: DEFAULT_JOB_TYPE,
       });
     }
-  }, [defaultProtectedDatasets, reset, defaultName, defaultTemplate]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialProtectedDatasets, reset]);
 
   useEffect(() => {
     if (dialogIsOpen) {

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -40,7 +40,6 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate, initialProtected
 
   const checkedWorkspaceName = defaultName ?? '';
   const checkedProtectedDatasets = initialProtectedDatasets ?? '';
-  const checkedTemplates = [defaultTemplate ?? DEFAULT_TEMPLATE_KEY];
 
   const {
     handleSubmit,
@@ -52,7 +51,7 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate, initialProtected
     defaultValues: {
       'workspace-name': checkedWorkspaceName,
       'protected-datasets': checkedProtectedDatasets,
-      templates: checkedTemplates,
+      templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
       workspaceJobTypeId: DEFAULT_JOB_TYPE,
     },
     mode: 'onChange',
@@ -76,12 +75,11 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate, initialProtected
       reset({
         'workspace-name': checkedWorkspaceName,
         'protected-datasets': checkedProtectedDatasets,
-        templates: checkedTemplates,
+        templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
         workspaceJobTypeId: DEFAULT_JOB_TYPE,
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialProtectedDatasets, reset]);
+  }, [initialProtectedDatasets, reset, checkedWorkspaceName, checkedProtectedDatasets, defaultTemplate]);
 
   useEffect(() => {
     if (dialogIsOpen) {

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -26,6 +26,7 @@ interface CreateWorkspaceFormTypes extends FormWithTemplates {
 interface UseCreateWorkspaceTypes {
   defaultName?: string;
   defaultTemplate?: string;
+  defaultProtectedDatasets?: string;
 }
 
 const schema = z
@@ -33,7 +34,7 @@ const schema = z
   .partial()
   .required({ 'workspace-name': true, templates: true });
 
-function useCreateWorkspaceForm({ defaultName, defaultTemplate }: UseCreateWorkspaceTypes) {
+function useCreateWorkspaceForm({ defaultName, defaultTemplate, defaultProtectedDatasets }: UseCreateWorkspaceTypes) {
   const [dialogIsOpen, setDialogIsOpen] = useState(false);
   const createTemplateNotebooks = useTemplateNotebooks();
 
@@ -46,7 +47,7 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate }: UseCreateWorks
   } = useForm({
     defaultValues: {
       'workspace-name': defaultName ?? '',
-      'protected-datasets': '',
+      'protected-datasets': defaultProtectedDatasets ?? '',
       templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
       workspaceJobTypeId: DEFAULT_JOB_TYPE,
     },
@@ -65,6 +66,17 @@ function useCreateWorkspaceForm({ defaultName, defaultTemplate }: UseCreateWorks
     reset();
     handleClose();
   }
+
+  useEffect(() => {
+    if (defaultProtectedDatasets && defaultProtectedDatasets !== '') {
+      reset({
+        'workspace-name': defaultName ?? '',
+        'protected-datasets': defaultProtectedDatasets ?? '',
+        templates: [defaultTemplate ?? DEFAULT_TEMPLATE_KEY],
+        workspaceJobTypeId: DEFAULT_JOB_TYPE,
+      });
+    }
+  }, [defaultProtectedDatasets, reset, defaultName, defaultTemplate]);
 
   useEffect(() => {
     if (dialogIsOpen) {

--- a/context/app/static/js/components/workspaces/WorkspaceField/WorkspaceField.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceField/WorkspaceField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { FieldValues, Path, PathValue, useController, UseControllerProps } from 'react-hook-form';
 import Box from '@mui/material/Box';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
@@ -23,6 +23,12 @@ function WorkspaceField<FormType extends FieldValues>({
     rules: { required: true },
     defaultValue: value,
   });
+
+  useEffect(() => {
+    if (value) {
+      field.onChange(value);
+    }
+  }, [value, field]);
 
   return (
     <Box display="flex" alignItems="center">

--- a/context/app/static/js/components/workspaces/WorkspaceField/WorkspaceField.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceField/WorkspaceField.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { FieldValues, Path, PathValue, useController, UseControllerProps } from 'react-hook-form';
 import Box from '@mui/material/Box';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
@@ -23,12 +23,6 @@ function WorkspaceField<FormType extends FieldValues>({
     rules: { required: true },
     defaultValue: value,
   });
-
-  useEffect(() => {
-    if (value) {
-      field.onChange(value);
-    }
-  }, [value, field]);
 
   return (
     <Box display="flex" alignItems="center">


### PR DESCRIPTION
## Summary

Fix bug that prevented protected dataset ids from being displayed in "Launch New Workspace" dialog.

## Design Documentation/Original Tickets

[CAT-840 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-840?atlOrigin=eyJpIjoiMDI3Mzg2MWMxNTBjNGRiZmI5MTkxNjZiMTRhYzVhYjciLCJwIjoiaiJ9)

## Testing

Tested by checking that the IDs only appear when one or more protected datasets are selected, that the datasets can be deleted via the provided method, and that the other Workspace field components work as expected (namely the "Workspace Name" field).

## Screenshots/Video

Update:
<img width="800" alt="Screenshot 2024-08-16 at 3 11 06 PM" src="https://github.com/user-attachments/assets/8c21ce38-9fe6-40ca-8786-f5daa7f6dd5c">

Previous bug:
<img width="800" alt="Screenshot 2024-08-16 at 3 24 18 PM" src="https://github.com/user-attachments/assets/20a8d895-a09b-4c4f-b99f-7860973bf189">

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

This may not be the most elegant solution to this issue of updating the IDs after the initial render - if there's another recommended method, I'd be open to it. 
