### PR TITLE
Austenem/CAT-1021 Add spacing

### DIFF
--- a/CHANGELOG-add-spacing.md
+++ b/CHANGELOG-add-spacing.md
@@ -1,0 +1,1 @@
+- Fix spacing between organ icon and name on detail pages.

--- a/context/app/static/js/pages/Dataset/Dataset.tsx
+++ b/context/app/static/js/pages/Dataset/Dataset.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 
 import ProvSection from 'js/components/detailPage/provenance/ProvSection';
 import Summary from 'js/components/detailPage/summary/Summary';
@@ -53,9 +54,9 @@ function SummaryDataChildren({ mapped_data_types, mapped_organ }: SummaryDataChi
       </SummaryItem>
       <SummaryItem showDivider={false}>
         <InternalLink href={`/organ/${mapped_organ}`} underline="none">
-          <Stack direction="row" spacing={0.25} alignItems="center">
+          <Stack direction="row" spacing={0.5} alignItems="center">
             <OrganIcon organName={mapped_organ} />
-            {mapped_organ}
+            <Typography fontSize="inherit">{mapped_organ}</Typography>
           </Stack>
         </InternalLink>
       </SummaryItem>


### PR DESCRIPTION
## Summary

Fixes spacing between organ icon and name on detail pages.

## Design Documentation/Original Tickets

[CAT-1021 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1021?atlOrigin=eyJpIjoiYTg4ZDZmZmJiZTc2NDA5ZWExNzI1MTIzMTUyYjVjMTIiLCJwIjoiaiJ9)

## Testing

Checked relevant detail pages.

## Screenshots/Video

Local:
![Screenshot 2024-11-18 at 11 25 22 AM](https://github.com/user-attachments/assets/82e37079-cc14-4859-a7ac-4ea117fb0549)

Prod:
![Screenshot 2024-11-18 at 11 25 38 AM](https://github.com/user-attachments/assets/ecf6d6d6-2000-4114-aca9-485b9eb80336)


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
