### PR TITLE
Updated portal-viz hash

### DIFF
--- a/CHANGELOG-update-portal-viz.md
+++ b/CHANGELOG-update-portal-viz.md
@@ -1,0 +1,1 @@
+- Update portal-viz hash to reflect the view adjustment for EPIC segmentation mask.

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -16,7 +16,7 @@ hubmap-commons>=2.1.15
 boto3==1.28.17
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.1.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.2.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -1186,8 +1186,8 @@ platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
     --hash=sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227
     # via black
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.1.zip \
-    --hash=sha256:74841fd9a8e186b4b2fdcd663e53a4119a3447868995ee739aa8d378f6f3ec75
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.2.zip \
+    --hash=sha256:35fbe073dba04295b918275842cc78502be7a316b4da6870127c90d50619bb64
     # via -r context/requirements.in
 property==2.2 \
     --hash=sha256:d25e4da4e415408b9eb39b6521c088e4e2b8a9e2f9f96fb2d91680e97207ea19


### PR DESCRIPTION
## Summary

This PR updates the portal-viz hash to reflect the changes in view width for the EPIC segmentation masks

## Design Documentation/Original Tickets

[CAT-673](https://hms-dbmi.atlassian.net/browse/CAT-673)

## Testing

Manually tested

## Screenshots/Video
<img width="1137" alt="Screenshot 2024-11-13 at 2 26 43 PM" src="https://github.com/user-attachments/assets/8e30bc04-e032-49bf-a23b-3670f90e9207">


Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.


[CAT-673]: https://hms-dbmi.atlassian.net/browse/CAT-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ