### PR TITLE
Austenem/CAT-985 Remove publication workspace button

### DIFF
--- a/CHANGELOG-cat-985-remove-publication-workspace-button.md
+++ b/CHANGELOG-cat-985-remove-publication-workspace-button.md
@@ -1,0 +1,1 @@
+- Remove workspace menu button from publication pages.

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
@@ -191,6 +191,7 @@ function EntityHeaderActionButtons({
     return null;
   }
 
+  const isDataset = entity_type === 'Dataset';
   const disabled = mapped_data_access_level === 'Protected';
 
   return (
@@ -198,21 +199,23 @@ function EntityHeaderActionButtons({
       {isLargeDesktop && <ViewSelectChips selectedView={view} setView={setView} entity_type={entity_type} />}
       <SaveEditEntityButton uuid={uuid} entity_type={entity_type} />
       <JSONButton entity_type={entity_type} uuid={uuid} />
-      <ProcessedDataWorkspaceMenu
-        button={
-          <ActionButton
-            icon={WorkspaceSVGIcon}
-            tooltip={
-              disabled
-                ? 'Protected datasets are not available in workspaces.'
-                : 'Launch new workspace or add dataset to an existing workspace.'
-            }
-            disabled={disabled}
-          />
-        }
-        datasetDetails={{ hubmap_id, uuid, status, mapped_data_access_level }}
-        dialogType="ADD_DATASETS_FROM_HEADER"
-      />
+      {isDataset && (
+        <ProcessedDataWorkspaceMenu
+          button={
+            <ActionButton
+              icon={WorkspaceSVGIcon}
+              tooltip={
+                disabled
+                  ? 'Protected datasets are not available in workspaces.'
+                  : 'Launch new workspace or add dataset to an existing workspace.'
+              }
+              disabled={disabled}
+            />
+          }
+          datasetDetails={{ hubmap_id, uuid, status, mapped_data_access_level }}
+          dialogType="ADD_DATASETS_FROM_HEADER"
+        />
+      )}
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary

Removes nonfunctional workspace menu button from publication pages.

## Design Documentation/Original Tickets

[CAT-985 Jira ticket ](https://hms-dbmi.atlassian.net/browse/CAT-985?atlOrigin=eyJpIjoiMzU3MDc3NGI5NjJkNGI2YTgzMmZkZTFmOWM4MmUwN2EiLCJwIjoiaiJ9)

## Testing

Manually checked for logged-in and logged-out publication pages.

## Screenshots/Video

Local:
![Screenshot 2024-11-04 at 4 28 23 PM](https://github.com/user-attachments/assets/18881c5c-24ce-4499-9ae0-1fc70cbd598a)

Prod:
![Screenshot 2024-11-04 at 4 28 59 PM](https://github.com/user-attachments/assets/098e6e63-83a3-4eb0-b71e-4198fa279c52)


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

