### PR TITLE
John conroy/sort by pub CAT-970

### DIFF
--- a/context/app/static/js/components/search/store.ts
+++ b/context/app/static/js/components/search/store.ts
@@ -8,6 +8,7 @@ import { z } from 'zod';
 export interface SortField {
   field: string;
   direction: 'asc' | 'desc';
+  secondarySort?: SortField;
 }
 
 export const FACETS = {

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -10,6 +10,7 @@ import {
   isHierarchicalFacet,
   isTermFacet,
   isRangeFacet,
+  SortField,
 } from './store';
 import { getPortalESField } from './buildTypesMap';
 
@@ -41,6 +42,17 @@ function buildFilterAggregation({
   return esb.filterAggregation(field, otherFiltersQuery).agg(aggregation);
 }
 
+function buildSortField({ sortField }: { sortField: SortField }) {
+  const primarySort = esb.sort(getPortalESField(sortField.field), sortField.direction);
+  const secondarySortField = sortField?.secondarySort;
+
+  const secondarySort = secondarySortField
+    ? [esb.sort(getPortalESField(secondarySortField.field), secondarySortField.direction)]
+    : [];
+
+  return [primarySort, ...secondarySort];
+}
+
 export function buildQuery({
   filters,
   facets,
@@ -55,7 +67,7 @@ export function buildQuery({
     .requestBodySearch()
     .size(size)
     .source([...new Set(Object.values(sourceFields).flat())])
-    .sort(esb.sort(getPortalESField(sortField.field), sortField.direction));
+    .sorts(buildSortField({ sortField }));
 
   const hasTextQuery = search.length > 0;
 

--- a/context/app/static/js/pages/search/S.tsx
+++ b/context/app/static/js/pages/search/S.tsx
@@ -168,6 +168,11 @@ const datasetConfig = {
     ],
     tile: [...sharedTileFields, 'thumbnail_file.file_uuid', 'origin_samples_unique_mapped_organs'],
   },
+  sortField: {
+    field: 'published_timestamp',
+    direction: 'desc' as const,
+    secondaryField: { field: 'mapped_status', direction: 'desc' as const },
+  },
   facets: datasetFacetGroups,
   ...buildDefaultQuery('Dataset'),
   // TODO: figure out how to make assertion unnecessary.


### PR DESCRIPTION
## Summary

Sorts by `publication_date` to put published data at the top, then by `mapped_status`.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added