### PR TITLE
NickAkhmetov/Adjust styles to avoid coloring alert icons

### DIFF
--- a/CHANGELOG-alert-fix.md
+++ b/CHANGELOG-alert-fix.md
@@ -1,0 +1,1 @@
+- Fix color of alerts' icons.

--- a/context/app/static/js/shared-styles/alerts/Alert.tsx
+++ b/context/app/static/js/shared-styles/alerts/Alert.tsx
@@ -28,7 +28,7 @@ interface StyledAlertProps extends AlertProps {
 
 // TODO: Figure out why `sx` doesn't work with this component. https://hms-dbmi.atlassian.net/browse/CAT-650
 const StyledAlert = styled(OutlinedAlert)<StyledAlertProps>(({ theme, $marginBottom, $marginTop }) => ({
-  ':not(svg)': {
+  '> &:not(svg)': {
     color: theme.palette.text.primary,
   },
   '& .MuiAlert-action': {


### PR DESCRIPTION
## Summary

This PR adjusts the styles for the `Alert` component to ensure that SVG icons' colors are not set to black.

## Design Documentation/Original Tickets

Hotfix for https://hubmapconsortium.slack.com/archives/C016TK0APV2/p1724877450443429?thread_ts=1724877411.212489&cid=C016TK0APV2

## Testing

Manual testing.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/187a66ae-a8a0-46e7-8208-96b07911ffe2)

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added