### PR TITLE
John conroy/handle creators or contributors collections

### DIFF
--- a/CHANGELOG-handle-creators-or-contributors-collections.md
+++ b/CHANGELOG-handle-creators-or-contributors-collections.md
@@ -1,0 +1,1 @@
+- Handle both contributors and creators fields for collections until the creators field is renamed to contributors.

--- a/context/app/static/js/pages/Collection/Collection.jsx
+++ b/context/app/static/js/pages/Collection/Collection.jsx
@@ -19,12 +19,15 @@ function Collection({ collection: collectionData }) {
     last_modified_timestamp,
     datasets,
     creators,
+    contributors,
     contacts,
   } = collectionData;
 
   const doi = getCollectionDOI(doi_url);
 
   useTrackID({ entity_type, hubmap_id });
+
+  const possible_contributors = contributors ?? contacts;
 
   return (
     <div>
@@ -48,8 +51,8 @@ function Collection({ collection: collectionData }) {
             )}
           </Summary>
           {'datasets' in collectionData && <CollectionDatasetsTable datasets={datasets} />}
-          {'creators' in collectionData && (
-            <ContributorsTable contributors={creators} contacts={contacts} title="Contributors" />
+          {possible_contributors && Boolean(possible_contributors.length) && (
+            <ContributorsTable contributors={possible_contributors} contacts={contacts} title="Contributors" />
           )}
         </>
       )}

--- a/context/app/static/js/pages/Collection/Collection.jsx
+++ b/context/app/static/js/pages/Collection/Collection.jsx
@@ -27,7 +27,8 @@ function Collection({ collection: collectionData }) {
 
   useTrackID({ entity_type, hubmap_id });
 
-  const possible_contributors = contributors ?? contacts;
+  // Handle both fields until creators is renamed to contributors.
+  const possible_contributors = contributors ?? creators;
 
   return (
     <div>

--- a/context/app/static/js/pages/Collection/Collection.jsx
+++ b/context/app/static/js/pages/Collection/Collection.jsx
@@ -28,7 +28,7 @@ function Collection({ collection: collectionData }) {
   useTrackID({ entity_type, hubmap_id });
 
   // Handle both fields until creators is renamed to contributors.
-  const possible_contributors = contributors ?? creators;
+  const possibleContributors = contributors ?? creators;
 
   return (
     <div>
@@ -52,8 +52,8 @@ function Collection({ collection: collectionData }) {
             )}
           </Summary>
           {'datasets' in collectionData && <CollectionDatasetsTable datasets={datasets} />}
-          {possible_contributors && Boolean(possible_contributors.length) && (
-            <ContributorsTable contributors={possible_contributors} contacts={contacts} title="Contributors" />
+          {possibleContributors && Boolean(possibleContributors.length) && (
+            <ContributorsTable contributors={possibleContributors} contacts={contacts} title="Contributors" />
           )}
         </>
       )}


### PR DESCRIPTION
## Summary

Zhou asked that we handle both `contributors` and `creators` until they can rename `creators` to `contributors`.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
