### PR TITLE
NickAkhmetov/CAT-876 Scrolling improvements, expand collapsed datasets on hash navigation

### DIFF
--- a/CHANGELOG-cat-876.md
+++ b/CHANGELOG-cat-876.md
@@ -1,0 +1,3 @@
+- Add smooth scrolling for dataset relationships links.
+- Make dataset relationship node behavior clearer by adding explanatory toast, tooltip, and using appropriate cursor.
+- Expand processed datasets if navigated to via table of contents or dataset relationships node link.

--- a/context/app/static/js/components/detailPage/DatasetRelationships/nodeTypes.tsx
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/nodeTypes.tsx
@@ -7,6 +7,8 @@ import { AccountTreeRounded, ExtensionRounded, SvgIconComponent } from '@mui/ico
 import Skeleton from '@mui/material/Skeleton';
 import { Box } from '@mui/system';
 import { useHash } from 'js/hooks/useHash';
+import { useSnackbarActions } from 'js/shared-styles/snackbars';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import StatusIcon from '../StatusIcon';
 import { usePipelineInfo } from './hooks';
 import { useProcessedDatasetDetails } from '../ProcessedData/ProcessedDataset/hooks';
@@ -37,6 +39,8 @@ interface NodeTemplateProps extends PropsWithChildren, CommonNodeInfo {
   bgColor?: string;
   isLoading?: boolean;
   href?: string;
+  toastText?: string;
+  tooltipText?: string;
 }
 
 export const nodeColors = {
@@ -67,6 +71,8 @@ function NodeTemplate({
   bgColor,
   isLoading,
   href,
+  toastText,
+  tooltipText,
 }: NodeTemplateProps) {
   // Outer wrapper Box makes sure that nodes are always the same height
   const contents = (
@@ -92,8 +98,9 @@ function NodeTemplate({
     </Box>
   );
   const [, setHash] = useHash();
+  const { toastInfo } = useSnackbarActions();
   if (href) {
-    return (
+    const linkedContents = (
       <a
         onClick={(e) => {
           if (isLoading) return;
@@ -102,6 +109,9 @@ function NodeTemplate({
             const sanitizedHref = `#${CSS.escape(href.split('#')[1])}`;
             document.querySelector(sanitizedHref)?.scrollIntoView({ behavior: 'smooth' });
             setHash(href);
+            if (toastText) {
+              toastInfo(toastText);
+            }
           }
         }}
         href={href}
@@ -109,6 +119,14 @@ function NodeTemplate({
         {contents}
       </a>
     );
+    if (tooltipText) {
+      return (
+        <SecondaryBackgroundTooltip title={tooltipText} placement="top">
+          {linkedContents}
+        </SecondaryBackgroundTooltip>
+      );
+    }
+    return linkedContents;
   }
   return contents;
 }
@@ -151,6 +169,8 @@ function ProcessedDatasetNode({ data }: NodeProps<ProcessedDatasetNodeProps>) {
       icon={nodeIcons.processedDataset}
       bgColor={nodeColors.processedDataset}
       isLoading={isLoading}
+      toastText={`Scrolled to ${datasetDetails.pipeline}`}
+      tooltipText={`Scroll to ${datasetDetails.pipeline}`}
       {...data}
     >
       {data.datasetType}
@@ -161,15 +181,13 @@ function ProcessedDatasetNode({ data }: NodeProps<ProcessedDatasetNodeProps>) {
 type ComponentDatasetNodeProps = Node<DatasetNodeInfo, 'componentDataset'>;
 
 function ComponentDatasetNode({ data }: NodeProps<ComponentDatasetNodeProps>) {
-  const { datasetDetails, isLoading } = useProcessedDatasetDetails(data.uuid);
   return (
     <NodeTemplate
       rounded
       target
       icon={nodeIcons.componentDataset}
-      href={makeNodeHref(datasetDetails)}
       bgColor={nodeColors.componentDataset}
-      isLoading={isLoading}
+      isLoading={false}
       {...data}
     >
       {data.datasetType}

--- a/context/app/static/js/components/detailPage/DatasetRelationships/nodeTypes.tsx
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/nodeTypes.tsx
@@ -6,6 +6,7 @@ import Typography from '@mui/material/Typography';
 import { AccountTreeRounded, ExtensionRounded, SvgIconComponent } from '@mui/icons-material';
 import Skeleton from '@mui/material/Skeleton';
 import { Box } from '@mui/system';
+import { useHash } from 'js/hooks/useHash';
 import StatusIcon from '../StatusIcon';
 import { usePipelineInfo } from './hooks';
 import { useProcessedDatasetDetails } from '../ProcessedData/ProcessedDataset/hooks';
@@ -69,7 +70,7 @@ function NodeTemplate({
 }: NodeTemplateProps) {
   // Outer wrapper Box makes sure that nodes are always the same height
   const contents = (
-    <Box height="4.125rem" display="flex" alignItems="center">
+    <Box height="4.125rem" display="flex" alignItems="center" sx={{ cursor: href ? 'pointer' : 'default' }}>
       <Stack
         direction="column"
         px={2}
@@ -90,8 +91,24 @@ function NodeTemplate({
       </Stack>
     </Box>
   );
+  const [, setHash] = useHash();
   if (href) {
-    return <a href={href}>{contents}</a>;
+    return (
+      <a
+        onClick={(e) => {
+          if (isLoading) return;
+          if (href.startsWith('#')) {
+            e.preventDefault();
+            const sanitizedHref = `#${CSS.escape(href.split('#')[1])}`;
+            document.querySelector(sanitizedHref)?.scrollIntoView({ behavior: 'smooth' });
+            setHash(href);
+          }
+        }}
+        href={href}
+      >
+        {contents}
+      </a>
+    );
   }
   return contents;
 }

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, useState } from 'react';
+import React, { PropsWithChildren, useEffect, useState } from 'react';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
@@ -9,6 +9,7 @@ import { VisualizationIcon } from 'js/shared-styles/icons';
 
 import { datasetSectionId } from 'js/pages/Dataset/utils';
 import { useInView } from 'react-intersection-observer';
+import { useHash } from 'js/hooks/useHash';
 import { useTrackEntityPageEvent } from '../../useTrackEntityPageEvent';
 import StatusIcon from '../../StatusIcon';
 import { StyledProcessedDatasetAccordion } from './styles';
@@ -43,11 +44,22 @@ export function ProcessedDatasetAccordion({ children }: PropsWithChildren) {
       }
     },
   });
-  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+  const datasetIdSubstring = datasetSectionId(sectionDataset);
+  const [hash] = useHash();
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded || hash.includes(datasetIdSubstring));
+
+  useEffect(() => {
+    const datasetId = datasetSectionId(sectionDataset);
+    if (hash.includes(datasetId)) {
+      setIsExpanded(true);
+    }
+  }, [hash, sectionDataset]);
+
   return (
     <DetailPageSection id={datasetSectionId(sectionDataset, 'section')}>
       <StyledProcessedDatasetAccordion
         defaultExpanded={defaultExpanded}
+        expanded={isExpanded}
         onChange={(_, expanded) => {
           track({
             action: `${expanded ? 'Expand' : 'Collapse'} Main Dataset Section`,

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetContext.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetContext.tsx
@@ -11,7 +11,7 @@ export interface ProcessedDataVisualizationProps {
 interface ProcessedDatasetContext extends ProcessedDataVisualizationProps {
   conf?: object;
   dataset: ProcessedDatasetDetails;
-  defaultExpanded?: boolean;
+  defaultExpanded: boolean;
 }
 
 const ProcessedDatasetContext = createContext<ProcessedDatasetContext>('ProcessedDatasetContext');

--- a/context/app/static/js/hooks/useHash.ts
+++ b/context/app/static/js/hooks/useHash.ts
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+export function useHash() {
+  const [hash, setHash] = useState(() => window.location.hash);
+
+  const hashChangeHandler = React.useCallback(() => {
+    setHash(window.location.hash);
+  }, []);
+
+  React.useEffect(() => {
+    window.addEventListener('hashchange', hashChangeHandler);
+    window.addEventListener('popstate', hashChangeHandler);
+    return () => {
+      window.removeEventListener('hashchange', hashChangeHandler);
+      window.removeEventListener('popstate', hashChangeHandler);
+    };
+  }, [hashChangeHandler]);
+
+  const updateHash = React.useCallback(
+    (newHash: string) => {
+      if (newHash !== hash) window.location.hash = newHash;
+    },
+    [hash],
+  );
+
+  return [hash, updateHash] as const;
+}

--- a/context/app/static/js/pages/Dataset/utils.ts
+++ b/context/app/static/js/pages/Dataset/utils.ts
@@ -2,7 +2,7 @@ import { ProcessedDatasetInfo } from './hooks';
 
 export function datasetSectionId(
   dataset: Pick<ProcessedDatasetInfo, 'pipeline' | 'hubmap_id' | 'status'>,
-  prefix: string,
+  prefix = '',
 ) {
   const { pipeline, hubmap_id, status } = dataset;
   const formattedDatasetIdentifier = (pipeline ?? hubmap_id).replace(/\s/g, '');


### PR DESCRIPTION
## Summary

This PR adds an explanatory toast/tooltip to dataset relationship nodes and makes dataset sections expand when navigated to via table of contents or the dataset relationship nodes.

Some caveats/limitations I've attempted to address but could not find a satisfactory solution for:
- If the user navigates to a processed dataset via a hash to expand it, manually collapses it, then scrolls back up to the dataset relationships and clicks the link again, the accordion will not expand as a hashchange event does not fire in this circumstance. Forcing an update in the `useHash` function doesn't help.
- Since the vitessce instance in the accordion mounts when the accordion expands, the initial scroll can be laggy as a result. Keeping the Vitessce instances always mounted by disabling the `unmountOnExit` behavior of the processed dataset accordion mitigates this issue somewhat, but results in major slowdowns on datasets with lots of Vitessce instances.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/issues/CAT-876

## Testing

Manual testing.

## Screenshots/Video

https://github.com/user-attachments/assets/723316de-cffb-4a39-a9ce-c59cc847654d


![image](https://github.com/user-attachments/assets/4ea4c7ed-3642-429d-b72a-98466763d3ec)
![image](https://github.com/user-attachments/assets/5fd38b1f-081f-4da6-8358-7db742d98148)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
