### PR TITLE
NickAkhmetov/CAT-1122, CAT-1123, CAT-1125, CAT-1126 Cellpop Fixes

### DIFF
--- a/CHANGELOG-cellpop-fixes.md
+++ b/CHANGELOG-cellpop-fixes.md
@@ -1,3 +1,4 @@
+- Fix missing space and period in Azimuth link above cell population chart.
 - Fix organ page crashing when marking dataset as visible while another dataset is expanded.
 - Fix field outline overlapping with label of heatmap normalization control.
 - Fix overlapping between violins in Cellpop visualizations.

--- a/CHANGELOG-cellpop-fixes.md
+++ b/CHANGELOG-cellpop-fixes.md
@@ -1,0 +1,3 @@
+- Fix organ page crashing when marking dataset as visible while another dataset is expanded.
+- Fix field outline overlapping with label of heatmap normalization control.
+- Fix overlapping between violins in Cellpop visualizations.

--- a/context/app/static/js/components/organ/CellPop/CellPopDescription.tsx
+++ b/context/app/static/js/components/organ/CellPop/CellPopDescription.tsx
@@ -39,8 +39,8 @@ export default function CellPopDescription() {
         </LabelledSectionText>,
       ]}
     >
-      This interactive heatmap visualizes cell populations in datasets from this organ. Cell type annotations are from
-      <OutboundIconLink href="https://azimuth.hubmapconsortium.org/">Azimuth.</OutboundIconLink> Key features are
+      This interactive heatmap visualizes cell populations in datasets from this organ. Cell type annotations are from{' '}
+      <OutboundIconLink href="https://azimuth.hubmapconsortium.org/">Azimuth</OutboundIconLink>. Key features are
       highlighted below and a tutorial is available.
     </SectionDescription>
   );

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -40,7 +40,7 @@
         "@visx/text": "^3.3.0",
         "@visx/tooltip": "^3.3.0",
         "@xyflow/react": "^12.0.3",
-        "cellpop": "^0.0.7",
+        "cellpop": "^0.0.8",
         "chart.js": "^4.4.2",
         "d3": "^7.9.0",
         "d3-array": "^3.2.4",
@@ -14924,9 +14924,9 @@
       }
     },
     "node_modules/cellpop": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/cellpop/-/cellpop-0.0.7.tgz",
-      "integrity": "sha512-fNsf0D+/8TSYeMASw0sic2E6yWs1+XbzkETSrkOxXevmJSE8WFvLhaITGLWctSW/r4J5RbDsEIRHL3pV1VhXdA==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/cellpop/-/cellpop-0.0.8.tgz",
+      "integrity": "sha512-96HVtZTEd6qPp2jH8LO0QN8N64L0SUXnL69ul3du3enHRpIut5nOWOXnb5Kdu7AFundMXkXVfpp0Y+xObV24bg==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/context/package.json
+++ b/context/package.json
@@ -33,7 +33,7 @@
     "@visx/text": "^3.3.0",
     "@visx/tooltip": "^3.3.0",
     "@xyflow/react": "^12.0.3",
-    "cellpop": "^0.0.7",
+    "cellpop": "^0.0.8",
     "chart.js": "^4.4.2",
     "d3": "^7.9.0",
     "d3-array": "^3.2.4",


### PR DESCRIPTION
## Summary

This PR contains fixes for several cellpop issues which were identified during QA testing.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1122
https://hms-dbmi.atlassian.net/browse/CAT-1123
https://hms-dbmi.atlassian.net/browse/CAT-1125
https://hms-dbmi.atlassian.net/browse/CAT-1126

## Testing

Manually tested.

## Screenshots/Video

CAT-1122 - fixed Azimuth link, removed period from inside link.
![image](https://github.com/user-attachments/assets/8dc88da1-b59f-40ed-834c-2b01bcda70b8)

The other fixes were made upstream and published in cellpop 0.0.8.

CAT-1123 - Fixed cellpop crash which occured from changing row visibility while another row is expanded. Also implemented behavior to control expand/hide behavior:
* Expanding a hidden row now marks the row as visible
* Hiding an expanded row now collapses the row

https://github.com/user-attachments/assets/007b4763-97be-4d03-befb-c9613ca088a2

CAT-1125 - Fixed `Heatmap Normalization` label line overlapping with label.
![image](https://github.com/user-attachments/assets/b876da83-7d10-441f-917c-dbdd8900f19f)

CAT-1126 - Fix overlap between violins on charts with few datasets

![image](https://github.com/user-attachments/assets/117cdec5-0225-4c5d-b06a-04b744dd6d51)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
