### PR TITLE
Austenem/Workspace title fixes

### DIFF
--- a/CHANGELOG-workspace-title-fixes.md
+++ b/CHANGELOG-workspace-title-fixes.md
@@ -1,0 +1,1 @@
+- Fix bug causing workspace title field in new workspace dialog to be cleared.

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -50,7 +50,6 @@ function ProcessedDataWorkspaceMenu({
     dialogIsOpen: createWorkspaceIsOpen,
     ...rest
   } = useCreateWorkspaceForm({
-    defaultName: hubmap_id,
     initialSelectedDatasets: [uuid].filter(Boolean),
   });
 

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -149,9 +149,8 @@ function useCreateWorkspaceForm({
     // Necessary to update dialog state between different processed datasets on detail pages
     if (initialSelectedDatasets && initialSelectedDatasets.length !== 0) {
       setValue('datasets', initialSelectedDatasets);
-      setValue('workspace-name', checkedWorkspaceName);
     }
-  }, [initialProtectedDatasets, initialSelectedDatasets, checkedWorkspaceName, setValue]);
+  }, [initialProtectedDatasets, initialSelectedDatasets, setValue]);
 
   useEffect(() => {
     if (dialogIsOpen) {


### PR DESCRIPTION
## Summary

Small fix for bug causing workspace title field in new workspace dialog (or the first character) to be cleared upon some form updates.

## Design Documentation/Original Tickets

[CAT-1127 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1127?atlOrigin=eyJpIjoiNzM2YzA0NGQxMDZhNGY0YzhlYjFiZmY3ZTJjNmU5NWUiLCJwIjoiaiJ9)

[CAT-1075 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1075?atlOrigin=eyJpIjoiODYyN2JjOTdjNWI1NDUwMjgxNjVjNjVhYWZmNGU5NmEiLCJwIjoiaiJ9)

## Testing

Tested by going through all entry points for the new workspace dialog and ensuring the issue is resolved without any regressions.

(Note: to reproduce the original issue, datasets must be selected or you must enter the dialog from a detail page). 

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added