### PR TITLE
NickAkhmetov/CAT-1126, CAT-1129, CAT-1130, More cellpop fixes

### DIFF
--- a/CHANGELOG-even-more-cellpop-fixes.md
+++ b/CHANGELOG-even-more-cellpop-fixes.md
@@ -1,0 +1,3 @@
+- Fix overlap between expanded rows and violins when there are few datasets in cellpop visualization.
+- Fix cellpop control position breaking on scroll.
+- Fix cellpop expanded rows handling when data is being normalized.

--- a/context/package-lock.json
+++ b/context/package-lock.json
@@ -40,7 +40,7 @@
         "@visx/text": "^3.3.0",
         "@visx/tooltip": "^3.3.0",
         "@xyflow/react": "^12.0.3",
-        "cellpop": "^0.0.8",
+        "cellpop": "^0.0.10",
         "chart.js": "^4.4.2",
         "d3": "^7.9.0",
         "d3-array": "^3.2.4",
@@ -14924,9 +14924,9 @@
       }
     },
     "node_modules/cellpop": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/cellpop/-/cellpop-0.0.8.tgz",
-      "integrity": "sha512-96HVtZTEd6qPp2jH8LO0QN8N64L0SUXnL69ul3du3enHRpIut5nOWOXnb5Kdu7AFundMXkXVfpp0Y+xObV24bg==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cellpop/-/cellpop-0.0.10.tgz",
+      "integrity": "sha512-PIKoUvjDH2ILDdYtmYmTiPOgP1g2/uziTDAQLLBkkxRwJPZt8MyBCTwZYhb4qGtDVRUNojX6RGYwIPlEvcwBhQ==",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",

--- a/context/package.json
+++ b/context/package.json
@@ -33,7 +33,7 @@
     "@visx/text": "^3.3.0",
     "@visx/tooltip": "^3.3.0",
     "@xyflow/react": "^12.0.3",
-    "cellpop": "^0.0.8",
+    "cellpop": "^0.0.10",
     "chart.js": "^4.4.2",
     "d3": "^7.9.0",
     "d3-array": "^3.2.4",


### PR DESCRIPTION
## Summary

This PR fixes more cellpop issues identified during QA. These fixes were all made upstream in the cellpop repo: https://github.com/hms-dbmi/cellpop/pull/61/files/c40d27ad973107909b419946667d013fa3e6a761..1afd50d044a915b81cf720742ffddd5e934ffe76

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1126
https://hms-dbmi.atlassian.net/browse/CAT-1129
https://hms-dbmi.atlassian.net/browse/CAT-1130

## Testing

Manual testing

## Screenshots/Video

CAT-1126 - fixed overlap between expanded bar chart scale and violins/bars when there were few rows
CAT-1129 - fixed background color for heatmap normalization label
CAT-1130 - prevent scrolling while plot controls modal is open
Additionally, the expanded bar chart now displays normalized data.
![image](https://github.com/user-attachments/assets/f405d4b2-9ab6-4a25-bd00-0d45bad7380f)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
