### PR TITLE
NickAkhmetov/CAT-880 Ensure data product and file URLs use relevant dateset UUID

### DIFF
--- a/CHANGELOG-cat-880.md
+++ b/CHANGELOG-cat-880.md
@@ -1,0 +1,1 @@
+- Ensure data product and file URLs use relevant dataset IDs when constructing.

--- a/context/app/static/js/components/detailPage/files/DataProducts/DataProducts.spec.tsx
+++ b/context/app/static/js/components/detailPage/files/DataProducts/DataProducts.spec.tsx
@@ -5,8 +5,11 @@ import { render, screen } from 'test-utils/functions';
 
 import { FlaskDataContext } from 'js/components/Contexts';
 import { DetailContext } from 'js/components/detailPage/DetailContext';
+import { ProcessedDatasetInfo } from 'js/pages/Dataset/hooks';
 import DataProducts from './DataProducts';
 import { flaskDataContext } from '../file-fixtures.spec';
+import { ProcessedDatasetContextProvider } from '../../ProcessedData/ProcessedDataset/ProcessedDatasetContext';
+import { ProcessedDatasetDetails } from '../../ProcessedData/ProcessedDataset/hooks';
 
 const files = {
   get all() {
@@ -39,11 +42,17 @@ const flaskDataContextEdited = { ...flaskDataContext, entity: { ...flaskDataCont
 
 function TestDataProducts({ files: passedFiles = files.all }) {
   return (
-    <FlaskDataContext.Provider value={flaskDataContextEdited}>
-      <DetailContext.Provider value={detailContext}>
-        <DataProducts files={passedFiles} />
-      </DetailContext.Provider>
-    </FlaskDataContext.Provider>
+    <ProcessedDatasetContextProvider
+      dataset={{ uuid: 'fakeuuid' } as unknown as ProcessedDatasetDetails}
+      defaultExpanded
+      sectionDataset={{ uuid: 'fakeparentuuid' } as unknown as ProcessedDatasetInfo}
+    >
+      <FlaskDataContext.Provider value={flaskDataContextEdited}>
+        <DetailContext.Provider value={detailContext}>
+          <DataProducts files={passedFiles} />
+        </DetailContext.Provider>
+      </FlaskDataContext.Provider>
+    </ProcessedDatasetContextProvider>
   );
 }
 

--- a/context/app/static/js/components/detailPage/files/DataProducts/hooks.ts
+++ b/context/app/static/js/components/detailPage/files/DataProducts/hooks.ts
@@ -2,9 +2,9 @@ import { useMemo } from 'react';
 
 import { useAppContext, useFlaskDataContext } from 'js/components/Contexts';
 import { DagProvenanceType, isDataset } from 'js/components/types';
-import { useDetailContext } from 'js/components/detailPage/DetailContext';
 import { getTokenParam } from 'js/helpers/functions';
 import { UnprocessedFile } from '../types';
+import { useProcessedDatasetContext } from '../../ProcessedData/ProcessedDataset/ProcessedDatasetContext';
 
 interface PipelineInfo {
   origin: string;
@@ -82,7 +82,9 @@ function formatFileLink(assetsEndpoint: string, uuid: string, relPath: string, t
 function useFileLinkParameters() {
   const { assetsEndpoint, groupsToken } = useAppContext();
   const token = getTokenParam(groupsToken);
-  const { uuid } = useDetailContext();
+  const {
+    dataset: { uuid },
+  } = useProcessedDatasetContext();
   return { assetsEndpoint, uuid, token };
 }
 

--- a/context/app/static/js/components/detailPage/files/FileBrowser/FileBrowser.spec.tsx
+++ b/context/app/static/js/components/detailPage/files/FileBrowser/FileBrowser.spec.tsx
@@ -4,9 +4,12 @@ import { render, screen } from 'test-utils/functions';
 
 import { FlaskDataContext } from 'js/components/Contexts';
 import { DetailContext } from 'js/components/detailPage/DetailContext';
+import { ProcessedDatasetInfo } from 'js/pages/Dataset/hooks';
 import FileBrowser from './FileBrowser';
 import { FilesContext } from '../FilesContext';
 import { detailContext, filesContext, flaskDataContext, testFiles } from '../file-fixtures.spec';
+import { ProcessedDatasetContextProvider } from '../../ProcessedData/ProcessedDataset/ProcessedDatasetContext';
+import { ProcessedDatasetDetails } from '../../ProcessedData/ProcessedDataset/hooks';
 
 const expectArrayOfStringsToExist = (arr: string[]) =>
   arr.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
@@ -15,13 +18,19 @@ const expectArrayOfStringsToNotExist = (arr: string[]) =>
 
 function FilesBrowserTest() {
   return (
-    <FlaskDataContext.Provider value={flaskDataContext}>
-      <DetailContext.Provider value={detailContext}>
-        <FilesContext.Provider value={filesContext}>
-          <FileBrowser files={testFiles} />
-        </FilesContext.Provider>
-      </DetailContext.Provider>
-    </FlaskDataContext.Provider>
+    <ProcessedDatasetContextProvider
+      dataset={{ uuid: 'fakeuuid' } as unknown as ProcessedDatasetDetails}
+      defaultExpanded
+      sectionDataset={{ uuid: 'fakeparentuuid' } as unknown as ProcessedDatasetInfo}
+    >
+      <FlaskDataContext.Provider value={flaskDataContext}>
+        <DetailContext.Provider value={detailContext}>
+          <FilesContext.Provider value={filesContext}>
+            <FileBrowser files={testFiles} />
+          </FilesContext.Provider>
+        </DetailContext.Provider>
+      </FlaskDataContext.Provider>
+    </ProcessedDatasetContextProvider>
   );
 }
 

--- a/context/app/static/js/components/detailPage/files/FileBrowserFile/FileBrowserFile.spec.tsx
+++ b/context/app/static/js/components/detailPage/files/FileBrowserFile/FileBrowserFile.spec.tsx
@@ -3,10 +3,13 @@ import { render, screen, appProviderEndpoints, appProviderToken } from 'test-uti
 
 import { DetailContext } from 'js/components/detailPage/DetailContext';
 
+import { ProcessedDatasetInfo } from 'js/pages/Dataset/hooks';
 import { FilesContext } from '../FilesContext';
 
 import FileBrowserFile from './FileBrowserFile';
 import { detailContext, filesContext, uuid } from '../file-fixtures.spec';
+import { ProcessedDatasetContextProvider } from '../../ProcessedData/ProcessedDataset/ProcessedDatasetContext';
+import { ProcessedDatasetDetails } from '../../ProcessedData/ProcessedDataset/hooks';
 
 const defaultFileObject = {
   rel_path: 'fakepath',
@@ -25,11 +28,17 @@ function RenderFileTest({ fileObjOverrides = {}, depth = 0 }) {
     ...fileObjOverrides,
   };
   return (
-    <DetailContext.Provider value={detailContext}>
-      <FilesContext.Provider value={filesContext}>
-        <FileBrowserFile fileObj={completeFileObject} depth={depth} />
-      </FilesContext.Provider>
-    </DetailContext.Provider>
+    <ProcessedDatasetContextProvider
+      dataset={{ uuid: 'fakeuuid' } as unknown as ProcessedDatasetDetails}
+      defaultExpanded
+      sectionDataset={{ uuid: 'fakeparentuuid' } as unknown as ProcessedDatasetInfo}
+    >
+      <DetailContext.Provider value={detailContext}>
+        <FilesContext.Provider value={filesContext}>
+          <FileBrowserFile fileObj={completeFileObject} depth={depth} />
+        </FilesContext.Provider>
+      </DetailContext.Provider>
+    </ProcessedDatasetContextProvider>
   );
 }
 

--- a/context/app/static/js/components/detailPage/files/FileBrowserNode/FileBrowserNode.spec.tsx
+++ b/context/app/static/js/components/detailPage/files/FileBrowserNode/FileBrowserNode.spec.tsx
@@ -2,16 +2,25 @@ import React, { PropsWithChildren } from 'react';
 import { render, screen } from 'test-utils/functions';
 
 import { DetailContext } from 'js/components/detailPage/DetailContext';
+import { ProcessedDatasetInfo } from 'js/pages/Dataset/hooks';
 import FileBrowserNode from './FileBrowserNode';
 import { FilesContext } from '../FilesContext';
 import { DatasetFile, FileTree } from '../types';
 import { detailContext, filesContext } from '../file-fixtures.spec';
+import { ProcessedDatasetContextProvider } from '../../ProcessedData/ProcessedDataset/ProcessedDatasetContext';
+import { ProcessedDatasetDetails } from '../../ProcessedData/ProcessedDataset/hooks';
 
 function FilesProviders({ children }: PropsWithChildren) {
   return (
-    <DetailContext.Provider value={detailContext}>
-      <FilesContext.Provider value={filesContext}>{children}</FilesContext.Provider>
-    </DetailContext.Provider>
+    <ProcessedDatasetContextProvider
+      dataset={{ uuid: 'fakeuuid' } as unknown as ProcessedDatasetDetails}
+      defaultExpanded
+      sectionDataset={{ uuid: 'fakeparentuuid' } as unknown as ProcessedDatasetInfo}
+    >
+      <DetailContext.Provider value={detailContext}>
+        <FilesContext.Provider value={filesContext}>{children}</FilesContext.Provider>
+      </DetailContext.Provider>
+    </ProcessedDatasetContextProvider>
   );
 }
 

--- a/context/app/static/js/components/detailPage/files/Files/Files.spec.tsx
+++ b/context/app/static/js/components/detailPage/files/Files/Files.spec.tsx
@@ -6,9 +6,12 @@ import { setupServer } from 'msw/node';
 
 import { FlaskDataContext } from 'js/components/Contexts';
 import { DetailContext } from 'js/components/detailPage/DetailContext';
+import { ProcessedDatasetInfo } from 'js/pages/Dataset/hooks';
 import Files from './Files';
 import { detailContext, flaskDataContext, testFiles, uuid as testUuid } from '../file-fixtures.spec';
 import { FilesContextProvider } from '../FilesContext';
+import { ProcessedDatasetDetails } from '../../ProcessedData/ProcessedDataset/hooks';
+import { ProcessedDatasetContextProvider } from '../../ProcessedData/ProcessedDataset/ProcessedDatasetContext';
 
 const globusHandler: RequestHandler = http.get<PathParams, DefaultBodyType, { url: string }>(
   `/${appProviderEndpoints.entityEndpoint}/entities/dataset/globus-url/${testUuid}`,
@@ -27,13 +30,19 @@ afterAll(() => server.close());
 
 function TestFiles({ files = testFiles }) {
   return (
-    <FlaskDataContext.Provider value={flaskDataContext}>
-      <DetailContext.Provider value={detailContext}>
-        <FilesContextProvider>
-          <Files files={files} />
-        </FilesContextProvider>
-      </DetailContext.Provider>
-    </FlaskDataContext.Provider>
+    <ProcessedDatasetContextProvider
+      dataset={{ uuid: 'fakeuuid' } as unknown as ProcessedDatasetDetails}
+      defaultExpanded
+      sectionDataset={{ uuid: 'fakeparentuuid' } as unknown as ProcessedDatasetInfo}
+    >
+      <FlaskDataContext.Provider value={flaskDataContext}>
+        <DetailContext.Provider value={detailContext}>
+          <FilesContextProvider>
+            <Files files={files} />
+          </FilesContextProvider>
+        </DetailContext.Provider>
+      </FlaskDataContext.Provider>
+    </ProcessedDatasetContextProvider>
   );
 }
 

--- a/context/app/static/js/pages/Dataset/Dataset.tsx
+++ b/context/app/static/js/pages/Dataset/Dataset.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import { InternalLink } from 'js/shared-styles/Links';
-import DataProducts from 'js/components/detailPage/files/DataProducts';
 import ProvSection from 'js/components/detailPage/provenance/ProvSection';
 import Summary from 'js/components/detailPage/summary/Summary';
 import Attribution from 'js/components/detailPage/Attribution';
@@ -82,7 +81,6 @@ interface EntityDetailProps<T extends Entity> {
 function DatasetDetail({ assayMetadata }: EntityDetailProps<Dataset>) {
   const {
     protocol_url,
-    files,
     uuid,
     mapped_data_types,
     origin_samples,
@@ -138,7 +136,6 @@ function DatasetDetail({ assayMetadata }: EntityDetailProps<Dataset>) {
             bottomFold={
               <>
                 <MultiAssayRelationship assay_modality={assay_modality} />
-                <DataProducts files={files} />
                 {shouldDisplayRelationships && (
                   <Box height={400} width="100%" component={Paper} p={2}>
                     <DatasetRelationships uuid={uuid} processing={processing} />


### PR DESCRIPTION
## Summary

This PR adjusts the data products and files components to use the proper dataset UUID when building their links. As part of this change, I needed to add relevant wrappers to all the specs.

I also removed the top level `data products` component as there are no data products on primary datasets, i.e. they are only present on processed datasets.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-880

## Testing

Manually tested several datasets' downloads, adjusted unit tests to pass.

## Screenshots/Video

Primary dataset UUID: 8afd1dccac093106c08c76209dde02d6

Download link includes processed dataset UUID: 
![image](https://github.com/user-attachments/assets/eedb5c4e-252e-479d-b307-94a58617de64)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
 