### PR TITLE
Austenem/CAT-246 dataset detail workspace updates

### DIFF
--- a/CHANGELOG-dataset-detail-workspace-updates.md
+++ b/CHANGELOG-dataset-detail-workspace-updates.md
@@ -1,0 +1,1 @@
+- Update menu choices for the workspace buttons in unified views dataset detail pages.

--- a/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
@@ -98,6 +98,9 @@ function HelperPanelActions() {
   if (!currentDataset) {
     return null;
   }
+
+  const { hubmap_id, uuid, status } = currentDataset;
+
   return (
     <>
       <ProcessedDataWorkspaceMenu
@@ -106,6 +109,7 @@ function HelperPanelActions() {
             <HelperPanelButton startIcon={<WorkspacesIcon color="primary" />}>Workspace</HelperPanelButton>
           </SecondaryBackgroundTooltip>
         }
+        datasetDetails={{ hubmap_id, uuid, status }}
       />
       <SecondaryBackgroundTooltip title="Scroll down to the Bulk Data Transfer Section.">
         <HelperPanelButton

--- a/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
@@ -1,34 +1,26 @@
 import React, { PropsWithChildren } from 'react';
+import { animated } from '@react-spring/web';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import { formatDate } from 'date-fns/format';
 import Divider from '@mui/material/Divider';
-import { useIsDesktop } from 'js/hooks/media-queries';
-import SchemaRounded from '@mui/icons-material/SchemaRounded';
-import { WorkspacesIcon } from 'js/shared-styles/icons';
-import CloudDownloadRounded from '@mui/icons-material/CloudDownloadRounded';
-import { useAppContext } from 'js/components/Contexts';
-import { useAnimatedSidebarPosition } from 'js/shared-styles/sections/TableOfContents/hooks';
-import { animated } from '@react-spring/web';
-import { useEventCallback } from '@mui/material/utils';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import Menu from '@mui/material/Menu';
-import MenuItem from '@mui/material/MenuItem';
-import AddRounded from '@mui/icons-material/AddRounded';
-import NewWorkspaceDialog from 'js/components/workspaces/NewWorkspaceDialog';
-import { useCreateWorkspaceForm } from 'js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
-import { useOpenDialog } from 'js/components/workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu';
-import SelectableTableProvider from 'js/shared-styles/tables/SelectableTableProvider/SelectableTableProvider';
-import AddDatasetsFromSearchDialog from 'js/components/workspaces/AddDatasetsFromSearchDialog';
-import { LineClamp } from 'js/shared-styles/text';
 import Fade from '@mui/material/Fade';
+import SchemaRounded from '@mui/icons-material/SchemaRounded';
+import CloudDownloadRounded from '@mui/icons-material/CloudDownloadRounded';
+
+import { useIsDesktop } from 'js/hooks/media-queries';
+import { WorkspacesIcon } from 'js/shared-styles/icons';
+import { useAnimatedSidebarPosition } from 'js/shared-styles/sections/TableOfContents/hooks';
+import { LineClamp } from 'js/shared-styles/text';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+
+import { formatDate } from 'date-fns/format';
 import { HelperPanelPortal } from '../../DetailLayout/DetailLayout';
 import useProcessedDataStore from '../store';
 import StatusIcon from '../../StatusIcon';
 import { getDateLabelAndValue } from '../../utils';
 import { HelperPanelButton } from './styles';
 import { useTrackEntityPageEvent } from '../../useTrackEntityPageEvent';
+import ProcessedDataWorkspaceMenu from '../ProcessedDataWorkspaceMenu';
 
 function useCurrentDataset() {
   return useProcessedDataStore((state) => state.currentDataset);
@@ -100,99 +92,6 @@ function HelperPanelBody() {
   );
 }
 
-function WorkspaceButton() {
-  const currentDataset = useCurrentDataset();
-  const { isWorkspacesUser } = useAppContext();
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
-  const track = useTrackEntityPageEvent();
-
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    track({
-      action: 'Open Workspace Menu',
-      label: currentDataset?.hubmap_id,
-    });
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
-    setAnchorEl(null);
-  };
-
-  const {
-    control,
-    errors,
-    removeDatasets,
-    setDialogIsOpen: setOpenCreateWorkspace,
-    dialogIsOpen: createWorkspaceIsOpen,
-    ...rest
-  } = useCreateWorkspaceForm({
-    defaultName: currentDataset?.hubmap_id,
-    initialSelectedDatasets: currentDataset ? [currentDataset.uuid] : [],
-  });
-
-  const openEditWorkspaceDialog = useOpenDialog('ADD_DATASETS_FROM_SEARCH');
-
-  const trackCreateWorkspace = useEventCallback(() => {
-    track({
-      action: 'Start Creating Workspace',
-      label: currentDataset?.hubmap_id,
-    });
-    setOpenCreateWorkspace(true);
-    handleClose();
-  });
-
-  const trackAddToWorkspace = useEventCallback(() => {
-    track({
-      action: 'Start Adding Dataset to Existing Workspace',
-      label: currentDataset?.hubmap_id,
-    });
-    openEditWorkspaceDialog();
-    handleClose();
-  });
-
-  if (!isWorkspacesUser || currentDataset?.status !== 'Published') {
-    return null;
-  }
-  // The selectable table provider is used here since a lot of the workspace logic relies on the selected rows
-  return (
-    <SelectableTableProvider tableLabel="Current Dataset" selectedRows={new Set([currentDataset.uuid])}>
-      <HelperPanelButton
-        startIcon={<WorkspacesIcon color="primary" />}
-        onClick={handleClick}
-        aria-controls={open ? 'basic-menu' : undefined}
-        aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
-      >
-        Workspace
-      </HelperPanelButton>
-      <Menu
-        open={open}
-        onClose={handleClose}
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'right',
-        }}
-      >
-        <MenuItem onClick={trackCreateWorkspace}>
-          <ListItemIcon>
-            <WorkspacesIcon color="primary" fontSize="1.5rem" />
-          </ListItemIcon>
-          Launch New Workspace
-        </MenuItem>
-        <MenuItem onClick={trackAddToWorkspace}>
-          <ListItemIcon>
-            <AddRounded />
-          </ListItemIcon>
-          Add to Workspace
-        </MenuItem>
-      </Menu>
-      <NewWorkspaceDialog dialogIsOpen={createWorkspaceIsOpen} control={control} errors={errors} {...rest} />
-      <AddDatasetsFromSearchDialog />
-    </SelectableTableProvider>
-  );
-}
-
 function HelperPanelActions() {
   const currentDataset = useCurrentDataset();
   const track = useTrackEntityPageEvent();
@@ -201,7 +100,9 @@ function HelperPanelActions() {
   }
   return (
     <>
-      <WorkspaceButton />
+      <ProcessedDataWorkspaceMenu
+        button={<HelperPanelButton startIcon={<WorkspacesIcon color="primary" />}>Workspace</HelperPanelButton>}
+      />
       <SecondaryBackgroundTooltip title="Scroll down to the Bulk Data Transfer Section.">
         <HelperPanelButton
           startIcon={<CloudDownloadRounded />}

--- a/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
@@ -101,7 +101,11 @@ function HelperPanelActions() {
   return (
     <>
       <ProcessedDataWorkspaceMenu
-        button={<HelperPanelButton startIcon={<WorkspacesIcon color="primary" />}>Workspace</HelperPanelButton>}
+        button={
+          <SecondaryBackgroundTooltip title="Launch new workspace or add dataset to an existing workspace.">
+            <HelperPanelButton startIcon={<WorkspacesIcon color="primary" />}>Workspace</HelperPanelButton>
+          </SecondaryBackgroundTooltip>
+        }
       />
       <SecondaryBackgroundTooltip title="Scroll down to the Bulk Data Transfer Section.">
         <HelperPanelButton

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -53,7 +53,7 @@ function ProcessedDataWorkspaceMenu({
     ...rest
   } = useCreateWorkspaceForm({
     defaultName: hubmap_id,
-    initialSelectedDatasets: [uuid] ?? [],
+    initialSelectedDatasets: [uuid].filter(Boolean),
   });
 
   const openEditWorkspaceDialog = useOpenDialog('ADD_DATASETS_FROM_SEARCH');

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { useEventCallback } from '@mui/material/utils';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import AddRounded from '@mui/icons-material/AddRounded';
+
+import SelectableTableProvider from 'js/shared-styles/tables/SelectableTableProvider';
+import { WorkspacesIcon } from 'js/shared-styles/icons';
+
+import { useOpenDialog } from '../../workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu';
+import { useCreateWorkspaceForm } from '../../workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
+import NewWorkspaceDialog from '../../workspaces/NewWorkspaceDialog/NewWorkspaceDialog';
+import AddDatasetsFromSearchDialog from '../../workspaces/AddDatasetsFromSearchDialog/AddDatasetsFromSearchDialog';
+import { useAppContext, useFlaskDataContext } from '../../Contexts';
+import { useTrackEntityPageEvent } from '../useTrackEntityPageEvent';
+
+interface ProcessedDataWorkspaceMenuProps {
+  button: React.ReactNode;
+}
+
+function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps) {
+  const {
+    entity: { mapped_data_access_level, hubmap_id, uuid, entity_type, status },
+  } = useFlaskDataContext();
+  const isDataset = entity_type === 'Dataset';
+  const { isWorkspacesUser } = useAppContext();
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+  const track = useTrackEntityPageEvent();
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    track({
+      action: 'Open Workspace Menu',
+      label: hubmap_id,
+    });
+    setAnchorEl(event.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const {
+    control,
+    errors,
+    removeDatasets,
+    setDialogIsOpen: setOpenCreateWorkspace,
+    dialogIsOpen: createWorkspaceIsOpen,
+    ...rest
+  } = useCreateWorkspaceForm({
+    defaultName: hubmap_id,
+    initialSelectedDatasets: [uuid] ?? [],
+  });
+
+  const openEditWorkspaceDialog = useOpenDialog('ADD_DATASETS_FROM_SEARCH');
+
+  const trackCreateWorkspace = useEventCallback(() => {
+    track({
+      action: 'Start Creating Workspace',
+      label: hubmap_id,
+    });
+    setOpenCreateWorkspace(true);
+    handleClose();
+  });
+
+  const trackAddToWorkspace = useEventCallback(() => {
+    track({
+      action: 'Start Adding Dataset to Existing Workspace',
+      label: hubmap_id,
+    });
+    openEditWorkspaceDialog();
+    handleClose();
+  });
+
+  // Clone the button element and add the onClick handler
+  const buttonWithClickHandler = React.cloneElement(button as React.ReactElement, {
+    onClick: handleClick,
+    'aria-controls': open ? 'basic-menu' : undefined,
+    'aria-haspopup': 'true',
+    'aria-expanded': open ? 'true' : undefined,
+  });
+
+  const showWorkspaceButton =
+    mapped_data_access_level && hubmap_id && isDataset && isWorkspacesUser && status === 'Published';
+
+  if (!showWorkspaceButton) {
+    return null;
+  }
+
+  // The selectable table provider is used here since a lot of the workspace logic relies on the selected rows
+  return (
+    <SelectableTableProvider tableLabel="Current Dataset" selectedRows={new Set([uuid])}>
+      {buttonWithClickHandler}
+      <>
+        <Menu
+          open={open}
+          onClose={handleClose}
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right',
+          }}
+        >
+          <MenuItem onClick={trackCreateWorkspace}>
+            <ListItemIcon>
+              <WorkspacesIcon color="primary" fontSize="1.5rem" />
+            </ListItemIcon>
+            Launch New Workspace
+          </MenuItem>
+          <MenuItem onClick={trackAddToWorkspace}>
+            <ListItemIcon>
+              <AddRounded />
+            </ListItemIcon>
+            Add to Workspace
+          </MenuItem>
+        </Menu>
+        <NewWorkspaceDialog dialogIsOpen={createWorkspaceIsOpen} control={control} errors={errors} {...rest} />
+        <AddDatasetsFromSearchDialog />
+      </>
+    </SelectableTableProvider>
+  );
+}
+
+export default ProcessedDataWorkspaceMenu;

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -7,13 +7,12 @@ import AddRounded from '@mui/icons-material/AddRounded';
 
 import SelectableTableProvider from 'js/shared-styles/tables/SelectableTableProvider';
 import { WorkspacesIcon } from 'js/shared-styles/icons';
-
-import { useOpenDialog } from '../../workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu';
-import { useCreateWorkspaceForm } from '../../workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
-import NewWorkspaceDialog from '../../workspaces/NewWorkspaceDialog/NewWorkspaceDialog';
-import AddDatasetsFromSearchDialog from '../../workspaces/AddDatasetsFromSearchDialog/AddDatasetsFromSearchDialog';
-import { useAppContext, useFlaskDataContext } from '../../Contexts';
-import { useTrackEntityPageEvent } from '../useTrackEntityPageEvent';
+import { useOpenDialog } from 'js/components/workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu';
+import { useCreateWorkspaceForm } from 'js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
+import { useAppContext, useFlaskDataContext } from 'js/components/Contexts';
+import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
+import NewWorkspaceDialog from 'js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog';
+import AddDatasetsFromSearchDialog from 'js/components/workspaces/AddDatasetsFromSearchDialog/AddDatasetsFromSearchDialog';
 
 interface ProcessedDataWorkspaceMenuProps {
   button: React.ReactNode;

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -87,6 +87,19 @@ function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps)
     return null;
   }
 
+  const options = [
+    {
+      children: 'Launch New Workspace',
+      onClick: trackCreateWorkspace,
+      icon: <WorkspacesIcon color="primary" fontSize="1.25rem" />,
+    },
+    {
+      children: 'Add to Workspace',
+      onClick: trackAddToWorkspace,
+      icon: <AddRounded color="primary" />,
+    },
+  ];
+
   // The selectable table provider is used here since a lot of the workspace logic relies on the selected rows
   return (
     <SelectableTableProvider tableLabel="Current Dataset" selectedRows={new Set([uuid])}>
@@ -101,18 +114,12 @@ function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps)
             horizontal: 'right',
           }}
         >
-          <MenuItem onClick={trackCreateWorkspace}>
-            <ListItemIcon>
-              <WorkspacesIcon color="primary" fontSize="1.5rem" />
-            </ListItemIcon>
-            Launch New Workspace
-          </MenuItem>
-          <MenuItem onClick={trackAddToWorkspace}>
-            <ListItemIcon>
-              <AddRounded />
-            </ListItemIcon>
-            Add to Workspace
-          </MenuItem>
+          {options.map(({ children, onClick, icon }) => (
+            <MenuItem key={children} onClick={onClick}>
+              <ListItemIcon>{icon}</ListItemIcon>
+              {children}
+            </MenuItem>
+          ))}
         </Menu>
         <NewWorkspaceDialog dialogIsOpen={createWorkspaceIsOpen} control={control} errors={errors} {...rest} />
         <AddDatasetsFromSearchDialog />

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -16,25 +16,30 @@ import AddDatasetsFromSearchDialog from 'js/components/workspaces/AddDatasetsFro
 
 interface ProcessedDataWorkspaceMenuProps {
   button: React.ReactNode;
+  datasetDetails: { hubmap_id: string; uuid: string; status: string };
 }
 
-function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps) {
+function ProcessedDataWorkspaceMenu({
+  button,
+  datasetDetails: { hubmap_id, uuid, status },
+}: ProcessedDataWorkspaceMenuProps) {
   const {
-    entity: { mapped_data_access_level, hubmap_id, uuid, entity_type, status },
+    entity: { mapped_data_access_level },
   } = useFlaskDataContext();
-  const isDataset = entity_type === 'Dataset';
+
   const { isWorkspacesUser } = useAppContext();
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const track = useTrackEntityPageEvent();
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+  const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
     track({
       action: 'Open Workspace Menu',
       label: hubmap_id,
     });
     setAnchorEl(event.currentTarget);
   };
+
   const handleClose = () => {
     setAnchorEl(null);
   };
@@ -53,7 +58,7 @@ function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps)
 
   const openEditWorkspaceDialog = useOpenDialog('ADD_DATASETS_FROM_SEARCH');
 
-  const trackCreateWorkspace = useEventCallback(() => {
+  const createWorkspace = useEventCallback(() => {
     track({
       action: 'Start Creating Workspace',
       label: hubmap_id,
@@ -62,7 +67,7 @@ function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps)
     handleClose();
   });
 
-  const trackAddToWorkspace = useEventCallback(() => {
+  const addToWorkspace = useEventCallback(() => {
     track({
       action: 'Start Adding Dataset to Existing Workspace',
       label: hubmap_id,
@@ -73,14 +78,13 @@ function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps)
 
   // Clone the button element and add the onClick handler
   const buttonWithClickHandler = React.cloneElement(button as React.ReactElement, {
-    onClick: handleClick,
+    onClick: handleOpen,
     'aria-controls': open ? 'basic-menu' : undefined,
     'aria-haspopup': 'true',
     'aria-expanded': open ? 'true' : undefined,
   });
 
-  const showWorkspaceButton =
-    mapped_data_access_level && hubmap_id && isDataset && isWorkspacesUser && status === 'Published';
+  const showWorkspaceButton = mapped_data_access_level && hubmap_id && isWorkspacesUser && status === 'Published';
 
   if (!showWorkspaceButton) {
     return null;
@@ -89,12 +93,12 @@ function ProcessedDataWorkspaceMenu({ button }: ProcessedDataWorkspaceMenuProps)
   const options = [
     {
       children: 'Launch New Workspace',
-      onClick: trackCreateWorkspace,
+      onClick: createWorkspace,
       icon: <WorkspacesIcon color="primary" fontSize="1.25rem" />,
     },
     {
       children: 'Add to Workspace',
-      onClick: trackAddToWorkspace,
+      onClick: addToWorkspace,
       icon: <AddRounded color="primary" />,
     },
   ];

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -138,7 +138,13 @@ function VisualizationAccordion() {
         This visualization includes various interactive elements such as scatter plots, spatial imaging plots, heat
         maps, genome browser tracks, and more.
       </SectionDescription>
-      <VisualizationWrapper vitData={conf} uuid={uuid} shouldDisplayHeader={false} hasBeenMounted={hasBeenSeen} />
+      <VisualizationWrapper
+        vitData={conf}
+        uuid={uuid}
+        shouldDisplayHeader={false}
+        hasBeenMounted={hasBeenSeen}
+        hasNotebook
+      />
     </Subsection>
   );
 }

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
@@ -13,12 +13,12 @@ import EditSavedStatusDialog from 'js/components/savedLists/EditSavedStatusDialo
 import useSavedEntitiesStore, { SavedEntitiesStore } from 'js/stores/useSavedEntitiesStore';
 import { Entity } from 'js/components/types';
 import { AllEntityTypes } from 'js/shared-styles/icons/entityIconMap';
-import NewWorkspaceDialog from 'js/components/workspaces/NewWorkspaceDialog';
-import { useCreateWorkspaceForm } from 'js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
-import { useAppContext, useFlaskDataContext } from 'js/components/Contexts';
-import WorkspacesIcon from 'assets/svg/workspaces.svg';
+import { useFlaskDataContext } from 'js/components/Contexts';
 import { sectionIconMap } from 'js/shared-styles/icons/sectionIconMap';
 import { useIsLargeDesktop } from 'js/hooks/media-queries';
+
+import WorkspacesIcon from 'assets/svg/workspaces.svg';
+import ProcessedDataWorkspaceMenu from '../../ProcessedData/ProcessedDataWorkspaceMenu';
 
 function ActionButton<E extends ElementType = IconButtonTypeMap['defaultComponent']>({
   icon: Icon,
@@ -87,33 +87,6 @@ function EditSavedEntityButton({ entity_type, uuid }: Pick<Entity, 'uuid'> & { e
 
 function WorkspaceSVGIcon({ color = 'primary', ...props }: SvgIconProps) {
   return <SvgIcon component={WorkspacesIcon} color={color} {...props} />;
-}
-
-function CreateWorkspaceButton({
-  uuid,
-  hubmap_id,
-  mapped_data_access_level,
-}: Pick<Entity, 'uuid' | 'hubmap_id' | 'mapped_data_access_level'>) {
-  const { setDialogIsOpen, removeDatasets, ...rest } = useCreateWorkspaceForm({
-    defaultName: hubmap_id,
-    initialSelectedDatasets: [uuid],
-  });
-
-  const disabled = mapped_data_access_level === 'Protected';
-
-  return (
-    <>
-      <ActionButton
-        onClick={() => {
-          setDialogIsOpen(true);
-        }}
-        icon={WorkspaceSVGIcon}
-        tooltip={disabled ? 'Protected datasets are not available in workspaces.' : 'Launch a new workspace.'}
-        disabled={disabled}
-      />
-      <NewWorkspaceDialog {...rest} />
-    </>
-  );
 }
 
 const useSavedEntitiesSelector = (state: SavedEntitiesStore) => state.savedEntities;
@@ -210,27 +183,31 @@ function EntityHeaderActionButtons({
   entity_type?: AllEntityTypes;
 }) {
   const isLargeDesktop = useIsLargeDesktop();
-  const { isWorkspacesUser } = useAppContext();
 
   const {
-    entity: { mapped_data_access_level, hubmap_id, uuid },
+    entity: { mapped_data_access_level, uuid },
   } = useFlaskDataContext();
 
   if (!(entity_type && uuid)) {
     return null;
   }
 
-  const isDataset = entity_type === 'Dataset';
-  const showWorkspaceButton = mapped_data_access_level && hubmap_id && isDataset && isWorkspacesUser;
+  const disabled = mapped_data_access_level === 'Protected';
 
   return (
     <Stack direction="row" spacing={1} alignItems="center">
       {isLargeDesktop && <ViewSelectChips selectedView={view} setView={setView} entity_type={entity_type} />}
       <SaveEditEntityButton uuid={uuid} entity_type={entity_type} />
       <JSONButton entity_type={entity_type} uuid={uuid} />
-      {showWorkspaceButton && (
-        <CreateWorkspaceButton uuid={uuid} hubmap_id={hubmap_id} mapped_data_access_level={mapped_data_access_level} />
-      )}
+      <ProcessedDataWorkspaceMenu
+        button={
+          <ActionButton
+            icon={WorkspaceSVGIcon}
+            tooltip={disabled ? 'Protected datasets are not available in workspaces.' : 'Launch a new workspace.'}
+            disabled={disabled}
+          />
+        }
+      />
     </Stack>
   );
 }

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
@@ -203,7 +203,11 @@ function EntityHeaderActionButtons({
         button={
           <ActionButton
             icon={WorkspaceSVGIcon}
-            tooltip={disabled ? 'Protected datasets are not available in workspaces.' : 'Launch a new workspace.'}
+            tooltip={
+              disabled
+                ? 'Protected datasets are not available in workspaces.'
+                : 'Launch new workspace or add dataset to an existing workspace.'
+            }
             disabled={disabled}
           />
         }

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
@@ -16,9 +16,8 @@ import { AllEntityTypes } from 'js/shared-styles/icons/entityIconMap';
 import { useFlaskDataContext } from 'js/components/Contexts';
 import { sectionIconMap } from 'js/shared-styles/icons/sectionIconMap';
 import { useIsLargeDesktop } from 'js/hooks/media-queries';
-
+import ProcessedDataWorkspaceMenu from 'js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu';
 import WorkspacesIcon from 'assets/svg/workspaces.svg';
-import ProcessedDataWorkspaceMenu from '../../ProcessedData/ProcessedDataWorkspaceMenu';
 
 function ActionButton<E extends ElementType = IconButtonTypeMap['defaultComponent']>({
   icon: Icon,
@@ -185,7 +184,7 @@ function EntityHeaderActionButtons({
   const isLargeDesktop = useIsLargeDesktop();
 
   const {
-    entity: { mapped_data_access_level, uuid },
+    entity: { mapped_data_access_level, uuid, hubmap_id, status },
   } = useFlaskDataContext();
 
   if (!(entity_type && uuid)) {
@@ -211,6 +210,7 @@ function EntityHeaderActionButtons({
             disabled={disabled}
           />
         }
+        datasetDetails={{ hubmap_id, uuid, status }}
       />
     </Stack>
   );


### PR DESCRIPTION
## Summary

Update menu choices for the workspace buttons in unified views dataset detail pages to allow for both creating and editing workspaces. 

## Design Documentation/Original Tickets

[CAT-246 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-246?atlOrigin=eyJpIjoiNDM0YWM4OGE0OGZjNDZkODgyY2I3ZWI0YWVkOTAyOWMiLCJwIjoiaiJ9)

[CAT-507 Jira ticket (design)](https://hms-dbmi.atlassian.net/browse/HMP-484?atlOrigin=eyJpIjoiYTNlMGMxYmQ1Y2M3NDgwNDgwZmI5MjA2NjZiZjQ1OTIiLCJwIjoiaiJ9)

## Testing

Went through both options for both workspace buttons on several dataset pages. 

## Screenshots/Video

https://github.com/user-attachments/assets/afd7baf3-a937-4cb8-a7ab-ff87b3828a9d

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

