### PR TITLE
Linting and type fixing

### DIFF
--- a/CHANGELOG-links-with-discernible-text.md
+++ b/CHANGELOG-links-with-discernible-text.md
@@ -1,0 +1,1 @@
+- Added discernible text to the links on stacked barcharts.

--- a/context/app/static/js/shared-styles/charts/StackedBar/StackedBar.tsx
+++ b/context/app/static/js/shared-styles/charts/StackedBar/StackedBar.tsx
@@ -1,5 +1,7 @@
 import React, { SVGProps } from 'react';
 
+import LZString from 'lz-string';
+import { FiltersType } from 'js/components/search/store';
 import { StyledRect } from './style';
 
 type Direction = 'vertical' | 'horizontal';
@@ -55,8 +57,31 @@ function StackedBar({ direction = 'vertical', bar, hoverProps, href }: StackedBa
     <StyledRect fill={bar.color} {...mappedProps} $showHover={Boolean(hoverProps) || Boolean(href)} {...hoverProps} />
   );
   if (href) {
+    const page = href.split('?')[0].replace('/search/', '');
+    const encodedURI = href.split('?')[1];
+    interface searchObj {
+      filters: FiltersType;
+    }
+
+    const decodedHref = JSON.parse(LZString.decompressFromEncodedURIComponent(encodedURI)) as searchObj;
+
+    // Extracting the filters from the searchURI
+    const extractedValues = (() => {
+      const results: string[] = [];
+      Object.values(decodedHref.filters).forEach(({ values }) => {
+        if (Array.isArray(values)) {
+          results.push(...values);
+        } else if (typeof values === 'object' && values !== null) {
+          results.push(...Object.keys(values));
+        }
+      });
+      return results;
+    })();
+
+    const labelString = `${page} page for the selected bar representing ${extractedValues.join(', ')}`;
+
     return (
-      <a href={href} target="_parent">
+      <a href={href} target="_parent" aria-label={labelString}>
         {rect}
       </a>
     );

--- a/context/app/static/js/shared-styles/tiles/Tile/Tile.tsx
+++ b/context/app/static/js/shared-styles/tiles/Tile/Tile.tsx
@@ -33,7 +33,11 @@ function Tile({
     </StyledPaper>
   );
   if (href) {
-    return <a href={href}>{tile}</a>;
+    return (
+      <a href={href} aria-label={href}>
+        {tile}
+      </a>
+    );
   }
   return tile;
 }


### PR DESCRIPTION
## Summary
This PR addresses the accessibility issue of `Ensuring links having discernible text`  by adding aria-labels to any links used in the code base, particularly, the tiles and stacked barchart components.


## Design Documentation/Original Tickets
[CAT-1029](https://hms-dbmi.atlassian.net/browse/CAT-1029)

## Testing
Manually tested with Axe DevTools

## Screenshots/Video

<img width="1717" alt="Screenshot 2024-11-25 at 10 53 00 AM" src="https://github.com/user-attachments/assets/7a034f1c-7c1d-4e93-84f3-2eb2bb8ed9e9">

Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
