### PR TITLE
Austenem/CAT-1242 Hide Shiny app links

### DIFF
--- a/CHANGELOG-hide-shiny-app-links.md
+++ b/CHANGELOG-hide-shiny-app-links.md
@@ -1,0 +1,1 @@
+- Hide links to Shiny apps in organ data products if unavailable.

--- a/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
+++ b/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
@@ -135,13 +135,15 @@ function DataProducts({ id, organName, dataProducts, isLateral, isLoading }: Dat
                       </InternalLink>
                     </TableCell>
                     <TableCell>
-                      <OutboundIconLink
-                        href={shiny_app}
-                        onClick={() => handleTrack({ action: 'View Shiny App', assayName, tissueType })}
-                        variant="body2"
-                      >
-                        View
-                      </OutboundIconLink>
+                      {shiny_app && (
+                        <OutboundIconLink
+                          href={shiny_app}
+                          onClick={() => handleTrack({ action: 'View Shiny App', assayName, tissueType })}
+                          variant="body2"
+                        >
+                          View
+                        </OutboundIconLink>
+                      )}
                     </TableCell>
                     <TableCell>{format(new Date(creation_time), 'yyyy-MM-dd')}</TableCell>
                     <TableCell>


### PR DESCRIPTION
## Summary

Hides links to Shiny apps in organ data products if unavailable.

## Design Documentation/Original Tickets

[CAT-1242 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1242?atlOrigin=eyJpIjoiZDUyMzIzNGY1MTkzNGUxY2EzODk5OWMzNWE0MjYzODEiLCJwIjoiaiJ9)

## Screenshots/Video

<img width="1178" alt="Screenshot 2025-04-03 at 4 37 18 PM" src="https://github.com/user-attachments/assets/2335ae28-9467-41a3-8aff-668711f99c46" />
