### PR TITLE
NickAkhmetov/CAT-1000 fix errant line in hero tabs, CAT-1001 fix image resizing behavior

### DIFF
--- a/CHANGELOG-cat-1000-1001.md
+++ b/CHANGELOG-cat-1000-1001.md
@@ -1,0 +1,1 @@
+- Fix minor graphical issues in homepage hero section.

--- a/context/app/static/js/components/home/Hero/styles.ts
+++ b/context/app/static/js/components/home/Hero/styles.ts
@@ -48,7 +48,7 @@ export const HeroTabContainer = styled(Box)<HeroSubContainerProps>(({ $index, $a
 
   [theme.breakpoints.up('md')]: {
     backgroundColor: $activeSlide === $index ? props.bgcolor : theme.palette.common.white,
-    ':not(:last-child)': {
+    '&:not(:last-child)': {
       borderRight: `1px solid ${theme.palette.grey[200]}`,
     },
   },

--- a/context/app/static/js/components/home/Hero/styles.ts
+++ b/context/app/static/js/components/home/Hero/styles.ts
@@ -73,9 +73,7 @@ export const HeroPanelContainer = styled(Box)<HeroSubContainerProps>(({ theme, $
   },
 }));
 
-export const StyledImage = styled('img')(({ theme }) => ({
-  [theme.breakpoints.up('md')]: {
-    maxWidth: '100%',
-    height: 'auto',
-  },
+export const StyledImage = styled('img')(() => ({
+  maxWidth: '100%',
+  height: 'auto',
 }));


### PR DESCRIPTION
## Summary

This PR contains some minor CSS fixes to resolve small graphical issues on the homepage.

* The hero tab container's right border rule was not specific enough to just the container, and cascaded down to the container's children as well; adding the `&` to the rule makes sure it gets applied to the current element.
* Hero images' sizes weren't properly adjusting when shrinking the viewport width; the media query used to gate those styles turned out to be unnecessary.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1000
https://hms-dbmi.atlassian.net/browse/CAT-1001

## Testing

Manually tested.

## Screenshots/Video

CAT-1000 (note no small borders to the right of each text item inside tab)
![image](https://github.com/user-attachments/assets/d1ca0824-3c99-4dcc-9e53-1011b85b7d63)


CAT-1001:
https://github.com/user-attachments/assets/0febabe0-2aad-41e8-bd6b-5734300b9e83



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added


