### PR TITLE
Austenem/CAT-964 Update external processing labels

### DIFF
--- a/CHANGELOG-update-external-processing-labels.md
+++ b/CHANGELOG-update-external-processing-labels.md
@@ -1,0 +1,1 @@
+- Display EPIC datasets as being generated via external processing in dataset relationship diagrams.

--- a/context/app/static/js/components/detailPage/DatasetRelationships/hooks.ts
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/hooks.ts
@@ -46,7 +46,7 @@ async function fetchPipelineInfo({ url, datasets, groupsToken }: PipelineInfoReq
 
   // Handle epics separately since their pipeline-shorthand is blank
   if (result.process_state === 'epic') {
-    return result['dataset-type'];
+    return result.description;
   }
 
   // Also handle image pyramids separately since their pipeline-shorthand is blank

--- a/context/app/static/js/components/detailPage/DatasetRelationships/hooks.ts
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/hooks.ts
@@ -46,7 +46,7 @@ async function fetchPipelineInfo({ url, datasets, groupsToken }: PipelineInfoReq
 
   // Handle epics separately since their pipeline-shorthand is blank
   if (result.process_state === 'epic') {
-    return 'External Process';
+    return result['dataset-type'];
   }
 
   // Also handle image pyramids separately since their pipeline-shorthand is blank

--- a/context/app/static/js/components/detailPage/DatasetRelationships/hooks.ts
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/hooks.ts
@@ -44,7 +44,12 @@ async function fetchPipelineInfo({ url, datasets, groupsToken }: PipelineInfoReq
   }
   const result = await fetchSoftAssay({ url, dataset: datasets[0], groupsToken });
 
-  // Handle image pyramids separately since their pipeline-shorthand is blank
+  // Handle epics separately since their pipeline-shorthand is blank
+  if (result.process_state === 'epic') {
+    return 'External Process';
+  }
+
+  // Also handle image pyramids separately since their pipeline-shorthand is blank
   if (result['vitessce-hints'].includes('pyramid') && result['vitessce-hints'].includes('is_image')) {
     return 'Image Pyramid Generation';
   }

--- a/context/app/static/js/hooks/useSoftAssay.tsx
+++ b/context/app/static/js/hooks/useSoftAssay.tsx
@@ -15,6 +15,7 @@ interface SoftAssayResponse {
   'pipeline-shorthand': string;
   primary: boolean;
   'vitessce-hints': string[];
+  process_state: string;
 }
 
 export async function fetchSoftAssay({ url, dataset, groupsToken }: SoftAssayRequest) {

--- a/context/app/static/js/hooks/useSoftAssay.tsx
+++ b/context/app/static/js/hooks/useSoftAssay.tsx
@@ -16,6 +16,7 @@ interface SoftAssayResponse {
   primary: boolean;
   'vitessce-hints': string[];
   process_state: string;
+  'dataset-type': string;
 }
 
 export async function fetchSoftAssay({ url, dataset, groupsToken }: SoftAssayRequest) {

--- a/context/app/static/js/hooks/useSoftAssay.tsx
+++ b/context/app/static/js/hooks/useSoftAssay.tsx
@@ -16,7 +16,6 @@ interface SoftAssayResponse {
   primary: boolean;
   'vitessce-hints': string[];
   process_state: string;
-  'dataset-type': string;
 }
 
 export async function fetchSoftAssay({ url, dataset, groupsToken }: SoftAssayRequest) {


### PR DESCRIPTION
## Summary

Displays EPIC datasets as being generated via external processing in dataset relationship diagrams. Previously, segmentation mask datasets were being shown as being generated via "Image Pyramid" processing due to their `vitessce-hints`.

## Design Documentation/Original Tickets

[CAT-964 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-964?atlOrigin=eyJpIjoiMGUzNzE0MjNhOGUwNDIwMGEyY2E4MmY0ZGU4MGQ2ZDIiLCJwIjoiaiJ9)

## Testing

Verified using a segmentation mask EPIC on dev: https://portal.dev.hubmapconsortium.org/browse/dataset/22901da5f080b219a514e38381acbb0e

## Screenshots/Video

Dev:
![Screenshot 2024-10-24 at 11 58 21 AM](https://github.com/user-attachments/assets/99de553b-3e17-4e04-99bd-7b9afb1adfba)

Local:
<img width="849" alt="Screenshot 2024-10-25 at 10 08 40 AM" src="https://github.com/user-attachments/assets/756bc712-7407-4095-92fe-b310c3f37c5d">


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
