### PR TITLE
NickAkhmetov/CAT-875 Improve status icon visibility for collapsed processed dataset accordions

### DIFF
--- a/CHANGELOG-cat-875.md
+++ b/CHANGELOG-cat-875.md
@@ -1,0 +1,1 @@
+- Improve status icon visibility on collapsed processed dataset accordions.

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
@@ -43,13 +43,18 @@ export function ProcessedDatasetAccordion({ children }: PropsWithChildren) {
       }
     },
   });
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
   return (
     <DetailPageSection id={datasetSectionId(sectionDataset, 'section')}>
       <StyledProcessedDatasetAccordion
         defaultExpanded={defaultExpanded}
-        onChange={(_, expanded) =>
-          track({ action: `${expanded ? 'Expand' : 'Collapse'} Main Dataset Section`, label: sectionDataset.hubmap_id })
-        }
+        onChange={(_, expanded) => {
+          track({
+            action: `${expanded ? 'Expand' : 'Collapse'} Main Dataset Section`,
+            label: sectionDataset.hubmap_id,
+          });
+          setIsExpanded(expanded);
+        }}
         slotProps={{ transition: { unmountOnExit: true } }}
       >
         <AccordionSummary expandIcon={<ArrowDropDownRounded />}>
@@ -58,7 +63,7 @@ export function ProcessedDatasetAccordion({ children }: PropsWithChildren) {
             {sectionDataset.pipeline}
           </Typography>
           <Typography variant="body1" ml="auto" component="div" display="flex" alignItems="center" gap={1}>
-            <StatusIcon status={sectionDataset.status} noColor tooltip />
+            <StatusIcon status={sectionDataset.status} noColor={isExpanded} tooltip />
             {dataset?.hubmap_id}
           </Typography>
         </AccordionSummary>


### PR DESCRIPTION
## Summary

This PR adjusts processed dataset accordions' icons to improve visibility when the accordion is collapsed.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/issues/CAT-875

## Testing

Manually tested.

## Screenshots/Video

Expanded Published:
![image](https://github.com/user-attachments/assets/e2e0b253-e269-4725-9fc2-0e29386bc737)

Collapsed Published:
![image](https://github.com/user-attachments/assets/fde4aa05-69ca-4314-ad33-90dff8788d8d)

Collapsed Error:
![image](https://github.com/user-attachments/assets/21128ea1-1efd-4356-94ba-082249765ff2)

Collapsed QA:
![image](https://github.com/user-attachments/assets/9cea50c8-0f59-4eb2-8025-64e3dd9d535c)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
