### PR TITLE
NickAkhmetov/CAT-634 Fix selection of samples on organ page when more than 500 are present

### DIFF
--- a/CHANGELOG-cat-634-fix-infinite-scroll-selection.md
+++ b/CHANGELOG-cat-634-fix-infinite-scroll-selection.md
@@ -1,0 +1,1 @@
+- Adjust ID fetching for infinite scroll table to ensure "select all" functionality works as expected.

--- a/context/app/static/js/hooks/useSearchData.ts
+++ b/context/app/static/js/hooks/useSearchData.ts
@@ -234,7 +234,7 @@ export function useAllSearchIDs(
   const { elasticsearchEndpoint, groupsToken } = useAppContext();
 
   const { searchData } = useSearchData(
-    { ...query, track_total_hits: true, size: 0, ...sharedIDsQueryClauses },
+    { ...query, track_total_hits: true, size: 10000, ...sharedIDsQueryClauses },
     {
       useDefaultQuery,
       fetcher,
@@ -243,21 +243,14 @@ export function useAllSearchIDs(
   );
 
   const totalHitsCount = getTotalHitsCount(searchData);
-  const numberOfPagesToRequest = totalHitsCount ? Math.ceil(10000 / totalHitsCount) : undefined;
 
   const getKey: SWRInfiniteKeyLoader = useCallback(() => {
-    if (numberOfPagesToRequest === undefined) {
+    if (totalHitsCount === undefined) {
       return null;
     }
 
-    return [
-      { ...query, ...sharedIDsQueryClauses },
-      elasticsearchEndpoint,
-      groupsToken,
-      useDefaultQuery,
-      numberOfPagesToRequest,
-    ];
-  }, [query, elasticsearchEndpoint, groupsToken, useDefaultQuery, numberOfPagesToRequest]);
+    return [{ ...query, ...sharedIDsQueryClauses, size: 10000 }, elasticsearchEndpoint, groupsToken, useDefaultQuery];
+  }, [totalHitsCount, query, elasticsearchEndpoint, groupsToken, useDefaultQuery]);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-argument
   // @ts-expect-error - revisit to make these keys more type safe


### PR DESCRIPTION
## Summary

The Kidney page on prod currently fails to select all results when using the "select all" checkbox of the samples table. This issue was caused by the `useAllSearchIds` hook being limited to only fetching the first 500 results. Lifting this limit/removing the "number of pages to fetch" from the ID lookup resolved this issue by enabling lookup of all 634 results in the table.

## Design Documentation/Original Tickets
https://hms-dbmi.atlassian.net/browse/CAT-634

## Testing

Tested on the kidney page as well as other organ pages.

## Screenshots/Video


https://github.com/user-attachments/assets/345dc850-6b0c-404e-8df7-a60bb7c0b031



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

I'm not sure if this PR overlaps with the changes in the searchkit PR - it can definitely wait if so.