### PR TITLE
John conroy/ws token for users

### DIFF
--- a/CHANGELOG-ws-token-for-users.md
+++ b/CHANGELOG-ws-token-for-users.md
@@ -1,0 +1,1 @@
+- Only request workspaces token for workspaces users during auth routine.


### PR DESCRIPTION
## Summary

- Only request workspaces token for workspaces users during auth routine. This will unblock Juan's work for discovering users when sharing workspaces.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
