### PR TITLE
NickAkhmetov/CAT-881 deduplicate errored processed datasets' urls

### DIFF
--- a/CHANGELOG-cat-881.md
+++ b/CHANGELOG-cat-881.md
@@ -1,0 +1,1 @@
+- Append HuBMAP ID to errored datasets' URL anchors to avoid anchor duplication on dataset pages with multiple failed processing attempts.

--- a/context/app/static/js/pages/Dataset/utils.spec.ts
+++ b/context/app/static/js/pages/Dataset/utils.spec.ts
@@ -1,0 +1,42 @@
+import { datasetSectionId } from './utils';
+
+const prefix = 'prefix';
+
+describe('datasetSectionId', () => {
+  it('should format the dataset section id correctly', () => {
+    const dataset = {
+      pipeline: 'pipeline',
+      hubmap_id: 'hubmap_id',
+      status: 'status',
+    };
+    expect(datasetSectionId(dataset, prefix)).toBe('prefix-pipeline-status');
+  });
+  it('Should include the hubmap id if the pipeline is missing', () => {
+    const dataset = {
+      hubmap_id: 'hubmap_id',
+      status: 'status',
+    };
+    expect(datasetSectionId(dataset, prefix)).toBe('prefix-hubmap_id-status');
+  });
+  it('should include the pipeline and hubmap_id if the pipeline is errored', () => {
+    const dataset = {
+      pipeline: 'pipeline',
+      hubmap_id: 'hubmap_id',
+      status: 'error',
+    };
+    expect(datasetSectionId(dataset, prefix)).toBe('prefix-pipeline-error-hubmap_id');
+  });
+  it('should generate unique ids for different errored datasets', () => {
+    const dataset1 = {
+      pipeline: 'pipeline',
+      hubmap_id: 'hubmap_id',
+      status: 'error',
+    };
+    const dataset2 = {
+      pipeline: 'pipeline',
+      hubmap_id: 'hubmap_id_2',
+      status: 'error',
+    };
+    expect(datasetSectionId(dataset1, prefix)).not.toBe(datasetSectionId(dataset2, prefix));
+  });
+});

--- a/context/app/static/js/pages/Dataset/utils.ts
+++ b/context/app/static/js/pages/Dataset/utils.ts
@@ -1,5 +1,7 @@
 import { ProcessedDatasetInfo } from './hooks';
 
+const potentialDuplicateStates = ['error'];
+
 export function datasetSectionId(
   dataset: Pick<ProcessedDatasetInfo, 'hubmap_id' | 'status'> & { pipeline?: string },
   prefix = '',
@@ -7,7 +9,8 @@ export function datasetSectionId(
   const { pipeline, hubmap_id, status } = dataset;
   const formattedDatasetIdentifier = (pipeline ?? hubmap_id).replace(/\s/g, '');
   const formattedStatus = status.replace(/\s/g, '');
-  const deduplicatedFormattedStatus =
-    formattedStatus.toLowerCase() === 'error' ? `${formattedStatus}-${hubmap_id}` : formattedStatus;
+  const deduplicatedFormattedStatus = potentialDuplicateStates.includes(formattedStatus.toLowerCase())
+    ? `${formattedStatus}-${hubmap_id}`
+    : formattedStatus;
   return `${prefix}-${encodeURIComponent(formattedDatasetIdentifier)}-${encodeURIComponent(deduplicatedFormattedStatus)}`.toLowerCase();
 }

--- a/context/app/static/js/pages/Dataset/utils.ts
+++ b/context/app/static/js/pages/Dataset/utils.ts
@@ -1,11 +1,13 @@
 import { ProcessedDatasetInfo } from './hooks';
 
 export function datasetSectionId(
-  dataset: Pick<ProcessedDatasetInfo, 'pipeline' | 'hubmap_id' | 'status'>,
+  dataset: Pick<ProcessedDatasetInfo, 'hubmap_id' | 'status'> & { pipeline?: string },
   prefix = '',
 ) {
   const { pipeline, hubmap_id, status } = dataset;
   const formattedDatasetIdentifier = (pipeline ?? hubmap_id).replace(/\s/g, '');
   const formattedStatus = status.replace(/\s/g, '');
-  return `${prefix}-${encodeURIComponent(formattedDatasetIdentifier)}-${encodeURIComponent(formattedStatus)}`.toLowerCase();
+  const deduplicatedFormattedStatus =
+    formattedStatus.toLowerCase() === 'error' ? `${formattedStatus}-${hubmap_id}` : formattedStatus;
+  return `${prefix}-${encodeURIComponent(formattedDatasetIdentifier)}-${encodeURIComponent(deduplicatedFormattedStatus)}`.toLowerCase();
 }


### PR DESCRIPTION
## Summary

This PR adds logic to prevent duplicate URL anchors on unified dataset pages that have multiple errored runs, such as https://portal.hubmapconsortium.org/browse/dataset/9e9085a732ae35d4a46b68d86167f475?redirected=True#summary-salmon%2barchr%2bmuon-error

Error datasets are the only duplicate state we've observed so far in the system, but I have implemented this such that we can extend this logic at will in the future.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-881

## Testing

Unit tests have been added for the related utility function, including a case specifically covering duplicate dataset statuses.

## Screenshots/Video

Sample URL after changes:
![image](https://github.com/user-attachments/assets/4006ae23-8d92-489b-85a2-c80a9cbc984c)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
