### PR TITLE
NickAkhmetov/CAT-706 Add title to changelog page

### DIFF
--- a/CHANGELOG-cat-706.md
+++ b/CHANGELOG-cat-706.md
@@ -1,0 +1,1 @@
+- Add title to changelog page.

--- a/context/app/markdown/CHANGELOG.md
+++ b/context/app/markdown/CHANGELOG.md
@@ -1,3 +1,5 @@
+# Changelog
+
 ## v1.12.1 - 2024-10-10
 
 - Prevent collections without a DOI from being counted on the homepage.

--- a/etc/build/push.sh
+++ b/etc/build/push.sh
@@ -44,6 +44,7 @@ else
   VERSION=`cd context && npm version major`
 fi
 
+
 echo "Version: $VERSION"
 
 ./grab-dependencies.sh
@@ -54,13 +55,16 @@ git commit -m "Version bump to $VERSION"
 
 if ls CHANGELOG-*.md; then
   (
+    echo '# Changelog'
+    echo 
     echo '##' $VERSION - `date +"%F"`
     echo
     # "-l" chomps and adds newline.
     perl -lpe '' CHANGELOG-*.md
     echo
     echo
-    cat CHANGELOG.md
+    # Skip the first line of the existing changelog (the header).
+    tail -n +2 context/app/markdown/CHANGELOG.md
   ) > CHANGELOG.md.new
   mv CHANGELOG.md.new context/app/markdown/CHANGELOG.md
   git rm CHANGELOG-*.md


### PR DESCRIPTION
## Summary

This PR leverages the existing markdown page logic to add a title to changelog markdown pages.

The markdown page logic looks for the first top-level header to use as the title; since the changelog did not include such a header, it was assigned the default `(no title)` title.

My change appends a `# Changelog` to the start of generated changelogs in the `push` script, then skips the first line of the old changelog during appending. This approach prevents duplicate `# Changelog` entries from appearing.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-706

## Testing

Manually tested by commenting out all git/docker-based functionalities and running the push script.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/b76956b7-d480-4d9b-8e7f-55ca1960792b)

![image](https://github.com/user-attachments/assets/4b33fcea-8a99-442c-939d-43f5cdd7bbf3)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

