### PR TITLE
NickAkhmetov/CAT-836 Fix multi-assay provenance overflow 

### DIFF
--- a/CHANGELOG-fix-prov-overflow.md
+++ b/CHANGELOG-fix-prov-overflow.md
@@ -1,0 +1,1 @@
+- Fix multi-assay provenance overflow.

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayProvenance/MultiAssayProvenance.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayProvenance/MultiAssayProvenance.tsx
@@ -25,7 +25,7 @@ function MultiTileStack({ datasets, title }: { datasets: MultiAssayEntity[]; tit
         <Icon component={entityIconMap.Dataset} color="primary" fontSize="inherit" sx={{ fontSize: '1.5rem' }} />
         <Typography variant="h5">{title}</Typography>
       </Stack>
-      <Stack direction="row" justifyContent="center" spacing={1}>
+      <Stack direction="row" justifyContent="center" spacing={1} flexWrap="wrap">
         {datasets?.map(
           ({ uuid, entity_type, hubmap_id, assay_display_name, descendant_counts, last_modified_timestamp }) => (
             <EntityTile


### PR DESCRIPTION
## Summary

This PR adds flex wrapping to multi-assay provenance tile sections. This prevents overflow when there are more than three tiles.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-836

## Testing

I checked the datasets linked in the original ticket; verification screenshots are included below.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/de7212d3-7d01-4a60-8dde-796834e78394)
![image](https://github.com/user-attachments/assets/0c482adc-4222-4a32-99ec-511142d1ed6b)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
