### PR TITLE
John conroy/switch pipeline to search CAT-1054

### DIFF
--- a/CHANGELOG-switch-pipeline-to-search.md
+++ b/CHANGELOG-switch-pipeline-to-search.md
@@ -1,0 +1,1 @@
+- Get dataset pipeline info from search-api not the soft assay endpoint.


### PR DESCRIPTION
## Summary

- Get dataset pipeline info from search-api not the soft assay endpoint.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
