### PR TITLE
Austenem/CAT-944 Entity header styling bugs

### DIFF
--- a/CHANGELOG-entity-header-styling.md
+++ b/CHANGELOG-entity-header-styling.md
@@ -1,0 +1,1 @@
+- Fix Webkit-specific bugs that caused the entity header to become misaligned.

--- a/context/app/static/js/components/Header/Header/Header.tsx
+++ b/context/app/static/js/components/Header/Header/Header.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import Box from '@mui/material/Box';
 import EntityHeader from 'js/components/detailPage/entityHeader/EntityHeader';
 import HeaderAppBar from '../HeaderAppBar';
 import HeaderContent from '../HeaderContent';
@@ -9,12 +10,12 @@ function Header() {
   const { shouldDisplayHeader, ...props } = useEntityHeaderVisibility();
 
   return (
-    <>
+    <Box sx={(theme) => ({ position: 'fixed', width: '100%', zIndex: theme.zIndex.header })}>
       <HeaderAppBar {...props}>
         <HeaderContent />
       </HeaderAppBar>
       {shouldDisplayHeader && <EntityHeader />}
-    </>
+    </Box>
   );
 }
 

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeader/style.ts
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeader/style.ts
@@ -7,7 +7,7 @@ const StyledPaper = styled(Paper)(({ theme }) => ({
   position: 'sticky',
   width: '100%',
   top: headerHeight,
-  zIndex: theme.zIndex.entityHeader,
+  zIndex: theme.zIndex.header,
 }));
 
 export { StyledPaper };

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
@@ -217,6 +217,7 @@ function EntityHeaderContent({ view, setView }: { view: SummaryViewsType; setVie
     <Stack
       direction="row"
       alignItems="center"
+      height="48px"
       px={2}
       py={0.5}
       sx={(theme) => ({ ...(view !== 'narrow' && { borderBottom: `1px solid ${theme.palette.primary.lowEmphasis}` }) })}

--- a/context/app/static/js/theme/theme.tsx
+++ b/context/app/static/js/theme/theme.tsx
@@ -42,7 +42,7 @@ declare module '@mui/material/styles' {
   export interface ZIndex {
     tutorial: number;
     dropdownOffset: number;
-    entityHeader: number;
+    header: number;
     dropdown: number;
     visualization: number;
     fileBrowserHeader: number;
@@ -264,7 +264,7 @@ const theme = createTheme({
   zIndex: {
     tutorial: 1101, // one higher than AppBar zIndex provided by MUI
     dropdownOffset: 1001,
-    entityHeader: 1000,
+    header: 1000,
     dropdown: 50,
     visualization: 3,
     fileBrowserHeader: 1,


### PR DESCRIPTION
## Summary

Fixes two WebKit/Safari-specific bugs that caused the entity header to become misaligned. 
- Bug 1: vertically misaligned view buttons in entity header, caused by their parent height being calculated differently in WebKit.
- Bug 2: app and entity headers shifted off-screen to make room for helper panel after scrolling to a processed dataset section.

## Design Documentation/Original Tickets

[CAT-944 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-944?atlOrigin=eyJpIjoiZDNkNmFkZTUyNTA5NGFjMjkwYzA3OWE5N2Q4MWI1MTgiLCJwIjoiaiJ9)

## Testing

Tested that both bugs were resolved in Chrome and Safari.

## Screenshots/Video

<details>
<summary>Bugs on prod in Safari:</summary>

https://github.com/user-attachments/assets/352de7d0-7e01-4110-a9ae-c0ede1be2f68

</details>

<details>
<summary>Resolved bugs locally in Safari:</summary>

https://github.com/user-attachments/assets/0163b79f-8b36-468b-bf65-af122fc8b3c6

</details>

<details>
<summary>Resolved bugs locally in Chrome:</summary>

https://github.com/user-attachments/assets/2fe925a9-cf40-4615-8ad7-2b9616870e02

</details>

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
