### PR TITLE
Austenem/CAT-962 Show panel title on hover

### DIFF
--- a/CHANGELOG-show-panel-title-on-hover.md
+++ b/CHANGELOG-show-panel-title-on-hover.md
@@ -1,0 +1,1 @@
+- If a title or description in a processed dataset helper panel is truncated, show the full text on hover in a tooltip.

--- a/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
@@ -10,7 +10,7 @@ import CloudDownloadRounded from '@mui/icons-material/CloudDownloadRounded';
 import { useIsDesktop } from 'js/hooks/media-queries';
 import { WorkspacesIcon } from 'js/shared-styles/icons';
 import { useAnimatedSidebarPosition } from 'js/shared-styles/sections/TableOfContents/hooks';
-import { LineClamp } from 'js/shared-styles/text';
+import { LineClampWithTooltip } from 'js/shared-styles/text';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 
 import { formatDate } from 'date-fns/format';
@@ -53,7 +53,7 @@ interface HelperPanelBodyItemProps extends PropsWithChildren {
 }
 
 function HelperPanelBodyItem({ label, children, noWrap }: HelperPanelBodyItemProps) {
-  const body = noWrap ? <LineClamp lines={3}>{children}</LineClamp> : children;
+  const body = noWrap ? <LineClampWithTooltip lines={3}>{children}</LineClampWithTooltip> : children;
   return (
     <Stack direction="column">
       <Typography variant="overline">{label}</Typography>

--- a/context/app/static/js/components/detailPage/summary/SummaryBody/SummaryDescription.tsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryBody/SummaryDescription.tsx
@@ -3,13 +3,13 @@ import Typography from '@mui/material/Typography';
 
 import { Entity } from 'js/components/types';
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
-import { LineClamp } from 'js/shared-styles/text';
+import { LineClampWithTooltip } from 'js/shared-styles/text';
 
 function CustomClamp({ children }: PropsWithChildren) {
   return (
-    <LineClamp lines={3} component={Typography}>
-      {children}
-    </LineClamp>
+    <LineClampWithTooltip lines={3}>
+      <Typography>{children}</Typography>
+    </LineClampWithTooltip>
   );
 }
 

--- a/context/app/static/js/shared-styles/text/LineClampWithTooltip.tsx
+++ b/context/app/static/js/shared-styles/text/LineClampWithTooltip.tsx
@@ -1,0 +1,37 @@
+import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import Box from '@mui/material/Box';
+import LineClamp from 'js/shared-styles/text/LineClamp';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+
+interface LineClampWithTooltipProps extends PropsWithChildren {
+  lines: number;
+}
+
+function LineClampWithTooltip({ lines, children }: LineClampWithTooltipProps) {
+  const [isTruncated, setIsTruncated] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Check whether the child text is truncated, and show the full text in a tooltip if so
+  useEffect(() => {
+    const element = ref.current;
+    if (element) {
+      setIsTruncated(element.scrollHeight > element.clientHeight);
+    }
+  }, [children]);
+
+  const content = (
+    <LineClamp ref={ref} lines={lines}>
+      {children}
+    </LineClamp>
+  );
+
+  return isTruncated ? (
+    <SecondaryBackgroundTooltip title={children}>
+      <Box>{content}</Box>
+    </SecondaryBackgroundTooltip>
+  ) : (
+    content
+  );
+}
+
+export default LineClampWithTooltip;

--- a/context/app/static/js/shared-styles/text/LineClampWithTooltip.tsx
+++ b/context/app/static/js/shared-styles/text/LineClampWithTooltip.tsx
@@ -1,5 +1,4 @@
 import React, { PropsWithChildren, useEffect, useRef, useState } from 'react';
-import Box from '@mui/material/Box';
 import LineClamp from 'js/shared-styles/text/LineClamp';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 
@@ -25,13 +24,7 @@ function LineClampWithTooltip({ lines, children }: LineClampWithTooltipProps) {
     </LineClamp>
   );
 
-  return isTruncated ? (
-    <SecondaryBackgroundTooltip title={children}>
-      <Box>{content}</Box>
-    </SecondaryBackgroundTooltip>
-  ) : (
-    content
-  );
+  return isTruncated ? <SecondaryBackgroundTooltip title={children}>{content}</SecondaryBackgroundTooltip> : content;
 }
 
 export default LineClampWithTooltip;

--- a/context/app/static/js/shared-styles/text/index.ts
+++ b/context/app/static/js/shared-styles/text/index.ts
@@ -1,3 +1,4 @@
 import { LineClamp } from './LineClamp';
+import LineClampWithTooltip from './LineClampWithTooltip';
 
-export { LineClamp };
+export { LineClamp, LineClampWithTooltip };


### PR DESCRIPTION
## Summary

If a title or description in a processed dataset helper panel is truncated, show the full text on hover in a tooltip.

## Design Documentation/Original Tickets

[CAT-962 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-962?atlOrigin=eyJpIjoiN2U3Y2RlYzI3MWFlNDE0YThlMmE3YzViYTQxMmVlODkiLCJwIjoiaiJ9)

## Testing

Tested by checking both truncated and non-truncated panel text examples. 

## Screenshots/Video

<img width="279" alt="Screenshot 2024-10-23 at 10 36 11 AM" src="https://github.com/user-attachments/assets/07e6e4de-16af-46ea-a499-49fe7520f8de">
<img width="258" alt="Screenshot 2024-10-23 at 10 35 25 AM" src="https://github.com/user-attachments/assets/7d4d0947-12a7-4272-88cc-7f233a4b5946">

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
