### PR TITLE
John conroy/fix range filter CAT-1093

### DIFF
--- a/CHANGELOG-fix-range-filter.md
+++ b/CHANGELOG-fix-range-filter.md
@@ -1,0 +1,1 @@
+- Fix bug on search pages where range filter was not applied if the min value is zero.

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -108,7 +108,7 @@ export function buildQuery({
 
       if (isRangeFilter(filter) || isDateFilter(filter)) {
         if (filterHasValues({ filter })) {
-          if (filter.values.min && filter.values.max) {
+          if (filter?.values?.min !== undefined && filter?.values?.max) {
             // TODO: consider using zod in filterHasValues for validation.
             draft[portalField] = esb.rangeQuery(portalField).gte(filter.values.min).lte(filter.values.max);
           }


### PR DESCRIPTION
## Summary

- Fix bug on search pages where range filter was not applied if the min value is zero.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added