### PR TITLE
John conroy/fix 303 redirect CAT-874

### DIFF
--- a/CHANGELOG-fix-303-redirect.md
+++ b/CHANGELOG-fix-303-redirect.md
@@ -1,0 +1,1 @@
+- Fix regression in 303 redirect.

--- a/context/app/static/js/components/publications/PublicationsDataSection/PublicationsDataSection.jsx
+++ b/context/app/static/js/components/publications/PublicationsDataSection/PublicationsDataSection.jsx
@@ -8,7 +8,7 @@ import { getIDsQuery } from 'js/helpers/queries';
 
 function PublicationsDataSection({ datasetUUIDs, uuid, associatedCollectionUUID }) {
   const query = associatedCollectionUUID
-    ? { query: getIDsQuery(associatedCollectionUUID) }
+    ? { query: getIDsQuery(associatedCollectionUUID), _source: ['uuid', 'title', 'hubmap_id', 'datasets.uuid'] }
     : buildCollectionsWithDatasetQuery(datasetUUIDs);
 
   const { searchHits: collectionsData } = useSearchHits(query);

--- a/context/app/static/js/helpers/swr/fetchers.ts
+++ b/context/app/static/js/helpers/swr/fetchers.ts
@@ -27,7 +27,7 @@ async function f({
     // Separate handling for 303 status code thrown by ES when documents are >10MB
     if (response.status === 303) {
       const s3URL = await response.text();
-      return fetch(s3URL);
+      return f({ url: s3URL });
     }
     if (!expectedStatusCodes.includes(response.status)) {
       const rawText = await response.text();

--- a/context/app/static/js/hooks/useSearchData.ts
+++ b/context/app/static/js/hooks/useSearchData.ts
@@ -109,13 +109,6 @@ export async function fetchSearchData<Documents, Aggs>(
     returnResponse: true,
   });
 
-  if (searchResponse?.status === 303) {
-    const s3URL = await searchResponse.text();
-    return fetch({
-      url: s3URL,
-    });
-  }
-
   return searchResponse.json() as Promise<SearchResponseBody<Documents, Aggs>>;
 }
 


### PR DESCRIPTION
## Summary

Fixes regression to 303 redirect to s3 handling introduced in fetcher refactoring. I also introduced `_source` to the publication collections query to avoid the 303.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
