### PR TITLE
Austenem/CAT-1064 Fix date picker

### DIFF
--- a/CHANGELOG-fix-date-picker.md
+++ b/CHANGELOG-fix-date-picker.md
@@ -1,0 +1,1 @@
+- Fix date picker bug on search page that prevented the user from selecting a year.

--- a/context/app/static/js/components/search/Facets/DateRangeFacet.tsx
+++ b/context/app/static/js/components/search/Facets/DateRangeFacet.tsx
@@ -1,11 +1,11 @@
 import React, { useCallback, useState, useEffect, useMemo } from 'react';
 import Stack from '@mui/material/Stack';
+import Popper from '@mui/material/Popper';
 import { DatePicker, DatePickerProps } from '@mui/x-date-pickers/DatePicker';
 import { DateValidationError } from '@mui/x-date-pickers/models';
 import { format } from 'date-fns/format';
 
 import { trackEvent } from 'js/helpers/trackers';
-import Popper from '@mui/material/Popper';
 import { useSearch } from '../Search';
 import { isDateFilter, useSearchStore } from '../store';
 import { useGetFieldLabel } from '../fieldConfigurations';

--- a/context/app/static/js/components/search/Facets/DateRangeFacet.tsx
+++ b/context/app/static/js/components/search/Facets/DateRangeFacet.tsx
@@ -5,6 +5,7 @@ import { DateValidationError } from '@mui/x-date-pickers/models';
 import { format } from 'date-fns/format';
 
 import { trackEvent } from 'js/helpers/trackers';
+import Popper from '@mui/material/Popper';
 import { useSearch } from '../Search';
 import { isDateFilter, useSearchStore } from '../store';
 import { useGetFieldLabel } from '../fieldConfigurations';
@@ -51,7 +52,30 @@ function DatePickerComponent({
       onError={setError}
       minDate={minDate}
       maxDate={maxDate}
+      slots={{
+        popper: Popper,
+      }}
       slotProps={{
+        popper: {
+          modifiers: [
+            {
+              name: 'flip',
+              enabled: false,
+            },
+          ],
+          placement: 'top',
+          sx: (theme) => ({
+            zIndex: theme.zIndex.modal,
+            '.MuiDateCalendar-root': {
+              height: 'auto',
+              padding: theme.spacing(1.25),
+              paddingBottom: theme.spacing(2.5),
+            },
+            '.MuiPickersMonth-monthButton.Mui-disabled, .MuiPickersYear-yearButton.Mui-disabled': {
+              color: theme.palette.text.disabled,
+            },
+          }),
+        },
         textField: {
           helperText: errorMessage,
           sx: (theme) => ({
@@ -62,18 +86,6 @@ function DatePickerComponent({
         },
         field: {
           readOnly: true,
-        },
-        popper: {
-          sx: (theme) => ({
-            '.MuiDateCalendar-root': {
-              height: 'auto',
-              padding: theme.spacing(1.25),
-              paddingBottom: theme.spacing(2.5),
-            },
-            '.MuiPickersMonth-monthButton.Mui-disabled, .MuiPickersYear-yearButton.Mui-disabled': {
-              color: theme.palette.text.disabled,
-            },
-          }),
         },
       }}
       {...rest}


### PR DESCRIPTION
## Summary

Fixes date picker bug on search page that prevented the user from selecting a year.

## Design Documentation/Original Tickets

[CAT-1064 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1064?atlOrigin=eyJpIjoiNjg0MmY5NDYzNzBhNDQ1ZGIwMWU2ZWE2OWRmMTBhMTciLCJwIjoiaiJ9)

## Screenshots/Video

Local:

https://github.com/user-attachments/assets/9d0cead2-182f-48eb-a6a5-77864a2e1ed4

Prod-Test:

https://github.com/user-attachments/assets/ad761da9-ece3-4f13-aecb-ece2e77aacae

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

This is a known bug with the MUI date picker component - see [this thread.](https://github.com/mui/mui-x/issues/9288)
