### PR TITLE
Austenem/CAT-941 Update HIVE group

### DIFF
--- a/CHANGELOG-update-hive-group.md
+++ b/CHANGELOG-update-hive-group.md
@@ -1,0 +1,1 @@
+- Update group for HIVE-processed datasets to be 'HIVE'.

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
@@ -34,7 +34,11 @@ function MetadataTable({ tableRows = [] as MetadataTableRow[], columns = default
               <TableRow key={row.key}>
                 <IconTooltipCell tooltipTitle={row?.description}>{row.key}</IconTooltipCell>
                 <TableCell>
-                  {row.key.endsWith('age_value') && <DonorAgeTooltip donorAge={row.value}>{row.value}</DonorAgeTooltip>}
+                  {row.key.endsWith('age_value') ? (
+                    <DonorAgeTooltip donorAge={row.value}>{row.value}</DonorAgeTooltip>
+                  ) : (
+                    row.value
+                  )}
                 </TableCell>
               </TableRow>
             ))}

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
@@ -5,7 +5,6 @@ import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableHead from '@mui/material/TableHead';
 import TableRow from '@mui/material/TableRow';
-import Stack from '@mui/material/Stack';
 
 import { StyledTableContainer, HeaderCell } from 'js/shared-styles/tables';
 import IconTooltipCell from 'js/shared-styles/tables/IconTooltipCell';
@@ -35,10 +34,7 @@ function MetadataTable({ tableRows = [] as MetadataTableRow[], columns = default
               <TableRow key={row.key}>
                 <IconTooltipCell tooltipTitle={row?.description}>{row.key}</IconTooltipCell>
                 <TableCell>
-                  <Stack direction="row">
-                    {row.value}
-                    {row.key.endsWith('age_value') && <DonorAgeTooltip donorAge={row.value} />}
-                  </Stack>
+                  {row.key.endsWith('age_value') && <DonorAgeTooltip donorAge={row.value}>{row.value}</DonorAgeTooltip>}
                 </TableCell>
               </TableRow>
             ))}

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -26,6 +26,7 @@ import { getDateLabelAndValue } from 'js/components/detailPage/utils';
 import { useSelectedVersionStore } from 'js/components/detailPage/VersionSelect/SelectedVersionStore';
 import { useVersions } from 'js/components/detailPage/VersionSelect/hooks';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
+import InfoTextTooltip from 'js/shared-styles/tooltips/InfoTextTooltip';
 
 import { DatasetTitle } from './DatasetTitle';
 import { ProcessedDatasetAccordion } from './ProcessedDatasetAccordion';
@@ -70,13 +71,23 @@ function Contact() {
 
 function SummaryAccordion() {
   const { dataset } = useProcessedDatasetContext();
+  const { group_name, mapped_consortium, creation_action } = dataset;
   const [dateLabel, dateValue] = getDateLabelAndValue(dataset);
+
+  const isHiveProcessed = creation_action === 'Central Process';
+
   return (
     <Subsection title="Summary" icon={<SummarizeRounded />}>
       <Stack spacing={1}>
         <ProcessedDatasetDescription />
-        <LabelledSectionText label="Group">{dataset.group_name}</LabelledSectionText>
-        <LabelledSectionText label="Consortium">{dataset.mapped_consortium}</LabelledSectionText>
+        <LabelledSectionText label="Group">
+          {isHiveProcessed ? (
+            <InfoTextTooltip tooltipTitle="HuBMAP Integration, Visualization & Engagement.">HIVE</InfoTextTooltip>
+          ) : (
+            group_name
+          )}
+        </LabelledSectionText>
+        <LabelledSectionText label="Consortium">{mapped_consortium}</LabelledSectionText>
         <Contact />
         <LabelledSectionText label={dateLabel}>
           {dateValue ? formatDate(new Date(dateValue), 'yyyy-MM-dd') : 'N/A'}

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
@@ -73,10 +73,9 @@ function DonorItems({ data: { entity } }: EntityHeaderItemsProps) {
       {race && <Typography>{race}</Typography>}
       {age_unit && age_value && (
         <Typography>
-          <Stack direction="row" justifyContent="center">
+          <DonorAgeTooltip donorAge={age_value}>
             {age_value} {age_unit}
-            <DonorAgeTooltip donorAge={age_value} />
-          </Stack>
+          </DonorAgeTooltip>
         </Typography>
       )}
       <Divider orientation="vertical" flexItem />

--- a/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Stack from '@mui/system/Stack';
 import Tile from 'js/shared-styles/tiles/Tile';
 import EntityTileThumbnail from 'js/components/entity-tile/EntityTileThumbnail';
 import { getOriginSamplesOrgan } from 'js/helpers/functions';
@@ -35,10 +34,9 @@ function EntityTileBody({ entity_type, id, entityData, invertColors }: EntityTil
               <Tile.Text>{entityData.mapped_metadata?.sex}</Tile.Text>
               <Tile.Divider invertColors={invertColors} />
               <Tile.Text>
-                <Stack direction="row">
+                <DonorAgeTooltip donorAge={entityData.mapped_metadata?.age_value}>
                   {entityData.mapped_metadata?.age_value} {entityData.mapped_metadata?.age_unit}
-                  <DonorAgeTooltip donorAge={entityData.mapped_metadata?.age_value} />
-                </Stack>
+                </DonorAgeTooltip>
               </Tile.Text>
             </Flex>
             <Tile.Text>{(entityData.mapped_metadata?.race ?? []).join(', ')}</Tile.Text>

--- a/context/app/static/js/components/searchPage/ResultsTable/utils.jsx
+++ b/context/app/static/js/components/searchPage/ResultsTable/utils.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Stack from '@mui/material/Stack';
 import { get } from 'js/helpers/nodash';
 import DonorAgeTooltip from 'js/shared-styles/tooltips/DonorAgeTooltip';
 
@@ -53,10 +52,7 @@ function getByPath(hitSource, field) {
   if (Array.isArray(fieldValue)) {
     if (field?.id === 'mapped_metadata.age_value') {
       return (
-        <Stack direction="row">
-          {fieldValue.join(' / ')}
-          {fieldValue.length > 0 && <DonorAgeTooltip donorAge={fieldValue[0]} />}
-        </Stack>
+        fieldValue.length > 0 && <DonorAgeTooltip donorAge={fieldValue[0]}>{fieldValue.join(' / ')}</DonorAgeTooltip>
       );
     }
     return fieldValue.join(' / ');

--- a/context/app/static/js/shared-styles/tooltips/DonorAgeTooltip/DonorAgeTooltip.tsx
+++ b/context/app/static/js/shared-styles/tooltips/DonorAgeTooltip/DonorAgeTooltip.tsx
@@ -9,7 +9,7 @@ interface DonorAgeTooltipProps extends PropsWithChildren {
 
 function DonorAgeTooltip({ donorAge, children }: DonorAgeTooltipProps) {
   if (!donorAge || Number(donorAge) <= 89) {
-    return null;
+    return children;
   }
 
   return <InfoTextTooltip tooltipTitle={DONOR_AGE_TEXT}>{children}</InfoTextTooltip>;

--- a/context/app/static/js/shared-styles/tooltips/DonorAgeTooltip/DonorAgeTooltip.tsx
+++ b/context/app/static/js/shared-styles/tooltips/DonorAgeTooltip/DonorAgeTooltip.tsx
@@ -1,25 +1,17 @@
-import React from 'react';
-
-import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
-import { StyledStack, StyledInfoIcon } from 'js/shared-styles/tooltips/DonorAgeTooltip/style';
+import React, { PropsWithChildren } from 'react';
+import InfoTextTooltip from 'js/shared-styles/tooltips/InfoTextTooltip';
 
 const DONOR_AGE_TEXT = 'For donors older than 89, the metadata will indicate an age of 90.';
 
-interface DonorAgeTooltipProps {
+interface DonorAgeTooltipProps extends PropsWithChildren {
   donorAge?: string;
 }
 
-function DonorAgeTooltip({ donorAge }: DonorAgeTooltipProps) {
+function DonorAgeTooltip({ donorAge, children }: DonorAgeTooltipProps) {
   if (!donorAge || Number(donorAge) <= 89) {
     return null;
   }
 
-  return (
-    <SecondaryBackgroundTooltip title={DONOR_AGE_TEXT}>
-      <StyledStack>
-        <StyledInfoIcon />
-      </StyledStack>
-    </SecondaryBackgroundTooltip>
-  );
+  return <InfoTextTooltip tooltipTitle={DONOR_AGE_TEXT}>{children}</InfoTextTooltip>;
 }
 export default DonorAgeTooltip;

--- a/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/InfoTextTooltip.tsx
+++ b/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/InfoTextTooltip.tsx
@@ -1,0 +1,22 @@
+import React, { PropsWithChildren } from 'react';
+
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import { StyledInfoIcon, StyledOuterStack, StyledInnerStack } from 'js/shared-styles/tooltips/InfoTextTooltip/style';
+
+interface InfoTextTooltipProps extends PropsWithChildren {
+  tooltipTitle: string;
+}
+
+function InfoTextTooltip({ tooltipTitle, children }: InfoTextTooltipProps) {
+  return (
+    <StyledOuterStack>
+      {children}
+      <SecondaryBackgroundTooltip title={tooltipTitle}>
+        <StyledInnerStack>
+          <StyledInfoIcon />
+        </StyledInnerStack>
+      </SecondaryBackgroundTooltip>
+    </StyledOuterStack>
+  );
+}
+export default InfoTextTooltip;

--- a/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/index.ts
+++ b/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/index.ts
@@ -1,0 +1,3 @@
+import InfoTextTooltip from './InfoTextTooltip';
+
+export default InfoTextTooltip;

--- a/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/style.ts
+++ b/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/style.ts
@@ -2,7 +2,12 @@ import { Stack } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import { InfoIcon } from 'js/shared-styles/icons';
 
-const StyledStack = styled(Stack)(({ theme }) => ({
+const StyledOuterStack = styled(Stack)({
+  alignItems: 'center',
+  flexDirection: 'row',
+});
+
+const StyledInnerStack = styled(Stack)(({ theme }) => ({
   marginLeft: theme.spacing(0.5),
   justifyContent: 'center',
 }));
@@ -12,4 +17,4 @@ const StyledInfoIcon = styled(InfoIcon)(({ theme }) => ({
   fontSize: '0.75rem',
 }));
 
-export { StyledStack, StyledInfoIcon };
+export { StyledOuterStack, StyledInnerStack, StyledInfoIcon };


### PR DESCRIPTION
## Summary

Update group for HIVE-processed datasets to be 'HIVE' with an explanatory tooltip. Refactoring was also done to tooltips for donor age messaging, as the style for both can be shared.

## Design Documentation/Original Tickets

[CAT-941 Jira ticket ](https://hms-dbmi.atlassian.net/browse/CAT-941?atlOrigin=eyJpIjoiMjEwYWVhYzc4ODU5NGY4ZWEzMGViMzllM2I0OGY3MmQiLCJwIjoiaiJ9)

## Testing

Manually checked group names for central and lab-processed dataset detail pages. 

## Screenshots/Video

<details>
<summary>Updated group names</summary>

Central processed:
![Screenshot 2024-10-07 at 2 54 43 PM](https://github.com/user-attachments/assets/fd7b6bb6-3346-4055-8f6b-c51412df91ee)

Lab processed:
![Screenshot 2024-10-07 at 2 57 11 PM](https://github.com/user-attachments/assets/c843d76b-a1a2-48df-a696-672271d80990)

</details>

<details>
<summary>Refactored age tooltips</summary>

Entity header:
![Screenshot 2024-10-07 at 4 05 37 PM](https://github.com/user-attachments/assets/76b1fc0f-d437-4087-a3e9-5d7a0f80529b)

Entity tile:
![Screenshot 2024-10-07 at 4 05 44 PM](https://github.com/user-attachments/assets/03dc0299-68bd-4cdb-862f-5537455c58bf)

Metadata table:
![Screenshot 2024-10-07 at 4 05 50 PM](https://github.com/user-attachments/assets/34aeedc7-3525-4a1b-adee-6fbabf305110)

Search page:
![Screenshot 2024-10-07 at 4 06 02 PM](https://github.com/user-attachments/assets/455a8554-1623-4354-a828-f8c2d0c6c966)

</details>


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
