### PR TITLE
NickAkhmetov/CAT-435 disable scrolling full page when using arrow keys to explore Vitessce visualizations

### DIFF
--- a/CHANGELOG-cat-435.md
+++ b/CHANGELOG-cat-435.md
@@ -1,0 +1,1 @@
+- Avoid page scrolling from using arrow keys on vitessce visualization.

--- a/context/app/static/js/components/detailPage/visualization/VisualizationTracker/hooks.ts
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationTracker/hooks.ts
@@ -32,6 +32,8 @@ export function useVitessceEventMetadata() {
   return formatEventCategoryAndLabel('Unknown', location);
 }
 
+const arrowKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
+
 export function useVisualizationTracker() {
   const { category, label } = useVitessceEventMetadata();
   // Track when the visualization is first mounted
@@ -66,6 +68,11 @@ export function useVisualizationTracker() {
   const trackKeyDown: React.KeyboardEventHandler<HTMLSpanElement> = useEventCallback((e) => {
     const target = getNearestIdentifier(e.target as HTMLElement);
     const key = e.key === ' ' ? 'Space' : e.key;
+    // Prevent default scrolling behavior of arrow keys
+    if (arrowKeys.includes(key)) {
+      trackVitessceAction(`${key} ${target}`);
+      e.preventDefault();
+    }
     if (!target || modifierKeys.includes(key)) return;
     if (typingTimeout.current) {
       clearTimeout(typingTimeout.current);


### PR DESCRIPTION
## Summary

This PR adjusts the Visualization Tracker to prevent default behaviors for arrow key events when the user has the vitessce visualization focused. This keeps the visualization in place while the user adjusts e.g. the position of a scatterplot or spatial view.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-435

## Testing

Manually tested; see video below.

## Screenshots/Video

In this video, I switch between the same dataset on production and on my local environment to compare the behaviors before and after these changes.

https://github.com/user-attachments/assets/2a0d0958-aefe-4342-876a-a0a5c97931ed


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

