### PR TITLE
John conroy/last minute workspace updates

### DIFF
--- a/CHANGELOG-last-minute-workspace-updates.md
+++ b/CHANGELOG-last-minute-workspace-updates.md
@@ -1,2 +1,2 @@
-- Increase maximum resource options for workspace jobs from 2 CPUs to 16, 32GB of memory to 128GB and session length from 3 hours to 12.
+- Increase maximum resource options for workspace jobs from 2 CPUs to 16, 32GB of memory to 128GB and session length from 6 hours to 12.
 - Add last modified date to template detail pages.

--- a/CHANGELOG-last-minute-workspace-updates.md
+++ b/CHANGELOG-last-minute-workspace-updates.md
@@ -1,0 +1,2 @@
+- Increase maximum resource options for workspace jobs from 2 CPUs to 16, 32GB of memory to 128GB and session length from 3 hours to 12.
+- Add last modified date to template detail pages.

--- a/context/app/static/js/components/workspaces/constants.ts
+++ b/context/app/static/js/components/workspaces/constants.ts
@@ -23,10 +23,10 @@ export const DEFAULT_GPU_ENABLED = false;
 
 /* Workspace resource limits */
 export const MIN_NUM_CPUS = 1;
-export const MAX_NUM_CPUS = 2;
+export const MAX_NUM_CPUS = 16;
 
 export const MIN_MEMORY_MB = 1024;
-export const MAX_MEMORY_MB = 32768;
+export const MAX_MEMORY_MB = 131072;
 
 export const MIN_TIME_LIMIT_MINUTES = 60;
 export const MAX_TIME_LIMIT_MINUTES = 360;

--- a/context/app/static/js/components/workspaces/constants.ts
+++ b/context/app/static/js/components/workspaces/constants.ts
@@ -29,4 +29,4 @@ export const MIN_MEMORY_MB = 1024;
 export const MAX_MEMORY_MB = 131072;
 
 export const MIN_TIME_LIMIT_MINUTES = 60;
-export const MAX_TIME_LIMIT_MINUTES = 360;
+export const MAX_TIME_LIMIT_MINUTES = 720;

--- a/context/app/static/js/components/workspaces/types.ts
+++ b/context/app/static/js/components/workspaces/types.ts
@@ -120,6 +120,7 @@ interface TemplateTypes {
   is_hidden: boolean;
   job_types?: string[];
   examples: TemplateExample[];
+  last_modified_unix_timestamp: number;
 }
 
 type TemplatesTypes = Record<string, TemplateTypes>;

--- a/context/app/static/js/pages/Template/Template.tsx
+++ b/context/app/static/js/pages/Template/Template.tsx
@@ -5,7 +5,6 @@ import Typography from '@mui/material/Typography';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
 import { format } from 'date-fns/format';
-import { fromUnixTime } from 'date-fns/fromUnixTime';
 
 import { useWorkspaceTemplates } from 'js/components/workspaces/NewWorkspaceDialog/hooks';
 import SummaryPaper from 'js/shared-styles/sections/SectionPaper';
@@ -148,7 +147,7 @@ function Template({ templateKey }: TemplatePageProps) {
               label="Last Modified"
               iconTooltipText="Date when this template was last modified by its template provider."
             >
-              {format(fromUnixTime(template.last_modified_unix_timestamp), 'yyyy-MM-dd')}
+              {format(template.last_modified_unix_timestamp * 1000, 'yyyy-MM-dd')}
             </LabelledSectionText>
           )}
         </Stack>

--- a/context/app/static/js/pages/Template/Template.tsx
+++ b/context/app/static/js/pages/Template/Template.tsx
@@ -4,6 +4,8 @@ import AccordionDetails from '@mui/material/AccordionDetails';
 import Typography from '@mui/material/Typography';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import KeyboardArrowDownRoundedIcon from '@mui/icons-material/KeyboardArrowDownRounded';
+import { format } from 'date-fns/format';
+import { fromUnixTime } from 'date-fns/fromUnixTime';
 
 import { useWorkspaceTemplates } from 'js/components/workspaces/NewWorkspaceDialog/hooks';
 import SummaryPaper from 'js/shared-styles/sections/SectionPaper';
@@ -139,6 +141,14 @@ function Template({ templateKey }: TemplatePageProps) {
                   <StyledChip key={tag} label={tag} variant="outlined" />
                 ))}
               </Stack>
+            </LabelledSectionText>
+          )}
+          {template?.last_modified_unix_timestamp && (
+            <LabelledSectionText
+              label="Last Modified"
+              iconTooltipText="Date when this template was last modified by its template provider."
+            >
+              {format(fromUnixTime(template.last_modified_unix_timestamp), 'yyyy-MM-dd')}
             </LabelledSectionText>
           )}
         </Stack>

--- a/context/app/static/js/pages/Template/Template.tsx
+++ b/context/app/static/js/pages/Template/Template.tsx
@@ -145,7 +145,7 @@ function Template({ templateKey }: TemplatePageProps) {
           {template?.last_modified_unix_timestamp && (
             <LabelledSectionText
               label="Last Modified"
-              iconTooltipText="Date when this template was last modified by its template provider."
+              iconTooltipText="Date when this template was last modified by its provider."
             >
               {format(template.last_modified_unix_timestamp * 1000, 'yyyy-MM-dd')}
             </LabelledSectionText>


### PR DESCRIPTION
## Summary

- Increase maximum resource options for workspace jobs from 2 CPUs to 16, 32GB of memory to 128GB and session length from 6 hours to 12.
- Add last modified date to template detail pages.

## Screenshots/Video

<img width="1792" alt="Screenshot 2024-09-18 at 3 05 36 PM" src="https://github.com/user-attachments/assets/8dd7069e-0d44-4126-9679-d3d76cd903fc">
<img width="1792" alt="Screenshot 2024-09-18 at 3 05 20 PM" src="https://github.com/user-attachments/assets/4f10da28-e8d5-4d9c-817c-1406e9365771">


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
