### PR TITLE
NickAkhmetov/CAT-858 Hide HuBMAP ID's for non-entity nodes in provenance graph

### DIFF
--- a/CHANGELOG-cat-858.md
+++ b/CHANGELOG-cat-858.md
@@ -1,0 +1,1 @@
+- Hide HuBMAP ID's for non-entity nodes in provenance graph.

--- a/context/app/static/js/components/detailPage/provenance/NodeElement/NodeElement.tsx
+++ b/context/app/static/js/components/detailPage/provenance/NodeElement/NodeElement.tsx
@@ -12,6 +12,18 @@ import { ProvNode } from '../types';
 const uuidSelector = (state: ProvenanceStore) => state.uuid;
 const setHasRenderedSelector = (state: ProvenanceStore) => state.setHasRendered;
 
+// Hide the HuBMAP ID from the display title for non-entity nodes returned by provenance
+// e.g. "Create Dataset" instead of "Create Dataset - HBM789.1234.123"
+function getDisplayTitle(node: ProvNode, title?: string) {
+  if (title) {
+    return title;
+  }
+  if (node.nodeType === 'step') {
+    return (node.title ?? node.name).split(' - ')[0];
+  }
+  return node.title ?? node.name;
+}
+
 interface NodeElementProps {
   node: ProvNode;
   title?: string;
@@ -21,7 +33,7 @@ interface NodeElementProps {
 function NodeElement({ node, title, columnWidth }: NodeElementProps) {
   const style = ['input', 'output'].includes(node.nodeType) ? { width: columnWidth ?? 100 } : undefined;
 
-  const displayTitle = title ?? node.title ?? node.name;
+  const displayTitle = getDisplayTitle(node, title);
 
   const uuid = useProvenanceStore(uuidSelector);
   const setHasRendered = useProvenanceStore(setHasRenderedSelector);

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.spec.js
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraph.spec.js
@@ -55,7 +55,7 @@ afterAll(() => server.close());
 test('should display the correct initial nodes for a donor', () => {
   const nodesText = [
     'hubmap:entities/308f5ffc-ed43-11e8-b56a-0e8017bdda58',
-    'Register Donor Activity - HBM826.XCGC.423',
+    'Register Donor Activity',
     'Donor - HBM528.WJLC.564',
   ];
 
@@ -66,12 +66,9 @@ test('should display the correct initial nodes for a donor', () => {
 
 test('should display the correct initial nodes for a sample', () => {
   const sampleEntityText = 'Sample - HBM666.CHPF.373';
-  const nodesText = ['Donor - HBM547.NCQL.874', 'Create Sample Activity - HBM665.NTZB.997', sampleEntityText];
+  const nodesText = ['Donor - HBM547.NCQL.874', 'Create Sample Activity', sampleEntityText];
 
-  const notIncludedNodesText = [
-    'hubmap:entities/73bb26e4-ed43-11e8-8f19-0a7c1eab007a',
-    'Register Donor Activity - HBM398.NBBW.527',
-  ];
+  const notIncludedNodesText = ['hubmap:entities/73bb26e4-ed43-11e8-8f19-0a7c1eab007a', 'Register Donor Activity'];
 
   render(<ProvGraph provData={sampleProv} />);
 
@@ -101,19 +98,6 @@ test('should display selected node information in detail pane and show immediate
   detailPaneText.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument());
 
   await waitFor(() => expect(derivedEntitiesButton).toBeEnabled());
-
-  /* TODO: After npm upgrade, the next line fails: */
-
-  // fireEvent.click(derivedEntitiesButton);
-  //
-  // const newNodesText = [
-  //   'Create Sample Activity - HBM358.MRDC.967',
-  //   'Sample - HBM743.BZVB.466',
-  //   'Create Sample Activity - HBM534.VGXH.932',
-  //   'Sample - HBM643.FDGT.862',
-  // ];
-  //
-  // await waitFor(() => newNodesText.forEach((text) => expect(screen.getByText(text)).toBeInTheDocument()));
 });
 
 test("should display an asterisk in the current page's node", () => {


### PR DESCRIPTION
## Summary

This PR hides the internal ID that was being displayed as part of the provenance graph for `step` nodes, as these are not accessible/meaningful in any way and only introduce confusion.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-858

## Testing

Manually tested on same dataset linked in original ticket.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/300bd84c-4fd3-4f8a-aa09-734c131a54da)
![image](https://github.com/user-attachments/assets/43369392-3e4d-4dae-b0be-9e73991f7be4)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
