### PR TITLE
Hotfix portal-visualization regression

### DIFF
--- a/CHANGELOG-hotfix-portal-vis.md
+++ b/CHANGELOG-hotfix-portal-vis.md
@@ -1,0 +1,1 @@
+- Fix a regression in portal-visualization which broke Vitessce view config generation.

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -16,7 +16,7 @@ hubmap-commons>=2.1.15
 boto3==1.28.17
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.3.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.5.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -1238,8 +1238,8 @@ platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
     --hash=sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227
     # via black
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.3.zip \
-    --hash=sha256:d1c9d09398c70dcba69dc9fcd7f72094783c4181ba9a10f2b5ad322c492f9777
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.5.zip \
+    --hash=sha256:b7355ea67bb985cf7ff173e13210c5789b89fa8f7d276385802a3225dd14952d
     # via -r context/requirements.in
 propcache==0.2.0 \
     --hash=sha256:00181262b17e517df2cd85656fcd6b4e70946fe62cd625b9d74ac9977b64d8d9 \


### PR DESCRIPTION
## Summary

THis PR bumps the version of `portal-visualization` to pull in a fix for a regression that occured with conf fetching, where the entity UUID was not properly pulled in to the `get_entity` function.

## Design Documentation/Original Tickets

N/A

## Testing

- confirmed visualizations broke with portal-vis 0.3.3 locally
- applied fix to portal-vis and bumped version
- Confirmed visualizations fixed with portal-vis 0.3.4

## Screenshots/Video

![image](https://github.com/user-attachments/assets/b022c680-bbad-4d08-835f-536a841bece4)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Python environment issues led to this - my local environment did not update to 0.3.3 successfully when originally QA testing this, so I mistakenly thought it was all set.
