### PR TITLE
John conroy/fix date facet typing CAT-1045

### DIFF
--- a/CHANGELOG-fix-date-facet-typing.md
+++ b/CHANGELOG-fix-date-facet-typing.md
@@ -1,0 +1,1 @@
+- Disable date facet text input and update button color.

--- a/context/app/static/js/components/search/Facets/DateRangeFacet.tsx
+++ b/context/app/static/js/components/search/Facets/DateRangeFacet.tsx
@@ -54,6 +54,14 @@ function DatePickerComponent({
       slotProps={{
         textField: {
           helperText: errorMessage,
+          sx: (theme) => ({
+            svg: {
+              color: theme.palette.primary.main,
+            },
+          }),
+        },
+        field: {
+          readOnly: true,
         },
         popper: {
           sx: (theme) => ({


### PR DESCRIPTION
## Summary

- Makes the date facet text field read only.
- Changes date facet's icon button color.

Making the text field read only is the simplest fix for now, but we can revisit in the future.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
