### PR TITLE
NickAkhmetov/CAT-1147 Fix display of provenance table for datasets with large ancestor trees

### DIFF
--- a/CHANGELOG-cat-1147.md
+++ b/CHANGELOG-cat-1147.md
@@ -1,0 +1,1 @@
+- Fix display of provenance table for datasets with large ancestor trees.

--- a/context/app/static/js/hooks/useEntityData.ts
+++ b/context/app/static/js/hooks/useEntityData.ts
@@ -7,6 +7,7 @@ export const useEntityQuery = (uuid: string | string[], source?: string[]) => {
     () => ({
       query: { ids: { values: typeof uuid === 'string' ? [uuid] : uuid } },
       _source: source,
+      size: 10000,
     }),
     [uuid, source],
   );


### PR DESCRIPTION
## Summary

This PR fixes the display of provenance tables for datasets with more than 10 ancestors. Since there was no size specified on the relevant query, not all ancestor information was being loaded, which caused error tiles to show up instead for every ancestor ID that was listed in the entity's data and was not reflected in the follow-up query.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1147

## Testing

Manually tested

## Screenshots/Video

![image](https://github.com/user-attachments/assets/b57065e1-7c30-4107-b2b2-de3e32597e69)

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

