### PR TITLE
Addressed the issue in metadata table

### DIFF
--- a/CHANGELOG-scrolling-accessibility-issue
+++ b/CHANGELOG-scrolling-accessibility-issue
@@ -1,0 +1,1 @@
+ - Addressed accessibility issue to ensure elements with scrollable content are accessible by keyboard.

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
@@ -20,7 +20,7 @@ interface MetadataTableRow {
 function MetadataTable({ tableRows = [] as MetadataTableRow[], columns = defaultColumns }) {
   return (
     <Paper sx={{ width: '100%' }}>
-      <StyledTableContainer>
+      <StyledTableContainer tabIndex={0} role="region" aria-label="Scrollable table container for Metadata">
         <Table stickyHeader>
           <TableHead>
             <TableRow>


### PR DESCRIPTION
## Summary

Addresses the accessibility issue `ensure elements with scrollable content are accessible by keyboard` in the metadata table included in the donor/sample/dataset pages.

## Design Documentation/Original Tickets

[CAT-1067](https://hms-dbmi.atlassian.net/browse/CAT-1067)

## Testing

Manually tested with Axe devTool

## Screenshots/Video

<img width="1726" alt="Screenshot 2024-12-18 at 3 09 25 PM" src="https://github.com/user-attachments/assets/b20423db-d7e1-4e6e-b81c-75a225632dee" />


## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.


[CAT-1067]: https://hms-dbmi.atlassian.net/browse/CAT-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ