### PR TITLE
Austenem/CAT-1085 Add sample workspace banner

### DIFF
--- a/CHANGELOG-add-sample-workspace-banner.md
+++ b/CHANGELOG-add-sample-workspace-banner.md
@@ -1,0 +1,1 @@
+- Add an info banner to template pages without sample workspaces.

--- a/context/app/static/js/pages/Template/Template.tsx
+++ b/context/app/static/js/pages/Template/Template.tsx
@@ -25,6 +25,9 @@ import { DEFAULT_JOB_TYPE } from 'js/components/workspaces/constants';
 import { useAppContext } from 'js/components/Contexts';
 import { buildSearchLink } from 'js/components/search/store';
 
+const sampleWorkspacesDescription =
+  'Sample workspaces are provided to help you get started with this template and to better understand the types of data that are compatible with it.';
+
 interface SampleWorkspacesInfoBannerProps {
   hasSampleWorkspaces: boolean;
 }
@@ -33,15 +36,14 @@ function SampleWorkspacesInfoBanner({ hasSampleWorkspaces }: SampleWorkspacesInf
     return <IconPanel status="info">No sample workspaces are currently available for this template.</IconPanel>;
   }
 
-  return isAuthenticated ? (
-    <IconPanel status="info">
-      Sample workspaces are provided to help you get started with this template and to better understand the types of
-      data that are compatible with it.
-    </IconPanel>
-  ) : (
+  if (isAuthenticated) {
+    return <IconPanel status="info">{sampleWorkspacesDescription}</IconPanel>;
+  }
+
+  return (
     <LogInPanel trackingInfo={{ category: WorkspacesEventCategories.WorkspaceTemplateDetailPage }}>
-      Sample workspaces are available to help you get started with this template and better understand the types of
-      compatible data. Please <InternalLink href="/login">log in</InternalLink> to explore a sample workspace.
+      {sampleWorkspacesDescription} Please <InternalLink href="/login">log in</InternalLink> to explore a sample
+      workspace.
     </LogInPanel>
   );
 }

--- a/context/app/static/js/pages/Template/Template.tsx
+++ b/context/app/static/js/pages/Template/Template.tsx
@@ -25,6 +25,27 @@ import { DEFAULT_JOB_TYPE } from 'js/components/workspaces/constants';
 import { useAppContext } from 'js/components/Contexts';
 import { buildSearchLink } from 'js/components/search/store';
 
+interface SampleWorkspacesInfoBannerProps {
+  hasSampleWorkspaces: boolean;
+}
+function SampleWorkspacesInfoBanner({ hasSampleWorkspaces }: SampleWorkspacesInfoBannerProps) {
+  if (!hasSampleWorkspaces) {
+    return <IconPanel status="info">No sample workspaces are currently available for this template.</IconPanel>;
+  }
+
+  return isAuthenticated ? (
+    <IconPanel status="info">
+      Sample workspaces are provided to help you get started with this template and to better understand the types of
+      data that are compatible with it.
+    </IconPanel>
+  ) : (
+    <LogInPanel trackingInfo={{ category: WorkspacesEventCategories.WorkspaceTemplateDetailPage }}>
+      Sample workspaces are available to help you get started with this template and better understand the types of
+      compatible data. Please <InternalLink href="/login">log in</InternalLink> to explore a sample workspace.
+    </LogInPanel>
+  );
+}
+
 interface ExampleAccordionProps {
   example: TemplateExample;
   templateKey: string;
@@ -170,33 +191,20 @@ function Template({ templateKey }: TemplatePageProps) {
           )}
         </Stack>
       </Stack>
-      {template.examples && (
-        <Stack spacing={1}>
-          <Typography variant="h4">Sample Workspaces</Typography>
-          {isAuthenticated ? (
-            <IconPanel status="info">
-              Sample workspaces are provided to help you get started with this template and to better understand the
-              types of data that are compatible with it.
-            </IconPanel>
-          ) : (
-            <LogInPanel trackingInfo={{ category: WorkspacesEventCategories.WorkspaceTemplateDetailPage }}>
-              Sample workspaces are available to help you get started with this template and better understand the types
-              of compatible data. Please <InternalLink href="/login">log in</InternalLink> to explore a sample
-              workspace.
-            </LogInPanel>
-          )}
-          {template.examples.map((example, idx) => (
-            <ExampleAccordion
-              key={example.title}
-              example={example}
-              templateKey={templateKey}
-              templateName={template.title}
-              jobType={template.job_types?.[0]}
-              defaultExpanded={idx === 0}
-            />
-          ))}
-        </Stack>
-      )}
+      <Stack spacing={1}>
+        <Typography variant="h4">Sample Workspaces</Typography>
+        <SampleWorkspacesInfoBanner hasSampleWorkspaces={template.examples?.length > 0} />
+        {template.examples?.map((example, idx) => (
+          <ExampleAccordion
+            key={example.title}
+            example={example}
+            templateKey={templateKey}
+            templateName={template.title}
+            jobType={template.job_types?.[0]}
+            defaultExpanded={idx === 0}
+          />
+        ))}
+      </Stack>
     </Stack>
   );
 }


### PR DESCRIPTION
## Summary

Adds an info banner to template pages without sample workspaces.

## Design Documentation/Original Tickets

[CAT-1085 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1085?atlOrigin=eyJpIjoiZGY3MTFkZmUzNGI2NGRkMzg3ZTdkNDA3MWFjNWU1MWYiLCJwIjoiaiJ9)

## Screenshots/Video

Local:
<img width="1050" alt="Screenshot 2025-02-03 at 12 34 11 PM" src="https://github.com/user-attachments/assets/225b5f08-effb-4b46-876f-799942084cd6" />

Prod:
<img width="1054" alt="Screenshot 2025-02-03 at 12 34 29 PM" src="https://github.com/user-attachments/assets/f9965ec5-1212-4b5e-a1e7-3029683d6c2e" />


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
