### PR TITLE
Austenem/CAT-955 Fix header bug

### DIFF
--- a/CHANGELOG-fix-header-bug.md
+++ b/CHANGELOG-fix-header-bug.md
@@ -1,0 +1,1 @@
+- Resolve issues of header cutting off the top of detail pages and header shifting off-screen when scrolling.

--- a/context/app/static/js/components/Header/Header/Header.tsx
+++ b/context/app/static/js/components/Header/Header/Header.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import Box from '@mui/material/Box';
 import EntityHeader from 'js/components/detailPage/entityHeader/EntityHeader';
 import HeaderAppBar from '../HeaderAppBar';
 import HeaderContent from '../HeaderContent';
@@ -10,12 +9,12 @@ function Header() {
   const { shouldDisplayHeader, ...props } = useEntityHeaderVisibility();
 
   return (
-    <Box sx={(theme) => ({ position: 'fixed', width: '100%', zIndex: theme.zIndex.header })}>
+    <>
       <HeaderAppBar {...props}>
         <HeaderContent />
       </HeaderAppBar>
       {shouldDisplayHeader && <EntityHeader />}
-    </Box>
+    </>
   );
 }
 

--- a/context/app/static/js/components/detailPage/DetailPageSection/DetailPageSection.tsx
+++ b/context/app/static/js/components/detailPage/DetailPageSection/DetailPageSection.tsx
@@ -26,7 +26,9 @@ function DetailPageSection({ children, ...rest }: PropsWithChildren<React.HTMLAt
         }, 1000);
       }
     }
-  }, [initialHash, rest.id, offset]);
+    // We do not want to re-scroll down to the section if the header view changes (aka offset changes)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialHash, rest.id]);
 
   return (
     <OffsetSection $offset={offset} ref={sectionRef} {...rest}>

--- a/context/app/static/js/components/detailPage/DetailPageSection/DetailPageSection.tsx
+++ b/context/app/static/js/components/detailPage/DetailPageSection/DetailPageSection.tsx
@@ -15,13 +15,18 @@ function DetailPageSection({ children, ...rest }: PropsWithChildren<React.HTMLAt
       const strippedHash = initialHash.slice(1);
       if (strippedHash === rest.id) {
         setTimeout(() => {
-          sectionRef.current?.scrollIntoView({
+          // Manually scroll to section and account for header offset
+          const sectionTop = sectionRef.current?.getBoundingClientRect().top ?? 0;
+          const scrollPosition = window.scrollY + sectionTop - offset;
+
+          window.scrollTo({
+            top: Math.max(scrollPosition, 0),
             behavior: 'smooth',
           });
         }, 1000);
       }
     }
-  }, [initialHash, rest.id]);
+  }, [initialHash, rest.id, offset]);
 
   return (
     <OffsetSection $offset={offset} ref={sectionRef} {...rest}>


### PR DESCRIPTION
## Summary

Fixes a bug resulting from #3569 that caused the entity header to cut off the top of the page. This was addressed by taking a different approach to fixing the entity header bug that was resolved in #3569, which resolved both issues. 

**Original bug:** header shifted off-screen on initial page load on narrow browser window sizes.
**New bug:** header cut off the top of the page (due to being removed from the document flow). 

## Design Documentation/Original Tickets

[CAT-955 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-955?atlOrigin=eyJpIjoiZTFlNmZkNjAzYTM5NDBiNGFlY2E0NmVhNGZmMjExYWMiLCJwIjoiaiJ9)

## Testing

Tested that both bugs were resolved in Chrome and Safari.

## Screenshots/Video

<details>
<summary>Original bug on prod:</summary>

https://github.com/user-attachments/assets/0043111f-d370-41ad-8b1e-3c99c8344c24

</details>

<details>
<summary>Resolved original bug locally:</summary>

https://github.com/user-attachments/assets/c8155da6-09ee-4d1c-8249-9b0c5326007b

</details>

<details>
<summary>Resolved new bug locally:</summary>

https://github.com/user-attachments/assets/6c91cff6-2366-47b3-bae7-6375866b5e34


</details>

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

