### PR TITLE
NickAkhmetov/Fix publications page crashing when supporting json data is completely missing

### DIFF
--- a/CHANGELOG-fix-publication-regression.md
+++ b/CHANGELOG-fix-publication-regression.md
@@ -1,0 +1,1 @@
+- Fix publications page crashing when supporting json data is completely missing.

--- a/context/app/static/js/pages/Publication/Publication.jsx
+++ b/context/app/static/js/pages/Publication/Publication.jsx
@@ -30,7 +30,7 @@ function Publication({ publication, vignette_json }) {
   const shouldDisplaySection = {
     summary: true,
     data: true,
-    visualizations: vignette_json?.vignettes.length > 0 && Boolean(Object.keys(vignette_json).length),
+    visualizations: vignette_json?.vignettes?.length > 0 && Boolean(Object.keys(vignette_json).length),
     files: Boolean(files?.length),
     'bulk-data-transfer': true,
     authors: true,


### PR DESCRIPTION
## Summary

This PR adjusts the condition for whether to display the visualizations section of the publication page so that the `.length` property is not accidentally accessed from a missing/undefined vignettes list.

## Design Documentation/Original Tickets

Commit 5e5f263 introduced this issue while attempting to fix handling of empty vignette lists in present json files.

## Testing

Manually tested locally with all publications on dev and test environments to confirm no crash occurs.

## Screenshots/Video

N/A

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
