### PR TITLE
Austenem/CAT-872 improve redirect toast

### DIFF
--- a/CHANGELOG-improve-redirect-toast.md
+++ b/CHANGELOG-improve-redirect-toast.md
@@ -1,0 +1,1 @@
+- Update Unified View redirect toast to be more informative.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -78,7 +78,11 @@ def details(type, uuid):
                         type='dataset',
                         uuid=supported_entity[0]['uuid'],
                         _anchor=anchor,
-                        redirected=True))
+                        redirected=True,
+                        redirectedFromId=entity['hubmap_id'],
+                        redirectedFromPipeline=entity['pipeline']
+                        )
+            )
 
     if type != actual_type:
         return redirect(url_for('routes_browse.details', type=actual_type, uuid=uuid))
@@ -89,6 +93,8 @@ def details(type, uuid):
         **get_default_flask_data(),
         'entity': entity,
         'redirected': redirected,
+        'redirectedFromId': request.args.get('redirectedFromId'),
+        'redirectedFromPipeline': request.args.get('redirectedFromPipeline')
     }
 
     if type == 'publication':

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -80,9 +80,7 @@ def details(type, uuid):
                         _anchor=anchor,
                         redirected=True,
                         redirectedFromId=entity['hubmap_id'],
-                        redirectedFromPipeline=entity['pipeline']
-                        )
-            )
+                        redirectedFromPipeline=entity['pipeline']))
 
     if type != actual_type:
         return redirect(url_for('routes_browse.details', type=actual_type, uuid=uuid))

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -79,8 +79,8 @@ def details(type, uuid):
                         uuid=supported_entity[0]['uuid'],
                         _anchor=anchor,
                         redirected=True,
-                        redirectedFromId=entity['hubmap_id'],
-                        redirectedFromPipeline=entity['pipeline']))
+                        redirectedFromId=entity.get('hubmap_id'),
+                        redirectedFromPipeline=entity.get('pipeline')))
 
     if type != actual_type:
         return redirect(url_for('routes_browse.details', type=actual_type, uuid=uuid))

--- a/context/app/static/js/components/Contexts.tsx
+++ b/context/app/static/js/components/Contexts.tsx
@@ -10,8 +10,8 @@ export interface FlaskDataContextType {
   title: string; // preview page title
   vis_lifted_uuid?: string;
   redirected?: boolean;
-  redirectedFromId?: string;
-  redirectedFromPipeline?: string;
+  redirectedFromId?: string | null;
+  redirectedFromPipeline?: string | null;
 }
 
 export const FlaskDataContext = createContext<FlaskDataContextType>('FlaskDataContext');

--- a/context/app/static/js/components/Contexts.tsx
+++ b/context/app/static/js/components/Contexts.tsx
@@ -10,6 +10,8 @@ export interface FlaskDataContextType {
   title: string; // preview page title
   vis_lifted_uuid?: string;
   redirected?: boolean;
+  redirectedFromId?: string;
+  redirectedFromPipeline?: string;
 }
 
 export const FlaskDataContext = createContext<FlaskDataContextType>('FlaskDataContext');

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -182,9 +182,13 @@ export function useRedirectAlert() {
 
   useEffect(() => {
     if (redirected) {
-      toastInfo(
-        `You have been redirected to the unified view for ${redirectedFromPipeline} dataset ${redirectedFromId}.`,
-      );
+      if (redirectedFromId && redirectedFromPipeline) {
+        toastInfo(
+          `You have been redirected to the unified view for ${redirectedFromPipeline} dataset ${redirectedFromId}.`,
+        );
+      } else {
+        toastInfo('You have been redirected to the unified view for this dataset.');
+      }
     }
   }, [redirected, toastInfo, redirectedFromId, redirectedFromPipeline]);
 }

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -177,13 +177,16 @@ function useProcessedDatasetsSections(): { sections: TableOfContentsItem | false
 }
 
 export function useRedirectAlert() {
-  const { redirected } = useFlaskDataContext();
+  const { redirected, redirectedFromId, redirectedFromPipeline } = useFlaskDataContext();
   const { toastInfo } = useSnackbarActions();
+
   useEffect(() => {
     if (redirected) {
-      toastInfo('You have been redirected to the unified view for this dataset.');
+      toastInfo(
+        `You have been redirected to the unified view for ${redirectedFromPipeline} dataset ${redirectedFromId}.`,
+      );
     }
-  }, [redirected, toastInfo]);
+  }, [redirected, toastInfo, redirectedFromId, redirectedFromPipeline]);
 }
 
 export { useProcessedDatasets, useProcessedDatasetsSections };


### PR DESCRIPTION
## Summary

Update Unified View redirect toast to be more informative with the processing type and HuBMAP ID of the redirected dataset.

## Design Documentation/Original Tickets

[CAT-872 Jira ticket ](https://hms-dbmi.atlassian.net/browse/CAT-872?atlOrigin=eyJpIjoiNDZhYTA4NWMwY2E5NDgxNmFiOGVmOGQ0ZTk1ZTU0MTAiLCJwIjoiaiJ9)

## Testing

Manually checked toast for several raw and processed datasets.

## Screenshots/Video

![Screenshot 2024-10-03 at 6 10 29 PM](https://github.com/user-attachments/assets/22a49b25-2ffc-408c-93da-0d2d9e49a5e3)

![Screenshot 2024-10-03 at 6 11 12 PM](https://github.com/user-attachments/assets/473ea067-bcad-4229-a90b-6f9d9c7dbc80)


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
