### PR TITLE
NickAkhmetov/CAT-419 Filter collections without DOI from being counted on homepage

### DIFF
--- a/CHANGELOG-cat-419.md
+++ b/CHANGELOG-cat-419.md
@@ -1,0 +1,1 @@
+- Prevent collections without a DOI from being counted on the homepage.

--- a/context/app/static/js/components/home/EntityCounts/hooks.ts
+++ b/context/app/static/js/components/home/EntityCounts/hooks.ts
@@ -3,7 +3,20 @@ import useSearchData from 'js/hooks/useSearchData';
 
 const entityCountsQuery: SearchRequest = {
   size: 0,
-  aggs: { entity_type: { terms: { field: 'entity_type.keyword' } } },
+  query: {
+    bool: {
+      // Only include collections with a DOI in count
+      should: [
+        { bool: { must_not: { term: { 'entity_type.keyword': 'Collection' } } } },
+        { bool: { must: [{ exists: { field: 'doi_url' } }, { exists: { field: 'registered_doi' } }] } },
+      ],
+    },
+  },
+  aggs: {
+    entity_type: {
+      terms: { field: 'entity_type.keyword' },
+    },
+  },
 };
 
 interface EntityCounts {


### PR DESCRIPTION
## Summary

This PR adds a query to the aggregation on the homepage which prevents collection entities without a registered/published DOI from being included in the counts while not impacting the other counts. This filtering behavior matches the conditions applied to the count and list on the collections page.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-419

## Testing

Manual testing/comparison to the logged in portal.

## Screenshots/Video

Hovering the samples count to verify the added query does not affect any of the other entity counts; the actual fix can be seen by checking the collections count on the right.

Logged in on prod:
![image](https://github.com/user-attachments/assets/02447d8c-f664-4c5d-ab54-0aac8bb32c42)

Logged in locally:
![image](https://github.com/user-attachments/assets/fecfe301-bd7c-40aa-bf32-990de9c7c0e4)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Not sure how else to test this functionality; the idea of using an e2e test to compare the counts came to mind, but since this issue was only observable while logged in as a HIVE user, that approach will not work.