### PR TITLE
Austenem/CAT-913 remove file accordion

### DIFF
--- a/CHANGELOG-remove-file-accordion.md
+++ b/CHANGELOG-remove-file-accordion.md
@@ -1,0 +1,1 @@
+- Remove extra files accordion from processed datasets summary sections. 

--- a/context/app/static/js/components/detailPage/files/Files/Files.tsx
+++ b/context/app/static/js/components/detailPage/files/Files/Files.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 
 import Box from '@mui/material/Box';
 
-import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
-
 import FileBrowser from '../FileBrowser';
 import { FilesContextProvider } from '../FilesContext';
 import { UnprocessedFile } from '../types';
@@ -15,13 +13,11 @@ interface FilesProps {
 function Files({ files }: FilesProps) {
   return (
     <FilesContextProvider>
-      <CollapsibleDetailPageSection id="files" title="Files">
-        {files.length > 0 && (
-          <Box mb={2}>
-            <FileBrowser files={files} />
-          </Box>
-        )}
-      </CollapsibleDetailPageSection>
+      {files.length > 0 && (
+        <Box mb={2}>
+          <FileBrowser files={files} />
+        </Box>
+      )}
     </FilesContextProvider>
   );
 }

--- a/context/app/static/js/components/detailPage/files/Files/Files.tsx
+++ b/context/app/static/js/components/detailPage/files/Files/Files.tsx
@@ -2,21 +2,32 @@ import React from 'react';
 
 import Box from '@mui/material/Box';
 
+import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
+
 import FileBrowser from '../FileBrowser';
 import { FilesContextProvider } from '../FilesContext';
 import { UnprocessedFile } from '../types';
 
 interface FilesProps {
   files: UnprocessedFile[];
+  includeAccordion?: boolean;
 }
 
-function Files({ files }: FilesProps) {
+function Files({ files, includeAccordion }: FilesProps) {
+  const fileContent = files.length > 0 && (
+    <Box mb={2}>
+      <FileBrowser files={files} />
+    </Box>
+  );
+
   return (
     <FilesContextProvider>
-      {files.length > 0 && (
-        <Box mb={2}>
-          <FileBrowser files={files} />
-        </Box>
+      {includeAccordion ? (
+        <CollapsibleDetailPageSection id="files" title="Files">
+          {fileContent}
+        </CollapsibleDetailPageSection>
+      ) : (
+        fileContent
       )}
     </FilesContextProvider>
   );

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -59,7 +59,7 @@ function Publication({ publication, vignette_json }) {
         {shouldDisplaySection.visualizations && (
           <PublicationsVisualizationSection vignette_json={vignette_json} uuid={uuid} />
         )}
-        {shouldDisplaySection.files && <Files files={files} uuid={uuid} hubmap_id={hubmap_id} />}
+        {shouldDisplaySection.files && <Files files={files} includeAccordion />}
         {shouldDisplaySection['bulk-data-transfer'] && <PublicationBulkDataTransfer uuid={uuid} label={hubmap_id} />}
         <ContributorsTable contributors={contributors} contacts={contacts} title="Authors" />
         {shouldDisplaySection.provenance && <ProvSection uuid={uuid} assayMetadata={publication} />}


### PR DESCRIPTION
## Summary

Removes extra files accordion from processed datasets summary sections. 

## Design Documentation/Original Tickets

[CAT-913 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-913?atlOrigin=eyJpIjoiYTdiYWVjN2UyMWJhNDg1ZmIyNjM4NjQyZGY0MTdjZmUiLCJwIjoiaiJ9)

## Testing

Visually checked processed dataset detail pages and tested accordion functionality.

## Screenshots/Video

Before fix:

![Screenshot 2024-09-20 at 3 28 18 PM](https://github.com/user-attachments/assets/1125936a-f353-46ad-b78c-ebd6fb57bb1a)

After fix:

![Screenshot 2024-09-20 at 3 28 12 PM](https://github.com/user-attachments/assets/d5c7d257-0de8-4fcc-8cc2-a4f59ecff686)

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
