### PR TITLE
John conroy/fix search menu styles CAT-762

### DIFF
--- a/CHANGELOG-fix-search-menu-styles.md
+++ b/CHANGELOG-fix-search-menu-styles.md
@@ -1,0 +1,1 @@
+- Update search page menu styles.

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -30,7 +30,7 @@ function NewWorkspaceDialogFromSelections() {
   return (
     <>
       <MenuItem onClick={() => setDialogIsOpen(true)}>
-        <SvgIcon component={WorkspacesIcon} sx={{ mr: 1, fontSize: '1.25rem' }} />
+        <SvgIcon component={WorkspacesIcon} sx={{ mr: 1, fontSize: '1.25rem' }} color="primary" />
         Create New Workspace
       </MenuItem>
       <NewWorkspaceDialog

--- a/context/app/static/js/components/workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu.tsx
+++ b/context/app/static/js/components/workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu.tsx
@@ -47,7 +47,7 @@ function WorkspaceDropdownMenuItem({ dialogType, children, icon: Icon }: Workspa
   const onClick = useOpenDialog(dialogType);
   return (
     <MenuItem onClick={onClick}>
-      <Icon sx={{ mr: 1, fontSize: '1.25rem' }} />
+      <Icon sx={{ mr: 1, fontSize: '1.25rem' }} color="primary" />
       {children}
     </MenuItem>
   );
@@ -68,7 +68,7 @@ function WorkspaceDropdownMenu({ type }: MetadataMenuProps) {
   }
   return (
     <>
-      <StyledDropdownMenuButton menuID={menuID} variant="contained">
+      <StyledDropdownMenuButton menuID={menuID} variant="outlined">
         <SvgIcon component={WorkspacesIcon} sx={{ mr: 1, fontSize: '1.25rem' }} />
         Workspaces
       </StyledDropdownMenuButton>


### PR DESCRIPTION
## Summary

- Update search page menu styles.

Tiffany asked that all menus be outlined outside of the tile sort dropdown. I've also updated the icons in the workspaces menu to be primary in color.

## Screenshots/Video

<img width="1259" alt="Screenshot 2025-02-20 at 10 51 15 AM" src="https://github.com/user-attachments/assets/e74f28ec-44ee-4728-90db-e29e84aaa297" />

<img width="1271" alt="Screenshot 2025-02-20 at 10 51 24 AM" src="https://github.com/user-attachments/assets/20507c54-0b19-4da5-9b5c-c83aa7b57e6c" />

<img width="1288" alt="Screenshot 2025-02-20 at 10 51 32 AM" src="https://github.com/user-attachments/assets/376821a1-164b-40a0-a55a-34c3e8ef63c9" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
