### PR TITLE
John conroy/fix blood chart casing CAT-1179

### DIFF
--- a/CHANGELOG-fix-blood-chart-casing.md
+++ b/CHANGELOG-fix-blood-chart-casing.md
@@ -1,0 +1,1 @@
+- Fix casing of ABO blood group chart titles on diversity page.

--- a/context/app/static/js/pages/Diversity/DonorChart.jsx
+++ b/context/app/static/js/pages/Diversity/DonorChart.jsx
@@ -122,7 +122,7 @@ function DonorChart({ xAxis, groups }) {
   };
   const colorKeys = colorKeysMap[groups];
   const xAxisLabel = xAxisLabelMap?.[xKey] ?? pretty(xAxis);
-  const title = `${pretty(xAxis)} & ${pretty(groups)}`;
+  const title = `${xAxisLabel} & ${pretty(groups)}`;
   const description = [xAxis, groups].includes('abo_blood_group_system') ? <BloodTypeDescription /> : null;
 
   return (


### PR DESCRIPTION
## Summary

- Fix casing of ABO blood group chart titles on diversity page.

## Screenshots/Video

<img width="1309" alt="Screenshot 2025-02-24 at 1 38 31 PM" src="https://github.com/user-attachments/assets/dc158821-bda8-484a-91a5-a771bfc17a54" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added