### PR TITLE
Austenem/CAT-912 update notebook download

### DIFF
--- a/CHANGELOG-update-notebook-download.md
+++ b/CHANGELOG-update-notebook-download.md
@@ -1,0 +1,1 @@
+- Allow Jupyter notebooks for dataset visualizations to be downloaded by all users.

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
@@ -7,7 +7,7 @@ import Divider from '@mui/material/Divider';
 
 import VizualizationThemeSwitch from 'js/components/detailPage/visualization/VisualizationThemeSwitch';
 import VisualizationCollapseButton from 'js/components/detailPage/visualization/VisualizationCollapseButton';
-import VisualizationNotebookButton from 'js/components/detailPage/visualization/VisualizationNotebookButton';
+import VisualizationNotebookButton from 'js/components/detailPage/visualization/VisualizationWorkspaceButton';
 import { AllEntityTypes, entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import OrganIcon from 'js/shared-styles/icons/OrganIcon';
 import { useHandleCopyClick } from 'js/hooks/useCopyText';

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
@@ -7,7 +7,7 @@ import Divider from '@mui/material/Divider';
 
 import VizualizationThemeSwitch from 'js/components/detailPage/visualization/VisualizationThemeSwitch';
 import VisualizationCollapseButton from 'js/components/detailPage/visualization/VisualizationCollapseButton';
-import VisualizationNotebookButton from 'js/components/detailPage/visualization/VisualizationWorkspaceButton';
+import VisualizationWorkspaceButton from 'js/components/detailPage/visualization/VisualizationWorkspaceButton';
 import { AllEntityTypes, entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 import OrganIcon from 'js/shared-styles/icons/OrganIcon';
 import { useHandleCopyClick } from 'js/hooks/useCopyText';
@@ -223,7 +223,7 @@ function EntityHeaderContent({ view, setView }: { view: SummaryViewsType; setVie
       <RightDiv>
         {vizIsFullscreen ? (
           <>
-            {vizNotebookId && <VisualizationNotebookButton uuid={vizNotebookId} />}
+            {vizNotebookId && <VisualizationWorkspaceButton uuid={vizNotebookId} />}
             <VisualizationShareButtonWrapper />
             <VizualizationThemeSwitch />
             <VisualizationCollapseButton />

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -1,8 +1,9 @@
-import Paper from '@mui/material/Paper';
-import FullscreenRoundedIcon from '@mui/icons-material/FullscreenRounded';
-
 import React, { useEffect } from 'react';
 import { Vitessce } from 'vitessce';
+
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import FullscreenRoundedIcon from '@mui/icons-material/FullscreenRounded';
 
 import DropdownListbox from 'js/shared-styles/dropdowns/DropdownListbox';
 import DropdownListboxOption from 'js/shared-styles/dropdowns/DropdownListboxOption';
@@ -11,9 +12,7 @@ import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
-import { useAppContext } from 'js/components/Contexts';
-
-import Stack from '@mui/material/Stack';
+import VisualizationDownloadButton from 'js/components/detailPage/visualization/VisualizationDownloadButton';
 import VisualizationNotebookButton from '../VisualizationNotebookButton';
 import VisualizationShareButton from '../VisualizationShareButton';
 import VisualizationThemeSwitch from '../VisualizationThemeSwitch';
@@ -72,7 +71,6 @@ function Visualization({
   //
   useCanvasScrollFix();
   const { toastError, toastInfo } = useSnackbarActions();
-  const { isWorkspacesUser } = useAppContext();
 
   const trackEntityPageEvent = useTrackEntityPageEvent();
 
@@ -123,14 +121,14 @@ function Visualization({
         <SpacedSectionButtonRow
           leftText={shouldDisplayHeader ? <StyledSectionHeader>Visualization</StyledSectionHeader> : undefined}
           buttons={
-            <Stack direction="row">
-              {isWorkspacesUser && hasNotebook && (
-                <VisualizationNotebookButton
-                  uuid={uuid}
-                  hubmap_id={hubmap_id}
-                  mapped_data_access_level={mapped_data_access_level}
-                />
-              )}
+            <Stack direction="row" spacing={1}>
+              <VisualizationNotebookButton
+                uuid={uuid}
+                hubmap_id={hubmap_id}
+                mapped_data_access_level={mapped_data_access_level}
+                hasNotebook={hasNotebook}
+              />
+              <VisualizationDownloadButton uuid={uuid} hasNotebook={hasNotebook} />
               <VisualizationShareButton />
               <VisualizationThemeSwitch />
               <SecondaryBackgroundTooltip title="Switch to Fullscreen">

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -13,11 +13,11 @@ import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 import VisualizationDownloadButton from 'js/components/detailPage/visualization/VisualizationDownloadButton';
-import VisualizationNotebookButton from '../VisualizationNotebookButton';
-import VisualizationShareButton from '../VisualizationShareButton';
-import VisualizationThemeSwitch from '../VisualizationThemeSwitch';
-import VisualizationFooter from '../VisualizationFooter';
-import VisualizationTracker from '../VisualizationTracker';
+import VisualizationNotebookButton from 'js/components/detailPage/visualization/VisualizationWorkspaceButton';
+import VisualizationShareButton from 'js/components/detailPage/visualization/VisualizationShareButton';
+import VisualizationThemeSwitch from 'js/components/detailPage/visualization/VisualizationThemeSwitch';
+import VisualizationFooter from 'js/components/detailPage/visualization/VisualizationFooter';
+import VisualizationTracker from 'js/components/detailPage/visualization/VisualizationTracker';
 
 import { useCanvasScrollFix, useCollapseViz, useFirefoxWarning, useVitessceConfig } from './hooks';
 import {

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -13,7 +13,7 @@ import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 import VisualizationDownloadButton from 'js/components/detailPage/visualization/VisualizationDownloadButton';
-import VisualizationNotebookButton from 'js/components/detailPage/visualization/VisualizationWorkspaceButton';
+import VisualizationWorkspaceButton from 'js/components/detailPage/visualization/VisualizationWorkspaceButton';
 import VisualizationShareButton from 'js/components/detailPage/visualization/VisualizationShareButton';
 import VisualizationThemeSwitch from 'js/components/detailPage/visualization/VisualizationThemeSwitch';
 import VisualizationFooter from 'js/components/detailPage/visualization/VisualizationFooter';
@@ -122,7 +122,7 @@ function Visualization({
           leftText={shouldDisplayHeader ? <StyledSectionHeader>Visualization</StyledSectionHeader> : undefined}
           buttons={
             <Stack direction="row" spacing={1}>
-              <VisualizationNotebookButton
+              <VisualizationWorkspaceButton
                 uuid={uuid}
                 hubmap_id={hubmap_id}
                 mapped_data_access_level={mapped_data_access_level}

--- a/context/app/static/js/components/detailPage/visualization/VisualizationDownloadButton/VisualizationDownloadButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationDownloadButton/VisualizationDownloadButton.tsx
@@ -1,0 +1,48 @@
+import React, { useCallback } from 'react';
+
+import Download from '@mui/icons-material/Download';
+import SvgIcon from '@mui/material/SvgIcon';
+
+import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
+import { useSnackbarActions } from 'js/shared-styles/snackbars';
+import postAndDownloadFile from 'js/helpers/postAndDownloadFile';
+import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+
+const tooltip = 'Download Jupyter Notebook';
+
+interface VisualizationDownloadButtonProps {
+  uuid?: string;
+  hasNotebook?: boolean;
+}
+
+function VisualizationDownloadButton({ uuid, hasNotebook }: VisualizationDownloadButtonProps) {
+  const trackEntityPageEvent = useTrackEntityPageEvent();
+  const { toastError } = useSnackbarActions();
+
+  const downloadNotebook = useCallback(() => {
+    trackEntityPageEvent({ action: `Vitessce / ${tooltip}` });
+    postAndDownloadFile({
+      url: `/notebooks/entities/dataset/${uuid}.ws.ipynb`,
+      body: {},
+    })
+      .then()
+      .catch(() => {
+        toastError('Failed to download Jupyter Notebook');
+      });
+  }, [uuid, toastError, trackEntityPageEvent]);
+
+  if (!uuid ?? !hasNotebook) {
+    return null;
+  }
+
+  return (
+    <SecondaryBackgroundTooltip title={tooltip}>
+      <WhiteBackgroundIconButton onClick={downloadNotebook}>
+        <SvgIcon color="primary" component={Download} />
+      </WhiteBackgroundIconButton>
+    </SecondaryBackgroundTooltip>
+  );
+}
+
+export default VisualizationDownloadButton;

--- a/context/app/static/js/components/detailPage/visualization/VisualizationDownloadButton/VisualizationDownloadButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationDownloadButton/VisualizationDownloadButton.tsx
@@ -6,8 +6,7 @@ import SvgIcon from '@mui/material/SvgIcon';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import postAndDownloadFile from 'js/helpers/postAndDownloadFile';
-import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
-import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import { WhiteBackgroundIconTooltipButton } from 'js/shared-styles/buttons';
 
 const tooltip = 'Download Jupyter Notebook';
 
@@ -32,16 +31,14 @@ function VisualizationDownloadButton({ uuid, hasNotebook }: VisualizationDownloa
       });
   }, [uuid, toastError, trackEntityPageEvent]);
 
-  if (!uuid ?? !hasNotebook) {
+  if (!uuid || !hasNotebook) {
     return null;
   }
 
   return (
-    <SecondaryBackgroundTooltip title={tooltip}>
-      <WhiteBackgroundIconButton onClick={downloadNotebook}>
-        <SvgIcon color="primary" component={Download} />
-      </WhiteBackgroundIconButton>
-    </SecondaryBackgroundTooltip>
+    <WhiteBackgroundIconTooltipButton tooltip={tooltip} onClick={downloadNotebook}>
+      <SvgIcon color="primary" component={Download} />
+    </WhiteBackgroundIconTooltipButton>
   );
 }
 

--- a/context/app/static/js/components/detailPage/visualization/VisualizationDownloadButton/index.ts
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationDownloadButton/index.ts
@@ -1,0 +1,3 @@
+import VisualizationDownloadButton from './VisualizationDownloadButton';
+
+export default VisualizationDownloadButton;

--- a/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/VisualizationNotebookButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/VisualizationNotebookButton.tsx
@@ -1,71 +1,50 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 
-import Download from '@mui/icons-material/Download';
+import SvgIcon from '@mui/icons-material/Download';
 
-import withDropdownMenuProvider from 'js/shared-styles/dropdowns/DropdownMenuProvider/withDropdownMenuProvider';
-import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
-import { useSnackbarActions } from 'js/shared-styles/snackbars';
 import { WorkspacesIcon } from 'js/shared-styles/icons';
-import postAndDownloadFile from 'js/helpers/postAndDownloadFile';
 import NewWorkspaceDialog from 'js/components/workspaces/NewWorkspaceDialog';
 import { useCreateWorkspaceForm } from 'js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
-import IconDropdownMenu from 'js/shared-styles/dropdowns/IconDropdownMenu';
-import { IconDropdownMenuItem } from 'js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
+import { useAppContext } from 'js/components/Contexts';
 
-const tooltip = 'Launch new workspace or download a Jupyter notebook for this visualization.';
+const tooltip = 'Launch New Workspace';
 
 interface VisualizationNotebookButtonProps {
-  uuid: string;
-  hubmap_id: string;
-  mapped_data_access_level: string;
+  uuid?: string;
+  hubmap_id?: string;
+  mapped_data_access_level?: string;
+  hasNotebook?: boolean;
 }
 
-function VisualizationNotebookButton({ uuid, hubmap_id, mapped_data_access_level }: VisualizationNotebookButtonProps) {
-  const trackEntityPageEvent = useTrackEntityPageEvent();
-  const { toastError } = useSnackbarActions();
-
+function VisualizationNotebookButton({
+  uuid = '',
+  hubmap_id,
+  mapped_data_access_level,
+  hasNotebook,
+}: VisualizationNotebookButtonProps) {
+  const { isWorkspacesUser } = useAppContext();
   const { setDialogIsOpen, removeDatasets, ...rest } = useCreateWorkspaceForm({
     defaultName: hubmap_id,
     defaultTemplate: 'visualization',
     initialSelectedDatasets: [uuid],
   });
 
-  const downloadNotebook = useCallback(() => {
-    trackEntityPageEvent({ action: `Vitessce / ${tooltip}` });
-    postAndDownloadFile({
-      url: `/notebooks/entities/dataset/${uuid}.ws.ipynb`,
-      body: {},
-    })
-      .then()
-      .catch(() => {
-        toastError('Failed to download Jupyter Notebook');
-      });
-  }, [uuid, toastError, trackEntityPageEvent]);
-
-  const options = [
-    {
-      children: 'Launch New Workspace',
-      onClick: () => setDialogIsOpen(true),
-      disabled: mapped_data_access_level === 'Protected',
-      icon: WorkspacesIcon,
-    },
-    {
-      children: 'Download Jupyter Notebook',
-      onClick: downloadNotebook,
-      icon: Download,
-    },
-  ];
+  if (!isWorkspacesUser ?? mapped_data_access_level === 'Protected' ?? !uuid ?? !hubmap_id ?? !hasNotebook) {
+    return null;
+  }
 
   return (
     <>
       <NewWorkspaceDialog {...rest} />
-      <IconDropdownMenu tooltip={tooltip} icon={WorkspacesIcon}>
-        {options.map((props) => (
-          <IconDropdownMenuItem key={props.children} {...props} />
-        ))}
-      </IconDropdownMenu>
+      <SecondaryBackgroundTooltip title={tooltip}>
+        <WhiteBackgroundIconButton onClick={() => setDialogIsOpen(true)}>
+          <SvgIcon color="primary" component={WorkspacesIcon} />
+        </WhiteBackgroundIconButton>
+      </SecondaryBackgroundTooltip>
     </>
   );
 }
 
-export default withDropdownMenuProvider(VisualizationNotebookButton, false);
+export default VisualizationNotebookButton;

--- a/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/index.ts
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationNotebookButton/index.ts
@@ -1,3 +1,0 @@
-import VisualizationNotebookButton from './VisualizationNotebookButton';
-
-export default VisualizationNotebookButton;

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
@@ -14,15 +14,15 @@ const tooltip = 'Launch New Workspace';
 interface VisualizationWorkspaceButtonProps {
   uuid?: string;
   hubmap_id?: string;
-  mapped_data_access_level?: string;
   hasNotebook?: boolean;
+  mapped_data_access_level?: string;
 }
 
 function VisualizationWorkspaceButton({
   uuid = '',
   hubmap_id,
-  mapped_data_access_level,
   hasNotebook,
+  mapped_data_access_level,
 }: VisualizationWorkspaceButtonProps) {
   const { isWorkspacesUser } = useAppContext();
   const { setDialogIsOpen, removeDatasets, ...rest } = useCreateWorkspaceForm({
@@ -31,7 +31,7 @@ function VisualizationWorkspaceButton({
     initialSelectedDatasets: [uuid],
   });
 
-  if (!isWorkspacesUser ?? mapped_data_access_level === 'Protected' ?? !uuid ?? !hubmap_id ?? !hasNotebook) {
+  if (!isWorkspacesUser ?? !uuid ?? !hubmap_id ?? !hasNotebook ?? mapped_data_access_level === 'Protected') {
     return null;
   }
 

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
@@ -5,8 +5,7 @@ import SvgIcon from '@mui/icons-material/Download';
 import { WorkspacesIcon } from 'js/shared-styles/icons';
 import NewWorkspaceDialog from 'js/components/workspaces/NewWorkspaceDialog';
 import { useCreateWorkspaceForm } from 'js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
-import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
-import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
+import { WhiteBackgroundIconTooltipButton } from 'js/shared-styles/buttons';
 import { useAppContext } from 'js/components/Contexts';
 
 const tooltip = 'Launch New Workspace';
@@ -38,11 +37,9 @@ function VisualizationWorkspaceButton({
   return (
     <>
       <NewWorkspaceDialog {...rest} />
-      <SecondaryBackgroundTooltip title={tooltip}>
-        <WhiteBackgroundIconButton onClick={() => setDialogIsOpen(true)}>
-          <SvgIcon color="primary" component={WorkspacesIcon} />
-        </WhiteBackgroundIconButton>
-      </SecondaryBackgroundTooltip>
+      <WhiteBackgroundIconTooltipButton tooltip={tooltip} onClick={() => setDialogIsOpen(true)}>
+        <SvgIcon color="primary" component={WorkspacesIcon} />
+      </WhiteBackgroundIconTooltipButton>
     </>
   );
 }

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
@@ -11,19 +11,19 @@ import { useAppContext } from 'js/components/Contexts';
 
 const tooltip = 'Launch New Workspace';
 
-interface VisualizationNotebookButtonProps {
+interface VisualizationWorkspaceButtonProps {
   uuid?: string;
   hubmap_id?: string;
   mapped_data_access_level?: string;
   hasNotebook?: boolean;
 }
 
-function VisualizationNotebookButton({
+function VisualizationWorkspaceButton({
   uuid = '',
   hubmap_id,
   mapped_data_access_level,
   hasNotebook,
-}: VisualizationNotebookButtonProps) {
+}: VisualizationWorkspaceButtonProps) {
   const { isWorkspacesUser } = useAppContext();
   const { setDialogIsOpen, removeDatasets, ...rest } = useCreateWorkspaceForm({
     defaultName: hubmap_id,
@@ -47,4 +47,4 @@ function VisualizationNotebookButton({
   );
 }
 
-export default VisualizationNotebookButton;
+export default VisualizationWorkspaceButton;

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/index.ts
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/index.ts
@@ -1,0 +1,3 @@
+import VisualizationWorkspaceButton from './VisualizationWorkspaceButton';
+
+export default VisualizationWorkspaceButton;

--- a/context/app/static/js/shared-styles/buttons/index.tsx
+++ b/context/app/static/js/shared-styles/buttons/index.tsx
@@ -3,6 +3,7 @@ import { Theme, styled } from '@mui/material/styles';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import ToggleButton from '@mui/material/ToggleButton';
 import Button from '@mui/material/Button';
+import { TooltipIconButton } from 'js/shared-styles/buttons/TooltipButton';
 import { SecondaryBackgroundTooltip } from '../tooltips';
 import IconDropdownMenuButton from '../dropdowns/IconDropdownMenuButton';
 
@@ -31,6 +32,12 @@ const WhiteBackgroundIconButton = styled(IconButton)<IconButtonProps>(({ theme }
 }));
 
 const WhiteBackgroundIconDropdownMenuButton = styled(IconDropdownMenuButton)(({ theme }) => ({
+  ...whiteBackgroundCSS,
+  ...border(theme),
+  '& svg': svgStyles,
+}));
+
+const WhiteBackgroundIconTooltipButton = styled(TooltipIconButton)(({ theme }) => ({
   ...whiteBackgroundCSS,
   ...border(theme),
   '& svg': svgStyles,
@@ -75,6 +82,7 @@ export default TooltipToggleButton;
 export {
   WhiteBackgroundIconButton,
   WhiteBackgroundIconDropdownMenuButton,
+  WhiteBackgroundIconTooltipButton,
   TooltipToggleButton,
   iconButtonHeight,
   WhiteTextButton,

--- a/context/app/static/js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu.tsx
+++ b/context/app/static/js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu.tsx
@@ -9,7 +9,7 @@ import { WhiteBackgroundIconDropdownMenuButton } from 'js/shared-styles/buttons'
 import withDropdownMenuProvider from 'js/shared-styles/dropdowns/DropdownMenuProvider/withDropdownMenuProvider';
 import DropdownMenu from 'js/shared-styles/dropdowns/DropdownMenu';
 
-import { StyledSecondaryBackgroundTooltip, StyledSvgIcon, StyledTypography } from './style';
+import { StyledSvgIcon, StyledTypography } from './style';
 
 interface IconDropdownMenuItemProps {
   children: string;
@@ -37,14 +37,9 @@ interface IconDropdownMenuProps {
 function IconDropdownMenu({ tooltip, icon, children }: PropsWithChildren<IconDropdownMenuProps>) {
   return (
     <>
-      <StyledSecondaryBackgroundTooltip title={tooltip}>
-        {/* Span is needed here for tooltip to appear without clicking */}
-        <span>
-          <WhiteBackgroundIconDropdownMenuButton menuID={tooltip}>
-            <SvgIcon component={icon} />
-          </WhiteBackgroundIconDropdownMenuButton>
-        </span>
-      </StyledSecondaryBackgroundTooltip>
+      <WhiteBackgroundIconDropdownMenuButton menuID={tooltip} tooltip={tooltip}>
+        <SvgIcon component={icon} />
+      </WhiteBackgroundIconDropdownMenuButton>
       <DropdownMenu id={`${tooltip}-menu`}>
         <MenuList id="menu-options">{children}</MenuList>
       </DropdownMenu>

--- a/context/app/static/js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu.tsx
+++ b/context/app/static/js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu.tsx
@@ -38,6 +38,7 @@ function IconDropdownMenu({ tooltip, icon, children }: PropsWithChildren<IconDro
   return (
     <>
       <StyledSecondaryBackgroundTooltip title={tooltip}>
+        {/* Span is needed here for tooltip to appear without clicking */}
         <span>
           <WhiteBackgroundIconDropdownMenuButton menuID={tooltip}>
             <SvgIcon component={icon} />

--- a/context/app/static/js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu.tsx
+++ b/context/app/static/js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu.tsx
@@ -38,9 +38,11 @@ function IconDropdownMenu({ tooltip, icon, children }: PropsWithChildren<IconDro
   return (
     <>
       <StyledSecondaryBackgroundTooltip title={tooltip}>
-        <WhiteBackgroundIconDropdownMenuButton menuID={tooltip}>
-          <SvgIcon component={icon} />
-        </WhiteBackgroundIconDropdownMenuButton>
+        <span>
+          <WhiteBackgroundIconDropdownMenuButton menuID={tooltip}>
+            <SvgIcon component={icon} />
+          </WhiteBackgroundIconDropdownMenuButton>
+        </span>
       </StyledSecondaryBackgroundTooltip>
       <DropdownMenu id={`${tooltip}-menu`}>
         <MenuList id="menu-options">{children}</MenuList>

--- a/context/app/static/js/shared-styles/dropdowns/IconDropdownMenuButton/IconDropdownMenuButton.tsx
+++ b/context/app/static/js/shared-styles/dropdowns/IconDropdownMenuButton/IconDropdownMenuButton.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
-import IconButton from '@mui/material/IconButton';
 
 import { useDropdownMenuStore } from 'js/shared-styles/dropdowns/DropdownMenuProvider';
+import { WhiteBackgroundIconTooltipButton } from 'js/shared-styles/buttons';
 
 interface IconDropdownMenuButtonProps {
   children: React.ReactNode;
   menuID: string;
+  tooltip: string;
 }
 
-function IconDropdownMenuButton({ children, menuID, ...rest }: IconDropdownMenuButtonProps) {
+function IconDropdownMenuButton({ children, menuID, tooltip, ...rest }: IconDropdownMenuButtonProps) {
   const { menuRef, menuIsOpen, openMenu } = useDropdownMenuStore();
 
   return (
-    <IconButton
+    <WhiteBackgroundIconTooltipButton
+      tooltip={tooltip}
       onClick={openMenu}
       color="primary"
       aria-controls={menuIsOpen ? menuID : undefined}
@@ -21,7 +23,7 @@ function IconDropdownMenuButton({ children, menuID, ...rest }: IconDropdownMenuB
       {...rest}
     >
       {children}
-    </IconButton>
+    </WhiteBackgroundIconTooltipButton>
   );
 }
 


### PR DESCRIPTION
## Summary

Separates the dataset visualization menu with options "Launch New Workspace" and "Download Jupyter Notebook" into two buttons, which allows non-authenticated users to see and utilize the "Download Jupyter Notebook" option.  

## Design Documentation/Original Tickets

[CAT-912 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-912?atlOrigin=eyJpIjoiNmVkZWVlYzcyNmRiNDQyOGI4Zjc2YTU5NzQ1MWE0NjgiLCJwIjoiaiJ9)

## Testing

Tested both options and checked that Workspaces button is hidden for non-authenticated users.

## Screenshots/Video

Previous menu:
![Screenshot 2024-09-23 at 12 21 15 PM](https://github.com/user-attachments/assets/3c63795b-61da-40fc-808a-206a39739edd)

Updated menu:
![Screenshot 2024-09-23 at 11 04 16 AM](https://github.com/user-attachments/assets/d091c484-87e5-4f5d-bc4d-b19b420e6867)

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
