### PR TITLE
John conroy/workspaces user group CAT-865

### DIFF
--- a/CHANGELOG-workspaces-user-group.md
+++ b/CHANGELOG-workspaces-user-group.md
@@ -1,0 +1,1 @@
+- Enable access to workspaces for users in HuBMAP Read or HuBMAP Workspaces globus groups.

--- a/context/app/routes_auth.py
+++ b/context/app/routes_auth.py
@@ -150,8 +150,7 @@ def login():
 
     permission_groups = {
         'HuBMAP': current_app.config['GROUP_ID'],
-        # Temporarily use HuBMAP Read while in consortium beta.
-        'Workspaces': current_app.config['GROUP_ID']
+        'Workspaces': current_app.config['WORKSPACES_GROUP_ID']
     }
 
     # Determine if the user belongs to any of the groups in the globus groups master list

--- a/context/app/static/js/components/App.jsx
+++ b/context/app/static/js/components/App.jsx
@@ -45,8 +45,8 @@ function App(props) {
   const { endpoints, globalAlertMd } = flaskData;
   delete flaskData.endpoints;
   delete flaskData.globalAlertMd;
-  const isWorkspacesUser = userGroups?.includes('Workspaces') || workspacesUsers.includes(userEmail);
   const isHubmapUser = userGroups?.includes('HuBMAP');
+  const isWorkspacesUser = userGroups?.includes('Workspaces') || workspacesUsers.includes(userEmail) || isHubmapUser;
 
   return (
     <StrictMode>


### PR DESCRIPTION
## Summary

Enables members of either the workspaces or hubmap globus groups to access workspace features. Confirmed with Zhou that the 'WORKSPACES_GROUP_ID' is still configured.

## Testing

I opened a workspace.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
