### PR TITLE
NickAkhmetov/CAT-892 add vitessce json link

### DIFF
--- a/CHANGELOG-cat-892-add-vitessce-json-link.md
+++ b/CHANGELOG-cat-892-add-vitessce-json-link.md
@@ -1,0 +1,1 @@
+- Add "View Vitessce Configuration" button to processed datasets with visualizations.

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/DatasetTitle.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/DatasetTitle.tsx
@@ -5,18 +5,23 @@ import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import IconButton from '@mui/material/IconButton';
 import ContentCopyIcon from '@mui/icons-material/ContentCopyRounded';
 import Stack from '@mui/material/Stack';
+import { useVitessceConfLink } from 'js/pages/Dataset/hooks';
 import StatusIcon from '../../StatusIcon';
 import { useProcessedDatasetContext } from './ProcessedDatasetContext';
 import VersionSelect from '../../VersionSelect';
 import { useTrackEntityPageEvent } from '../../useTrackEntityPageEvent';
 import SummaryJSONButton from '../../summary/SummaryJSONButton';
+import VisualizationIconButton from './VisualizationIconButton';
 
 export function DatasetTitle() {
   const {
     dataset: { hubmap_id, status, uuid, entity_type },
+    conf,
   } = useProcessedDatasetContext();
   const copyText = useHandleCopyClick();
   const track = useTrackEntityPageEvent();
+  const parentUuid = conf && 'parentUuid' in conf ? (conf.parentUuid as string) : undefined;
+  const vitessceConfUrl = useVitessceConfLink(uuid, parentUuid);
   return (
     <Typography variant="h5" display="flex" alignItems="center" gap={0.5}>
       <StatusIcon status={status} tooltip />
@@ -35,6 +40,7 @@ export function DatasetTitle() {
         </IconButton>
       </SecondaryBackgroundTooltip>
       <Stack ml="auto" direction="row" gap={1} alignItems="center">
+        {conf && <VisualizationIconButton href={vitessceConfUrl} />}
         <SummaryJSONButton entity_type={entity_type} uuid={uuid} />
         <VersionSelect />
       </Stack>

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/VisualizationIconButton.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/VisualizationIconButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 
 import { WhiteRectangularTooltipIconButton } from 'js/shared-styles/buttons/TooltipButton';
 import { VisualizationIcon } from 'js/shared-styles/icons';
@@ -11,12 +11,16 @@ interface Props {
 function VisualizationIconButton({ href }: Props) {
   const trackEntityPageEvent = useTrackEntityPageEvent();
 
+  const trackViewVitessceConf = useCallback(() => {
+    trackEntityPageEvent({ action: 'View Vitessce Conf' });
+  }, [trackEntityPageEvent]);
+
   return (
     <WhiteRectangularTooltipIconButton
       tooltip="View Vitessce Configuration"
       href={href}
       target="_blank"
-      onClick={() => trackEntityPageEvent({ action: 'View Vitessce Conf' })}
+      onClick={trackViewVitessceConf}
     >
       <VisualizationIcon color="primary" />
     </WhiteRectangularTooltipIconButton>

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/VisualizationIconButton.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/VisualizationIconButton.tsx
@@ -1,27 +1,26 @@
 import React from 'react';
 
 import { WhiteRectangularTooltipIconButton } from 'js/shared-styles/buttons/TooltipButton';
-import { FileIcon } from 'js/shared-styles/icons';
+import { VisualizationIcon } from 'js/shared-styles/icons';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 
 interface Props {
-  entity_type: string;
-  uuid: string;
+  href: string;
 }
 
-function SummaryJSONButton({ entity_type, uuid }: Props) {
+function VisualizationIconButton({ href }: Props) {
   const trackEntityPageEvent = useTrackEntityPageEvent();
 
   return (
     <WhiteRectangularTooltipIconButton
-      tooltip="View JSON"
-      href={`/browse/${entity_type.toLowerCase()}/${uuid}.json`}
+      tooltip="View Vitessce Configuration"
+      href={href}
       target="_blank"
-      onClick={() => trackEntityPageEvent({ action: 'View JSON' })}
+      onClick={() => trackEntityPageEvent({ action: 'View Vitessce Conf' })}
     >
-      <FileIcon color="primary" />
+      <VisualizationIcon color="primary" />
     </WhiteRectangularTooltipIconButton>
   );
 }
 
-export default SummaryJSONButton;
+export default VisualizationIconButton;

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -65,15 +65,20 @@ function getVitessceConfKey(uuid: string, groupsToken: string) {
   return `vitessce-conf-${uuid}-${groupsToken}`;
 }
 
-export function useVitessceConf(uuid: string, parentUuid?: string) {
-  const { groupsToken } = useAppContext();
+export function useVitessceConfLink(uuid: string, parentUuid?: string) {
   const base = `/browse/dataset/${uuid}.vitessce.json`;
   const urlParams = new URLSearchParams(window.location.search);
   if (parentUuid) {
     urlParams.set('parent', parentUuid);
   }
+  return `${base}?${urlParams.toString()}`;
+}
+
+export function useVitessceConf(uuid: string, parentUuid?: string) {
+  const { groupsToken } = useAppContext();
+  const url = useVitessceConfLink(uuid, parentUuid);
   const swr = useSWR<VitessceConf | VitessceConf[]>(getVitessceConfKey(uuid, groupsToken), (_key: unknown) =>
-    fetcher({ url: `${base}?${urlParams.toString()}`, requestInit: { headers: getAuthHeader(groupsToken) } }),
+    fetcher({ url, requestInit: { headers: getAuthHeader(groupsToken) } }),
   );
   if (parentUuid) {
     if (Array.isArray(swr.data)) {

--- a/context/app/static/js/shared-styles/buttons/TooltipButton/TooltipIconButton.tsx
+++ b/context/app/static/js/shared-styles/buttons/TooltipButton/TooltipIconButton.tsx
@@ -30,6 +30,8 @@ const WhiteRectangularTooltipIconButton = styled(RectangularTooltipIconButton)((
   color: theme.palette.primary.main,
   border: `1px solid ${theme.palette.divider}`,
   borderRadius: theme.spacing(0.5),
+  height: theme.spacing(4.5),
+  display: 'flex',
 }));
 
 export { RectangularTooltipIconButton, WhiteRectangularTooltipIconButton };


### PR DESCRIPTION
## Summary

This PR introduces a "Download Vitessce Configuration" link to the titles of processed datasets with Vitessce configurations. This is accomplished by pulling out the link construction logic from the `useVitessceConf` hook into its own `useVitessceConfLink` hook to ensure consistency and adding a corresponding button to the same row.

I used the `SummaryJSONButton` as a base for the styling. After confirming that the `WhiteRectangularTooltipIconButton` component used for this was not used anywhere else, I placed the sizing/position styling into the styles for that component, to ensure consistency going forward. To differentiate the buttons, I used the `VisualizationIcon`.

We could potentially place this button inline with the other Vitessce-specific buttons if desired; the non-unified view had this functionality in the header next to the json button, however, so I colocated the buttons for familiarity purposes.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-892

## Testing

I tested the functionality with the processed descendants of the following datasets:
- Codex SPRM/Cytokit v2 (to confirm this works with normal processed datasets): 3d14dcc3d7c3e0cd339c9366e34b37c7
- SnareSeq2 (to confirm this works with processed datasets that contain multiple configurations/slides): 93c57af112056142084e08b2416d9b02
- PAS Stained Microscopy (to confirm this works with configurations that rely on a parent dataset): 7e3f3b5d1890f9612efb91d3a820cdcc

## Screenshots/Video

![image](https://github.com/user-attachments/assets/48afaee7-89a0-486e-8171-afa3c4729ff5)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
