### PR TITLE
Austenem/CAT-1037 Sort homepage publications

### DIFF
--- a/CHANGELOG-sort-homepage-publications.md
+++ b/CHANGELOG-sort-homepage-publications.md
@@ -1,0 +1,1 @@
+- Sort "Recent Publications" on home page by publication date.

--- a/context/app/static/js/components/home/RecentEntities/queries.ts
+++ b/context/app/static/js/components/home/RecentEntities/queries.ts
@@ -42,7 +42,7 @@ export const recentPublicationsQuery: SearchRequest = {
   },
   sort: [
     {
-      last_modified_timestamp: {
+      'publication_date.keyword': {
         order: 'desc',
       },
     },
@@ -55,7 +55,7 @@ export const recentPublicationsQuery: SearchRequest = {
     'publication_status',
     'publication_venue',
     'publication_date',
-    'last_modified_timestamp',
+    'published_timestamp',
   ],
 };
 

--- a/context/app/static/js/components/home/RecentEntities/queries.ts
+++ b/context/app/static/js/components/home/RecentEntities/queries.ts
@@ -48,15 +48,7 @@ export const recentPublicationsQuery: SearchRequest = {
     },
   ],
   size: 6,
-  _source: [
-    'uuid',
-    'title',
-    'contributors',
-    'publication_status',
-    'publication_venue',
-    'publication_date',
-    'published_timestamp',
-  ],
+  _source: ['uuid', 'title', 'contributors', 'publication_status', 'publication_venue', 'publication_date'],
 };
 
 // Fetches the most recent datasets with a visualization


### PR DESCRIPTION
## Summary

Sorts "Recent Publications" on home page by publication date.

## Design Documentation/Original Tickets

[CAT-1037 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1037?atlOrigin=eyJpIjoiNGQzNGU1YTRlZDc5NDFlOGJjMjJjYWQ0ZjhhMmU2ZTgiLCJwIjoiaiJ9)

## Screenshots/Video

Local:
<img width="635" alt="Screenshot 2025-02-10 at 2 31 46 PM" src="https://github.com/user-attachments/assets/d70b82bc-1c27-423f-9f9e-9a69048d1303" />

Prod:
<img width="640" alt="Screenshot 2025-02-10 at 2 32 05 PM" src="https://github.com/user-attachments/assets/34110267-6321-4c95-a177-32d06e859efa" />


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
