### PR TITLE
NickAkhmetov/CAT-974 Fix parent UUID handling for multi-vitessce conf datasets

### DIFF
--- a/CHANGELOG-cat-974.md
+++ b/CHANGELOG-cat-974.md
@@ -1,0 +1,1 @@
+- Fix parent UUID handling for multi-vitessce conf datasets.

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -72,10 +72,13 @@ export function useVitessceConf(uuid: string, parentUuid?: string) {
   if (parentUuid) {
     urlParams.set('parent', parentUuid);
   }
-  const swr = useSWR<VitessceConf>(getVitessceConfKey(uuid, groupsToken), (_key: unknown) =>
+  const swr = useSWR<VitessceConf | VitessceConf[]>(getVitessceConfKey(uuid, groupsToken), (_key: unknown) =>
     fetcher({ url: `${base}?${urlParams.toString()}`, requestInit: { headers: getAuthHeader(groupsToken) } }),
   );
   if (parentUuid) {
+    if (Array.isArray(swr.data)) {
+      return { ...swr, data: swr.data.map((conf) => ({ ...conf, parentUuid }) as VitessceConf) };
+    }
     return { ...swr, data: { ...swr.data, parentUuid } };
   }
   return swr;


### PR DESCRIPTION
## Summary

This PR fixes an issue introduced in #3570. Since the parent UUID was being added as a property on the array object, `Array.isArray` was no longer picking up the resulting object as an array. This PR adjusts the approach so that the parent UUID is properly passed down to the configs themselves.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-974

## Testing

Manually tested.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/81a526c5-9b67-4495-a521-6fb8e4ddb642)

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
