### PR TITLE
NickAkhmetov/Hotfix descendants lookup query

### DIFF
--- a/CHANGELOG-fix-processed-descendants-query.md
+++ b/CHANGELOG-fix-processed-descendants-query.md
@@ -1,0 +1,1 @@
+- Fix descendants lookup query so it looks for either dataset descendants or image pyramid support descendants.

--- a/context/app/static/js/helpers/queries.ts
+++ b/context/app/static/js/helpers/queries.ts
@@ -35,9 +35,16 @@ export const includeDatasetsAndImageSupports: QueryDslQueryContainer = {
   bool: {
     should: [
       {
-        terms: { entity_type: ['Dataset', 'Support'] },
+        term: { 'entity_type.keyword': 'Dataset' },
       },
-      { terms: { 'vitessce-hints': ['pyramid', 'is_image'] } },
+      {
+        bool: {
+          must: [
+            { term: { 'entity_type.keyword': 'Support' } },
+            { terms: { 'vitessce-hints': ['pyramid', 'is_image'] } },
+          ],
+        },
+      },
     ],
     minimum_should_match: 1,
   },


### PR DESCRIPTION
## Summary

This PR fixes the query used to look up the processed descendants of a primary dataset so that it returns either Dataset descendants or supporting image pyramid descendants. This fixes the regression caused by a related change in #3519.

## Design Documentation/Original Tickets

N/A

## Testing

Tested with the pages that the issue was observed on staging.

## Screenshots/Video

<details><summary>Details</summary>
<p>

![image](https://github.com/user-attachments/assets/ce34f8c1-a13a-4a7f-9aeb-43494147c808)


</p>
</details> 

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes
