### PR TITLE
NickAkhmetov/CAT-882 Improve entity header resize handling

### DIFF
--- a/CHANGELOG-cat-882.md
+++ b/CHANGELOG-cat-882.md
@@ -1,0 +1,1 @@
+- Improve entity header state handling of page resizes.

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeader/EntityHeader.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeader/EntityHeader.tsx
@@ -56,6 +56,21 @@ function Header() {
     }
   }, [vizIsFullscreen, handleViewChange]);
 
+  // Switch to narrow view if screen size changes from large desktop to smaller
+  // Restore previous view when screen size changes back to large desktop
+  const previousView = useRef(view);
+  const wasLargeDesktop = useRef(isLargeDesktop);
+  useEffect(() => {
+    if (!isLargeDesktop && wasLargeDesktop.current) {
+      previousView.current = view;
+      handleViewChange('narrow');
+      // Else if is required to prevent infinite loop/maintain functionality
+    } else if (isLargeDesktop && !wasLargeDesktop.current) {
+      handleViewChange(previousView.current);
+    }
+    wasLargeDesktop.current = isLargeDesktop;
+  }, [isLargeDesktop, handleViewChange, view]);
+
   const [springValues] = springs;
 
   if (springValues[0] === undefined) {


### PR DESCRIPTION
## Summary

This PR adjusts the entity header to automatically respond to screen size changes.

- On change from large screen to small screen, the entity header is set to the narrow view.
- On change from small screen to large screen, the entity header is restored to its previous view.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-882

## Testing

Manually tested via screen resizing.

## Screenshots/Video


https://github.com/user-attachments/assets/b8a1e241-12fa-4552-912e-d09ea8fa368c



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

