### PR TITLE
Dedupe single valued hierarchical parents/children

### DIFF
--- a/context/app/static/js/components/search/Facets/TermFacet.tsx
+++ b/context/app/static/js/components/search/Facets/TermFacet.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import IndeterminateCheckBoxOutlinedIcon from '@mui/icons-material/IndeterminateCheckBoxOutlined';
 import Accordion from '@mui/material/Accordion';
@@ -230,6 +231,22 @@ export const HierarchicalTermFacetItem = React.memo(function HierarchicalTermFac
 
   const hasChildBuckets = childBuckets?.length;
   const childValues = childBuckets.map((b) => b.key);
+
+  if (childValues.length === 1 && childBuckets[0].key === label) {
+    return (
+      // 26px is the width of the Accordion's expand icon.
+      <Box pr="26px">
+        <HierarchicalFacetParent
+          childValues={childValues}
+          label={label}
+          field={field}
+          title={title}
+          {...rest}
+          indeterminate={childState?.size > 0 && !childValues.every((v) => childState?.has(v))}
+        />
+      </Box>
+    );
+  }
 
   return (
     <Accordion


### PR DESCRIPTION
## Summary

Dedupes hierarchical facet items where the parent only has a single child which matches the parent.

## Screenshots/Video

<img width="297" alt="Screenshot 2024-11-05 at 4 39 17 PM" src="https://github.com/user-attachments/assets/34415d5b-e5e0-4dbf-ac13-bdc309db3a86">


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added