### PR TITLE
Austenem/CAT-922 Remove QA workspace option

### DIFF
--- a/CHANGELOG-remove-qa-workspace-option.md
+++ b/CHANGELOG-remove-qa-workspace-option.md
@@ -1,0 +1,1 @@
+- Fix issue of Workspaces button being available for protected datasets in the Visualization section.

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -43,8 +43,6 @@ const visualizationStoreSelector = (state: VisualizationStore) => ({
 interface VisualizationProps {
   vitData: object | object[];
   uuid?: string;
-  hubmap_id?: string;
-  mapped_data_access_level?: string;
   hasNotebook: boolean;
   shouldDisplayHeader: boolean;
   shouldMountVitessce?: boolean;
@@ -54,8 +52,6 @@ interface VisualizationProps {
 function Visualization({
   vitData,
   uuid,
-  hubmap_id,
-  mapped_data_access_level,
   hasNotebook,
   shouldDisplayHeader,
   shouldMountVitessce = true,
@@ -122,12 +118,7 @@ function Visualization({
           leftText={shouldDisplayHeader ? <StyledSectionHeader>Visualization</StyledSectionHeader> : undefined}
           buttons={
             <Stack direction="row" spacing={1}>
-              <VisualizationWorkspaceButton
-                uuid={uuid}
-                hubmap_id={hubmap_id}
-                mapped_data_access_level={mapped_data_access_level}
-                hasNotebook={hasNotebook}
-              />
+              <VisualizationWorkspaceButton uuid={uuid} hasNotebook={hasNotebook} />
               <VisualizationDownloadButton uuid={uuid} hasNotebook={hasNotebook} />
               <VisualizationShareButton />
               <VisualizationThemeSwitch />

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -118,7 +118,7 @@ function Visualization({
           leftText={shouldDisplayHeader ? <StyledSectionHeader>Visualization</StyledSectionHeader> : undefined}
           buttons={
             <Stack direction="row" spacing={1}>
-              <VisualizationWorkspaceButton uuid={uuid} hasNotebook={hasNotebook} />
+              {hasNotebook && <VisualizationWorkspaceButton uuid={uuid} />}
               <VisualizationDownloadButton uuid={uuid} hasNotebook={hasNotebook} />
               <VisualizationShareButton />
               <VisualizationThemeSwitch />

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
@@ -30,7 +30,7 @@ function VisualizationWorkspaceButton({ uuid = '', hasNotebook }: VisualizationW
     initialSelectedDatasets: [uuid],
   });
 
-  if (!isWorkspacesUser || !hubmap_id || !hasNotebook || mapped_data_access_level === 'Protected') {
+  if (!isWorkspacesUser || !hubmap_id || !hasNotebook || mapped_data_access_level !== 'Public') {
     return null;
   }
 

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
@@ -7,30 +7,30 @@ import NewWorkspaceDialog from 'js/components/workspaces/NewWorkspaceDialog';
 import { useCreateWorkspaceForm } from 'js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm';
 import { WhiteBackgroundIconTooltipButton } from 'js/shared-styles/buttons';
 import { useAppContext } from 'js/components/Contexts';
+import { useDetailContext } from 'js/components/detailPage/DetailContext';
+import { useProcessedDatasetDetails } from 'js/components/detailPage/ProcessedData/ProcessedDataset/hooks';
 
 const tooltip = 'Launch New Workspace';
 
 interface VisualizationWorkspaceButtonProps {
   uuid?: string;
-  hubmap_id?: string;
   hasNotebook?: boolean;
-  mapped_data_access_level?: string;
 }
 
-function VisualizationWorkspaceButton({
-  uuid = '',
-  hubmap_id,
-  hasNotebook,
-  mapped_data_access_level,
-}: VisualizationWorkspaceButtonProps) {
+function VisualizationWorkspaceButton({ uuid = '', hasNotebook }: VisualizationWorkspaceButtonProps) {
+  const { mapped_data_access_level } = useDetailContext();
+  const {
+    datasetDetails: { hubmap_id },
+  } = useProcessedDatasetDetails(uuid);
   const { isWorkspacesUser } = useAppContext();
+
   const { setDialogIsOpen, removeDatasets, ...rest } = useCreateWorkspaceForm({
     defaultName: hubmap_id,
     defaultTemplate: 'visualization',
     initialSelectedDatasets: [uuid],
   });
 
-  if (!isWorkspacesUser ?? !uuid ?? !hubmap_id ?? !hasNotebook ?? mapped_data_access_level === 'Protected') {
+  if (!isWorkspacesUser || !hubmap_id || !hasNotebook || mapped_data_access_level === 'Protected') {
     return null;
   }
 

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWorkspaceButton/VisualizationWorkspaceButton.tsx
@@ -14,10 +14,9 @@ const tooltip = 'Launch New Workspace';
 
 interface VisualizationWorkspaceButtonProps {
   uuid?: string;
-  hasNotebook?: boolean;
 }
 
-function VisualizationWorkspaceButton({ uuid = '', hasNotebook }: VisualizationWorkspaceButtonProps) {
+function VisualizationWorkspaceButton({ uuid = '' }: VisualizationWorkspaceButtonProps) {
   const { mapped_data_access_level } = useDetailContext();
   const {
     datasetDetails: { hubmap_id },
@@ -30,7 +29,7 @@ function VisualizationWorkspaceButton({ uuid = '', hasNotebook }: VisualizationW
     initialSelectedDatasets: [uuid],
   });
 
-  if (!isWorkspacesUser || !hubmap_id || !hasNotebook || mapped_data_access_level !== 'Public') {
+  if (!isWorkspacesUser || !hubmap_id || mapped_data_access_level !== 'Public') {
     return null;
   }
 

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.tsx
@@ -10,8 +10,6 @@ const Visualization = React.lazy(() => import('../Visualization'));
 interface VisualizationWrapperProps {
   vitData: object | object[];
   uuid?: string;
-  hubmap_id?: string;
-  mapped_data_access_level?: string;
   hasNotebook?: boolean;
   shouldDisplayHeader?: boolean;
   hasBeenMounted?: boolean;
@@ -22,8 +20,6 @@ interface VisualizationWrapperProps {
 function VisualizationWrapper({
   vitData,
   uuid,
-  hubmap_id,
-  mapped_data_access_level,
   hasNotebook = false,
   shouldDisplayHeader = true,
   hasBeenMounted,
@@ -45,8 +41,6 @@ function VisualizationWrapper({
           <Visualization
             vitData={vitData}
             uuid={uuid}
-            hubmap_id={hubmap_id}
-            mapped_data_access_level={mapped_data_access_level}
             hasNotebook={hasNotebook}
             shouldDisplayHeader={shouldDisplayHeader}
             shouldMountVitessce={hasBeenMounted}


### PR DESCRIPTION
## Summary

Fixes issue of Workspaces button being available for protected datasets in the Visualization section.

## Design Documentation/Original Tickets

[CAT-922 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-922?atlOrigin=eyJpIjoiZmY4M2YyYjViODUzNGU1M2E5YzYwMWU0ZmE3NjI2ZjEiLCJwIjoiaiJ9)

## Testing

Tested protected and public datasets to ensure Workspaces button appeared only for visualizations of public + published datasets.

## Screenshots/Video

Local on left, prod on right:
![Screenshot 2024-10-11 at 12 34 45 PM](https://github.com/user-attachments/assets/15b15d75-8f55-4aa3-8a3d-3c3e6a0b703e)

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
