### PR TITLE
NickAkhmetov/CAT-896 Fix push script logic

### DIFF
--- a/CHANGELOG-cat-896.md
+++ b/CHANGELOG-cat-896.md
@@ -1,0 +1,1 @@
+- Fix push script to correctly check latest minor version date.

--- a/etc/build/push.sh
+++ b/etc/build/push.sh
@@ -16,7 +16,7 @@ if [[ -z "$MAJOR" ]]; then
 
   TAGS=`git for-each-ref --sort=creatordate --format '%(refname) %(creatordate)' refs/tags | tac`
   while read -r -d $'\n' TAG DATE; do
-    if [[ $TAG =~ v0\.([0-9]+)\.0$ ]]; then
+    if [[ $TAG =~ ([0-9]+)\.([0-9]+)\.0$ ]]; then
       echo "Last minor tag: $TAG"
       # Strip timezone info (last 6 characters)
       DATE=${DATE%??????}


### PR DESCRIPTION
## Summary

After the revisions in #3510 and #3516, subsequent releases have not followed the logic of only incrementing the patch version if it has been less than two weeks since the last minor version.

Upon revisiting, this appears to be due to the logic checking for the last release with a 0 major version. This approach worked during development, since I was testing it with a `0.` major version, but broke immediately following the first major version. I have adjusted the logic to check for the last minor version with any major version.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-896

## Testing

Local testing with dry-runs of the push script, with the `git` pieces commented out to test the date logic.

## Screenshots/Video

Before the change:
![image](https://github.com/user-attachments/assets/fd9926ca-8726-4606-a9bf-bdff9d7e2b81)

After the change:
![image](https://github.com/user-attachments/assets/49b1c9cf-34c2-4d67-b7ff-34e43970a6d7)

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Potential future improvements:
- An explicit `--dry-run` option could be useful if any future development is ever needed
- It may be worth revising so that a consistent `date` implementation is used in case any other future developers use Linux: https://stackoverflow.com/questions/9804966/date-command-does-not-follow-linux-specifications-mac-os-x-lion