### PR TITLE
Austenem/CAT-647 update workspace detail page

### DIFF
--- a/CHANGELOG-update-workspace-detail-page.md
+++ b/CHANGELOG-update-workspace-detail-page.md
@@ -1,0 +1,1 @@
+- Add "Relevant Pages" section to workspace detail pages.

--- a/context/app/static/js/pages/Workspace/Workspace.tsx
+++ b/context/app/static/js/pages/Workspace/Workspace.tsx
@@ -35,12 +35,12 @@ const noDatasetsText =
 
 const pageLinks = [
   {
-    label: 'My Workspaces',
     link: '/workspaces',
+    children: 'My Workspaces',
   },
   {
-    label: 'Dataset Search Page',
     link: '/search?entity_type[0]=Dataset',
+    children: 'Dataset Search Page',
   },
 ];
 
@@ -108,7 +108,7 @@ function WorkspaceContent({ workspaceId }: WorkspacePageProps) {
             <LabelledSectionText label="Relevant Pages" spacing={1}>
               <Stack direction="row" spacing={1}>
                 {pageLinks.map((page) => (
-                  <OutlinedLinkButton key={page.label} {...page} />
+                  <OutlinedLinkButton key={page.link} {...page} />
                 ))}
               </Stack>
             </LabelledSectionText>

--- a/context/app/static/js/pages/Workspace/Workspace.tsx
+++ b/context/app/static/js/pages/Workspace/Workspace.tsx
@@ -22,6 +22,7 @@ import { EditIcon, AddIcon } from 'js/shared-styles/icons';
 import WorkspacesUpdateButton from 'js/components/workspaces/WorkspacesUpdateButton';
 import { Alert } from 'js/shared-styles/alerts/Alert';
 import InternalLink from 'js/shared-styles/Links/InternalLink';
+import OutlinedLinkButton from 'js/shared-styles/buttons/OutlinedLinkButton';
 
 const tooltips = {
   name: 'Edit workspace name.',
@@ -31,6 +32,17 @@ const tooltips = {
 
 const noDatasetsText =
   'There are no datasets in this workspace. Navigate to the dataset search page to find and add datasets to your workspace.';
+
+const pageLinks = [
+  {
+    label: 'My Workspaces',
+    link: '/workspaces',
+  },
+  {
+    label: 'Dataset Search Page',
+    link: '/search?entity_type[0]=Dataset',
+  },
+];
 
 interface WorkspacePageProps {
   workspaceId: number;
@@ -89,9 +101,18 @@ function WorkspaceContent({ workspaceId }: WorkspacePageProps) {
           </Typography>
         </SummaryData>
         <SectionPaper>
-          <LabelledSectionText label="Creation Date">
-            {format(new Date(workspace.datetime_created), 'yyyy-MM-dd')}
-          </LabelledSectionText>
+          <Stack spacing={1}>
+            <LabelledSectionText label="Creation Date">
+              {format(new Date(workspace.datetime_created), 'yyyy-MM-dd')}
+            </LabelledSectionText>
+            <LabelledSectionText label="Relevant Pages" spacing={1}>
+              <Stack direction="row" spacing={1}>
+                {pageLinks.map((page) => (
+                  <OutlinedLinkButton key={page.label} {...page} />
+                ))}
+              </Stack>
+            </LabelledSectionText>
+          </Stack>
         </SectionPaper>
       </Box>
       <WorkspaceDatasetsTable

--- a/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/OutlinedLinkButton.tsx
+++ b/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/OutlinedLinkButton.tsx
@@ -1,15 +1,14 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import Button from '@mui/material/Button';
 import LinkIcon from '@mui/icons-material/Link';
 import SvgIcon from '@mui/material/SvgIcon';
 import Typography from '@mui/material/Typography';
 
-interface OutlinedLinkButtonProps {
-  label: string;
+interface OutlinedLinkButtonProps extends PropsWithChildren {
   link: string;
 }
 
-function OutlinedLinkButton({ label, link }: OutlinedLinkButtonProps) {
+function OutlinedLinkButton({ link, children }: OutlinedLinkButtonProps) {
   return (
     <Button
       variant="outlined"
@@ -21,7 +20,7 @@ function OutlinedLinkButton({ label, link }: OutlinedLinkButtonProps) {
       href={link}
     >
       <Typography variant="inherit" marginRight=".5rem">
-        {label}
+        {children}
       </Typography>
       <SvgIcon component={LinkIcon} color="info" sx={{ fontSize: '1rem' }} />
     </Button>

--- a/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/OutlinedLinkButton.tsx
+++ b/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/OutlinedLinkButton.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Button from '@mui/material/Button';
+import LinkIcon from '@mui/icons-material/Link';
+import SvgIcon from '@mui/material/SvgIcon';
+import Typography from '@mui/material/Typography';
+
+interface OutlinedLinkButtonProps {
+  label: string;
+  link: string;
+}
+
+function OutlinedLinkButton({ label, link }: OutlinedLinkButtonProps) {
+  return (
+    <Button
+      variant="outlined"
+      color="info"
+      sx={(theme) => ({
+        borderColor: theme.palette.grey[300],
+        borderRadius: theme.spacing(0.5),
+      })}
+      href={link}
+    >
+      <Typography variant="inherit" marginRight=".5rem">
+        {label}
+      </Typography>
+      <SvgIcon component={LinkIcon} color="info" sx={{ fontSize: '1rem' }} />
+    </Button>
+  );
+}
+
+export default OutlinedLinkButton;

--- a/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/OutlinedLinkButton.tsx
+++ b/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/OutlinedLinkButton.tsx
@@ -1,8 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import Button from '@mui/material/Button';
 import LinkIcon from '@mui/icons-material/Link';
-import SvgIcon from '@mui/material/SvgIcon';
-import Typography from '@mui/material/Typography';
 
 interface OutlinedLinkButtonProps extends PropsWithChildren {
   link: string;
@@ -18,11 +16,9 @@ function OutlinedLinkButton({ link, children }: OutlinedLinkButtonProps) {
         borderRadius: theme.spacing(0.5),
       })}
       href={link}
+      endIcon={<LinkIcon color="info" fontSize="1rem" />}
     >
-      <Typography variant="inherit" marginRight=".5rem">
-        {children}
-      </Typography>
-      <SvgIcon component={LinkIcon} color="info" sx={{ fontSize: '1rem' }} />
+      {children}
     </Button>
   );
 }

--- a/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/index.ts
+++ b/context/app/static/js/shared-styles/buttons/OutlinedLinkButton/index.ts
@@ -1,0 +1,3 @@
+import OutlinedLinkButton from './OutlinedLinkButton';
+
+export default OutlinedLinkButton;


### PR DESCRIPTION
## Summary

This update adds a "Relevant Pages" section to workspace detail pages with links to the workspaces landing page and dataset search page.

## Design Documentation/Original Tickets

[CAT-647 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-647?atlOrigin=eyJpIjoiYjQzY2Y2YTE3Y2I0NDFhMWFjMDJjNDEyMGMzNTk5MjYiLCJwIjoiaiJ9)

[Figma mockup](https://www.figma.com/design/NgBjvs0jRbDHhiyn5nicDm/Workspace?node-id=2947-5816&m=dev)

## Testing

Manually tested through visual comparison and by testing links.

## Screenshots/Video

<img width="1000" alt="Screenshot 2024-08-26 at 1 38 21 PM" src="https://github.com/user-attachments/assets/58cd8274-71fc-4e5e-a383-c8e3a61ae8df">

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
