### PR TITLE
NickAkhmetov/CAT-844 Migrate away from using `descendants` and `ancestors` in favor of `id` equivalents

### DIFF
--- a/CHANGELOG-cat-844.md
+++ b/CHANGELOG-cat-844.md
@@ -1,0 +1,1 @@
+- Deprecate `ancestors`, `descendants`, and their `immediate` variants to only look up by ID.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -139,18 +139,12 @@ def details_rui_json(type, uuid):
         abort(404)
     client = get_client()
     entity = client.get_entity(uuid)
-    # For Samples...
+    # For samples and datasets, the nearest RUI location is indexed with the entity itself.
+    # https://github.com/hubmapconsortium/search-api/pull/860
     if 'rui_location' in entity:
         return json.loads(entity['rui_location'])
-    # For Datasets...
-    if 'ancestors' not in entity:
-        abort(404)
-    located_ancestors = [a for a in entity['ancestors'] if 'rui_location' in a]
-    if not located_ancestors:
-        abort(404)
-    # There may be multiple: The last should be the closest...
-    # but this should be confirmed, when there are examples.
-    return json.loads(located_ancestors[-1]['rui_location'])
+    # Otherwise throw 404
+    abort(404)
 
 
 @blueprint.route('/sitemap.txt')

--- a/context/app/static/js/components/detailPage/provenance/ProvTableTile/ProvTableTile.tsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvTableTile/ProvTableTile.tsx
@@ -1,48 +1,29 @@
 import React, { ComponentProps } from 'react';
 
-import { useEntityData } from 'js/hooks/useEntityData';
 import EntityTile from 'js/components/entity-tile/EntityTile';
 import { getTileDescendantCounts } from 'js/components/entity-tile/EntityTile/utils';
-import { ErrorTile } from 'js/components/entity-tile/EntityTile/EntityTile';
 import ProvTableDerivedLink from '../ProvTableDerivedLink';
 import { DownIcon } from './style';
 
-interface ProvTableTileProps extends Omit<ComponentProps<typeof EntityTile>, 'entityData' | 'descendantCounts'> {
+interface ProvTableTileProps extends Omit<ComponentProps<typeof EntityTile>, 'descendantCounts'> {
   isCurrentEntity: boolean;
   isSampleSibling: boolean;
   isFirstTile: boolean;
   isLastTile: boolean;
 }
 
-const provTilesSource = [
-  'descendant_counts',
-  'mapped_data_types',
-  'last_modified_timestamp',
-  'origin_samples_unique_mapped_organs',
-  'mapped_metadata',
-  'sample_category',
-  'origin_samples_unique_mapped_organs',
-  'thumbnail_file',
-];
-
 function ProvTableTile({
   uuid,
   entity_type,
+  entityData,
   isCurrentEntity,
   isSampleSibling,
   isFirstTile,
   isLastTile,
   ...rest
 }: ProvTableTileProps) {
-  // mapped fields are not included in ancestor object, so we need to fetch them separately
-  const [entityData, isLoading] = useEntityData(uuid, provTilesSource);
   const descendantCounts = entityData?.descendant_counts?.entity_type;
   const descendantCountsToDisplay = getTileDescendantCounts(entityData, entity_type);
-
-  if (!entityData && !isLoading) {
-    // No entity data found for this tile and not loading = the entity failed to index
-    return <ErrorTile entity_type={entity_type} id={rest.id} />;
-  }
 
   return (
     <>
@@ -57,7 +38,7 @@ function ProvTableTile({
           {...rest}
         />
       )}
-      {isLastTile && entity_type !== 'Donor' && descendantCounts?.[entity_type] > 0 && (
+      {isLastTile && entity_type !== 'Donor' && (descendantCounts?.[entity_type] ?? 0) > 0 && (
         <ProvTableDerivedLink uuid={uuid} type={entity_type} />
       )}
     </>

--- a/context/app/static/js/components/detailPage/provenance/queries.ts
+++ b/context/app/static/js/components/detailPage/provenance/queries.ts
@@ -42,15 +42,6 @@ export const getAncestorsQuery = (uuid: string) => ({
             },
           },
         },
-        {
-          bool: {
-            must_not: {
-              term: {
-                'ancestors.entity_type.keyword': 'Dataset',
-              },
-            },
-          },
-        },
       ],
     },
   },

--- a/context/app/static/js/components/entity-tile/EntityTile/EntityTile.tsx
+++ b/context/app/static/js/components/entity-tile/EntityTile/EntityTile.tsx
@@ -1,6 +1,5 @@
 import React, { ComponentProps, ComponentType } from 'react';
 import Typography from '@mui/material/Typography';
-import IconButton from '@mui/material/IconButton';
 import ContentCopyIcon from '@mui/icons-material/ContentCopyRounded';
 
 import Tile from 'js/shared-styles/tiles/Tile/';
@@ -12,6 +11,7 @@ import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
 import { useHandleCopyClick } from 'js/hooks/useCopyText';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import IconLink from 'js/shared-styles/Links/iconLinks/IconLink';
 import EntityTileFooter from '../EntityTileFooter/index';
 import EntityTileBody from '../EntityTileBody/index';
 import { StyledIcon } from './style';
@@ -73,56 +73,25 @@ function ErrorTile({ entity_type, id }: Pick<EntityTileProps, 'id' | 'entity_typ
       })}
       variant="outlined"
     >
-      <Stack direction="row" gap={1} color="error.main" alignItems="center">
-        <StatusIcon status="error" sx={{ fontSize: '1.5rem' }} />
-        <Typography variant="subtitle1">{id}</Typography>
-        <IconButton onClick={() => copy(id)}>
-          <ContentCopyIcon color="info" />
-        </IconButton>
+      <Stack direction="row" gap={1}>
+        <StatusIcon status="error" sx={{ alignSelf: 'start', fontSize: '1.3rem' }} />
+        <Typography variant="body2">
+          Unable to load {entityTypeLowercase}. <ContactUsLink capitalize /> with the{' '}
+          <IconLink
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              copy(id);
+            }}
+            icon={<ContentCopyIcon />}
+          >
+            {entityTypeLowercase} ID
+          </IconLink>
+          for more information.
+        </Typography>
       </Stack>
-      <Typography variant="body2">
-        Unable to load {entityTypeLowercase}. <ContactUsLink capitalize /> with the {entityTypeLowercase} ID for more
-        information.
-      </Typography>
     </Paper>
   );
-  // return (
-  //   <Tile
-  //     icon={
-  // <StatusIcon
-  //   status="error"
-  //   sx={{ fontSize: '1.5rem', marginRight: (theme) => theme.spacing(1), alignSelf: 'start' }}
-  // />
-  //     }
-  //     bodyContent={
-  //       <>
-  //         <Tile.Title>Unable to load {entityTypeLowercase}.</Tile.Title>
-  //         <Typography variant="body2">
-  //           Please <ContactUsLink /> with the {entityTypeLowercase}&apos;s ID for more information.
-  //         </Typography>
-  //         <Typography variant="body2">
-  //           ID:{' '}
-  //           <IconLink
-  //             onClick={(e) => {
-  //               e.preventDefault();
-  //               copy(id);
-  //             }}
-  //             href="#"
-  //             icon={
-  //               <IconButton>
-  //                 <ContentCopyIcon />
-  //               </IconButton>
-  //             }
-  //           >
-  //             {id}
-  //           </IconLink>
-  //         </Typography>
-  //       </>
-  //     }
-  //     footerContent={undefined}
-  //     tileWidth={tileWidth}
-  //   />
-  // );
 }
 
 export { tileWidth, ErrorTile };

--- a/context/app/static/js/components/entity-tile/EntityTile/EntityTile.tsx
+++ b/context/app/static/js/components/entity-tile/EntityTile/EntityTile.tsx
@@ -74,7 +74,7 @@ function ErrorTile({ entity_type, id }: Pick<EntityTileProps, 'id' | 'entity_typ
       variant="outlined"
     >
       <Stack direction="row" gap={1}>
-        <StatusIcon status="error" sx={{ alignSelf: 'start', fontSize: '1.3rem' }} />
+        <StatusIcon status="error" sx={{ alignSelf: 'start', fontSize: '1.25rem' }} />
         <Typography variant="body2">
           Unable to load {entityTypeLowercase}. <ContactUsLink capitalize /> with the{' '}
           <IconLink

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -49,6 +49,7 @@ export interface Entity {
     dag_provenance_list: DagProvenanceType[];
     [key: string]: unknown;
   };
+  /** @deprecated Use `descendant_ids` and `useEntitiesData` instead */
   descendants: Entity[];
   group_name: string;
   created_by_user_displayname: string;

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -38,7 +38,9 @@ export interface Entity {
   contacts: ContactAPIResponse[];
   contributors: ContributorAPIResponse[];
   created_timestamp: number;
+  /** @deprecated Use `ancestor_ids` and `useEntitiesData` instead */
   ancestors: Entity[];
+  ancestor_ids: string[];
   // eslint-disable-next-line no-use-before-define -- Donor is defined later in the file and extends Entity
   donor: Donor;
   descendant_counts: { entity_type: Record<string, number> };

--- a/context/app/static/js/hooks/useEntityData.ts
+++ b/context/app/static/js/hooks/useEntityData.ts
@@ -2,12 +2,30 @@ import { useMemo } from 'react';
 import { useSearchHits } from 'js/hooks/useSearchData';
 import { Entity } from 'js/components/types';
 
+export const useEntityQuery = (uuid: string | string[], source?: string[]) => {
+  return useMemo(
+    () => ({
+      query: { ids: { values: typeof uuid === 'string' ? [uuid] : uuid } },
+      _source: source,
+    }),
+    [uuid, source],
+  );
+};
+
 export function useEntityData(uuid: string, source?: string[]): [Entity, boolean] {
-  const query = useMemo(() => ({ query: { ids: { values: [uuid] } }, _source: source }), [uuid, source]);
+  const query = useEntityQuery(uuid, source);
 
   const { searchHits, isLoading } = useSearchHits<Entity>(query);
 
   return [searchHits[0]?._source, isLoading];
+}
+
+export function useEntitiesData(uuids: string[], source?: string[]): [Entity[], boolean] {
+  const query = useEntityQuery(uuids, source);
+
+  const { searchHits, isLoading } = useSearchHits<Entity>(query);
+
+  return [searchHits.map((hit) => hit._source), isLoading];
 }
 
 export default useEntityData;

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ExistsQuery, BoolMustNot, TermQuery } from 'searchkit';
+import { ExistsQuery, BoolMustNot, BoolMust, TermQuery } from 'searchkit';
 
 import { Alert } from 'js/shared-styles/alerts';
 import { useAppContext } from 'js/components/Contexts';
@@ -52,8 +52,8 @@ function DevSearch() {
         listFilter('mapped_data_types', 'mapped_data_types'),
         listFilter('metadata.metadata.assay_category', 'assay_category'),
         listFilter('metadata.metadata.assay_type', 'assay_type'),
-        checkboxFilter('is_derived', 'Is derived?', TermQuery('processing', 'processed')),
-        checkboxFilter('is_raw', 'Is raw?', BoolMustNot(TermQuery('processing', 'raw'))),
+        checkboxFilter('is_derived', 'Is derived?', BoolMust(TermQuery('processing.keyword', 'processed'))),
+        checkboxFilter('is_raw', 'Is raw?', BoolMust(TermQuery('processing.keyword', 'raw'))),
         hierarchicalFilter({
           fields: {
             parent: { id: 'metadata.metadata.analyte_class.keyword' },

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -52,8 +52,8 @@ function DevSearch() {
         listFilter('mapped_data_types', 'mapped_data_types'),
         listFilter('metadata.metadata.assay_category', 'assay_category'),
         listFilter('metadata.metadata.assay_type', 'assay_type'),
-        checkboxFilter('is_derived', 'Is derived?', TermQuery('ancestors.entity_type', 'dataset')),
-        checkboxFilter('is_raw', 'Is raw?', BoolMustNot(TermQuery('ancestors.entity_type', 'dataset'))),
+        checkboxFilter('is_derived', 'Is derived?', TermQuery('processing', 'processed')),
+        checkboxFilter('is_raw', 'Is raw?', BoolMustNot(TermQuery('processing', 'raw'))),
         hierarchicalFilter({
           fields: {
             parent: { id: 'metadata.metadata.analyte_class.keyword' },

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -88,10 +88,8 @@ function DevSearch() {
         checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata.metadata'))),
         checkboxFilter('has_files', 'Has files?', ExistsQuery('files')),
         checkboxFilter('no_files', 'No files?', BoolMustNot(ExistsQuery('files'))),
-        checkboxFilter('has_rui_sample', 'Spatial Sample?', ExistsQuery('rui_location')),
-        checkboxFilter('no_rui_sample', 'Not Spatial Sample?', BoolMustNot(ExistsQuery('rui_location'))),
-        checkboxFilter('has_rui_dataset', 'Spatial Dataset?', ExistsQuery('ancestors.rui_location')),
-        checkboxFilter('no_rui_dataset', 'Not Spatial Dataset?', BoolMustNot(ExistsQuery('ancestors.rui_location'))),
+        checkboxFilter('is_spatial', 'Spatial?', ExistsQuery('rui_location')),
+        checkboxFilter('not_spatial', 'Not Spatial?', BoolMustNot(ExistsQuery('rui_location'))),
         checkboxFilter('has_errors', 'Validation Errors?', ExistsQuery('mapper_metadata.validation_errors')),
         checkboxFilter(
           'no_errors',


### PR DESCRIPTION
## Summary

This PR removes the portal UI's dependencies on the direct ancestor/descendant information available in the entity API in favor of using the corresponding `ids`.

### Progress
- `ancestors`
	- [x] Dev search used `ancestors` to determine raw/processed status -> revised to use `processing` field
	- [x] Prov table used `ancestors` to construct the table -> revised to use `ancestor_ids`, corresponding revisions made to error display for donors
	- [x] Ancestors' `rui_location` field is used for `details_rui_json` on back-end and to determine whether a dataset is spatial in the dev search
	- [x] Ancestors not being datasets is currently a condition for the unified prov view lookup when looking up the top level dataset -> dropped the condition in favor of using `processing: raw`, there should be 0..1 raw datasets in any given dataset's ancestors anyway.
- `descendants`
  - Not in use.
- `immediate_ancestors`
  - Mentioned in an artillery config, but otherwise not present.
- `immediate_descendants`
  - ~~`useImmediateDescendantProv` is used for the `view derived entities` button~~ This actually uses the entity API endpoint; this can be improved to use the search API equivalent once the upstream change is made to the search API, but is not currently a blocker.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-844

## Testing

Manually verified, confirmed functionality is analogous to current production behaviors.

## Screenshots/Video

Not very informative since this matches existing functionality, but for verification:

![image](https://github.com/user-attachments/assets/c8d79608-316a-4365-9207-74ac71c50288)

<details><summary>Dev search filters</summary>
<p>

![image](https://github.com/user-attachments/assets/0fbb4ee4-23d0-4a8d-8e17-8b8be0c6629b)

![image](https://github.com/user-attachments/assets/ef31a89c-505f-43ff-91af-e94ee4f63dc7)

![image](https://github.com/user-attachments/assets/4197148a-3456-453a-b9c8-86a2eef39c4b)

</p>
</details> 

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

