### PR TITLE
NickAkhmetov/CAT-976 Visualization link in table of contents

### DIFF
--- a/CHANGELOG-cat-976.md
+++ b/CHANGELOG-cat-976.md
@@ -1,0 +1,1 @@
+- Use `Image Pyramid` pipeline name as a heuristic for whether a visualization link should be present in unified dataset table of contents.


### PR DESCRIPTION
## Summary

This PR adjusts the logic for whether or not to display the `visualization` link in the table of contents.

The current logic just checks whether there is a loaded conf in the SWR cache; this approach works well for fast-running configs (such as self-contained processed datasets) but runs into issues with configs that are slower to build (such as image pyramids with multiple slides or other multi-conf cases like 10X).

The updated approach adds a heuristic condition to check whether the dataset is an image pyramid; since image pyramids always have visualizations, this is a safe assumption to make.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-976

## Testing

Tested with image pyramid datasets and 10X datasets to confirm the visualization link shows up when expected. Tested with non-image pyramid processed datasets to confirm the visualization link does not show up when one is not present.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/c1b63c59-a3e4-4892-a359-0ca30af6cb9b)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

An alternative way to approach this would be to mark the image pyramids themselves as having a visualization, which would make the boolean check in line 162 sufficient and allow us to remove the dependency on the SWR cache; this solution would require revising search indexing to mark image pyramids as having a visualization.