### PR TITLE
NickAkhmetov/CAT-842 Update push script to handle major version bumps

### DIFF
--- a/CHANGELOG-push-script-cat-842.md
+++ b/CHANGELOG-push-script-cat-842.md
@@ -1,0 +1,1 @@
+- Extended push script to support major version bumps.


### PR DESCRIPTION
## Summary

This PR updates the `push.sh` script to allow making major version bumps.

Major version bumps are opted into by including a second param while calling the script (e.g. `./etc/build/push.sh major`). Otherwise, the previous behavior is used.

In order to account for the major version no longer being a constant 0, I had to adjust the logic for whether a patch or minor version release is made. Rather than calculating the new version tag based on a starting date in 2021, the updated logic compares the date of the last minor or major version to the current date to determine whether to make a minor or patch version bump.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-842

## Testing

Manually tested by adding a `die` statement after the version tag was printed and attempting both major and minor version bumps.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/b881bf77-59cb-49a9-a836-78407fab66be)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
