### PR TITLE
Austenem/Accessibility updates

### DIFF
--- a/CHANGELOG-accessibility-updates.md
+++ b/CHANGELOG-accessibility-updates.md
@@ -1,0 +1,1 @@
+- Resolve accessibility issues related to arias and interactive controls throughout the portal.

--- a/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
+++ b/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
@@ -64,6 +64,8 @@ export default function CollapsibleDetailPageSection({
               <StyledInfoIcon color="primary" />
             </SecondaryBackgroundTooltip>
           )}
+        </AccordionSummary>
+        <AccordionDetails sx={{ padding: 0 }}>
           {action && (
             <Box
               onClick={(e) => {
@@ -72,12 +74,13 @@ export default function CollapsibleDetailPageSection({
               }}
               ml="auto"
               className="accordion-section-action"
+              sx={{ position: 'absolute', right: 0, top: 0 }}
             >
               {action}
             </Box>
           )}
-        </AccordionSummary>
-        <AccordionDetails sx={{ padding: 0 }}>{children}</AccordionDetails>
+          {children}
+        </AccordionDetails>
       </DetailPageSectionAccordion>
     </DetailPageSection>
   );

--- a/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
+++ b/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
@@ -74,7 +74,7 @@ export default function CollapsibleDetailPageSection({
               }}
               ml="auto"
               className="accordion-section-action"
-              sx={{ position: 'absolute', right: 0, top: 0 }}
+              sx={{ position: 'absolute', right: 0, top: 7 }}
             >
               {action}
             </Box>

--- a/context/app/static/js/components/detailPage/MetadataSection/MetadataSection.tsx
+++ b/context/app/static/js/components/detailPage/MetadataSection/MetadataSection.tsx
@@ -11,7 +11,8 @@ import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { sectionIconMap } from 'js/shared-styles/icons/sectionIconMap';
 import { SectionDescription } from 'js/shared-styles/sections/SectionDescription';
 import { getTableEntities } from 'js/components/detailPage/MetadataSection/utils';
-import { DownloadIcon, StyledWhiteBackgroundIconButton } from '../MetadataTable/style';
+import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
+import { DownloadIcon } from '../MetadataTable/style';
 import MetadataTabs from '../multi-assay/MultiAssayMetadataTabs';
 import { Columns, defaultTSVColumns } from './columns';
 
@@ -54,12 +55,12 @@ function MetadataWrapper({ allTableRows, tsvColumns = defaultTSVColumns, childre
       action={
         <SecondaryBackgroundTooltip title="Download">
           <a href={downloadUrl} download={`${hubmap_id}.tsv`}>
-            <StyledWhiteBackgroundIconButton
+            <WhiteBackgroundIconButton
               aria-label="Download TSV of selected items' metadata"
               onClick={() => trackEntityPageEvent({ action: `Metadata / Download Metadata` })}
             >
               <DownloadIcon color="primary" />
-            </StyledWhiteBackgroundIconButton>
+            </WhiteBackgroundIconButton>
           </a>
         </SecondaryBackgroundTooltip>
       }

--- a/context/app/static/js/components/detailPage/MetadataTable/style.ts
+++ b/context/app/static/js/components/detailPage/MetadataTable/style.ts
@@ -1,7 +1,5 @@
 import { styled } from '@mui/material/styles';
 import GetAppIcon from '@mui/icons-material/GetAppRounded';
-
-import { WhiteBackgroundIconButton } from 'js/shared-styles/buttons';
 import SectionHeader from 'js/shared-styles/sections/SectionHeader';
 
 const DownloadIcon = styled(GetAppIcon)({
@@ -13,12 +11,8 @@ const Flex = styled('div')({
   justifyContent: 'space-between',
 });
 
-const StyledWhiteBackgroundIconButton = styled(WhiteBackgroundIconButton)(({ theme }) => ({
-  marginBottom: theme.spacing(0.5),
-}));
-
 const StyledSectionHeader = styled(SectionHeader)({
   alignSelf: 'flex-end',
 });
 
-export { DownloadIcon, Flex, StyledWhiteBackgroundIconButton, StyledSectionHeader };
+export { DownloadIcon, Flex, StyledSectionHeader };

--- a/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.tsx
+++ b/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.tsx
@@ -44,7 +44,7 @@ const StatusIcon = forwardRef(function StatusIcon(
 
   if (tooltip) {
     return (
-      <SecondaryBackgroundTooltip title={irregularCaseStatus}>
+      <SecondaryBackgroundTooltip title={irregularCaseStatus} role="status">
         {/* The wrapper is required for the tooltip to work */}
         <Box display="flex">{content}</Box>
       </SecondaryBackgroundTooltip>

--- a/context/app/static/js/components/home/Hero/Hero.tsx
+++ b/context/app/static/js/components/home/Hero/Hero.tsx
@@ -80,7 +80,7 @@ const heroTabs = [
 export default function Hero() {
   const [activeTab, setActiveTab] = useState(0);
   return (
-    <Paper component="section" role="tablist" aria-label="HuBMAP Introduction">
+    <Paper component="section" aria-label="HuBMAP Introduction">
       <HeroTabContextProvider activeTab={activeTab} setActiveTab={setActiveTab}>
         <HeroGridContainer $activeSlide={activeTab} role="tablist">
           {heroTabs.map((tab, index) => (

--- a/context/app/static/js/components/search/Results/ResultsTiles.tsx
+++ b/context/app/static/js/components/search/Results/ResultsTiles.tsx
@@ -5,6 +5,7 @@ import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 import ListItemIcon from '@mui/material/ListItemIcon';
+import InputLabel from '@mui/material/InputLabel';
 import Check from '@mui/icons-material/Check';
 
 import { Entity } from 'js/components/types';
@@ -13,7 +14,6 @@ import { getTileDescendantCounts } from 'js/components/entity-tile/EntityTile/ut
 import { capitalizeString } from 'js/helpers/functions';
 import TileGrid from 'js/shared-styles/tiles/TileGrid';
 import { trackEvent } from 'js/helpers/trackers';
-import InputLabel from '@mui/material/InputLabel';
 import { StyledDownIcon } from 'js/shared-styles/dropdowns/DropdownMenuButton/style';
 import { useSearch } from '../Search';
 import ViewMoreResults from './ViewMoreResults';

--- a/context/app/static/js/components/search/Results/ResultsTiles.tsx
+++ b/context/app/static/js/components/search/Results/ResultsTiles.tsx
@@ -13,6 +13,8 @@ import { getTileDescendantCounts } from 'js/components/entity-tile/EntityTile/ut
 import { capitalizeString } from 'js/helpers/functions';
 import TileGrid from 'js/shared-styles/tiles/TileGrid';
 import { trackEvent } from 'js/helpers/trackers';
+import InputLabel from '@mui/material/InputLabel';
+import { StyledDownIcon } from 'js/shared-styles/dropdowns/DropdownMenuButton/style';
 import { useSearch } from '../Search';
 import ViewMoreResults from './ViewMoreResults';
 import { useSearchStore } from '../store';
@@ -44,10 +46,16 @@ function TilesSortSelect() {
 
   return (
     <FormControl>
+      <InputLabel id="sort-select-label" sx={{ display: 'none' }}>
+        Sort by
+      </InputLabel>
       <Select
         value={sortField.field}
         onChange={handleChange}
+        labelId="sort-select-label"
         color="primary"
+        variant="outlined"
+        IconComponent={StyledDownIcon}
         sx={(theme) => ({
           backgroundColor: theme.palette.primary.main,
           color: theme.palette.white.main,

--- a/context/app/static/js/components/search/Search.tsx
+++ b/context/app/static/js/components/search/Search.tsx
@@ -175,7 +175,7 @@ function Bar({ type }: TypeProps) {
   return (
     <Stack direction="row" spacing={1}>
       <Box flexGrow={1}>
-        <SearchBar />
+        <SearchBar type={type} />
       </Box>
       <MetadataMenu type={type} />
       <WorkspacesDropdownMenu type={type} />

--- a/context/app/static/js/components/search/SearchBar.tsx
+++ b/context/app/static/js/components/search/SearchBar.tsx
@@ -5,7 +5,7 @@ import { trackSiteSearch, trackEvent } from 'js/helpers/trackers';
 import SearchBarComponent from 'js/shared-styles/inputs/SearchBar';
 import { useSearchStore } from './store';
 
-function SearchBar() {
+function SearchBar({ type }: { type: string }) {
   const { setSearch, search, analyticsCategory } = useSearchStore(
     useShallow((state) => ({
       setSearch: state.setSearch,
@@ -41,6 +41,7 @@ function SearchBar() {
       <SearchBarComponent
         id="free-text-search"
         fullWidth
+        placeholder={`Search ${type.toLowerCase()}s`}
         value={input}
         onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
           setInput(event.target.value);

--- a/context/app/static/js/components/workspaces/WorkspaceListItem.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceListItem.tsx
@@ -62,7 +62,9 @@ function WorkspaceListItem({
         <SecondaryBackgroundTooltip title={tooltipToDisplay}>
           <span>
             <ToggleComponent
-              aria-label={`Select ${workspace.name}.`}
+              inputProps={{
+                'aria-label': `Select ${workspace.name}.`,
+              }}
               checked={selected}
               onChange={() => toggleItem(workspace.id)}
               disabled={isRunning || disabled}

--- a/context/app/static/js/shared-styles/buttons/index.tsx
+++ b/context/app/static/js/shared-styles/buttons/index.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren, ComponentProps } from 'react';
+import React, { PropsWithChildren, ComponentProps, useId } from 'react';
 import { Theme, styled } from '@mui/material/styles';
 import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import ToggleButton from '@mui/material/ToggleButton';
@@ -66,10 +66,11 @@ function TooltipToggleButton({
   ...rest
 }: TooltipToggleButtonProps) {
   const Tooltip = tooltipComponent;
+  const tooltipId = useId();
 
   return (
-    <Tooltip title={tooltipTitle}>
-      <span role="tooltip">
+    <Tooltip title={tooltipTitle} id={tooltipId}>
+      <span aria-describedby={tooltipId}>
         <WhiteBackgroundToggleButton {...rest} id={id} data-testid={id}>
           {children}
         </WhiteBackgroundToggleButton>

--- a/context/app/static/js/shared-styles/buttons/index.tsx
+++ b/context/app/static/js/shared-styles/buttons/index.tsx
@@ -69,7 +69,7 @@ function TooltipToggleButton({
 
   return (
     <Tooltip title={tooltipTitle}>
-      <span>
+      <span role="tooltip">
         <WhiteBackgroundToggleButton {...rest} id={id} data-testid={id}>
           {children}
         </WhiteBackgroundToggleButton>

--- a/context/app/static/js/shared-styles/dropdowns/DropdownMenuButton/style.ts
+++ b/context/app/static/js/shared-styles/dropdowns/DropdownMenuButton/style.ts
@@ -1,12 +1,12 @@
-import { styled } from '@mui/material/styles';
+import { Theme, styled } from '@mui/material/styles';
 import { UpIcon, DownIcon } from 'js/shared-styles/icons';
 
-const StyledUpIcon = styled(UpIcon)(({ theme }) => ({
+const sharedIconStyles = ({ theme }: { theme: Theme }) => ({
   marginLeft: theme.spacing(0.5),
-}));
+  fontSize: '1.5rem',
+});
 
-const StyledDownIcon = styled(DownIcon)(({ theme }) => ({
-  marginLeft: theme.spacing(0.5),
-}));
+const StyledUpIcon = styled(UpIcon)(sharedIconStyles);
+const StyledDownIcon = styled(DownIcon)(sharedIconStyles);
 
 export { StyledUpIcon, StyledDownIcon };

--- a/context/app/static/js/shared-styles/icons/icons.tsx
+++ b/context/app/static/js/shared-styles/icons/icons.tsx
@@ -18,7 +18,7 @@ import EditRoundedIcon from '@mui/icons-material/EditRounded';
 import CollectionsBookmarkRoundedIcon from '@mui/icons-material/CollectionsBookmarkRounded';
 import EmailRoundedIcon from '@mui/icons-material/EmailRounded';
 import ListAltRoundedIcon from '@mui/icons-material/ListAltRounded';
-import ArrowDropDownRoundedIcon from '@mui/icons-material/ExpandMoreRounded';
+import ArrowDropDownRoundedIcon from '@mui/icons-material/ArrowDropDownRounded';
 import ArrowDropUpRoundedIcon from '@mui/icons-material/ArrowDropUpRounded';
 import AddRoundedIcon from '@mui/icons-material/AddRounded';
 import DescriptionRoundedIcon from '@mui/icons-material/DescriptionRounded';

--- a/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/InfoTextTooltip.tsx
+++ b/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/InfoTextTooltip.tsx
@@ -11,7 +11,7 @@ function InfoTextTooltip({ tooltipTitle, children }: InfoTextTooltipProps) {
   return (
     <StyledOuterStack>
       {children}
-      <SecondaryBackgroundTooltip title={tooltipTitle}>
+      <SecondaryBackgroundTooltip title={tooltipTitle} role="definition">
         <StyledInnerStack>
           <StyledInfoIcon />
         </StyledInnerStack>

--- a/context/app/static/js/shared-styles/tooltips/index.tsx
+++ b/context/app/static/js/shared-styles/tooltips/index.tsx
@@ -19,8 +19,8 @@ function SecondaryBackgroundTooltip({ disabled, children, ...rest }: SecondaryBa
           },
         }),
       }}
-      {...rest}
       arrow
+      {...rest}
     >
       {children}
     </Tooltip>

--- a/context/app/static/js/shared-styles/tooltips/index.tsx
+++ b/context/app/static/js/shared-styles/tooltips/index.tsx
@@ -19,8 +19,8 @@ function SecondaryBackgroundTooltip({ disabled, children, ...rest }: SecondaryBa
           },
         }),
       }}
-      arrow
       {...rest}
+      arrow
     >
       {children}
     </Tooltip>

--- a/context/app/templates/base-pages/base.html
+++ b/context/app/templates/base-pages/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
## Summary

Resolves accessibility issues related to arias and interactive controls throughout the portal.

## Design Documentation/Original Tickets

[CAT-1027](https://hms-dbmi.atlassian.net/browse/CAT-1027?atlOrigin=eyJpIjoiYzBiZmFjMjBhOTIxNDBkMjhhNzJjNWI1NTg1YWM5YmUiLCJwIjoiaiJ9): Certain ARIA roles must contain particular children
[CAT-1056](https://hms-dbmi.atlassian.net/browse/CAT-1056?atlOrigin=eyJpIjoiYjcyNTY1MzYzMzAzNGNiMmI5ZWE3NTE1OGY1MGYyNDkiLCJwIjoiaiJ9): Ensure interactive controls are not nested
[CAT-1058](https://hms-dbmi.atlassian.net/browse/CAT-1058?atlOrigin=eyJpIjoiYzA0NGQyYjgzMThmNDk5YWFiMDZjMWQwY2Q0ZGE5ZWYiLCJwIjoiaiJ9): Elements must only use permitted ARIA attributes
[CAT-1059](https://hms-dbmi.atlassian.net/browse/CAT-1059?atlOrigin=eyJpIjoiZWU5ODU1NzE0MmY0NGQwN2E2NzM4OTQyM2UzZDIyMDYiLCJwIjoiaiJ9): Ensure role attribute has an appropriate value for the element

## Testing

Tested that each issue was resolved using Axe Devtools on all portal pages. 

## Screenshots/Video

No significant visual/behavioral changes should be present. One exception is the placeholder text added to the search bar on search pages, as per discussion with @tsliaw.

<img width="651" alt="Screenshot 2024-12-16 at 12 24 58 PM" src="https://github.com/user-attachments/assets/42c7e59d-56d6-4aa7-8806-76f45a4be5cd" />

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Two instances of [CAT-1056](https://hms-dbmi.atlassian.net/browse/CAT-1056?atlOrigin=eyJpIjoiYjcyNTY1MzYzMzAzNGNiMmI5ZWE3NTE1OGY1MGYyNDkiLCJwIjoiaiJ9) (Ensure interactive controls are not nested) could not be resolved.

The first is present on the homepage and is the result of the Hero component used there - the interactive controls are inherent to the design, and as the links present in the Hero are available in multiple other locations, this will not be altered.

The second is present on multiple pages and could not be resolved as it is inherent to the MUI Checkbox component ([related thread](https://github.com/mui/material-ui/issues/42159)). This issue is present on the following pages that use this component:

- All search pages
- Workspaces page
- Organ detail page
- Workspace detail page


[CAT-1027]: https://hms-dbmi.atlassian.net/browse/CAT-1027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAT-1056]: https://hms-dbmi.atlassian.net/browse/CAT-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAT-1058]: https://hms-dbmi.atlassian.net/browse/CAT-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAT-1059]: https://hms-dbmi.atlassian.net/browse/CAT-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAT-1056]: https://hms-dbmi.atlassian.net/browse/CAT-1056?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ