### PR TITLE
NickAkhmetov/CAT-969 Increase homepage counts query specificity

### DIFF
--- a/CHANGELOG-cat-969.md
+++ b/CHANGELOG-cat-969.md
@@ -1,0 +1,2 @@
+- Adjust homepage queries to exclude donors/samples without descended datasets.
+- Adjust homepage queries to exclude datasets in a non-QA/Published state.

--- a/context/app/static/js/components/home/EntityCounts/hooks.ts
+++ b/context/app/static/js/components/home/EntityCounts/hooks.ts
@@ -5,11 +5,6 @@ const entityCountsQuery: SearchRequest = {
   size: 0,
   query: {
     bool: {
-      // Only include collections with a DOI in count
-      should: [
-        { bool: { must_not: { term: { 'entity_type.keyword': 'Collection' } } } },
-        { bool: { must: [{ exists: { field: 'doi_url' } }, { exists: { field: 'registered_doi' } }] } },
-      ],
       // Exclude invalid/new datasets from count
       // using `must_not` for this allows entities without a mapped status to still be matched
       must_not: {
@@ -17,14 +12,30 @@ const entityCountsQuery: SearchRequest = {
           'mapped_status.keyword': ['Invalid', 'Error', 'New', 'Processing', 'Submitted'],
         },
       },
-      // Exclude donors/samples with no associated datasets
+      // Nested musts are necessary to form an AND of ORs (i.e. a MUST of SHOULDs)
       must: {
         bool: {
-          should: [
-            // Either not a donor/sample
-            { bool: { must_not: { terms: { 'entity_type.keyword': ['Donor', 'Sample'] } } } },
-            // or has at least one descended dataset
-            { bool: { must: { exists: { field: 'descendant_counts.entity_type.Dataset' } } } },
+          must: [
+            {
+              // Exclude donors/samples with no associated datasets
+              bool: {
+                should: [
+                  // Either not a donor/sample
+                  { bool: { must_not: { terms: { 'entity_type.keyword': ['Donor', 'Sample'] } } } },
+                  // or has at least one descended dataset
+                  { bool: { must: { exists: { field: 'descendant_counts.entity_type.Dataset' } } } },
+                ],
+              },
+            },
+            {
+              // Only include collections with a DOI in count
+              bool: {
+                should: [
+                  { bool: { must_not: { term: { 'entity_type.keyword': 'Collection' } } } },
+                  { bool: { must: [{ exists: { field: 'doi_url' } }, { exists: { field: 'registered_doi' } }] } },
+                ],
+              },
+            },
           ],
         },
       },

--- a/context/app/static/js/components/home/EntityCounts/hooks.ts
+++ b/context/app/static/js/components/home/EntityCounts/hooks.ts
@@ -10,6 +10,24 @@ const entityCountsQuery: SearchRequest = {
         { bool: { must_not: { term: { 'entity_type.keyword': 'Collection' } } } },
         { bool: { must: [{ exists: { field: 'doi_url' } }, { exists: { field: 'registered_doi' } }] } },
       ],
+      // Exclude invalid/new datasets from count
+      // using `must_not` for this allows entities without a mapped status to still be matched
+      must_not: {
+        terms: {
+          'mapped_status.keyword': ['Invalid', 'Error', 'New', 'Processing', 'Submitted'],
+        },
+      },
+      // Exclude donors/samples with no associated datasets
+      must: {
+        bool: {
+          should: [
+            // Either not a donor/sample
+            { bool: { must_not: { terms: { 'entity_type.keyword': ['Donor', 'Sample'] } } } },
+            // or has at least one descended dataset
+            { bool: { must: { exists: { field: 'descendant_counts.entity_type.Dataset' } } } },
+          ],
+        },
+      },
     },
   },
   aggs: {


### PR DESCRIPTION
## Summary

This PR:
- Excludes datasets in a non-QA/Published state from being counted on the homepage.
- Excludes samples/donors without a descendant dataset from being counted on the homepage.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-969

## Testing

I tested by comparing homepage counts while logged in on local and production environments, and confirming that the dataset total count matches a manually calculated count from the search page.

## Screenshots/Video

Localhost counts:
![image](https://github.com/user-attachments/assets/9d0efd85-76de-46c8-ab88-ca070dc78701)

Prod counts:
![image](https://github.com/user-attachments/assets/12aea69a-792e-4e93-9f54-c0d7bc95c1b0)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

There is a related ticket to exclude these samples/donors from the search page results (https://hms-dbmi.atlassian.net/browse/CAT-968); I did not include that change in this PR because of the pending searchkit changes, but these changes should probably be deployed in tandem to minimize confusion from the donor/sample count mismatches.