### PR TITLE
Austenem/CAT-1090 Dev-search metadata filter

### DIFF
--- a/CHANGELOG-dev-metadata-filter.md
+++ b/CHANGELOG-dev-metadata-filter.md
@@ -1,0 +1,1 @@
+- Fix metadata filter on dev-search.

--- a/context/app/static/js/pages/search/DevSearch.jsx
+++ b/context/app/static/js/pages/search/DevSearch.jsx
@@ -85,7 +85,7 @@ function DevSearch() {
         checkboxFilter('is_living_donor', 'Is living donor?', ExistsQuery('metadata.living_donor_data')),
         checkboxFilter('is_organ_donor', 'Is organ donor?', ExistsQuery('metadata.organ_donor_data')),
         checkboxFilter('has_metadata', 'Has metadata?', ExistsQuery('metadata')),
-        checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata.metadata'))),
+        checkboxFilter('no_metadata', 'No metadata?', BoolMustNot(ExistsQuery('metadata'))),
         checkboxFilter('has_files', 'Has files?', ExistsQuery('files')),
         checkboxFilter('no_files', 'No files?', BoolMustNot(ExistsQuery('files'))),
         checkboxFilter('is_spatial', 'Spatial?', ExistsQuery('rui_location')),


### PR DESCRIPTION
## Summary

Fixes "No metadata?" filter on dev-search.

## Design Documentation/Original Tickets

[CAT-1090 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1090?atlOrigin=eyJpIjoiNjU1NDM4ZWJmZWFhNGNjMzg2NDIwNjRkYjkyOTMzMmIiLCJwIjoiaiJ9)

## Screenshots/Video

Local:

<img width="268" alt="Screenshot 2025-01-07 at 3 53 15 PM" src="https://github.com/user-attachments/assets/9e77ea5a-106f-4548-8b53-5a3fd0d1d322" />


Test:

<img width="272" alt="Screenshot 2025-01-07 at 3 55 06 PM" src="https://github.com/user-attachments/assets/fb359559-d782-4fc8-bbfd-6361a744f201" />

