### PR TITLE
NickAkhmetov/CAT-751 Prevent full-page errors from malformed provenance data

### DIFF
--- a/CHANGELOG-cat-751.md
+++ b/CHANGELOG-cat-751.md
@@ -1,0 +1,1 @@
+- Prevent malformed provenance graph data from crashing the entire page.

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraphErrorBoundary.tsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraphErrorBoundary.tsx
@@ -13,7 +13,7 @@ function ErrorFallback(error: Error) {
     <Stack p={4}>
       <Typography variant="subtitle1">An error occurred while attempting to display the provenance graph.</Typography>
       <DetailsAccordion summary="Click to expand error details">
-        <div>{error?.message}</div>
+        <Typography variant="body2">{error?.message}</Typography>
       </DetailsAccordion>
     </Stack>
   );

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraphErrorBoundary.tsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/ProvGraphErrorBoundary.tsx
@@ -1,0 +1,24 @@
+import { FaroErrorBoundary } from '@grafana/faro-react';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import DetailsAccordion from 'js/shared-styles/accordions/DetailsAccordion';
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+function ErrorFallback(error: Error) {
+  return (
+    <Stack p={4}>
+      <Typography variant="subtitle1">An error occurred while attempting to display the provenance graph.</Typography>
+      <DetailsAccordion summary="Click to expand error details">
+        <div>{error?.message}</div>
+      </DetailsAccordion>
+    </Stack>
+  );
+}
+
+export default function ProvGraphErrorBoundary({ children }: ErrorBoundaryProps) {
+  return <FaroErrorBoundary fallback={ErrorFallback}>{children}</FaroErrorBoundary>;
+}

--- a/context/app/static/js/components/detailPage/provenance/ProvSection/ProvSection.tsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvSection/ProvSection.tsx
@@ -83,6 +83,7 @@ function ProvSection() {
       <SectionDescription>
         <Description />
       </SectionDescription>
+
       <ProvTabs provData={provData} />
     </CollapsibleDetailPageSection>
   );

--- a/context/app/static/js/components/detailPage/provenance/ProvTabs/ProvTabs.tsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvTabs/ProvTabs.tsx
@@ -9,6 +9,7 @@ import ProvTable from '../ProvTable';
 import { hasDataTypes } from './utils';
 import { filterTabsToDisplay } from './filterTabsToDisplay';
 import { ProvData } from '../types';
+import ProvGraphErrorBoundary from '../ProvGraph/ProvGraphErrorBoundary';
 
 const availableTabDetails = {
   multi: { label: 'Multi-Assay', 'data-testid': 'multi-prov-tab' },
@@ -67,7 +68,9 @@ function ProvTabs({ provData }: ProvTabsProps) {
       )}
       {filteredTabs?.graph && (
         <TabPanel value={open} index={filteredTabs.graph.index}>
-          <ProvGraph provData={provData} entity_type={entity_type} uuid={uuid} />
+          <ProvGraphErrorBoundary>
+            <ProvGraph provData={provData} entity_type={entity_type} uuid={uuid} />
+          </ProvGraphErrorBoundary>
         </TabPanel>
       )}
     </Paper>


### PR DESCRIPTION
## Summary

This donor's provenance data is incomplete (it is missing the edges that connect activities to their parent entities): https://portal.hubmapconsortium.org/browse/donor/a0bdb4249eb3a6bd1865f948875c2f96

Removing the `required` status from that key does not resolve the issue, since these edges are mandatory to be able to draw the graph.

I have escalated the underlying data issue to Zhou in a private message; in the meantime, we can improve the way this error is handled on the front-end by preventing the triggering of the full-page error boundary and interrupting the user's browsing session. 

I used the same `DetailsAccordion` component we use to report Vitessce visualization errors to be consistent.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-751

## Testing

The problematic donor page has been visited with the dev server configured to suppress exception overlays to confirm that only the appropriate error handling is included.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/c955c447-a8d1-466c-9c63-575f9d536d9e)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Should we consider removing the webpack dev server error overlay in general? It seems counterproductive since it takes up the full page, which errors not caught by a lower-level error boundary do as well; not having this overlay might encourage us to add targeted boundaries such as this.