### PR TITLE
Austenem/CAT-1199 Remove contributors sorting

### DIFF
--- a/CHANGELOG-remove-contributors-sorting.md
+++ b/CHANGELOG-remove-contributors-sorting.md
@@ -1,0 +1,1 @@
+- List publication contributors in original author order.

--- a/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.tsx
+++ b/context/app/static/js/components/detailPage/ContributorsTable/ContributorsTable.tsx
@@ -19,7 +19,7 @@ import { isValidEmail, validateAndFormatOrcidId } from 'js/helpers/functions';
 import IconPanel from 'js/shared-styles/panels/IconPanel';
 
 import { useNormalizedContacts, useNormalizedContributors } from './hooks';
-import { ContributorAPIResponse, sortContributors, contributorIsContact, ContactAPIResponse } from './utils';
+import { ContributorAPIResponse, contributorIsContact, ContactAPIResponse } from './utils';
 
 const contributorsIconPanelText =
   'Below is the information for the individuals who provided this dataset. For questions for this dataset, reach out to the individuals listed as contacts, either via the email address listed in the table or contact information provided on their ORCID profile page.';
@@ -76,8 +76,6 @@ function ContributorsTable({
     return null;
   }
 
-  const sortedContributors = sortContributors(normalizedContributors, normalizedContacts);
-
   const contents = (
     <Stack spacing={1}>
       {showIconPanel && <IconPanel status="info">{contributorsIconPanelText}</IconPanel>}
@@ -103,7 +101,7 @@ function ContributorsTable({
               </TableRow>
             </TableHead>
             <TableBody>
-              {sortedContributors.map((contributor) => {
+              {normalizedContributors.map((contributor) => {
                 const { affiliation, name, email, isPrincipalInvestigator, orcid } = contributor;
                 const validatedOrcidId = validateAndFormatOrcidId(orcid);
                 return (

--- a/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
+++ b/context/app/static/js/components/detailPage/ContributorsTable/utils.ts
@@ -107,35 +107,3 @@ export const contributorIsContact = (contributor: Contributor, contacts: Contact
       return false;
   }
 };
-
-/**
- * Given an array of contributors, sort them by contact status and then alphabetically by name.
- *   Ex sorted array: PI Contact C, PI Contact D, Contact, Contributor A, Contributor B
- * @author Austen Money
- * @param contributors an array of contributors to be sorted.
- * @param contacts an array of contacts to be used for sorting.
- * @returns a sorted array.
- */
-export const sortContributors = (contributors: Contributor[], contacts: Contact[]): Contributor[] =>
-  contributors.sort((a, b) => {
-    const aIsContact = contributorIsContact(a, contacts);
-    const bIsContact = contributorIsContact(b, contacts);
-
-    const aIsPIContact = aIsContact && a.isPrincipalInvestigator;
-    const bIsPIContact = bIsContact && b.isPrincipalInvestigator;
-
-    if (aIsPIContact && !bIsPIContact) {
-      return -1;
-    }
-    if (!aIsPIContact && bIsPIContact) {
-      return 1;
-    }
-    if (aIsContact && !bIsContact) {
-      return -1;
-    }
-    if (!aIsContact && bIsContact) {
-      return 1;
-    }
-
-    return a.name.localeCompare(b.name);
-  });


### PR DESCRIPTION
## Summary

Lists publication contributors in original author order.

## Design Documentation/Original Tickets

[CAT-1199 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1199?atlOrigin=eyJpIjoiNzY4NGZhZDg5OGJkNGM2MmE5ZDlhMDhmODk2ZjY2ZmUiLCJwIjoiaiJ9)

## Testing

Checked that contributor tables on publication pages match original author order. On dataset detail pages, contributor order is often already provided in alphabetical order by last name.

## Screenshots/Video

Local:

<img width="925" alt="Screenshot 2025-03-31 at 1 02 06 PM" src="https://github.com/user-attachments/assets/8c3bb1b2-9588-4629-8a3c-c16a6149d706" />


Prod:

<img width="926" alt="Screenshot 2025-03-31 at 1 01 53 PM" src="https://github.com/user-attachments/assets/c2d193cd-d006-45a9-9f15-7915acebb613" />

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Verify that we are also removing sorting for dataset and collection detail pages, which do not always list contributors in order of most->least contribution as is the norm for publications.

