### PR TITLE
NickAkhmetov/Fix portal-visualization image pyramid regression

### DIFF
--- a/CHANGELOG-portal-vis-0.3.6.md
+++ b/CHANGELOG-portal-vis-0.3.6.md
@@ -1,0 +1,1 @@
+- Bump portal-visualization version to 0.3.6 to resolve regression with vis-lifting image pyramid assays.

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -16,7 +16,7 @@ hubmap-commons>=2.1.15
 boto3==1.28.17
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.5.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.6.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -1238,8 +1238,8 @@ platformdirs==2.5.1 \
     --hash=sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d \
     --hash=sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227
     # via black
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.5.zip \
-    --hash=sha256:b7355ea67bb985cf7ff173e13210c5789b89fa8f7d276385802a3225dd14952d
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.3.6.zip \
+    --hash=sha256:8683dad4dac6a81d64d2220e75497f34a55bc67e71f0b1faee49bd2edecfb1d0
     # via -r context/requirements.in
 propcache==0.2.0 \
     --hash=sha256:00181262b17e517df2cd85656fcd6b4e70946fe62cd625b9d74ac9977b64d8d9 \


### PR DESCRIPTION
## Summary

This PR fixes the remaining regression issue from portal-viz 0.3.3-0.3.5, where the visualizations for image pyramids failed to visualize due to the `get parent entity` lookup function being inconsistently passed either a string or an object containing a uuid key; this has been resolved upstream.

## Design Documentation/Original Tickets

Link to any design documents, diagrams, or JIRA tickets relevant to this feature.

## Testing

Tested manually with datasets that failed in `portal-prod.test` environment.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/8f13f131-8e16-4d08-af4d-e872b3165c48)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes
