### PR TITLE
Austenem/CAT-1022 Entity header alignment

### DIFF
--- a/CHANGELOG-entity-header-alignment.md
+++ b/CHANGELOG-entity-header-alignment.md
@@ -1,0 +1,1 @@
+- Ensure that helper menu/table of contents only appear when the browser is wide enough to show both fully.

--- a/context/app/static/js/components/Routes/Route/Route.tsx
+++ b/context/app/static/js/components/Routes/Route/Route.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack';
 import Box from '@mui/material/Box';
 import { ContainerProps } from '@mui/material/Container';
 
-import { useIsDesktop } from 'js/hooks/media-queries';
+import { useIsLargeDesktop } from 'js/hooks/media-queries';
 import RouteLoader from '../RouteLoader';
 import { StyledContainer } from './style';
 
@@ -25,7 +25,7 @@ function Route({ children, disableWidthConstraint = false }: PropsWithChildren<{
     ? { maxWidth: false, disableGutters: true }
     : { maxWidth: 'lg' };
 
-  const isDesktop = useIsDesktop();
+  const isDesktop = useIsLargeDesktop();
   const shouldShowBoundaries = !disableWidthConstraint && isDesktop;
 
   return (

--- a/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/HelperPanel/HelperPanel.tsx
@@ -7,7 +7,7 @@ import Fade from '@mui/material/Fade';
 import SchemaRounded from '@mui/icons-material/SchemaRounded';
 import CloudDownloadRounded from '@mui/icons-material/CloudDownloadRounded';
 
-import { useIsDesktop } from 'js/hooks/media-queries';
+import { useIsLargeDesktop } from 'js/hooks/media-queries';
 import { WorkspacesIcon } from 'js/shared-styles/icons';
 import { useAnimatedSidebarPosition } from 'js/shared-styles/sections/TableOfContents/hooks';
 import { LineClampWithTooltip } from 'js/shared-styles/text';
@@ -134,8 +134,9 @@ const AnimatedStack = animated(Stack);
 
 export default function HelperPanel() {
   const currentDataset = useCurrentDataset();
-  const isDesktop = useIsDesktop();
+  const isDesktop = useIsLargeDesktop();
   const style = useAnimatedSidebarPosition();
+
   return (
     <HelperPanelPortal>
       <Fade


### PR DESCRIPTION
## Summary

Ensures that helper menu/table of contents only appear when the browser is wide enough to show both fully, preventing the header and menu from being cut off.

## Design Documentation/Original Tickets

[CAT-1022 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1022?atlOrigin=eyJpIjoiZjA2NTExYTRkZDc5NDlhYmE0YTE4NzllMjg4NjE3ZmMiLCJwIjoiaiJ9)

## Screenshots/Video

Local:


https://github.com/user-attachments/assets/ffadf0bd-f35a-460e-a574-89dbe2f39dba


Prod:


https://github.com/user-attachments/assets/067f0941-afdc-484d-a9e2-c278a8b6f689



## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

