### PR TITLE
Austenem/CAT-966 Refactor ingest metadata

### DIFF
--- a/CHANGELOG-refactor-ingest-metadata.md
+++ b/CHANGELOG-refactor-ingest-metadata.md
@@ -1,0 +1,1 @@
+- Update portal to account for refactored metadata from search api.

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -183,7 +183,7 @@ function AnalysisDetailsAccordion() {
   }
 
   const {
-    metadata: { dag_provenance_list },
+    ingest_metadata: { dag_provenance_list },
     protocol_url,
   } = dataset;
 

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
@@ -18,6 +18,7 @@ export type ProcessedDatasetDetails = ProcessedDatasetInfo &
     | 'created_timestamp'
     | 'published_timestamp'
     | 'last_modified_timestamp'
+    | 'ingest_metadata'
     | 'metadata'
     | 'protocol_url' // TODO: This is present for non-dataset entities, but not for datasets.
     | 'dataset_type'
@@ -48,8 +49,8 @@ export function useProcessedDatasetDetails(uuid: string) {
       'created_timestamp',
       'published_timestamp',
       'last_modified_timestamp',
-      'metadata.dag_provenance_list',
-      'metadata.metadata',
+      'ingest_metadata.dag_provenance_list',
+      'metadata',
       'protocol_url',
       'dataset_type',
       'creation_action',

--- a/context/app/static/js/components/detailPage/files/DataProducts/hooks.ts
+++ b/context/app/static/js/components/detailPage/files/DataProducts/hooks.ts
@@ -57,7 +57,7 @@ function usePipelineInfo(): PipelineInfo {
   if (!isDataset(entity)) {
     return defaultPipeline;
   }
-  const dagList = entity.metadata.dag_provenance_list ?? [];
+  const dagList = entity.ingest_metadata.dag_provenance_list ?? [];
   // Iterate over the list of DAGs and extract the latest origin and name
   const pipelineInfo = dagList.reduce<PipelineInfo>(processDagList, defaultPipeline);
   return pipelineInfo;

--- a/context/app/static/js/components/search/Results/utils.ts
+++ b/context/app/static/js/components/search/Results/utils.ts
@@ -15,7 +15,7 @@ const paths = {
   dataset: {
     donor: `donor.${donorMetadataPath}`,
     sample: `source_samples.${sampleMetadataPath}`,
-    dataset: 'metadata.metadata',
+    dataset: 'metadata',
   },
 };
 

--- a/context/app/static/js/components/searchPage/ResultsTable/utils.jsx
+++ b/context/app/static/js/components/searchPage/ResultsTable/utils.jsx
@@ -16,7 +16,7 @@ const paths = {
   dataset: {
     donor: `donor.${donorMetadataPath}`,
     sample: `source_samples.${sampleMetdataPath}`,
-    dataset: 'metadata.metadata',
+    dataset: 'metadata',
   },
 };
 

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -45,10 +45,11 @@ export interface Entity {
   donor: Donor;
   descendant_counts: { entity_type: Record<string, number> };
   descendant_ids: string[];
-  metadata: {
+  ingest_metadata: {
     dag_provenance_list: DagProvenanceType[];
     [key: string]: unknown;
   };
+  metadata: Record<string, unknown>;
   /** @deprecated Use `descendant_ids` and `useEntitiesData` instead */
   descendants: Entity[];
   group_name: string;

--- a/context/app/static/js/helpers/metadata.ts
+++ b/context/app/static/js/helpers/metadata.ts
@@ -10,7 +10,7 @@ import {
 import { get } from './nodash';
 
 const donorMetadataPath = 'mapped_metadata';
-const sampleAndDatasetMetadataPath = 'metadata';
+const sampleOrDatasetMetadataPath = 'metadata';
 
 type ESEntityTypesWithIcons = Extract<ESEntityType, 'Donor' | 'Sample' | 'Dataset'>;
 
@@ -20,11 +20,11 @@ const paths: Record<ESEntityTypesWithIcons, Partial<Record<ESEntityType, string>
   },
   Sample: {
     Donor: `donor.${donorMetadataPath}`,
-    Sample: sampleAndDatasetMetadataPath,
+    Sample: sampleOrDatasetMetadataPath,
   },
   Dataset: {
     Donor: `donor.${donorMetadataPath}`,
-    Dataset: sampleAndDatasetMetadataPath,
+    Dataset: sampleOrDatasetMetadataPath,
   },
 };
 

--- a/context/app/static/js/helpers/metadata.ts
+++ b/context/app/static/js/helpers/metadata.ts
@@ -10,7 +10,7 @@ import {
 import { get } from './nodash';
 
 const donorMetadataPath = 'mapped_metadata';
-const sampleMetadataPath = 'metadata';
+const sampleAndDatasetMetadataPath = 'metadata';
 
 type ESEntityTypesWithIcons = Extract<ESEntityType, 'Donor' | 'Sample' | 'Dataset'>;
 
@@ -20,11 +20,11 @@ const paths: Record<ESEntityTypesWithIcons, Partial<Record<ESEntityType, string>
   },
   Sample: {
     Donor: `donor.${donorMetadataPath}`,
-    Sample: sampleMetadataPath,
+    Sample: sampleAndDatasetMetadataPath,
   },
   Dataset: {
     Donor: `donor.${donorMetadataPath}`,
-    Dataset: 'metadata.metadata',
+    Dataset: sampleAndDatasetMetadataPath,
   },
 };
 

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -47,6 +47,7 @@ export type ProcessedDatasetInfo = Pick<
   | 'files'
   | 'pipeline'
   | 'status'
+  | 'ingest_metadata'
   | 'metadata'
   | 'creation_action'
   | 'created_timestamp'
@@ -164,13 +165,13 @@ function getProcessedDatasetSection({
   dataset: ProcessedDatasetInfo & { label: string };
   hasConf?: boolean;
 }) {
-  const { files, metadata, visualization, creation_action, contributors } = dataset;
+  const { files, ingest_metadata, visualization, creation_action, contributors } = dataset;
 
   const shouldDisplaySection = {
     summary: true,
     visualization: visualization || conf,
     files: Boolean(files?.length),
-    analysis: Boolean(metadata?.dag_provenance_list),
+    analysis: Boolean(ingest_metadata?.dag_provenance_list),
     attribution: creation_action !== 'Central Process' && Boolean(contributors?.length),
   };
 

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -50,20 +50,20 @@ function DevSearch() {
       'Assay Types': [
         listFilter('data_types', 'data_types'),
         listFilter('mapped_data_types', 'mapped_data_types'),
-        listFilter('metadata.metadata.assay_category', 'assay_category'),
-        listFilter('metadata.metadata.assay_type', 'assay_type'),
+        listFilter('metadata.assay_category', 'assay_category'),
+        listFilter('metadata.assay_type', 'assay_type'),
         checkboxFilter('is_derived', 'Is derived?', BoolMust(TermQuery('processing.keyword', 'processed'))),
         checkboxFilter('is_raw', 'Is raw?', BoolMust(TermQuery('processing.keyword', 'raw'))),
         hierarchicalFilter({
           fields: {
-            parent: { id: 'metadata.metadata.analyte_class.keyword' },
+            parent: { id: 'metadata.analyte_class.keyword' },
             child: { id: 'mapped_data_types.keyword' },
           },
           name: 'By analyte',
         }),
         hierarchicalFilter({
           fields: {
-            parent: { id: 'metadata.metadata.assay_category.keyword' },
+            parent: { id: 'metadata.assay_category.keyword' },
             child: { id: 'mapped_data_types.keyword' },
           },
           name: 'By category',
@@ -84,7 +84,7 @@ function DevSearch() {
         checkboxFilter('has_substatus', 'Has substatus?', ExistsQuery('sub_status')),
         checkboxFilter('is_living_donor', 'Is living donor?', ExistsQuery('metadata.living_donor_data')),
         checkboxFilter('is_organ_donor', 'Is organ donor?', ExistsQuery('metadata.organ_donor_data')),
-        checkboxFilter('has_metadata', 'Has metadata?', ExistsQuery('metadata.metadata')),
+        checkboxFilter('has_metadata', 'Has metadata?', ExistsQuery('metadata')),
         checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata.metadata'))),
         checkboxFilter('has_files', 'Has files?', ExistsQuery('files')),
         checkboxFilter('no_files', 'No files?', BoolMustNot(ExistsQuery('files'))),


### PR DESCRIPTION
## Summary

Updates the portal to account for refactored metadata from search api.

The relevant search-api changes include:

`Dataset.ingest_metadata.metadata` → `Dataset.metadata`
`Dataset.ingest_metadata.files` → `Dataset.files`
`Dataset.metadata` → `Dataset.ingest_metadata`

## Design Documentation/Original Tickets

[CAT-966 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-966?atlOrigin=eyJpIjoiNzAwOTVlNDQyNmViNDgxNjg1MDhmZmFjM2VhZTIyZmIiLCJwIjoiaiJ9)

## Testing

Checked detail pages and in particular metadata sections from several entities. 

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

