### PR TITLE
NickAkhmetov/CAT-990 Fix ProvGraph Viewport

### DIFF
--- a/CHANGELOG-cat-990-fix-prov-viewport.md
+++ b/CHANGELOG-cat-990-fix-prov-viewport.md
@@ -1,0 +1,1 @@
+- Fix styling for provenance graph to avoid tall, difficult to read graphs.

--- a/context/app/static/js/components/detailPage/provenance/ProvGraph/style.ts
+++ b/context/app/static/js/components/detailPage/provenance/ProvGraph/style.ts
@@ -12,7 +12,7 @@ const StyledTypography = styled(Typography)(({ theme }) => ({
 
 const maxGraphHeight = 500;
 const StyledDiv = styled('div')({
-  '&.scroll-container-wrapper': {
+  '& .scroll-container-wrapper': {
     maxHeight: maxGraphHeight,
   },
 });


### PR DESCRIPTION
## Summary

This PR fixes a regression which caused the provenance graph not to be constrained to 500px tall max. This appears to be due to the migration from styled-components 5 to 6 that occurred as part of the unified views work.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-990

## Testing

Loaded http://localhost:5001/browse/publication/e8338966c69e759157d6c6ad24847989, provenance graph did not massively grow the page.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/362c8179-031d-45bf-883a-e583632afd93)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
