### PR TITLE
Austenem/CAT-957 Fix shaking viewport

### DIFF
--- a/CHANGELOG-fix-shaking-viewport.md
+++ b/CHANGELOG-fix-shaking-viewport.md
@@ -1,0 +1,1 @@
+- Fix bug where expanding a processed dataset section leads to a shaking viewport.

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
@@ -18,6 +18,7 @@ import useProcessedDataStore from '../store';
 import { DetailPageSection } from '../../DetailPageSection';
 
 const iconPlaceholder = <Skeleton variant="circular" width={24} height={24} animation="pulse" />;
+const inViewThreshold = 0.1;
 
 function LoadingFallback() {
   return <Skeleton variant="rectangular" height={200} />;
@@ -27,19 +28,22 @@ export function ProcessedDatasetAccordion({ children }: PropsWithChildren) {
   const { defaultExpanded, dataset, sectionDataset, conf, isLoading } = useProcessedDatasetContext();
   const visualizationIcon = conf ? <VisualizationIcon /> : null;
   const track = useTrackEntityPageEvent();
+  const [threshold, setThreshold] = useState(inViewThreshold);
 
   const { setCurrentDataset, removeVisibleDataset } = useProcessedDataStore((state) => ({
     setCurrentDataset: state.setCurrentDataset,
     removeVisibleDataset: state.removeFromVisibleDatasets,
   }));
   const { ref } = useInView({
-    threshold: 0,
+    threshold,
     initialInView: false,
     onChange: (visible) => {
       if (visible && dataset) {
+        setThreshold(0);
         setCurrentDataset(dataset);
       }
       if (!visible) {
+        setThreshold(inViewThreshold);
         removeVisibleDataset(sectionDataset.hubmap_id);
       }
     },


### PR DESCRIPTION
## Summary

Fixes bug where scrolling to the top of a processed dataset section led to a shaking viewport.

**Explanation:** The processed dataset helper panel appears when any part of the processed dataset accordion is visible. In narrower browser windows, opening the helper panel means there is less width for the accordion, so it is moved further down the page. The panel then closes, which causes the accordion to be visible, which opens it again and triggers an infinite loop.

This was resolved by only showing the helper panel when 10% or more of the accordion is visible, and only hiding the panel when the accordion is completely off-screen.

## Design Documentation/Original Tickets

[CAT-957 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-954?atlOrigin=eyJpIjoiYWQ2NTkzNGI2MzVkNGJjYWE4MGM0MDBkZWE4MTg1ZWQiLCJwIjoiaiJ9)

## Testing

Attempted to reproduce bug in Chrome/Safari on browsers of varying widths on pages with one or several processed datasets.

## Screenshots/Video

<details>
<summary>Original bug on prod:</summary>

https://github.com/user-attachments/assets/fc621103-d8a6-4d48-85f6-200e537774f1

</details>

<details>
<summary>Local:</summary>

https://github.com/user-attachments/assets/11f0bda5-c44d-418b-a869-e38235467638

</details>

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
