### PR TITLE
Austenem/CAT-933 fix helper panel dialogs

### DIFF
--- a/CHANGELOG-fix-helper-panel-dialogs.md
+++ b/CHANGELOG-fix-helper-panel-dialogs.md
@@ -1,0 +1,1 @@
+- Fix bug on dataset detail page for workspace dialogs opened in succession for different processed datasets. 

--- a/context/app/static/js/components/workspaces/AddDatasetsFromDetailDialog/AddDatasetsFromDetailDialog.tsx
+++ b/context/app/static/js/components/workspaces/AddDatasetsFromDetailDialog/AddDatasetsFromDetailDialog.tsx
@@ -18,7 +18,7 @@ function AddDatasetsFromDetailDialog({ uuid, dialogType }: AddDatasetsFromDetail
 
   return (
     // We're populating the table provider with the dataset from the detail page so as not to duplicate logic from the search dialog
-    <SelectableTableProvider tableLabel="Add Datasets From Detail Dialog" selectedRows={new Set([uuid])}>
+    <SelectableTableProvider key={uuid} tableLabel="Add Datasets From Detail Dialog" selectedRows={new Set([uuid])}>
       <AddDatasetsFromSearchDialog />
     </SelectableTableProvider>
   );

--- a/context/app/static/js/components/workspaces/AddDatasetsFromDetailDialog/AddDatasetsFromDetailDialog.tsx
+++ b/context/app/static/js/components/workspaces/AddDatasetsFromDetailDialog/AddDatasetsFromDetailDialog.tsx
@@ -17,7 +17,6 @@ function AddDatasetsFromDetailDialog({ uuid, dialogType }: AddDatasetsFromDetail
   }
 
   return (
-    // We're populating the table provider with the dataset from the detail page so as not to duplicate logic from the search dialog
     <SelectableTableProvider key={uuid} tableLabel="Add Datasets From Detail Dialog" selectedRows={new Set([uuid])}>
       <AddDatasetsFromSearchDialog />
     </SelectableTableProvider>

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -146,7 +146,11 @@ function useCreateWorkspaceForm({
     if (initialProtectedDatasets && initialProtectedDatasets !== '') {
       setValue('protected-datasets', initialProtectedDatasets);
     }
-  }, [initialProtectedDatasets, setValue]);
+    if (initialSelectedDatasets && initialSelectedDatasets.length !== 0) {
+      setValue('datasets', initialSelectedDatasets);
+      setValue('workspace-name', checkedWorkspaceName);
+    }
+  }, [initialProtectedDatasets, initialSelectedDatasets, checkedWorkspaceName, setValue]);
 
   useEffect(() => {
     if (dialogIsOpen) {

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -146,6 +146,7 @@ function useCreateWorkspaceForm({
     if (initialProtectedDatasets && initialProtectedDatasets !== '') {
       setValue('protected-datasets', initialProtectedDatasets);
     }
+    // Necessary to update dialog state between different processed datasets on detail pages
     if (initialSelectedDatasets && initialSelectedDatasets.length !== 0) {
       setValue('datasets', initialSelectedDatasets);
       setValue('workspace-name', checkedWorkspaceName);


### PR DESCRIPTION
## Summary

Fix bug on dataset detail page for workspace dialogs opened in succession for different processed datasets. 

## Design Documentation/Original Tickets

[CAT-933 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-933?atlOrigin=eyJpIjoiZGE5ZjJhNjQwMjhjNGQ3MmE1MzUzZDI5NDhhY2Q1MTAiLCJwIjoiaiJ9)

## Testing

Tested by manually going through dialogs.

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
