### PR TITLE
NickAkhmetov/CAT-1119 SnareSeq2/Multi-Assay Changes

### DIFF
--- a/CHANGELOG-cat-1119.md
+++ b/CHANGELOG-cat-1119.md
@@ -1,0 +1,1 @@
+- Update unified dataset detail page to improve clarity surrounding SnareSeq2 datasets.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -6,7 +6,7 @@ from flask import (
     abort, request, redirect, url_for, Response)
 
 from .utils import (
-    get_default_flask_data, make_blueprint, get_client,
+    find_sibling_datasets, get_default_flask_data, make_blueprint, get_client,
     get_url_base_from_request, entity_types, find_raw_dataset_ancestor,
     should_redirect_entity)
 
@@ -76,12 +76,18 @@ def details(type, uuid):
 
     redirected = request.args.get('redirected') == 'True'
 
+    sibling_ids = []
+
+    if entity['entity_type'].lower() == 'dataset':
+        sibling_ids = find_sibling_datasets(client, entity)
+
     flask_data = {
         **get_default_flask_data(),
         'entity': entity,
         'redirected': redirected,
         'redirectedFromId': request.args.get('redirectedFromId'),
-        'redirectedFromPipeline': request.args.get('redirectedFromPipeline')
+        'redirectedFromPipeline': request.args.get('redirectedFromPipeline'),
+        'siblingIds': sibling_ids
     }
 
     if type == 'publication':

--- a/context/app/static/js/components/Contexts.tsx
+++ b/context/app/static/js/components/Contexts.tsx
@@ -12,6 +12,7 @@ export interface FlaskDataContextType {
   redirected?: boolean;
   redirectedFromId?: string | null;
   redirectedFromPipeline?: string | null;
+  siblingIds?: string[];
 }
 
 export const FlaskDataContext = createContext<FlaskDataContextType>('FlaskDataContext');

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
@@ -6,7 +6,7 @@ import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPag
 import { FilesContextProvider } from 'js/components/detailPage/files/FilesContext';
 import { Tabs, Tab, TabPanel } from 'js/shared-styles/tables/TableTabs';
 import { DetailSectionPaper } from 'js/shared-styles/surfaces';
-import { InternalLink, OutboundLink } from 'js/shared-styles/Links';
+import { OutboundLink } from 'js/shared-styles/Links';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { sectionIconMap } from 'js/shared-styles/icons/sectionIconMap';
 import { SectionDescription } from 'js/shared-styles/sections/SectionDescription';
@@ -15,8 +15,7 @@ import { LINKS } from 'js/components/bulkDownload/constants';
 import BulkDownloadSuccessAlert from 'js/components/bulkDownload/BulkDownloadSuccessAlert';
 import BulkDataTransferPanels from './BulkDataTransferPanels';
 import { useProcessedDatasetTabs } from '../ProcessedData/ProcessedDataset/hooks';
-import { useIsMultiAssay } from '../multi-assay/hooks';
-import { DetailPageAlert } from '../style';
+import SnareSeq2Alert from '../multi-assay/SnareSeq2Alert';
 
 const description = (
   <Typography>
@@ -27,27 +26,6 @@ const description = (
     processed data has separate download directories in Globus or dbGaP, distinct from the raw data directory.
   </Typography>
 );
-
-function SnareSeq2Alert() {
-  const { isSnareSeq2 } = useIsMultiAssay();
-  if (!isSnareSeq2) return null;
-  return (
-    <DetailPageAlert
-      severity="info"
-      sx={{
-        '.MuiAlert-message': {
-          flexGrow: 1,
-        },
-      }}
-    >
-      SNARE-seq2 processed datasets are derived from multiple primary raw datasets. All relevant primary raw datasets
-      are available for download in this section, depending on your access permissions. To better understand the dataset
-      relationships, scroll to the{' '}
-      <InternalLink href="#section-dataset-relationships">Dataset Relationship</InternalLink> section or explore the{' '}
-      <InternalLink href="#provenance">provenance graph</InternalLink>.
-    </DetailPageAlert>
-  );
-}
 
 function BulkDataTransfer() {
   const tabs = useProcessedDatasetTabs(true, true);

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
@@ -50,7 +50,7 @@ function SnareSeq2Alert() {
 }
 
 function BulkDataTransfer() {
-  const tabs = useProcessedDatasetTabs();
+  const tabs = useProcessedDatasetTabs(true);
   const uuids = new Set(tabs.map((tab) => tab.uuid));
 
   const [openTabIndex, setOpenTabIndex] = useState(0);
@@ -76,6 +76,8 @@ function BulkDataTransfer() {
           onChange={(_, newValue) => {
             setOpenTabIndex(newValue as number);
           }}
+          variant="scrollable"
+          scrollButtons="auto"
         >
           {tabs.map(({ label, icon: Icon }, index) => (
             <Tab key={label} label={label} index={index} icon={Icon ? <Icon /> : undefined} iconPosition="start" />

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
@@ -6,7 +6,7 @@ import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPag
 import { FilesContextProvider } from 'js/components/detailPage/files/FilesContext';
 import { Tabs, Tab, TabPanel } from 'js/shared-styles/tables/TableTabs';
 import { DetailSectionPaper } from 'js/shared-styles/surfaces';
-import { OutboundLink } from 'js/shared-styles/Links';
+import { InternalLink, OutboundLink } from 'js/shared-styles/Links';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { sectionIconMap } from 'js/shared-styles/icons/sectionIconMap';
 import { SectionDescription } from 'js/shared-styles/sections/SectionDescription';
@@ -15,6 +15,8 @@ import { LINKS } from 'js/components/bulkDownload/constants';
 import BulkDownloadSuccessAlert from 'js/components/bulkDownload/BulkDownloadSuccessAlert';
 import BulkDataTransferPanels from './BulkDataTransferPanels';
 import { useProcessedDatasetTabs } from '../ProcessedData/ProcessedDataset/hooks';
+import { useIsMultiAssay } from '../multi-assay/hooks';
+import { DetailPageAlert } from '../style';
 
 const description = (
   <Typography>
@@ -25,6 +27,27 @@ const description = (
     processed data has separate download directories in Globus or dbGaP, distinct from the raw data directory.
   </Typography>
 );
+
+function SnareSeq2Alert() {
+  const { isSnareSeq2 } = useIsMultiAssay();
+  if (!isSnareSeq2) return null;
+  return (
+    <DetailPageAlert
+      severity="info"
+      sx={{
+        '.MuiAlert-message': {
+          flexGrow: 1,
+        },
+      }}
+    >
+      SNARE-seq2 processed datasets are derived from multiple primary raw datasets. All relevant primary raw datasets
+      are available for download in this section, depending on your access permissions. To better understand the dataset
+      relationships, scroll to the{' '}
+      <InternalLink href="#section-dataset-relationships">Dataset Relationship</InternalLink> section or explore the{' '}
+      <InternalLink href="#provenance">provenance graph</InternalLink>.
+    </DetailPageAlert>
+  );
+}
 
 function BulkDataTransfer() {
   const tabs = useProcessedDatasetTabs();
@@ -39,6 +62,7 @@ function BulkDataTransfer() {
       title="Bulk Data Transfer"
       icon={sectionIconMap['bulk-data-transfer']}
     >
+      <SnareSeq2Alert />
       <FilesContextProvider>
         <BulkDownloadSuccessAlert />
         <SectionDescription>

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
@@ -50,7 +50,7 @@ function SnareSeq2Alert() {
 }
 
 function BulkDataTransfer() {
-  const tabs = useProcessedDatasetTabs(true);
+  const tabs = useProcessedDatasetTabs(true, true);
   const uuids = new Set(tabs.map((tab) => tab.uuid));
 
   const [openTabIndex, setOpenTabIndex] = useState(0);

--- a/context/app/static/js/components/detailPage/DatasetRelationships/DatasetRelationships.tsx
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/DatasetRelationships.tsx
@@ -22,7 +22,7 @@ interface DatasetRelationshipsVisualizationProps {
 
 function DatasetRelationshipsHeader() {
   return (
-    <Stack direction="column" gap={1} px={1}>
+    <Stack direction="column" gap={1} px={1} id="section-dataset-relationships">
       <Typography variant="subtitle1">Dataset Relationship Diagram</Typography>
       <Stack direction="row" gap={1} alignItems="center">
         <InfoIcon color="primary" />

--- a/context/app/static/js/components/detailPage/DatasetRelationships/DatasetRelationships.tsx
+++ b/context/app/static/js/components/detailPage/DatasetRelationships/DatasetRelationships.tsx
@@ -50,7 +50,7 @@ function ReactFlowBody({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) {
   }
   const label = makeAriaLabel(nodes);
   return (
-    <ReactFlow {...reactFlowConfig} nodes={nodes} edges={edges} aria-label={label}>
+    <ReactFlow {...reactFlowConfig} nodes={nodes} edges={edges} aria-label={label} fitView>
       <Controls showInteractive={false} onFitView={trackFitView} onZoomIn={trackZoomIn} onZoomOut={trackZoomOut} />
     </ReactFlow>
   );

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
@@ -70,8 +70,10 @@ export function useProcessedDatasetDetails(uuid: string) {
   return { datasetDetails, isLoading };
 }
 
-export function useProcessedDatasetTabs(): { label: string; uuid: string; icon: ComponentType | undefined }[] {
-  const { searchHitsWithLabels } = useLabeledProcessedDatasets();
+export function useProcessedDatasetTabs(
+  includeComponents?: boolean,
+): { label: string; uuid: string; icon: ComponentType | undefined }[] {
+  const { searchHitsWithLabels } = useLabeledProcessedDatasets(includeComponents);
   const { entity } = useFlaskDataContext();
 
   if (!isDataset(entity)) {
@@ -102,7 +104,7 @@ export function useProcessedDatasetTabs(): { label: string; uuid: string; icon: 
     .map(({ _source }, _) => ({
       label: _source.label,
       uuid: _source.uuid,
-      icon: nodeIcons.processedDataset,
+      icon: _source.is_component ? nodeIcons.componentDataset : nodeIcons.processedDataset,
     }));
 
   return [primaryDatasetTab, ...processedDatasetTabs];

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
@@ -72,8 +72,9 @@ export function useProcessedDatasetDetails(uuid: string) {
 
 export function useProcessedDatasetTabs(
   includeComponents?: boolean,
+  includeSiblings?: boolean,
 ): { label: string; uuid: string; icon: ComponentType | undefined }[] {
-  const { searchHitsWithLabels } = useLabeledProcessedDatasets(includeComponents);
+  const { searchHitsWithLabels } = useLabeledProcessedDatasets(includeComponents, includeSiblings);
   const { entity } = useFlaskDataContext();
 
   if (!isDataset(entity)) {

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderActionButtons/EntityHeaderActionButtons.tsx
@@ -18,6 +18,7 @@ import { useIsLargeDesktop } from 'js/hooks/media-queries';
 import ProcessedDataWorkspaceMenu from 'js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu';
 import useSavedLists from 'js/components/savedLists/hooks';
 import WorkspacesIcon from 'assets/svg/workspaces.svg';
+import { useDatasetRelationships } from '../../DatasetRelationships/hooks';
 
 function ActionButton<E extends ElementType = IconButtonTypeMap['defaultComponent']>({
   icon: Icon,
@@ -114,15 +115,17 @@ function ViewSelectChip({
 
 const ProcessedDataIcon = sectionIconMap['processed-data'];
 
-function ViewSelectChips({
-  selectedView,
-  setView,
-  entity_type,
-}: {
+interface ViewSelectChipsProps {
   selectedView: SummaryViewsType;
   setView: (v: SummaryViewsType) => void;
-} & { entity_type: AllEntityTypes }) {
-  if (!['Donor', 'Sample', 'Dataset', 'Publication'].includes(entity_type)) {
+  entity_type: AllEntityTypes;
+  uuid: string;
+}
+
+function ViewSelectChips({ selectedView, setView, entity_type, uuid }: ViewSelectChipsProps) {
+  const { shouldDisplay } = useDatasetRelationships(uuid);
+
+  if (!shouldDisplay || !['Donor', 'Sample', 'Dataset', 'Publication'].includes(entity_type)) {
     return null;
   }
 
@@ -178,7 +181,9 @@ function EntityHeaderActionButtons({
 
   return (
     <Stack direction="row" spacing={1} alignItems="center">
-      {isLargeDesktop && <ViewSelectChips selectedView={view} setView={setView} entity_type={entity_type} />}
+      {isLargeDesktop && (
+        <ViewSelectChips selectedView={view} setView={setView} entity_type={entity_type} uuid={uuid} />
+      )}
       <SaveEditEntityButton uuid={uuid} />
       <JSONButton entity_type={entity_type} uuid={uuid} />
       {isDataset && (

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayRelationship/MultiAssayRelationship.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayRelationship/MultiAssayRelationship.tsx
@@ -4,13 +4,12 @@ import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
 import RelatedMultiAssayLinks from '../RelatedMultiAssayLinks';
+import { useIsMultiAssay } from '../hooks';
 
-interface Props {
-  assay_modality: 'single' | 'multiple';
-}
+function MultiAssayRelationship() {
+  const { isMultiAssay } = useIsMultiAssay();
 
-function MultiAssayRelationship({ assay_modality }: Props) {
-  if (assay_modality === 'single') {
+  if (!isMultiAssay) {
     return null;
   }
   return (

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayRelationship/MultiAssayRelationship.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayRelationship/MultiAssayRelationship.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import RelatedMultiAssayLinks from '../RelatedMultiAssayLinks';
+
+interface Props {
+  assay_modality: 'single' | 'multiple';
+}
+
+function MultiAssayRelationship({ assay_modality }: Props) {
+  if (assay_modality === 'single') {
+    return null;
+  }
+  return (
+    <Paper sx={(theme) => ({ p: 2, borderTop: `1px solid ${theme.palette.divider}` })}>
+      <Stack justifyContent="space-between" alignItems="start" pb={2} spacing={2}>
+        <Typography component="h3" variant="h4">
+          Multi-Assay Relationship
+        </Typography>
+        <Typography>
+          This dataset is a component of a multi-assay dataset and the relationships between datasets are displayed
+          below. The current dataset will be highlighted by a green line.
+        </Typography>
+        <RelatedMultiAssayLinks />
+      </Stack>
+    </Paper>
+  );
+}
+
+export default MultiAssayRelationship;

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayRelationship/index.ts
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayRelationship/index.ts
@@ -1,0 +1,3 @@
+import MultiAssayRelationship from './MultiAssayRelationship';
+
+export default MultiAssayRelationship;

--- a/context/app/static/js/components/detailPage/multi-assay/RelatedMultiAssayLinks/RelatedMultiAssayLinks.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/RelatedMultiAssayLinks/RelatedMultiAssayLinks.tsx
@@ -13,17 +13,17 @@ import useRelatedMultiAssayDatasets, { MultiAssayEntity } from '../useRelatedMul
 const text = {
   component: {
     label: 'Component Datasets (Raw)',
-    tooltip: 'Listed are the component datasets that comprise the multi-assay dataset.',
+    tooltip: 'A component dataset is a dataset that comprises the multi-assay dataset.',
   },
   raw: {
     label: 'Primary Dataset (Raw)',
     tooltip:
-      'Listed is the primary multi-assay dataset, which contains comprehensive information about the multi-assay.',
+      'Primary (raw) datasets contain comprehensive information about the multi-assay, as provided by the data providers, and are composed of the component datasets.',
   },
   processed: {
     label: 'Primary Dataset (Processed)',
     tooltip:
-      'Listed is the processed primary multi-assay dataset, which may contain additional multi-assay information including visualizations.',
+      'Processed primary datasets are analyses generated based on primary (raw) datasets by either HuBMAP using uniform processing pipelines or by an external processing approach.',
   },
   current: {
     tooltip: 'Current Dataset | ',

--- a/context/app/static/js/components/detailPage/multi-assay/RelatedMultiAssayLinks/RelatedMultiAssayLinks.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/RelatedMultiAssayLinks/RelatedMultiAssayLinks.tsx
@@ -7,6 +7,7 @@ import { InternalLink } from 'js/shared-styles/Links';
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { useFlaskDataContext } from 'js/components/Contexts';
+import { datasetSectionId } from 'js/pages/Dataset/utils';
 import StatusIcon from '../../StatusIcon';
 import useRelatedMultiAssayDatasets, { MultiAssayEntity } from '../useRelatedMultiAssayDatasets';
 
@@ -24,6 +25,7 @@ const text = {
     label: 'Primary Dataset (Processed)',
     tooltip:
       'Processed primary datasets are analyses generated based on primary (raw) datasets by either HuBMAP using uniform processing pipelines or by an external processing approach.',
+    linkTooltip: (status: string) => `Scroll down to the processed dataset. Status: ${status}`,
   },
   current: {
     tooltip: 'Current Dataset | ',
@@ -37,21 +39,30 @@ type Entries<T> = {
 interface MultiAssayLinkProps {
   dataset: MultiAssayEntity;
   tooltipText?: string;
+  href?: string | null;
 }
 
 function MultiAssayLink({
-  dataset: { assay_display_name, uuid, hubmap_id, status },
+  dataset: { assay_display_name, hubmap_id, status },
   tooltipText,
+  href,
 }: MultiAssayLinkProps) {
+  const link = href ? <InternalLink href={href}>{hubmap_id}</InternalLink> : hubmap_id;
   return (
-    <SecondaryBackgroundTooltip title={tooltipText ?? status}>
-      <Typography>
-        <Stack direction="row" useFlexGap gap={0.5} alignItems="center">
-          {assay_display_name}:<InternalLink href={`/browse/dataset/${uuid}`}>{hubmap_id}</InternalLink>
-          <StatusIcon status={status} />
-        </Stack>
-      </Typography>
-    </SecondaryBackgroundTooltip>
+    <Typography>
+      <Stack direction="row" useFlexGap gap={0.5} alignItems="center">
+        <SecondaryBackgroundTooltip title={tooltipText} disabled={!tooltipText}>
+          <Box display="inline-block" component="span">
+            {assay_display_name}: {link}
+          </Box>
+        </SecondaryBackgroundTooltip>
+        <SecondaryBackgroundTooltip title={`Status: ${status}`}>
+          <Box display="inline-block" component="span">
+            <StatusIcon status={status} />
+          </Box>
+        </SecondaryBackgroundTooltip>
+      </Stack>
+    </Typography>
   );
 }
 
@@ -61,6 +72,24 @@ function CurrentMultiAssayLink({ dataset }: Pick<MultiAssayLinkProps, 'dataset'>
       <MultiAssayLink dataset={dataset} tooltipText={`${text.current.tooltip} ${dataset.status}`} />
     </Box>
   );
+}
+
+function createLinkHref(dataset: MultiAssayEntity) {
+  if (dataset.is_component) {
+    return null;
+  }
+  if (dataset.processing === 'raw') {
+    return `/browse/dataset/${dataset.uuid}`;
+  }
+
+  return `#${datasetSectionId(dataset, 'section')}`;
+}
+
+function createTooltipText(dataset: MultiAssayEntity) {
+  if (dataset.processing !== 'raw') {
+    return text.processed.linkTooltip(dataset.status);
+  }
+  return undefined;
 }
 
 function RelatedMultiAssayLinks() {
@@ -75,6 +104,7 @@ function RelatedMultiAssayLinks() {
     if (v.length === 0) {
       return null;
     }
+
     return (
       <LabelledSectionText label={text?.[key]?.label} key={key} iconTooltipText={text?.[key]?.tooltip}>
         <Stack>
@@ -82,7 +112,12 @@ function RelatedMultiAssayLinks() {
             dataset.uuid === uuid ? (
               <CurrentMultiAssayLink dataset={dataset} key={dataset.uuid} />
             ) : (
-              <MultiAssayLink dataset={dataset} key={dataset.uuid} />
+              <MultiAssayLink
+                dataset={dataset}
+                key={dataset.uuid}
+                href={createLinkHref(dataset)}
+                tooltipText={createTooltipText(dataset)}
+              />
             ),
           )}
         </Stack>

--- a/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
@@ -20,7 +20,7 @@ function SnareSeq2Alert() {
       }}
     >
       SNARE-seq2 processed datasets are derived from multiple primary raw datasets. You are currently viewing one of
-      these raw SNARE-seq2 datasets. SNARE-seq2 dataset are multi-assay datasets comprised of RNA-seq and ATAC-seq
+      these raw SNARE-seq2 datasets. SNARE-seq2 datasets are multi-assay datasets comprised of RNA-seq and ATAC-seq
       datasets. For a detailed understanding of dataset relationships, scroll down to the Dataset Relationship section
       or explore the provenance graph.
     </DetailPageAlert>

--- a/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { DetailPageAlert } from 'js/components/detailPage/style';
+import { useIsMultiAssay } from '../hooks';
+
+function SnareSeq2Alert() {
+  const { isSnareSeq2 } = useIsMultiAssay();
+
+  if (!isSnareSeq2) {
+    return null;
+  }
+
+  return (
+    <DetailPageAlert
+      severity="info"
+      sx={{
+        '.MuiAlert-message': {
+          flexGrow: 1,
+        },
+      }}
+    >
+      SNARE-seq2 processed datasets are derived from multiple primary raw datasets. You are currently viewing one of
+      these raw SNARE-seq2 datasets. SNARE-seq2 dataset are multi-assay datasets comprised of RNA-seq and ATAC-seq
+      datasets. For a detailed understanding of dataset relationships, scroll down to the Dataset Relationship section
+      or explore the provenance graph.
+    </DetailPageAlert>
+  );
+}
+
+export default SnareSeq2Alert;

--- a/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { DetailPageAlert } from 'js/components/detailPage/style';
+import { InternalLink } from 'js/shared-styles/Links';
 import { useIsMultiAssay } from '../hooks';
 
 function SnareSeq2Alert() {
@@ -21,8 +22,9 @@ function SnareSeq2Alert() {
     >
       SNARE-seq2 processed datasets are derived from multiple primary raw datasets. You are currently viewing one of
       these raw SNARE-seq2 datasets. SNARE-seq2 datasets are multi-assay datasets comprised of RNA-seq and ATAC-seq
-      datasets. For a detailed understanding of dataset relationships, scroll down to the Dataset Relationship section
-      or explore the provenance graph.
+      datasets. For a detailed understanding of dataset relationships, scroll down to the{' '}
+      <InternalLink href="#section-dataset-relationships">Dataset Relationship section</InternalLink> or explore the{' '}
+      <InternalLink href="#provenance">provenance</InternalLink> graph.
     </DetailPageAlert>
   );
 }

--- a/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/SnareSeq2Alert.tsx
@@ -4,12 +4,21 @@ import { DetailPageAlert } from 'js/components/detailPage/style';
 import { InternalLink } from 'js/shared-styles/Links';
 import { useIsMultiAssay } from '../hooks';
 
-function SnareSeq2Alert() {
+interface SnareSeq2AlertProps {
+  isHeader?: boolean;
+}
+
+const headerText = `SNARE-seq2 processed datasets are derived from multiple primary raw datasets. You are currently viewing one of these raw SNARE-seq2 datasets. SNARE-seq2 datasets are multi-assay datasets comprised of RNA-seq and ATAC-seq datasets.`;
+const bulkDataSectionText = `SNARE-seq2 processed datasets are derived from multiple primary raw datasets. All relevant primary raw datasets are available for download in this section, depending on your access permissions.`;
+
+function SnareSeq2Alert({ isHeader }: SnareSeq2AlertProps) {
   const { isSnareSeq2 } = useIsMultiAssay();
 
   if (!isSnareSeq2) {
     return null;
   }
+
+  const descriptionText = isHeader ? headerText : bulkDataSectionText;
 
   return (
     <DetailPageAlert
@@ -20,9 +29,8 @@ function SnareSeq2Alert() {
         },
       }}
     >
-      SNARE-seq2 processed datasets are derived from multiple primary raw datasets. You are currently viewing one of
-      these raw SNARE-seq2 datasets. SNARE-seq2 datasets are multi-assay datasets comprised of RNA-seq and ATAC-seq
-      datasets. For a detailed understanding of dataset relationships, scroll down to the{' '}
+      {descriptionText}
+      For a detailed understanding of dataset relationships, scroll down to the{' '}
       <InternalLink href="#section-dataset-relationships">Dataset Relationship section</InternalLink> or explore the{' '}
       <InternalLink href="#provenance">provenance</InternalLink> graph.
     </DetailPageAlert>

--- a/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/index.ts
+++ b/context/app/static/js/components/detailPage/multi-assay/SnareSeq2Alert/index.ts
@@ -1,0 +1,3 @@
+import SnareSeq2Alert from './SnareSeq2Alert';
+
+export default SnareSeq2Alert;

--- a/context/app/static/js/components/detailPage/multi-assay/hooks.ts
+++ b/context/app/static/js/components/detailPage/multi-assay/hooks.ts
@@ -1,0 +1,26 @@
+import { useFlaskDataContext } from 'js/components/Contexts';
+import { isDataset } from 'js/components/types';
+
+interface UseIsMultiAssay {
+  isMultiAssay: boolean;
+  isSnareSeq2: boolean;
+}
+
+/**
+ * Checks if the current dataset is a multi-assay dataset.
+ * @returns {UseIsMultiAssay}
+ */
+export function useIsMultiAssay(): UseIsMultiAssay {
+  const { entity } = useFlaskDataContext();
+  const entityIsDataset = isDataset(entity);
+  if (!entityIsDataset) {
+    return {
+      isMultiAssay: false,
+      isSnareSeq2: false,
+    };
+  }
+  return {
+    isMultiAssay: entity.assay_modality === 'multiple',
+    isSnareSeq2: entity.assay_modality === 'multiple' && entity.dataset_type.toLowerCase() === 'snare-seq2',
+  };
+}

--- a/context/app/static/js/components/detailPage/multi-assay/useRelatedMultiAssayDatasets.ts
+++ b/context/app/static/js/components/detailPage/multi-assay/useRelatedMultiAssayDatasets.ts
@@ -4,6 +4,7 @@ import { useSearchHits } from 'js/hooks/useSearchData';
 import { useFlaskDataContext } from 'js/components/Contexts';
 import { Dataset, isDataset } from 'js/components/types';
 import { getEntityCreationInfo } from 'js/helpers/functions';
+import { useSiblingDatasets } from 'js/pages/Dataset/hooks';
 
 const source = [
   'uuid',
@@ -135,7 +136,6 @@ function buildRelatedDatasets({ entities }: { entities: MultiAssayEntity[] }) {
 
 function useRelatedMultiAssayDatasets() {
   const { entity } = useFlaskDataContext();
-
   const { uuid } = entity;
 
   const entityIsDataset = isDataset(entity);
@@ -150,6 +150,7 @@ function useRelatedMultiAssayDatasets() {
       shouldFetch: !isPrimary && entityIsDataset,
     },
   );
+  const { searchHits: siblingDatasets } = useSiblingDatasets();
 
   const primary = primaryHits?.[0]?._source ?? entity;
 
@@ -160,7 +161,11 @@ function useRelatedMultiAssayDatasets() {
     },
   );
 
-  const entities = [primary, ...(primaryDescendantHits ?? []).map((hit) => hit?._source)].filter(Boolean);
+  const entities = [
+    primary,
+    ...(primaryDescendantHits ?? []).map((hit) => hit?._source),
+    ...(siblingDatasets ?? []).map((hit) => hit?._source),
+  ].filter(Boolean);
 
   if (!entityIsDataset) {
     return {

--- a/context/app/static/js/components/detailPage/provenance/ProvTabs/ProvTabs.tsx
+++ b/context/app/static/js/components/detailPage/provenance/ProvTabs/ProvTabs.tsx
@@ -3,7 +3,6 @@ import Paper from '@mui/material/Paper';
 import { useFlaskDataContext } from 'js/components/Contexts';
 import { Tabs, Tab, TabPanel } from 'js/shared-styles/tabs';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
-import MultiAssayProvenance from 'js/components/detailPage/multi-assay/MultiAssayProvenance';
 import ProvGraph from '../ProvGraph';
 import ProvTable from '../ProvTable';
 import { hasDataTypes } from './utils';
@@ -12,7 +11,6 @@ import { ProvData } from '../types';
 import ProvGraphErrorBoundary from '../ProvGraph/ProvGraphErrorBoundary';
 
 const availableTabDetails = {
-  multi: { label: 'Multi-Assay', 'data-testid': 'multi-prov-tab' },
   table: { label: 'Table', 'data-testid': 'prov-table-tab' },
   graph: { label: 'Graph', 'data-testid': 'prov-graph-tab' },
 };
@@ -23,14 +21,13 @@ interface ProvTabsProps {
 
 function ProvTabs({ provData }: ProvTabsProps) {
   const {
-    entity: { uuid, entity_type, data_types, assay_modality },
+    entity: { uuid, entity_type, data_types },
   } = useFlaskDataContext();
 
   const trackEntityPageEvent = useTrackEntityPageEvent();
   const [open, setOpen] = React.useState(0);
 
   const tabsToDisplay = {
-    multi: assay_modality === 'multiple',
     table:
       entity_type !== 'Publication' &&
       !hasDataTypes(data_types, [
@@ -56,11 +53,6 @@ function ProvTabs({ provData }: ProvTabsProps) {
           <Tab label={label} index={index} data-testid={dataTestID} key={label} />
         ))}
       </Tabs>
-      {filteredTabs?.multi && (
-        <TabPanel value={open} index={filteredTabs.multi.index}>
-          <MultiAssayProvenance />
-        </TabPanel>
-      )}
       {filteredTabs?.table && (
         <TabPanel value={open} index={filteredTabs.table.index} pad>
           <ProvTable />

--- a/context/app/static/js/pages/Dataset/Dataset.tsx
+++ b/context/app/static/js/pages/Dataset/Dataset.tsx
@@ -31,6 +31,7 @@ import OrganIcon from 'js/shared-styles/icons/OrganIcon';
 import { useEntitiesData } from 'js/hooks/useEntityData';
 import { hasMetadata } from 'js/helpers/metadata';
 import SnareSeq2Alert from 'js/components/detailPage/multi-assay/SnareSeq2Alert';
+import MultiAssayRelationship from 'js/components/detailPage/multi-assay/MultiAssayRelationship';
 import { useProcessedDatasets, useProcessedDatasetsSections, useRedirectAlert } from './hooks';
 
 interface SummaryDataChildrenProps {
@@ -152,9 +153,12 @@ function DatasetDetail({ assayMetadata }: EntityDetailProps<Dataset>) {
             mapped_external_group_name={mapped_external_group_name}
             bottomFold={
               shouldDisplayRelationships ? (
-                <Box height={datasetRelationshipsContainerHeight} width="100%" component={Paper} p={2}>
-                  <DatasetRelationships uuid={uuid} processing={processing} />
-                </Box>
+                <>
+                  <MultiAssayRelationship />
+                  <Box height={datasetRelationshipsContainerHeight} width="100%" component={Paper} p={2}>
+                    <DatasetRelationships uuid={uuid} processing={processing} />
+                  </Box>
+                </>
               ) : null
             }
           >

--- a/context/app/static/js/pages/Dataset/Dataset.tsx
+++ b/context/app/static/js/pages/Dataset/Dataset.tsx
@@ -144,7 +144,7 @@ function DatasetDetail({ assayMetadata }: EntityDetailProps<Dataset>) {
       <SelectedVersionStoreProvider initialVersionUUIDs={processedDatasets?.map((ds) => ds._id) ?? []}>
         <ExternalDatasetAlert isExternal={Boolean(mapped_external_group_name)} />
         {Boolean(is_component) && <ComponentAlert />}
-        <SnareSeq2Alert />
+        <SnareSeq2Alert isHeader />
         <DetailLayout sections={shouldDisplaySection} isLoading={isLoading}>
           <Summary
             entityTypeDisplay="Dataset"

--- a/context/app/static/js/pages/Dataset/Dataset.tsx
+++ b/context/app/static/js/pages/Dataset/Dataset.tsx
@@ -30,6 +30,7 @@ import { InternalLink } from 'js/shared-styles/Links';
 import OrganIcon from 'js/shared-styles/icons/OrganIcon';
 import { useEntitiesData } from 'js/hooks/useEntityData';
 import { hasMetadata } from 'js/helpers/metadata';
+import SnareSeq2Alert from 'js/components/detailPage/multi-assay/SnareSeq2Alert';
 import { useProcessedDatasets, useProcessedDatasetsSections, useRedirectAlert } from './hooks';
 
 interface SummaryDataChildrenProps {
@@ -142,6 +143,7 @@ function DatasetDetail({ assayMetadata }: EntityDetailProps<Dataset>) {
       <SelectedVersionStoreProvider initialVersionUUIDs={processedDatasets?.map((ds) => ds._id) ?? []}>
         <ExternalDatasetAlert isExternal={Boolean(mapped_external_group_name)} />
         {Boolean(is_component) && <ComponentAlert />}
+        <SnareSeq2Alert />
         <DetailLayout sections={shouldDisplaySection} isLoading={isLoading}>
           <Summary
             entityTypeDisplay="Dataset"

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -59,6 +59,25 @@ export type ProcessedDatasetInfo = Pick<
   | 'contacts'
 >;
 
+const ProcessedDatasetInfoSource = [
+  'hubmap_id',
+  'entity_type',
+  'uuid',
+  'assay_display_name',
+  'files',
+  'pipeline',
+  'status',
+  'metadata',
+  'creation_action',
+  'created_timestamp',
+  'dbgap_study_url',
+  'dbgap_sra_experiment_url',
+  'ingest_metadata',
+  'is_component',
+  'visualization',
+  'contributors',
+];
+
 type VitessceConf = object | undefined;
 
 // Helper function to access the result in the cache.
@@ -99,6 +118,24 @@ export function useVitessceConf(uuid: string, parentUuid?: string) {
   return swr;
 }
 
+export function useSiblingDatasets() {
+  const { siblingIds } = useFlaskDataContext();
+  return useSearchHits<ProcessedDatasetInfo>(
+    {
+      query: {
+        bool: {
+          must: [getIDsQuery(siblingIds ?? [])],
+        },
+      },
+      _source: ProcessedDatasetInfoSource,
+      size: 10000,
+    },
+    {
+      shouldFetch: Boolean(siblingIds?.length),
+    },
+  );
+}
+
 function useProcessedDatasets(includeComponents?: boolean) {
   const { entity } = useFlaskDataContext();
   const entityIsDataset = isDataset(entity);
@@ -114,24 +151,7 @@ function useProcessedDatasets(includeComponents?: boolean) {
           : [getIDsQuery(descendant_ids), includeDatasetsAndImageSupports, excludeComponentDatasetsClause],
       },
     },
-    _source: [
-      'hubmap_id',
-      'entity_type',
-      'uuid',
-      'assay_display_name',
-      'files',
-      'pipeline',
-      'status',
-      'metadata',
-      'creation_action',
-      'created_timestamp',
-      'dbgap_study_url',
-      'dbgap_sra_experiment_url',
-      'ingest_metadata',
-      'is_component',
-      'visualization',
-      'contributors',
-    ],
+    _source: ProcessedDatasetInfoSource,
     size: 10000,
   };
 

--- a/context/app/static/js/pages/Dataset/hooks.ts
+++ b/context/app/static/js/pages/Dataset/hooks.ts
@@ -146,8 +146,8 @@ function useProcessedDatasets(includeComponents?: boolean) {
   return { searchHits, isLoading };
 }
 
-function useLabeledProcessedDatasets() {
-  const { searchHits, isLoading } = useProcessedDatasets();
+function useLabeledProcessedDatasets(includeComponents?: boolean) {
+  const { searchHits, isLoading } = useProcessedDatasets(includeComponents);
   const searchHitsWithLabels = searchHits.map((hit) => ({
     ...hit,
     _source: {

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -132,3 +132,75 @@ def find_raw_dataset_ancestor(client, ancestor_ids):
             'is_component'
         ]
     )
+
+
+def find_sibling_datasets(client, dataset):
+    if (dataset.get("dataset_type").lower() != "snare-seq2"):
+        print("actual type: ", dataset.get("dataset_type").lower())
+        return []
+
+    main_raw_dataset_uuid = dataset.get("uuid", None)
+    if not main_raw_dataset_uuid:
+        return []
+
+    processed_descendants = client.get_entities(
+        'datasets',
+        query_override={
+            "bool": {
+                "must": [
+                    {
+                        "term": {
+                            "ancestor_ids": main_raw_dataset_uuid
+                        }
+                    },
+                    {
+                        "term": {
+                            "processing": "processed"
+                        }
+                    }
+                ]
+            }
+        },
+        non_metadata_fields=[
+            'uuid',
+            'processing',
+            'entity_type',
+            'is_component'
+        ]
+    )
+    print("processed_descendants: ", processed_descendants)
+    if len(processed_descendants) == 0:
+        return []
+    # Get the first processed dataset
+    processed_dataset = processed_descendants[0]
+
+    # Get the siblings of the raw dataset by finding datasets with the same processed descendant
+
+    processed_dataset_uuid = processed_dataset.get("uuid", None)
+
+    if not processed_dataset_uuid:
+        return []
+
+    siblings = client.get_entities(
+        'datasets',
+        query_override={
+            "bool": {
+                "must": [
+                    {
+                        "term": {
+                            "descendant_ids": processed_dataset_uuid,
+                        },
+                    },
+                ],
+            },
+        },
+        non_metadata_fields=[
+            'uuid',
+        ]
+    )
+
+    # Filter out the original dataset
+    sibling_ids = [sibling.get("uuid")
+                   for sibling in siblings if sibling.get("uuid") != main_raw_dataset_uuid]
+
+    return sibling_ids

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -167,7 +167,6 @@ def find_sibling_datasets(client, dataset):
             'is_component'
         ]
     )
-    print("processed_descendants: ", processed_descendants)
     if len(processed_descendants) == 0:
         return []
     # Get the first processed dataset

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -136,7 +136,6 @@ def find_raw_dataset_ancestor(client, ancestor_ids):
 
 def find_sibling_datasets(client, dataset):
     if (dataset.get("dataset_type").lower() != "snare-seq2"):
-        print("actual type: ", dataset.get("dataset_type").lower())
         return []
 
     main_raw_dataset_uuid = dataset.get("uuid", None)


### PR DESCRIPTION
## Summary

This PR implements changes to the detail page to provide more information to users when they are viewing multi-assay datasets, particularly SnareSeq2. We are restoring the text-based "multi assay relationship" section and are now displaying component datasets in the bulk data transfer tabs.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1119

## Testing


## Screenshots/Video

<details><summary>Full page screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/b7e1d104-f128-458a-a094-f9d4ebc555b9)


</p>
</details> 

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes
