### PR TITLE
Austenem/CAT-934 fix metadata table

### DIFF
--- a/CHANGELOG-fix-metadata-table.md
+++ b/CHANGELOG-fix-metadata-table.md
@@ -1,0 +1,1 @@
+- Fix issue of sample metadata not showing up in the sample detail page metadata table.

--- a/context/app/static/js/pages/Sample/Sample.jsx
+++ b/context/app/static/js/pages/Sample/Sample.jsx
@@ -37,7 +37,7 @@ function SampleDetail() {
   const origin_sample = origin_samples[0];
   const { mapped_organ } = origin_sample;
 
-  const combinedMetadata = combineMetadata(donor, undefined, metadata);
+  const combinedMetadata = combineMetadata(donor, origin_samples, metadata);
 
   const shouldDisplaySection = {
     summary: true,


### PR DESCRIPTION
## Summary

Fix issue of sample metadata not showing up in the sample metadata tables.

## Design Documentation/Original Tickets

CAT-934 Jira ticket

## Testing

Checked metadata tables on several detail pages, including these samples that have additional sample metadata:

https://portal.hubmapconsortium.org/browse/sample/068aef7b9a77c6c61b85ad69cc8cf0d5#metadata

https://portal.hubmapconsortium.org/browse/sample/e4ee92c09a755f8889cb8c37a669e160#metadata

This issue appears to have been restricted to Sample pages (for example, [this dataset detail page](https://portal.hubmapconsortium.org/browse/dataset/3ce5e603c9f6187b2c8f16340924355d) shows the sample metadata that is hidden on the associated Sample page).

## Screenshots/Video

Issue on prod:
![Screenshot 2024-10-03 at 12 01 40 PM](https://github.com/user-attachments/assets/8b94d225-22a4-44da-9593-2933f574b378)

Fix:
![Screenshot 2024-10-03 at 11 59 12 AM](https://github.com/user-attachments/assets/d11c0fc6-46df-4832-bdf8-11408288f947)


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
