### PR TITLE
NickAkhmetov/CAT-961 Increase spacing between footer columns

### DIFF
--- a/CHANGELOG-cat-961.md
+++ b/CHANGELOG-cat-961.md
@@ -1,0 +1,1 @@
+- Add space between footer columns to improve readability.

--- a/context/app/static/js/components/Footer/style.ts
+++ b/context/app/static/js/components/Footer/style.ts
@@ -15,6 +15,7 @@ const Flex = styled('div')(({ theme }) => ({
   display: 'flex',
   marginBottom: theme.spacing(4),
   flexWrap: 'wrap',
+  gap: theme.spacing(1),
 }));
 
 interface FlexColumnProps {


### PR DESCRIPTION
## Summary

This PR introduces an 8-px gap between footer columns to improve readability/ensure that column text doesn't touch.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-961

## Testing

I initially tried a 4px gap, but this did not provide enough space (the columns were still very close together). After bumping the spacing up to 8px, I confirmed it looks okay at all breakpoints.

## Screenshots/Video

Mobile (385px):
![image](https://github.com/user-attachments/assets/356bcc8c-5f06-4926-85aa-6af77b434d7a)

Tablet (768px):
![image](https://github.com/user-attachments/assets/ce370d74-cddc-4e96-805c-e87b831f6ec6)

Desktop:

![image](https://github.com/user-attachments/assets/ecf362ad-39df-4b56-94a1-8eea3d20ec78)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
