### PR TITLE
Rolled back portal-viz version update

### DIFF
--- a/CHANGELOG-revert-portal-viz
+++ b/CHANGELOG-revert-portal-viz
@@ -1,0 +1,1 @@
+- Rolled back portal-viz version to address Visium scaling issue pending further clarification.

--- a/context/requirements.in
+++ b/context/requirements.in
@@ -16,7 +16,7 @@ hubmap-commons>=2.1.18
 boto3==1.28.17
 
 # Plain "git+https://github.com/..." references can't be hashed, so we point to a release zip instead.
-https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.4.3.zip
+https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.4.2.zip
 
 # Security warning for older versions;
 # Can be removed when commons drops prov dependency.

--- a/context/requirements.txt
+++ b/context/requirements.txt
@@ -258,7 +258,7 @@ pillow==11.0.0
     #   scikit-image
 platformdirs==2.5.1
     # via black
-portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.4.3.zip
+portal-visualization @ https://github.com/hubmapconsortium/portal-visualization/archive/refs/tags/0.4.2.zip
     # via -r context/requirements.in
 propcache==0.2.0
     # via yarl


### PR DESCRIPTION
## Summary

This PR reverts the portal-viz version update done to fix the scalability issue with visium datasets.

## Design Documentation/Original Tickets

[CAT-1206](https://hms-dbmi.atlassian.net/browse/CAT-1206)

## Testing

Manually performed on the visium datasets.


## Screenshots/Video
<img width="1469" alt="Screenshot 2025-04-11 at 2 19 13 PM" src="https://github.com/user-attachments/assets/afcfea5f-6976-4f30-80fa-e266c7273bee" />


Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.


[CAT-1206]: https://hms-dbmi.atlassian.net/browse/CAT-1206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ