### PR TITLE
Austenem/CAT-1020 Improve scroll tracking

### DIFF
--- a/CHANGELOG-improve-scroll-tracking.md
+++ b/CHANGELOG-improve-scroll-tracking.md
@@ -1,0 +1,1 @@
+- Fix scroll tracking on detail page table of contents so that processed dataset subsections are properly selected.

--- a/context/app/static/js/shared-styles/sections/TableOfContents/TableOfContents.tsx
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/TableOfContents.tsx
@@ -102,14 +102,30 @@ function ItemSkeleton() {
   );
 }
 
+const flattenTableOfContentsItems = (items: TableOfContentsItem[]): TableOfContentsItem[] => {
+  const result: TableOfContentsItem[] = [];
+
+  const flatten = (nestedItems: TableOfContentsItem[]) => {
+    nestedItems.forEach((item) => {
+      result.push({ ...item, items: undefined });
+      if (item.items) {
+        flatten(item.items);
+      }
+    });
+  };
+
+  flatten(items);
+  return result;
+};
+
 function TableOfContents({ items, isLoading = false }: { items: TableOfContentsItems; isLoading?: boolean }) {
   const [currentSection, setCurrentSection] = useState(items[0].hash);
 
   const itemsWithNodeRef = React.useRef<TableOfContentsItems<TableOfContentsItemWithNode>>([]);
 
   React.useEffect(() => {
-    itemsWithNodeRef.current = getItemsClient(items);
-  }, [items]);
+    itemsWithNodeRef.current = getItemsClient(flattenTableOfContentsItems(items));
+  }, [items, isLoading]);
 
   const clickedRef = React.useRef(false);
   const unsetClickedRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/context/app/static/js/shared-styles/sections/TableOfContents/TableOfContents.tsx
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/TableOfContents.tsx
@@ -102,30 +102,14 @@ function ItemSkeleton() {
   );
 }
 
-const flattenTableOfContentsItems = (items: TableOfContentsItem[]): TableOfContentsItem[] => {
-  const result: TableOfContentsItem[] = [];
-
-  const flatten = (nestedItems: TableOfContentsItem[]) => {
-    nestedItems.forEach((item) => {
-      result.push({ ...item, items: undefined });
-      if (item.items) {
-        flatten(item.items);
-      }
-    });
-  };
-
-  flatten(items);
-  return result;
-};
-
 function TableOfContents({ items, isLoading = false }: { items: TableOfContentsItems; isLoading?: boolean }) {
   const [currentSection, setCurrentSection] = useState(items[0].hash);
 
   const itemsWithNodeRef = React.useRef<TableOfContentsItems<TableOfContentsItemWithNode>>([]);
 
   React.useEffect(() => {
-    itemsWithNodeRef.current = getItemsClient(flattenTableOfContentsItems(items));
-  }, [items, isLoading]);
+    itemsWithNodeRef.current = getItemsClient(items);
+  }, [items]);
 
   const clickedRef = React.useRef(false);
   const unsetClickedRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/context/app/static/js/shared-styles/sections/TableOfContents/hooks.ts
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/hooks.ts
@@ -39,10 +39,21 @@ function useFindActiveIndex({
     let active;
     const d = document.documentElement;
 
-    for (let i = itemsWithNodeRef.current.length - 1; i >= 0; i -= 1) {
-      const item = itemsWithNodeRef.current[i];
+    const itemsWithAdjustedOffsetTop = [...itemsWithNodeRef.current].map((item) => {
+      const element = document.getElementById(item.hash);
+      const rect = element?.getBoundingClientRect();
+      const adjustedOffsetTop = rect ? rect.top / 4 + window.scrollY : 0;
 
-      if (item.node && item.node.offsetTop < d.scrollTop + d.clientHeight / 8) {
+      return {
+        ...item,
+        adjustedOffsetTop,
+      };
+    });
+
+    for (let i = itemsWithAdjustedOffsetTop.length - 1; i >= 0; i -= 1) {
+      const item = itemsWithAdjustedOffsetTop[i];
+
+      if (item.adjustedOffsetTop < d.scrollTop + d.clientHeight / 8) {
         active = item;
         break;
       }

--- a/context/app/static/js/shared-styles/sections/TableOfContents/hooks.ts
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/hooks.ts
@@ -39,21 +39,14 @@ function useFindActiveIndex({
     let active;
     const d = document.documentElement;
 
-    const itemsWithAdjustedOffsetTop = [...itemsWithNodeRef.current].map((item) => {
+    for (let i = itemsWithNodeRef.current.length - 1; i >= 0; i -= 1) {
+      const item = itemsWithNodeRef.current[i];
+
       const element = document.getElementById(item.hash);
       const rect = element?.getBoundingClientRect();
-      const adjustedOffsetTop = rect ? rect.top / 4 + window.scrollY : 0;
+      const adjustedOffset = rect ? rect.top / 4 + window.scrollY : 0;
 
-      return {
-        ...item,
-        adjustedOffsetTop,
-      };
-    });
-
-    for (let i = itemsWithAdjustedOffsetTop.length - 1; i >= 0; i -= 1) {
-      const item = itemsWithAdjustedOffsetTop[i];
-
-      if (item.adjustedOffsetTop < d.scrollTop + d.clientHeight / 8) {
+      if (adjustedOffset < d.scrollTop + d.clientHeight / 8) {
         active = item;
         break;
       }

--- a/context/app/static/js/shared-styles/sections/TableOfContents/hooks.ts
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/hooks.ts
@@ -46,7 +46,7 @@ function useFindActiveIndex({
       const rect = element?.getBoundingClientRect();
       const adjustedOffset = rect ? rect.top / 4 + window.scrollY : 0;
 
-      if (adjustedOffset < d.scrollTop + d.clientHeight / 8) {
+      if (element && adjustedOffset < d.scrollTop + d.clientHeight / 8) {
         active = item;
         break;
       }

--- a/context/app/static/js/shared-styles/sections/TableOfContents/utils.ts
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/utils.ts
@@ -29,8 +29,26 @@ function getSections(sectionOrder: SectionOrder) {
   });
 }
 
+const flattenSections = (sections: TableOfContentsItem[]): TableOfContentsItem[] => {
+  const flattenedSections: TableOfContentsItem[] = [];
+
+  const flatten = (nestedItems: TableOfContentsItem[]) => {
+    nestedItems.forEach((item) => {
+      flattenedSections.push({ ...item, items: undefined });
+      if (item.items) {
+        flatten(item.items);
+      }
+    });
+  };
+
+  flatten(sections);
+  return flattenedSections;
+};
+
 function getItemsClient(items: TableOfContentsItems): TableOfContentsItems<TableOfContentsItemWithNode> {
-  return items.map((item) => ({
+  const flattenedItems = flattenSections(items);
+
+  return flattenedItems.map((item) => ({
     text: item.text,
     hash: item.hash,
     node: document.getElementById(item.hash),
@@ -40,4 +58,4 @@ function getItemsClient(items: TableOfContentsItems): TableOfContentsItems<Table
   }));
 }
 
-export { getSections, getSectionFromString, getItemsClient, formatSectionHash };
+export { getSections, flattenSections, getSectionFromString, getItemsClient, formatSectionHash };

--- a/context/app/static/js/shared-styles/sections/TableOfContents/utils.ts
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/utils.ts
@@ -34,7 +34,7 @@ const flattenSections = (sections: TableOfContentsItem[]): TableOfContentsItem[]
 
   const flatten = (nestedItems: TableOfContentsItem[]) => {
     nestedItems.forEach((item) => {
-      flattenedSections.push({ ...item, items: undefined });
+      flattenedSections.push(item);
       if (item.items) {
         flatten(item.items);
       }

--- a/context/app/static/js/shared-styles/sections/TableOfContents/utils.ts
+++ b/context/app/static/js/shared-styles/sections/TableOfContents/utils.ts
@@ -30,19 +30,7 @@ function getSections(sectionOrder: SectionOrder) {
 }
 
 const flattenSections = (sections: TableOfContentsItem[]): TableOfContentsItem[] => {
-  const flattenedSections: TableOfContentsItem[] = [];
-
-  const flatten = (nestedItems: TableOfContentsItem[]) => {
-    nestedItems.forEach((item) => {
-      flattenedSections.push(item);
-      if (item.items) {
-        flatten(item.items);
-      }
-    });
-  };
-
-  flatten(sections);
-  return flattenedSections;
+  return sections.flatMap((item) => (item.items ? [item, ...flattenSections(item.items)] : [item]));
 };
 
 function getItemsClient(items: TableOfContentsItems): TableOfContentsItems<TableOfContentsItemWithNode> {


### PR DESCRIPTION
## Summary

Fixes scroll tracking on detail page table of contents so that processed dataset subsections are properly selected. Also adjusts scroll tracking to track the element closest to the middle of the page rather than the element at the top of the page.

## Design Documentation/Original Tickets

[CAT-1020 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1020?atlOrigin=eyJpIjoiNWI5OGUzMmI0YzY5NGVmOGI2MWZjMGY2YTRjZjhhMDciLCJwIjoiaiJ9)

## Testing

Tested examples of entity detail pages with and without processed dataset sections.

## Screenshots/Video

Local:

https://github.com/user-attachments/assets/553db1af-055c-425e-aab9-75f3d0c4f719


Prod:

https://github.com/user-attachments/assets/3e1f8614-ca1b-4c58-a55c-9a8abf4545dc


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
