### PR TITLE
Austenem/CAT-1234 Add data products tracking

### DIFF
--- a/CHANGELOG-add-data-products-tracking.md
+++ b/CHANGELOG-add-data-products-tracking.md
@@ -1,0 +1,1 @@
+- Add event tracking for all data products sections on organ pages.

--- a/context/app/static/js/components/organ/ViewEntitiesButton.tsx
+++ b/context/app/static/js/components/organ/ViewEntitiesButton.tsx
@@ -1,15 +1,13 @@
 import React from 'react';
-import Button from '@mui/material/Button';
+import Button, { ButtonProps } from '@mui/material/Button';
 import { DatasetIcon } from 'js/shared-styles/icons';
 import { SearchURLTypes, getSearchURL } from 'js/components/organ/utils';
 
-function ViewEntitiesButton({
-  entityType,
-  filters,
-}: {
+interface ViewEntitiesButtonProps extends ButtonProps {
   entityType: 'Donor' | 'Dataset' | 'Sample';
   filters: Omit<SearchURLTypes, 'entityType'>;
-}) {
+}
+function ViewEntitiesButton({ entityType, filters, ...rest }: ViewEntitiesButtonProps) {
   return (
     <Button
       color="primary"
@@ -17,6 +15,7 @@ function ViewEntitiesButton({
       component="a"
       href={getSearchURL({ entityType, ...filters })}
       startIcon={<DatasetIcon />}
+      {...rest}
     >
       View {entityType}s
     </Button>

--- a/context/app/static/js/pages/Organ/Organ.tsx
+++ b/context/app/static/js/pages/Organ/Organ.tsx
@@ -33,7 +33,7 @@ function Organ({ organ }: OrganProps) {
   const assayBuckets = useAssayBucketsQuery(searchItems);
   const samplesHits = useHasSamplesQuery(searchItems);
   const labeledDatasetUuids = useLabelledDatasetsQuery(searchItems);
-  const { dataProducts, isLoading } = useDataProducts(organ);
+  const { dataProducts, isLoading, isLateral } = useDataProducts(organ);
 
   const shouldDisplaySection: Record<string, boolean> = {
     [summaryId]: Boolean(organ?.description),
@@ -74,6 +74,8 @@ function Organ({ organ }: OrganProps) {
       <DataProducts
         id={dataProductsId}
         dataProducts={dataProducts}
+        organName={organ.name}
+        isLateral={isLateral}
         isLoading={isLoading}
         shouldDisplay={shouldDisplaySection[dataProductsId]}
       />

--- a/context/app/static/js/pages/Organ/hooks.ts
+++ b/context/app/static/js/pages/Organ/hooks.ts
@@ -178,5 +178,5 @@ export function useDataProducts(organ: OrganFile) {
     datasetUUIDs: product.dataSets.map((dataset) => dataset.uuid),
   }));
 
-  return { dataProducts: dataProductsWithUUIDs, isLoading };
+  return { dataProducts: dataProductsWithUUIDs, isLoading, isLateral };
 }


### PR DESCRIPTION
## Summary

Adds event tracking for data products sections on organ pages.

## Design Documentation/Original Tickets

[CAT-1234 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1234?atlOrigin=eyJpIjoiZDM1OWI0YzNiYzk5NDEyNDg2ZWFiNTU0Zjk2ZmQ0MjQiLCJwIjoiaiJ9)

[Trackable organ page events](https://docs.google.com/spreadsheets/d/18hF0VDrepN58GiDX22_jJ6vsnfGwKE_GiL8hdD_Art4/edit?gid=126226029#gid=126226029)

## Testing

Tested by logging formatted events in `trackEvent`.

Ex: `{category: "Organ Detail Page: Data Products", action: "Data Products / Download Raw", label: "Kidney Laterality: right Assay: rna-seq File: RK_raw.h5ad", name: "Kidney Laterality: right Assay: rna-seq File: RK_raw.h5ad"}`

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
