### PR TITLE
Austenem/CAT-1118 Check for missing symlinks

### DIFF
--- a/CHANGELOG-check-for-missing-symlinks.md
+++ b/CHANGELOG-check-for-missing-symlinks.md
@@ -1,0 +1,1 @@
+- Add checks before trying to access a workspace's symlinked files (resolves 2023 workspaces API bug).

--- a/context/app/static/js/helpers/functions.ts
+++ b/context/app/static/js/helpers/functions.ts
@@ -206,6 +206,7 @@ export function generateCommaList(list: string[]): string {
  * @author Austen Money
  * @param workspace the workspace to check.
  * @returns true if the workspace has reached the maximum number of datasets allowed, false otherwise.
+ * @note must also check for each of the workspace details being null or undefined in case of malformed workspace.
  */
 export function isWorkspaceAtDatasetLimit(workspace: MergedWorkspace) {
   return workspace.workspace_details?.current_workspace_details?.symlinks?.length >= MAX_NUMBER_OF_WORKSPACE_DATASETS;

--- a/context/app/static/js/helpers/functions.ts
+++ b/context/app/static/js/helpers/functions.ts
@@ -208,7 +208,7 @@ export function generateCommaList(list: string[]): string {
  * @returns true if the workspace has reached the maximum number of datasets allowed, false otherwise.
  */
 export function isWorkspaceAtDatasetLimit(workspace: MergedWorkspace) {
-  return workspace.workspace_details.current_workspace_details.symlinks.length >= MAX_NUMBER_OF_WORKSPACE_DATASETS;
+  return workspace.workspace_details?.current_workspace_details?.symlinks?.length >= MAX_NUMBER_OF_WORKSPACE_DATASETS;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds checks before trying to access a workspace's symlinked files (resolves 2023 workspaces API bug that resulted in malformed workspaces with empty `current_workspace_details` objects).

## Design Documentation/Original Tickets

[CAT-1118 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1118?atlOrigin=eyJpIjoiOTU3NmNkNDY5ZjI3NDkxOWI5NDdkYTU3YzgyNjAyYzEiLCJwIjoiaiJ9)

## Testing

Was able to reproduce the original error by calling `isWorkspaceAtDatasetLimit` on a workspace with a manually deleted `current_workspace_details` object, and used the same method to confirm that the issue was resolved by this fix.

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
