### PR TITLE
Austenem/CAT-1241 Add admin banner

### DIFF
--- a/CHANGELOG-add-admin-banner.md
+++ b/CHANGELOG-add-admin-banner.md
@@ -1,0 +1,1 @@
+- Add admin banner to top of portal header.

--- a/context/app/static/js/components/Header/Header/Header.tsx
+++ b/context/app/static/js/components/Header/Header/Header.tsx
@@ -10,19 +10,19 @@ import HeaderContent from '../HeaderContent';
 import { useEntityHeaderVisibility } from './hooks';
 
 function Header() {
-  const { shouldDisplayHeader, elevation, ...props } = useEntityHeaderVisibility();
+  const { shouldDisplayHeader, ...props } = useEntityHeaderVisibility();
 
   return (
     <>
       <FixedHeightBanner>
         <Stack direction="row" spacing={1} alignItems="center">
-          <InfoIcon fontSize="0.85rem" />
+          <InfoIcon />
           <Typography variant="button">
             This repository is under review for potential modification in compliance with Administration directives.
           </Typography>
         </Stack>
       </FixedHeightBanner>
-      <HeaderAppBar elevation={elevation} {...props}>
+      <HeaderAppBar {...props}>
         <HeaderContent />
       </HeaderAppBar>
       {shouldDisplayHeader && <EntityHeader />}

--- a/context/app/static/js/components/Header/Header/Header.tsx
+++ b/context/app/static/js/components/Header/Header/Header.tsx
@@ -1,16 +1,28 @@
 import React from 'react';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 
 import EntityHeader from 'js/components/detailPage/entityHeader/EntityHeader';
+import { FixedHeightBanner } from 'js/components/Header/HeaderAppBar/style';
+import { InfoIcon } from 'js/shared-styles/icons';
 import HeaderAppBar from '../HeaderAppBar';
 import HeaderContent from '../HeaderContent';
 import { useEntityHeaderVisibility } from './hooks';
 
 function Header() {
-  const { shouldDisplayHeader, ...props } = useEntityHeaderVisibility();
+  const { shouldDisplayHeader, elevation, ...props } = useEntityHeaderVisibility();
 
   return (
     <>
-      <HeaderAppBar {...props}>
+      <FixedHeightBanner>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <InfoIcon fontSize="0.85rem" />
+          <Typography variant="button">
+            This repository is under review for potential modification in compliance with Administration directives.
+          </Typography>
+        </Stack>
+      </FixedHeightBanner>
+      <HeaderAppBar elevation={elevation} {...props}>
         <HeaderContent />
       </HeaderAppBar>
       {shouldDisplayHeader && <EntityHeader />}

--- a/context/app/static/js/components/Header/HeaderAppBar/style.ts
+++ b/context/app/static/js/components/Header/HeaderAppBar/style.ts
@@ -14,7 +14,7 @@ const FixedHeightAppBar = styled(AppBar)({
 
 const FixedHeightBanner = styled(Paper)(({ theme }) => ({
   height: bannerHeight,
-  backgroundColor: theme.palette.info.main,
+  backgroundColor: theme.palette.info.dark,
   color: theme.palette.white.main,
   display: 'flex',
   position: 'sticky',

--- a/context/app/static/js/components/Header/HeaderAppBar/style.ts
+++ b/context/app/static/js/components/Header/HeaderAppBar/style.ts
@@ -1,10 +1,27 @@
 import { styled } from '@mui/material/styles';
 import AppBar from '@mui/material/AppBar';
+import Paper from '@mui/material/Paper';
 
-const headerHeight = 64;
+const bannerHeight = 40;
+const appBarHeight = 64;
+
+const headerHeight = appBarHeight + bannerHeight;
 
 const FixedHeightAppBar = styled(AppBar)({
-  height: headerHeight,
+  height: appBarHeight,
+  top: bannerHeight,
 });
 
-export { FixedHeightAppBar, headerHeight };
+const FixedHeightBanner = styled(Paper)(({ theme }) => ({
+  height: bannerHeight,
+  backgroundColor: theme.palette.info.main,
+  color: theme.palette.white.main,
+  display: 'flex',
+  position: 'sticky',
+  justifyContent: 'center',
+  alignItems: 'center',
+  top: 0,
+  zIndex: 1000,
+}));
+
+export { FixedHeightAppBar, FixedHeightBanner, headerHeight, bannerHeight };


### PR DESCRIPTION
## Summary

Add admin banner to top of portal header.

## Design Documentation/Original Tickets

[CAT-1241 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1241?atlOrigin=eyJpIjoiZjgwMjQxN2Y2NTE1NDhkN2FmNjVkZDNkNDU1NDJmMjgiLCJwIjoiaiJ9)

## Screenshots/Video

<img width="1422" alt="Screenshot 2025-04-03 at 10 46 52 AM" src="https://github.com/user-attachments/assets/bc168910-861f-413c-9cea-ecea0a697de6" />
