### PR TITLE
Austenem/CAT-867 update workspace toasts

### DIFF
--- a/CHANGELOG-update-workspace-toasts.md
+++ b/CHANGELOG-update-workspace-toasts.md
@@ -1,0 +1,1 @@
+- Update workspace success toast to indicate whether the workspace has launched in a new tab or just been created.

--- a/context/app/static/js/components/workspaces/WorkspaceLaunchSuccessToast.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceLaunchSuccessToast.tsx
@@ -3,16 +3,27 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 
-function WorkspaceLaunchSuccessToast(id: number) {
+interface WorkspaceLaunchSuccessToastProps {
+  id: number;
+  workspaceLaunched: boolean;
+}
+
+function WorkspaceLaunchSuccessToast({ id, workspaceLaunched }: WorkspaceLaunchSuccessToastProps) {
   return (
     <Stack spacing={1} maxWidth="22rem">
-      <Typography>
-        Workspace successfully launched in a new tab. If the tab didn&apos;t open, please check your pop-up blocker
-        settings and relaunch your workspace.
-      </Typography>
-      <Button href={`/workspaces/${id}`} variant="text" color="inherit" sx={{ alignSelf: 'flex-end' }}>
-        View Workspace Detail Page
-      </Button>
+      {workspaceLaunched ? (
+        <>
+          <Typography>
+            Workspace successfully launched in a new tab. If the tab didn&apos;t open, please check your pop-up blocker
+            settings and relaunch your workspace.
+          </Typography>
+          <Button href={`/workspaces/${id}`} variant="text" color="inherit" sx={{ alignSelf: 'flex-end' }}>
+            View Workspace Detail Page
+          </Button>
+        </>
+      ) : (
+        <Typography>Workspace successfully created.</Typography>
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary

Updates workspace success toasts to indicate whether the workspace has launched in a new tab. Additionally, updates logic to show this toast not just when a workspace is created, but any time a workspace is launched.

## Design Documentation/Original Tickets

[CAT-867 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-867?atlOrigin=eyJpIjoiMGFlMzJhYjE4NDdmNGZhZGEzZDRlNGVjYTEwY2RkYTMiLCJwIjoiaiJ9)

## Testing

Tested various entry points for the toast:
* Creating a new workspace
  * When another workspace is running: `"Workspace successfully created."` + launch dialog, then if launched `"Workspace successfully launched..."`
  * When no workspaces are running: `"Workspace successfully launched..."`
* Launching an existing workspace
  * When another workspace is running: launch dialog, then if launched `"Workspace successfully launched..."`
  * When no workspaces are running: `"Workspace successfully launched..."`

## Screenshots/Video

<img width="500" alt="Screenshot 2024-08-29 at 3 24 19 PM" src="https://github.com/user-attachments/assets/3e31c1db-2006-4846-bfa4-d1878916d3a5">

<img width="500" alt="Screenshot 2024-08-29 at 3 24 08 PM" src="https://github.com/user-attachments/assets/9561d687-416c-4859-979c-78c20c0826b2">

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

