### PR TITLE
Austenem/CAT-923 fix sample workspace access

### DIFF
--- a/CHANGELOG-fix-sample-workspace-access.md
+++ b/CHANGELOG-fix-sample-workspace-access.md
@@ -1,0 +1,1 @@
+- Only allow Globus group members to access sample workspaces.

--- a/context/app/static/js/pages/Template/Template.tsx
+++ b/context/app/static/js/pages/Template/Template.tsx
@@ -22,6 +22,7 @@ import { TemplateExample, WorkspacesEventCategories } from 'js/components/worksp
 import PrimaryColorAccordion from 'js/shared-styles/accordions/PrimaryColorAccordion';
 import { trackEvent } from 'js/helpers/trackers';
 import { DEFAULT_JOB_TYPE } from 'js/components/workspaces/constants';
+import { useAppContext } from 'js/components/Contexts';
 
 interface ExampleAccordionProps {
   example: TemplateExample;
@@ -55,6 +56,8 @@ function ExampleAccordion({ example, templateKey, defaultExpanded, templateName,
     return map;
   }, [datasetTypeMap]);
 
+  const { isWorkspacesUser } = useAppContext();
+
   return (
     <>
       <PrimaryColorAccordion defaultExpanded={defaultExpanded}>
@@ -67,7 +70,7 @@ function ExampleAccordion({ example, templateKey, defaultExpanded, templateName,
           <Stack spacing={2}>
             <StyledButton
               variant="contained"
-              disabled={!isAuthenticated}
+              disabled={!isWorkspacesUser}
               onClick={() => {
                 trackEvent({
                   category: WorkspacesEventCategories.WorkspaceTemplateDetailPage,


### PR DESCRIPTION
## Summary

Fix bug allowing logged-in users without consortium access to try sample workspaces.

## Design Documentation/Original Tickets

[CAT-923 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-923?atlOrigin=eyJpIjoiYTIxOTI0MGUyYzZlNGIyMWJmYWJlOThkNWM1MDYwNDciLCJwIjoiaiJ9)

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
