### PR TITLE
Austenem/Minor group updates (CAT-795, CAT-972, & CAT-982)

### DIFF
--- a/CHANGELOG-minor-group-updates.md
+++ b/CHANGELOG-minor-group-updates.md
@@ -1,0 +1,2 @@
+- Label centrally processed dataset groups as HIVE in the helper panel.
+- Fix typo in publication collections summary.

--- a/CHANGELOG-minor-group-updates.md
+++ b/CHANGELOG-minor-group-updates.md
@@ -1,2 +1,3 @@
 - Label centrally processed dataset groups as HIVE in the helper panel.
 - Fix typo in publication collections summary.
+- Add group name to raw dataset summary section.

--- a/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
@@ -14,6 +14,7 @@ import { LineClampWithTooltip } from 'js/shared-styles/text';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 
 import { formatDate } from 'date-fns/format';
+import ProcessedDataGroup from 'js/components/detailPage/ProcessedData/ProcessedDatasetGroup';
 import { HelperPanelPortal } from '../../DetailLayout/DetailLayout';
 import StatusIcon from '../../StatusIcon';
 import { getDateLabelAndValue, useCurrentDataset } from '../../utils';
@@ -68,22 +69,24 @@ function HelperPanelBody() {
     return null;
   }
   const [dateLabel, date] = getDateLabelAndValue(currentDataset);
+
+  const { title, description, pipeline, assay_display_name, creation_action, group_name } = currentDataset;
   return (
     <>
-      {currentDataset.title && (
+      {title && (
         <HelperPanelBodyItem label="Title" noWrap>
-          {currentDataset.title}
+          {title}
         </HelperPanelBodyItem>
       )}
-      {currentDataset.description && (
+      {description && (
         <HelperPanelBodyItem label="Description" noWrap>
-          {currentDataset.description}
+          {description}
         </HelperPanelBodyItem>
       )}
-      <HelperPanelBodyItem label="Analysis Type">
-        {currentDataset.pipeline ?? currentDataset.assay_display_name[0]}
+      <HelperPanelBodyItem label="Analysis Type">{pipeline ?? assay_display_name[0]}</HelperPanelBodyItem>
+      <HelperPanelBodyItem label="Group">
+        <ProcessedDataGroup creation_action={creation_action} group_name={group_name} />
       </HelperPanelBodyItem>
-      <HelperPanelBodyItem label="Group">{currentDataset.group_name}</HelperPanelBodyItem>
       <HelperPanelBodyItem label={dateLabel}>{date && formatDate(date, 'yyyy-MM-dd')}</HelperPanelBodyItem>
     </>
   );

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -26,7 +26,7 @@ import { getDateLabelAndValue } from 'js/components/detailPage/utils';
 import { useSelectedVersionStore } from 'js/components/detailPage/VersionSelect/SelectedVersionStore';
 import { useVersions } from 'js/components/detailPage/VersionSelect/hooks';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
-import InfoTextTooltip from 'js/shared-styles/tooltips/InfoTextTooltip';
+import ProcessedDataGroup from 'js/components/detailPage/ProcessedData/ProcessedDatasetGroup';
 
 import { DatasetTitle } from './DatasetTitle';
 import { ProcessedDatasetAccordion } from './ProcessedDatasetAccordion';
@@ -74,18 +74,12 @@ function SummaryAccordion() {
   const { group_name, mapped_consortium, creation_action } = dataset;
   const [dateLabel, dateValue] = getDateLabelAndValue(dataset);
 
-  const isHiveProcessed = creation_action === 'Central Process';
-
   return (
     <Subsection title="Summary" icon={<SummarizeRounded />}>
       <Stack spacing={1}>
         <ProcessedDatasetDescription />
         <LabelledSectionText label="Group">
-          {isHiveProcessed ? (
-            <InfoTextTooltip tooltipTitle="HuBMAP Integration, Visualization & Engagement.">HIVE</InfoTextTooltip>
-          ) : (
-            group_name
-          )}
+          <ProcessedDataGroup creation_action={creation_action} group_name={group_name} />
         </LabelledSectionText>
         <LabelledSectionText label="Consortium">{mapped_consortium}</LabelledSectionText>
         <Contact />

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDatasetGroup.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDatasetGroup.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import InfoTextTooltip from 'js/shared-styles/tooltips/InfoTextTooltip';
+import { ProcessedDatasetDetails } from 'js/components/detailPage/ProcessedData/ProcessedDataset/hooks';
+
+function ProcessedDataGroup({
+  creation_action,
+  group_name,
+}: Pick<ProcessedDatasetDetails, 'creation_action' | 'group_name'>) {
+  const isHiveProcessed = creation_action === 'Central Process';
+
+  return isHiveProcessed ? (
+    <InfoTextTooltip tooltipTitle="HuBMAP Integration, Visualization & Engagement.">HIVE</InfoTextTooltip>
+  ) : (
+    group_name
+  );
+}
+
+export default ProcessedDataGroup;

--- a/context/app/static/js/components/detailPage/summary/SummaryBody/SummaryBody.tsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryBody/SummaryBody.tsx
@@ -70,6 +70,22 @@ function DatasetConsortium() {
   return <LabelledSectionText label="Consortium">{mapped_consortium}</LabelledSectionText>;
 }
 
+function DatasetGroup() {
+  const { entity } = useFlaskDataContext();
+
+  if (!isDataset(entity)) {
+    return null;
+  }
+
+  const { group_name } = entity;
+
+  if (!group_name) {
+    return null;
+  }
+
+  return <LabelledSectionText label="Group">{group_name}</LabelledSectionText>;
+}
+
 function CollectionCitation() {
   const { entity } = useFlaskDataContext();
 
@@ -122,6 +138,7 @@ function SummaryBodyContent({
     <Stack component={SummaryPaper} direction={direction} spacing={1} {...stackProps}>
       <CollectionName />
       <SummaryDescription description={description} clamp={isEntityHeader} />
+      <DatasetGroup />
       <DatasetConsortium />
       <DatasetCitation />
       <CollectionCitation />

--- a/context/app/static/js/components/publications/PublicationCollections/PublicationCollections.tsx
+++ b/context/app/static/js/components/publications/PublicationCollections/PublicationCollections.tsx
@@ -19,7 +19,7 @@ function PublicationCollections({ collectionsData = [], isCollectionPublication 
     <CollapsibleDetailPageSection id="data" title="Data">
       <StyledSectionPaper $isCollectionPublication={isCollectionPublication}>
         <LabelledSectionText label="Collections">
-          Datasets associated with this publication are included in the Collections listed below.
+          Datasets associated with this publication are included in the collections listed below.
         </LabelledSectionText>
       </StyledSectionPaper>
       <PanelList panelsProps={panelsProps} />


### PR DESCRIPTION
## Summary

Several minor updates mainly related to groups on the dataset detail pages:
  - Fix typo in publication collections summary (CAT-795)
  - Label centrally processed dataset groups as HIVE in the helper panel (CAT-972)
  - Add group name to raw dataset summary section (CAT-982)

## Design Documentation/Original Tickets

[CAT-795 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-795?atlOrigin=eyJpIjoiNmI0ZWJlYTkyZjE1NDY5ZjliNzEzYTI4M2YzY2FjNGMiLCJwIjoiaiJ9)
[CAT-972 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-972?atlOrigin=eyJpIjoiZWNjODg3OTNkM2YzNDQ0Njk2ZTFkYjFkYmY1NTdmZjMiLCJwIjoiaiJ9)
[CAT-982 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-982?atlOrigin=eyJpIjoiNjMyMjBjNzRlMWVhNGIyYWI1ZTc5N2QxNzE3MDViZGIiLCJwIjoiaiJ9)

## Testing

Tested by manually checking detail pages for updates.

## Screenshots/Video

<details>
<summary>CAT-795</summary>

![Screenshot 2024-10-29 at 5 13 50 PM](https://github.com/user-attachments/assets/ae2a2188-a956-41e2-af36-a3e77e4918a2)

</details>

<details>
<summary>CAT-972</summary>

![Screenshot 2024-10-29 at 5 14 52 PM](https://github.com/user-attachments/assets/73512a77-d9f2-4f6f-b584-007a59724201)

</details>

<details>
<summary>CAT-982</summary>

![Screenshot 2024-10-29 at 5 16 10 PM](https://github.com/user-attachments/assets/fedfc7d4-b178-46ab-b667-c07dc0645bda)

</details>


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
