### PR TITLE
John conroy/search last page

### DIFF
--- a/CHANGELOG-search-last-page.md
+++ b/CHANGELOG-search-last-page.md
@@ -1,0 +1,1 @@
+- Fix bug where you could not scroll to deeper search pages.

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -54,7 +54,10 @@ function buildSortField({ sortField, mappings }: { sortField: SortField; mapping
     ? [esb.sort(getESField({ field: secondarySortField.field, mappings }), secondarySortField.direction)]
     : [];
 
-  return [primarySort, ...secondarySort];
+  // Sort values need to be unique for
+  const scoreSort = esb.sort('uuid.keyword', 'desc');
+
+  return [primarySort, ...secondarySort, scoreSort];
 }
 
 export function buildQuery({

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -55,9 +55,9 @@ function buildSortField({ sortField, mappings }: { sortField: SortField; mapping
     : [];
 
   // Sort values need to be unique for search_after.
-  const scoreSort = esb.sort('uuid.keyword', 'desc');
+  const uniqueSort = esb.sort('uuid.keyword', 'desc');
 
-  return [primarySort, ...secondarySort, scoreSort];
+  return [primarySort, ...secondarySort, uniqueSort];
 }
 
 export function buildQuery({

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -54,7 +54,7 @@ function buildSortField({ sortField, mappings }: { sortField: SortField; mapping
     ? [esb.sort(getESField({ field: secondarySortField.field, mappings }), secondarySortField.direction)]
     : [];
 
-  // Sort values need to be unique for
+  // Sort values need to be unique for search_after.
   const scoreSort = esb.sort('uuid.keyword', 'desc');
 
   return [primarySort, ...secondarySort, scoreSort];


### PR DESCRIPTION
## Summary

Phil noticed a bug scrolling through deeper search pages. The `sort_after` requires a unique tiebreaker.

From Phil:

> The "see more results" stops working before it gets to the very end of the list of datasets (see snapshot where it stopped revealing more datasets)

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added