### PR TITLE
John conroy/new ws envs CAT-902

### DIFF
--- a/CHANGELOG-new-ws-envs.md
+++ b/CHANGELOG-new-ws-envs.md
@@ -1,0 +1,1 @@
+- Add language to workspace environment sections to help users distinguish between environments.

--- a/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/LaunchWorkspaceDialog/LaunchWorkspaceDialog.tsx
@@ -15,16 +15,21 @@ import {
   useLaunchWorkspaceDialog,
   LaunchWorkspaceFormTypes,
 } from 'js/components/workspaces/LaunchWorkspaceDialog/hooks';
+import WorkspaceEnvironmentDescription from '../WorkspaceEnvironmentDescription';
 
 const formId = 'launch-workspace-form';
 
 const text = {
   environment: {
     title: 'Environment Selection',
-    description: [
-      'All workspaces are launched with Python support, with the option to add support for R. Workspaces with added R support may experience longer load times.',
-      'If a workspace was previously launched with R, launching a workspace without R support may cause issues with your saved work.',
-    ],
+    description: (
+      <WorkspaceEnvironmentDescription>
+        <Typography>
+          If a workspace was previously launched with R, launching a workspace without R support may cause issues with
+          your saved work.
+        </Typography>
+      </WorkspaceEnvironmentDescription>
+    ),
   },
   resources: {
     alert:
@@ -100,9 +105,7 @@ function LaunchWorkspaceDialog() {
               <SummaryPaper>
                 <Stack direction="column" spacing={2}>
                   <StyledSubtitle1>{text.environment.title}</StyledSubtitle1>
-                  {text.environment.description.map((description) => (
-                    <Typography key={description}>{description}</Typography>
-                  ))}
+                  {text.environment.description}
                   <WorkspaceJobTypeField control={control} name="workspaceJobTypeId" />
                 </Stack>
               </SummaryPaper>

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialog.tsx
@@ -28,6 +28,7 @@ import AdvancedConfigOptions from '../AdvancedConfigOptions';
 import AddDatasetsTable from '../AddDatasetsTable';
 import { SearchAheadHit } from '../AddDatasetsTable/hooks';
 import { StyledSubtitle1 } from '../style';
+import WorkspaceEnvironmentDescription from '../WorkspaceEnvironmentDescription';
 
 const text = {
   overview: {
@@ -63,9 +64,7 @@ const text = {
   },
   configure: {
     title: 'Configure Workspace',
-    description: [
-      'All workspaces are launched with Python support, with the option to add support for R. Workspaces with added R support may experience longer load times.',
-    ],
+    description: <WorkspaceEnvironmentDescription />,
     advancedDescription: 'Adjusting these settings may result in longer workspace load times.',
   },
   templates: {
@@ -211,7 +210,7 @@ function NewWorkspaceDialog({
             />
             <Stack spacing={2} p={2} component={Paper} direction="column">
               <StyledSubtitle1>Environment Selection</StyledSubtitle1>
-              <Typography>{text.configure.description}</Typography>
+              {text.configure.description}
               <WorkspaceJobTypeField control={control} name="workspaceJobTypeId" />
             </Stack>
             <AdvancedConfigOptions control={control} description={text.configure.advancedDescription} />

--- a/context/app/static/js/components/workspaces/WorkspaceEnvironmentDescription/WorkspaceEnvironmentDescription.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceEnvironmentDescription/WorkspaceEnvironmentDescription.tsx
@@ -2,15 +2,8 @@ import React, { PropsWithChildren } from 'react';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 
+import HighEmphasis from 'js/shared-styles/text/HighEmphasis';
 import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
-
-function HighEmphasis({ children }: PropsWithChildren) {
-  return (
-    <Typography variant="subtitle2" color="textPrimary" component="span">
-      {children}
-    </Typography>
-  );
-}
 
 function WorkspaceEnvironmentDescription({ children }: PropsWithChildren) {
   return (

--- a/context/app/static/js/components/workspaces/WorkspaceEnvironmentDescription/WorkspaceEnvironmentDescription.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceEnvironmentDescription/WorkspaceEnvironmentDescription.tsx
@@ -1,0 +1,37 @@
+import React, { PropsWithChildren } from 'react';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+
+import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
+
+function HighEmphasis({ children }: PropsWithChildren) {
+  return (
+    <Typography variant="subtitle2" color="textPrimary" component="span">
+      {children}
+    </Typography>
+  );
+}
+
+function WorkspaceEnvironmentDescription({ children }: PropsWithChildren) {
+  return (
+    <Stack spacing={2}>
+      <Typography>
+        All workspaces environments have built-in Python support, with the option to include R or pre-installed packages
+        as needed. To view the full list of packages, use the <HighEmphasis>help(&apos;modules&apos;)</HighEmphasis>{' '}
+        command for Python or <HighEmphasis>install.packages()</HighEmphasis> for R in your workspace.
+      </Typography>
+      {children}
+      <Typography>
+        Please note that selecting environments with extra features may result in longer loading times. For environments
+        with GPU packages, it is strongly recommended to enable GPU support in the advanced configurations section.
+        Since GPU resources are limited, please select this option only if it is essential for your workspace.
+      </Typography>
+      <Typography>
+        If you have questions about these environments and their respective packages or suggestions for improvements,
+        please <ContactUsLink />.
+      </Typography>
+    </Stack>
+  );
+}
+
+export default WorkspaceEnvironmentDescription;

--- a/context/app/static/js/components/workspaces/WorkspaceEnvironmentDescription/index.ts
+++ b/context/app/static/js/components/workspaces/WorkspaceEnvironmentDescription/index.ts
@@ -1,0 +1,3 @@
+import WorkspaceEnvironmentDescription from './WorkspaceEnvironmentDescription';
+
+export default WorkspaceEnvironmentDescription;

--- a/context/app/static/js/components/workspaces/WorkspaceJobTypeField/WorkspaceJobTypeField.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceJobTypeField/WorkspaceJobTypeField.tsx
@@ -5,9 +5,36 @@ import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import FormLabel from '@mui/material/FormLabel';
 import { FieldValues, useController, UseControllerProps } from 'react-hook-form';
+
+import InfoTooltipIcon from 'js/shared-styles/icons/TooltipIcon';
 import { useJobTypes } from '../api';
+import {
+  JUPYTER_LAB_GPU_JOB_TYPE,
+  JUPYTER_LAB_JOB_TYPE,
+  JUPYTER_LAB_NON_GPU_JOB_TYPE,
+  JUPYTER_LAB_R_JOB_TYPE,
+} from '../constants';
 
 type WorkspaceJobTypeFieldProps<FormType extends FieldValues> = Pick<UseControllerProps<FormType>, 'name' | 'control'>;
+
+const jobTypeDescriptions: Record<string, string> = {
+  [JUPYTER_LAB_JOB_TYPE]: 'No packages.',
+  [JUPYTER_LAB_R_JOB_TYPE]: 'Standard R packages. No Python packages.',
+  [JUPYTER_LAB_NON_GPU_JOB_TYPE]:
+    'Python packages: Pandas, Numpy, Scikit Learn, Pytorch (CPU), Seaborn, Scipy, Biopython, cellxgene_census, scanpy, squidpy, matplotlib, scVI, anndata, spatialdata, umap, napari.',
+  [JUPYTER_LAB_GPU_JOB_TYPE]:
+    'Python packages: Pandas, Numpy, Scikit Learn, Pytorch, Seaborn, Scipy, Biopython, cellxgene_census, scanpy, squidpy, matplotlib, scVI, anndata, spatialdata, umap, napari, rapids, rapids-singlecell.',
+};
+
+function JobTypeLabel({ label, id }: { label: string; id: string }) {
+  const tooltip = jobTypeDescriptions?.[id];
+  return (
+    <>
+      {label}
+      {tooltip && <InfoTooltipIcon iconTooltipText={tooltip} />}
+    </>
+  );
+}
 
 function WorkspaceJobTypeField<FormType extends FieldValues>({ control, name }: WorkspaceJobTypeFieldProps<FormType>) {
   const { field } = useController({
@@ -36,9 +63,16 @@ function WorkspaceJobTypeField<FormType extends FieldValues>({ control, name }: 
         value={field.value}
         onChange={(e, value) => field.onChange(value)}
       >
-        {Object.values(data).map(({ id, name: jobTypeName }) => (
-          <FormControlLabel value={id} control={<Radio />} label={jobTypeName} key={id} />
-        ))}
+        {Object.values(data).map(({ id, name: jobTypeName }) => {
+          return (
+            <FormControlLabel
+              value={id}
+              control={<Radio />}
+              label={<JobTypeLabel label={jobTypeName} id={id} />}
+              key={id}
+            />
+          );
+        })}
       </RadioGroup>
     </Box>
   );

--- a/context/app/static/js/components/workspaces/constants.ts
+++ b/context/app/static/js/components/workspaces/constants.ts
@@ -1,5 +1,11 @@
+/* Workspace job types */
+export const JUPYTER_LAB_JOB_TYPE = 'jupyter_lab';
+export const JUPYTER_LAB_R_JOB_TYPE = 'jupyter_lab_r';
+export const JUPYTER_LAB_GPU_JOB_TYPE = 'jupyter_lab_gpu_common_packages';
+export const JUPYTER_LAB_NON_GPU_JOB_TYPE = 'jupyter_lab_non_gpu_common_packages';
+
 /* Workspace defaults */
-export const DEFAULT_JOB_TYPE = 'jupyter_lab';
+export const DEFAULT_JOB_TYPE = JUPYTER_LAB_JOB_TYPE;
 export const DEFAULT_TEMPLATE_KEY = 'blank';
 
 /* Workspace resource defaults */

--- a/context/app/static/js/shared-styles/text/HighEmphasis.tsx
+++ b/context/app/static/js/shared-styles/text/HighEmphasis.tsx
@@ -1,0 +1,12 @@
+import React, { PropsWithChildren } from 'react';
+import Typography, { TypographyProps } from '@mui/material/Typography';
+
+function HighEmphasis({ children, ...rest }: PropsWithChildren & TypographyProps) {
+  return (
+    <Typography variant="subtitle2" color="textPrimary" component="span" {...rest}>
+      {children}
+    </Typography>
+  );
+}
+
+export default HighEmphasis;


### PR DESCRIPTION
## Summary

Add language to workspace environment sections to help users distinguish between environments.

## Design Documentation/Original Tickets

- [Ticket](https://hms-dbmi.atlassian.net/browse/CAT-902)
- [Figma](https://www.figma.com/design/NgBjvs0jRbDHhiyn5nicDm/Workspace?node-id=3235-2490&node-type=canvas&m=dev)

## Screenshots/Video

New Workspace

<img width="1266" alt="Screenshot 2024-09-17 at 3 35 32 PM" src="https://github.com/user-attachments/assets/b67ac7d9-cc11-4d18-b6a2-ebf8e4970fb2">

Launch Workspace

<img width="938" alt="Screenshot 2024-09-17 at 3 36 34 PM" src="https://github.com/user-attachments/assets/781c8822-f62c-4812-9530-be084ce2fa04">


Tooltips
<img width="476" alt="Screenshot 2024-09-17 at 3 35 43 PM" src="https://github.com/user-attachments/assets/00e959c2-4e7b-48f5-9ad5-2629b1b1af11">
<img width="548" alt="Screenshot 2024-09-17 at 3 36 01 PM" src="https://github.com/user-attachments/assets/49e4e6e0-7af4-4589-b087-2074924ee2df">
<img width="602" alt="Screenshot 2024-09-17 at 3 35 53 PM" src="https://github.com/user-attachments/assets/b3ed9771-b8eb-4377-8a22-16a04fc9e9c7">
<img width="428" alt="Screenshot 2024-09-17 at 3 35 47 PM" src="https://github.com/user-attachments/assets/9ce38938-bb59-4da5-9692-63d5e1b51c1a">


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
