### PR TITLE
Austenem/CAT-1086 Fix processed dataset sections

### DIFF
--- a/CHANGELOG-fix-processed-analysis.md
+++ b/CHANGELOG-fix-processed-analysis.md
@@ -1,0 +1,1 @@
+- Update processed dataset files and analysis sections to match updated ingest metadata.

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -92,17 +92,19 @@ function FilesAccordion() {
   const {
     dataset: { files, hubmap_id },
   } = useProcessedDatasetContext();
-  const hasDataProducts = Boolean(files.filter((file) => file.is_data_product).length);
   const [openTabIndex, setOpenTabIndex] = useState(0);
-  const fileBrowserIndex = hasDataProducts ? 1 : 0;
   const track = useTrackEntityPageEvent();
-  if (files.length === 0) {
+
+  if (!files || files.length === 0) {
     return (
       <Subsection title="Files" icon={<InsertDriveFileRounded />}>
         <SectionDescription subsection>No files are available for this dataset.</SectionDescription>
       </Subsection>
     );
   }
+
+  const hasDataProducts = Boolean(files.filter((file) => file.is_data_product).length);
+  const fileBrowserIndex = hasDataProducts ? 1 : 0;
   return (
     <Subsection title="Files" icon={<InsertDriveFileRounded />}>
       <SectionDescription subsection>
@@ -172,7 +174,7 @@ function AnalysisDetailsAccordion() {
     return <Skeleton variant="rectangular" height={200} />;
   }
 
-  if (!dataset.metadata) {
+  if (!dataset.ingest_metadata) {
     return (
       <Subsection title="Analysis Details & Protocols" idTitleOverride="analysis" icon={<FactCheckRounded />}>
         <SectionDescription subsection>

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -127,6 +127,7 @@ function useProcessedDatasets(includeComponents?: boolean) {
       'created_timestamp',
       'dbgap_study_url',
       'dbgap_sra_experiment_url',
+      'ingest_metadata',
       'is_component',
       'visualization',
       'contributors',


### PR DESCRIPTION
## Summary

Update processed dataset files and analysis sections to match updated ingest metadata.

Previously:
- Files section intermittently produced runtime error in cases where the files property was absent.
- Analysis section did not appear when expected.

## Design Documentation/Original Tickets

[CAT-1086 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1086?atlOrigin=eyJpIjoiNjRiMmQzYzE5NzJhNDZkMmI4Y2FiNzNiYTc5MzI4ODUiLCJwIjoiaiJ9)

## Screenshots/Video

Local:

<img width="1057" alt="Screenshot 2025-01-06 at 12 39 15 PM" src="https://github.com/user-attachments/assets/4f4699b6-759d-4d1a-b5d4-1db73f44cbce" />

On TEST:

<img width="1097" alt="Screenshot 2025-01-06 at 12 39 31 PM" src="https://github.com/user-attachments/assets/843dacc9-efaa-40b2-9182-7aeb154d9b2b" />

<img width="1410" alt="Screenshot 2025-01-06 at 1 05 33 PM" src="https://github.com/user-attachments/assets/09008a35-8520-44df-811a-6f64061b56e2" />

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
