### PR TITLE
NickAkhmetov/CAT-661 Fix View PDF button disappearance

### DIFF
--- a/CHANGELOG-cat-661.md
+++ b/CHANGELOG-cat-661.md
@@ -1,0 +1,2 @@
+- Fix View PDF button disappearing while PDF is processing.
+- Remove square white background behind PDF modal's close button.

--- a/context/app/static/js/components/detailPage/files/PDFViewer/PDFViewer.tsx
+++ b/context/app/static/js/components/detailPage/files/PDFViewer/PDFViewer.tsx
@@ -31,14 +31,12 @@ function PDFViewer({ pdfUrl }: PDFViewerProps) {
 
   return (
     <>
-      {(!isProcessingPDF || open) && (
-        <Box minWidth="125px">
-          {/* We don't open the modal here because there may be an error processing the PDF. */}
-          <Button type="button" onClick={() => setIsProcessingPDF(true)} variant="outlined">
-            View PDF
-          </Button>
-        </Box>
-      )}
+      <Box minWidth="125px">
+        {/* We don't open the modal here because there may be an error processing the PDF. */}
+        <Button type="button" onClick={() => setIsProcessingPDF(true)} variant="outlined">
+          View PDF
+        </Button>
+      </Box>
       {isProcessingPDF && (
         <Document
           file={pdfUrl}

--- a/context/app/static/js/components/detailPage/files/PDFViewer/PDFViewer.tsx
+++ b/context/app/static/js/components/detailPage/files/PDFViewer/PDFViewer.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { Document, Page } from 'react-pdf';
 import Modal from '@mui/material/Modal';
 import Button from '@mui/material/Button';
@@ -18,16 +18,45 @@ interface PDFFile {
   numPages: number;
 }
 
+interface PDFLoadingIndicatorProps {
+  isProcessingPDF: boolean;
+  onLoadSuccess: (pdfObj: PDFFile) => void;
+  pdfUrl: string;
+}
+function PDFLoadingIndicator({ isProcessingPDF, onLoadSuccess, pdfUrl }: PDFLoadingIndicatorProps) {
+  if (!isProcessingPDF) {
+    return null;
+  }
+  return (
+    <Document
+      file={pdfUrl}
+      onLoadSuccess={onLoadSuccess}
+      loading={<LinearProgress sx={{ maxWidth: '100px' }} />}
+      error={
+        <Box display="flex">
+          <ErrorIcon />
+          <Typography>Failed to load</Typography>
+        </Box>
+      }
+    />
+  );
+}
+
 function PDFViewer({ pdfUrl }: PDFViewerProps) {
   const [currentPageNum, setCurrentPageNum] = useState(1);
   const [open, setOpen] = useState(false);
   const [pdf, setPdf] = useState<PDFFile>();
   const [isProcessingPDF, setIsProcessingPDF] = useState(false);
 
-  const handleClose = () => {
+  const onLoadSuccess = useCallback((pdfObj: PDFFile) => {
+    setOpen(true);
+    setPdf(pdfObj);
+  }, []);
+
+  const handleClose = useCallback(() => {
     setOpen(false);
     setIsProcessingPDF(false);
-  };
+  }, []);
 
   return (
     <>
@@ -37,26 +66,11 @@ function PDFViewer({ pdfUrl }: PDFViewerProps) {
           View PDF
         </Button>
       </Box>
-      {isProcessingPDF && (
-        <Document
-          file={pdfUrl}
-          onLoadSuccess={(pdfObj) => {
-            setOpen(true);
-            setPdf(pdfObj);
-          }}
-          loading={<LinearProgress sx={{ maxWidth: '100px' }} />}
-          error={
-            <Box display="flex">
-              <ErrorIcon />
-              <Typography>Failed to load</Typography>
-            </Box>
-          }
-        />
-      )}
+      <PDFLoadingIndicator isProcessingPDF={isProcessingPDF} onLoadSuccess={onLoadSuccess} pdfUrl={pdfUrl} />
       <Modal open={open} onClose={handleClose} aria-labelledby="pdf-viewer-modal" aria-describedby="pdf-viewer-modal">
         <ModalContentWrapper>
           <Document file={pdfUrl}>
-            <Page pageNumber={currentPageNum} renderTextLayer={false} />
+            <Page pageNumber={currentPageNum} renderTextLayer={false} renderAnnotationLayer={false} />
           </Document>
           {pdf && (
             <PDFViewerControlButtons

--- a/context/app/static/js/components/detailPage/files/PDFViewer/style.ts
+++ b/context/app/static/js/components/detailPage/files/PDFViewer/style.ts
@@ -23,7 +23,7 @@ const StyledIconButton = styled(IconButton)({
 
 const StyledCloseIcon = styled(CancelRoundedIcon)({
   backgroundColor: '#fff',
-  borderCadius: '100%',
+  borderRadius: '100%',
 });
 
 const ErrorIcon = styled(ErrorRoundedIcon)(({ theme }) => ({


### PR DESCRIPTION
## Summary

This PR fixes the "View PDF" button disappearing while the PDF is processing. It also fixes the styles for the PDF modal's "close" button, which had a typo that caused the background of the close button to show up without a border radius.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-661

## Testing

Tested manually with datasets linked in original ticket.

## Screenshots/Video

View button doesn't disappear while loading anymore:
https://github.com/user-attachments/assets/63bae256-bdf2-4c55-be4c-a274496c21d7

Close button has appropriate styles:
![image](https://github.com/user-attachments/assets/4fbad133-56fd-4734-a106-20b5019bc041)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
