### PR TITLE
NickAkhmetov/CAT-879 Improve handling of loading/potentially undefined data in dataset relationship diagram

### DIFF
--- a/CHANGELOG-cat-879.md
+++ b/CHANGELOG-cat-879.md
@@ -1,0 +1,1 @@
+- Improve handling of loading/potentially undefined data in dataset relationship diagram.

--- a/context/app/static/js/components/detailPage/DatasetRelationships/nodeTypes.tsx
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/nodeTypes.tsx
@@ -169,8 +169,8 @@ function ProcessedDatasetNode({ data }: NodeProps<ProcessedDatasetNodeProps>) {
       icon={nodeIcons.processedDataset}
       bgColor={nodeColors.processedDataset}
       isLoading={isLoading}
-      toastText={`Scrolled to ${datasetDetails.pipeline}`}
-      tooltipText={`Scroll to ${datasetDetails.pipeline}`}
+      toastText={`Scrolled to ${datasetDetails?.pipeline}`}
+      tooltipText={`Scroll to ${datasetDetails?.pipeline}`}
       {...data}
     >
       {data.datasetType}


### PR DESCRIPTION
## Summary

This PR corrects an issue introduced in #3530; attempting to access the `pipeline` of a dataset which had not finished loading led to this regression.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-879

## Testing

Manually tested with the dataset that was crashing on stage.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/d59796d6-b70d-4df0-a142-417d2873f67d)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
