### PR TITLE
NickAkhmetov/CAT-1073 Keep the `marker` URL param during redirect to unified view

### DIFF
--- a/CHANGELOG-marker-gene-fix.md
+++ b/CHANGELOG-marker-gene-fix.md
@@ -1,0 +1,1 @@
+- Fix persistence of selected marker genes after redirect to primary dataset.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -58,6 +58,8 @@ def details(type, uuid):
         if raw_dataset is None or len(raw_dataset) == 0:
             abort(404)
 
+        marker = request.args.get('marker') or None
+
         # Redirect to the primary dataset
         return redirect(
             url_for('routes_browse.details',
@@ -66,7 +68,8 @@ def details(type, uuid):
                     _anchor=anchor,
                     redirected=True,
                     redirectedFromId=entity.get('hubmap_id'),
-                    redirectedFromPipeline=entity.get('pipeline')))
+                    redirectedFromPipeline=entity.get('pipeline'),
+                    marker=marker))
 
     if type != actual_type:
         return redirect(url_for('routes_browse.details', type=actual_type, uuid=uuid))


### PR DESCRIPTION
## Summary

This PR fixes a regression observed when navigating from the biological query results, where a marker gene is provided as part of the URL params. Due to the logic to redirect to the unified primary dataset page not explicitly including the marker param, this param has been getting dropped since the implementation of unified views.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1073

## Testing

Locally tested by following reproduction steps in original ticket.

## Screenshots/Video

![image](https://github.com/user-attachments/assets/48cad6e7-fb03-48f5-83d5-c6ccff91aa19)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
