### PR TITLE
NickAkhmetov/CAT-948 restore missing columns in derived entities tables

### DIFF
--- a/CHANGELOG-cat-948.md
+++ b/CHANGELOG-cat-948.md
@@ -1,0 +1,1 @@
+- Restore missing columns to derived entities section.

--- a/context/app/static/js/components/detailPage/derivedEntities/columns.ts
+++ b/context/app/static/js/components/detailPage/derivedEntities/columns.ts
@@ -22,7 +22,8 @@ const lastModifiedTimestampCol: Column = {
 const organCol: Column = {
   id: 'origin_samples_unique_mapped_organs',
   label: 'Organ',
-  renderColumnCell: (entity) => (isDataset(entity) ? entity.origin_samples_unique_mapped_organs.join(', ') : ''),
+  renderColumnCell: (entity) =>
+    isDataset(entity) || isSample(entity) ? entity.origin_samples_unique_mapped_organs.join(', ') : '',
 };
 
 const dataTypesCol: Column = {
@@ -34,7 +35,7 @@ const dataTypesCol: Column = {
 const statusCol: Column = {
   id: 'mapped_status',
   label: 'Status',
-  renderColumnCell: ({ mapped_status }) => mapped_status ?? '',
+  renderColumnCell: ({ mapped_status, status }) => mapped_status ?? status ?? '',
 };
 
 const derivedSamplesColumns: Column[] = [

--- a/context/app/static/js/hooks/useDerivedEntitySearchHits.ts
+++ b/context/app/static/js/hooks/useDerivedEntitySearchHits.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 
 import { useSearchHits } from 'js/hooks/useSearchData';
+import { Dataset, Sample } from 'js/components/types';
 
-function getTypeQuery(ancestorUUID, type) {
+function getTypeQuery(ancestorUUID: string, type: string) {
   return {
     bool: {
       filter: [
@@ -21,7 +22,7 @@ function getTypeQuery(ancestorUUID, type) {
   };
 }
 
-function useDerivedDatasetSearchHits(ancestorUUID) {
+function useDerivedDatasetSearchHits(ancestorUUID: string) {
   const query = useMemo(
     () => ({
       query: getTypeQuery(ancestorUUID, 'dataset'),
@@ -39,10 +40,10 @@ function useDerivedDatasetSearchHits(ancestorUUID) {
     [ancestorUUID],
   );
 
-  return useSearchHits(query);
+  return useSearchHits<Dataset>(query);
 }
 
-function useDerivedSampleSearchHits(ancestorUUID) {
+function useDerivedSampleSearchHits(ancestorUUID: string) {
   const query = useMemo(
     () => ({
       query: getTypeQuery(ancestorUUID, 'sample'),
@@ -59,7 +60,7 @@ function useDerivedSampleSearchHits(ancestorUUID) {
     }),
     [ancestorUUID],
   );
-  return useSearchHits(query);
+  return useSearchHits<Sample>(query);
 }
 
 export { useDerivedDatasetSearchHits, useDerivedSampleSearchHits };


### PR DESCRIPTION
## Summary

This PR restores the `status` column for derived datasets and the `organ` column for derived samples.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-948

## Testing

Manual testing

## Screenshots/Video

Prod link: https://portal.hubmapconsortium.org/browse/donor/be425f8a2963dda1d3a7a0c79de5e466#derived-data

Fixed screenshots:
![image](https://github.com/user-attachments/assets/3c85569e-ca8d-4ad8-abee-0bb4ce2023fe)

![image](https://github.com/user-attachments/assets/1c16919f-e8e0-4c92-941c-ebb98a339639)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
