### PR TITLE
Austenem/CAT-897 remove collections columns

### DIFF
--- a/CHANGELOG-remove-collections-columns.md
+++ b/CHANGELOG-remove-collections-columns.md
@@ -1,0 +1,1 @@
+- Remove "Contact" and "Last Modified" columns from the Datasets table on Collections pages.

--- a/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.ts
+++ b/context/app/static/js/components/detailPage/CollectionDatasetsTable/hooks.ts
@@ -1,25 +1,10 @@
 import { useSearchHits } from 'js/hooks/useSearchData';
 import { getIDsQuery } from 'js/helpers/queries';
-import {
-  lastModifiedTimestampCol,
-  organCol,
-  dataTypesCol,
-  statusCol,
-} from 'js/components/detailPage/derivedEntities/columns';
-import { Dataset, Entity } from 'js/components/types';
+import { organCol, dataTypesCol, statusCol } from 'js/components/detailPage/derivedEntities/columns';
+import { Dataset } from 'js/components/types';
 import { RelatedEntitiesColumn } from 'js/components/detailPage/related-entities/RelatedEntitiesTable/RelatedEntitiesTable';
 
-const columns = [
-  organCol,
-  dataTypesCol,
-  lastModifiedTimestampCol,
-  {
-    id: 'created_by_user_displayname',
-    label: 'Contact',
-    renderColumnCell: ({ created_by_user_displayname }: Partial<Entity>) => created_by_user_displayname,
-  },
-  statusCol,
-] as RelatedEntitiesColumn[];
+const columns = [organCol, dataTypesCol, statusCol] as RelatedEntitiesColumn[];
 
 interface CollectionDatasetsHook {
   ids: string[];


### PR DESCRIPTION
## Summary

Remove "Contact" and "Last Modified" columns from the Datasets table on Collections pages.

## Design Documentation/Original Tickets

[CAT-897 Jira ticket ](https://hms-dbmi.atlassian.net/browse/CAT-897?atlOrigin=eyJpIjoiM2FkY2Q1MTkwMDQzNGJkOGFhODU2NjI2YzMwZDM0ZDYiLCJwIjoiaiJ9)

## Testing

Manual visual comparison.

## Screenshots/Video

Previous table:

![Screenshot 2024-10-04 at 10 32 41 AM](https://github.com/user-attachments/assets/1d1ec95c-5586-4ea4-8760-aa1dcf696405)

Update:

![Screenshot 2024-10-04 at 10 34 12 AM](https://github.com/user-attachments/assets/f0e7e654-30d9-4984-b21d-25eccb7521ff)

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

