### PR TITLE
Austenem/CAT-1074 Fix protected datasets bug

### DIFF
--- a/CHANGELOG-fix-protected-datasets-bug.md
+++ b/CHANGELOG-fix-protected-datasets-bug.md
@@ -1,0 +1,1 @@
+- Fix bug allowing non-public datasets to be added to workspaces.

--- a/context/app/static/js/hooks/useProtectedDatasets.tsx
+++ b/context/app/static/js/hooks/useProtectedDatasets.tsx
@@ -11,7 +11,8 @@ function useDatasetsAccessLevel(ids: string[]) {
   const query = {
     query: {
       bool: {
-        must: [getIDsQuery(ids), getTermClause('mapped_data_access_level.keyword', 'Protected')],
+        must: [getIDsQuery(ids)],
+        must_not: [getTermClause('mapped_data_access_level.keyword', 'Public')],
       },
     },
     _source: ['mapped_data_access_level', 'hubmap_id', 'uuid'],
@@ -35,6 +36,7 @@ function useProtectedDatasetsForm({
 }: useProtectedDatasetsFormProps) {
   const { toastSuccessRemoveProtectedDatasets } = useWorkspaceToasts();
   const protectedRows = useDatasetsAccessLevel(selectedRows.size > 0 ? [...selectedRows] : []).datasets;
+
   const containsProtectedDataset = protectedRows.length > 0;
 
   const reportedProtectedRows = useRef(false);


### PR DESCRIPTION
## Summary

Fix bug allowing non-public datasets to be added to workspaces.

## Design Documentation/Original Tickets

[CAT-1074 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1074?atlOrigin=eyJpIjoiYWU3YjM3ODQ5ZDM0NDk3MWI2NzhmMjQ3ZjgzYWRmZTIiLCJwIjoiaiJ9)

## Testing

Tested by attempting to add various combinations of public and non-public datasets from the search page to a workspace.

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
