### PR TITLE
Austenem/CAT-1240 Add organ tracking

### DIFF
--- a/CHANGELOG-add-organ-tracking.md
+++ b/CHANGELOG-add-organ-tracking.md
@@ -1,0 +1,1 @@
+- Add analytics to organ pages.

--- a/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
+++ b/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
@@ -5,7 +5,7 @@ import ExpandMore from '@mui/icons-material/ExpandMore';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import { SvgIconComponent } from '@mui/icons-material';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { StyledInfoIcon } from 'js/shared-styles/sections/LabelledSectionText/style';

--- a/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
+++ b/context/app/static/js/components/detailPage/DetailPageSection/CollapsibleDetailPageSection.tsx
@@ -1,14 +1,19 @@
-import React, { PropsWithChildren } from 'react';
+import React, { PropsWithChildren, useState } from 'react';
 import AccordionDetails from '@mui/material/AccordionDetails';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import ExpandMore from '@mui/icons-material/ExpandMore';
 import Typography, { TypographyProps } from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import { SvgIconComponent } from '@mui/icons-material';
+import useEventCallback from '@mui/material/utils/useEventCallback';
+
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { StyledInfoIcon } from 'js/shared-styles/sections/LabelledSectionText/style';
 import { sectionIconMap, sectionImageIconMap } from 'js/shared-styles/icons/sectionIconMap';
 import ExternalImageIcon from 'js/shared-styles/icons/ExternalImageIcon';
+import { EventInfo } from 'js/components/types';
+import { trackEvent } from 'js/helpers/trackers';
+
 import DetailPageSection from './DetailPageSection';
 import { DetailPageSectionAccordion, StyledExternalImageIconContainer, StyledSvgIcon } from './style';
 
@@ -19,6 +24,7 @@ export interface CollapsibleDetailPageSectionProps extends PropsWithChildren<Rea
   variant?: TypographyProps['variant'];
   component?: TypographyProps['component'];
   iconTooltipText?: string;
+  trackingInfo?: EventInfo;
 }
 
 interface IconDisplayProps {
@@ -49,11 +55,33 @@ export default function CollapsibleDetailPageSection({
   component = 'h3',
   action,
   iconTooltipText,
+  trackingInfo,
   ...rest
 }: CollapsibleDetailPageSectionProps) {
+  // Handle expanded state manually in order to track the event
+  const [expanded, setExpanded] = useState(true);
+
+  const handleAccordionToggle = useEventCallback(() => {
+    const newExpandedState = !expanded;
+    setExpanded(newExpandedState);
+
+    if (trackingInfo) {
+      trackEvent({
+        action: `${newExpandedState ? 'Expand' : 'Collapse'} Section`,
+        label: title,
+        ...trackingInfo,
+      });
+    }
+  });
+
   return (
     <DetailPageSection {...rest}>
-      <DetailPageSectionAccordion defaultExpanded disableGutters variant="unstyled">
+      <DetailPageSectionAccordion
+        expanded={expanded}
+        onChange={handleAccordionToggle}
+        disableGutters
+        variant="unstyled"
+      >
         <AccordionSummary expandIcon={<ExpandMore />}>
           <IconDisplay icon={icon} id={rest.id!} />
           <Typography variant={variant} component={component}>

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -182,6 +182,7 @@ function VisualizationAccordion() {
       </SectionDescription>
       <VisualizationWrapper
         vitData={conf}
+        trackingInfo={{ action: 'Vitessce' }}
         uuid={uuid}
         shouldDisplayHeader={false}
         hasBeenMounted={hasBeenSeen}

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeaderContent/EntityHeaderContent.tsx
@@ -240,7 +240,7 @@ function EntityHeaderContent({ view, setView }: { view: SummaryViewsType; setVie
           <>
             {vizNotebookId && <VisualizationWorkspaceButton />}
             {isVitessce && <VisualizationShareButtonWrapper />}
-            <VisualizationThemeSwitch />
+            <VisualizationThemeSwitch trackingInfo={{ action: 'Vitessce' }} />
             <VisualizationCollapseButton />
           </>
         ) : (

--- a/context/app/static/js/components/detailPage/entityHeader/VisualizationShareButtonWrapper/VisualizationShareButtonWrapper.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/VisualizationShareButtonWrapper/VisualizationShareButtonWrapper.tsx
@@ -19,7 +19,7 @@ function ShareButtonFallback() {
 function VisualizationShareButtonWrapper() {
   return (
     <Suspense fallback={<ShareButtonFallback />}>
-      <VisualizationShareButton />
+      <VisualizationShareButton trackingInfo={{ action: 'Vitessce / Share Visualization' }} />
     </Suspense>
   );
 }

--- a/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
+++ b/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
@@ -1,20 +1,17 @@
 import { useCallback } from 'react';
 
 import { trackEvent } from 'js/helpers/trackers';
+import { EventInfo } from 'js/components/types';
 import { useFlaskDataContext } from '../Contexts';
 
-interface TrackingEventType {
-  action: string;
-  label?: string;
-  value?: number;
-}
-
-function useTrackEntityPageEvent() {
+function useTrackEntityPageEvent(pageType?: string) {
   const { entity = { hubmap_id: undefined, entity_type: undefined } } = useFlaskDataContext();
   const { hubmap_id, entity_type } = entity;
+
+  const category = pageType ?? (entity_type ? `${entity_type} Page` : 'Detail Page');
+
   return useCallback(
-    (event: TrackingEventType) => {
-      const category = entity_type ? `${entity_type} Page` : 'Detail Page';
+    (event: Omit<EventInfo, 'category'> & { category?: string }) => {
       trackEvent(
         {
           category,
@@ -23,7 +20,7 @@ function useTrackEntityPageEvent() {
         hubmap_id,
       );
     },
-    [hubmap_id, entity_type],
+    [hubmap_id, category],
   );
 }
 

--- a/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
+++ b/context/app/static/js/components/detailPage/useTrackEntityPageEvent.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { trackEvent } from 'js/helpers/trackers';
-import { EventInfo } from 'js/components/types';
+import { EventWithOptionalCategory } from 'js/components/types';
 import { useFlaskDataContext } from '../Contexts';
 
 function useTrackEntityPageEvent(pageType?: string) {
@@ -11,7 +11,7 @@ function useTrackEntityPageEvent(pageType?: string) {
   const category = pageType ?? (entity_type ? `${entity_type} Page` : 'Detail Page');
 
   return useCallback(
-    (event: Omit<EventInfo, 'category'> & { category?: string }) => {
+    (event: EventWithOptionalCategory) => {
       trackEvent(
         {
           category,

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -118,8 +118,8 @@ function Visualization({
 
   const expandVisualization = useCallback(() => {
     expandViz(id);
-    trackEntityPageEvent({ action: 'Vitessce / Full Screen' });
-  }, [expandViz, id, trackEntityPageEvent]);
+    trackEntityPageEvent({ ...trackingInfo, action: `${trackingInfo.action} / Expand Full Screen` });
+  }, [expandViz, id, trackEntityPageEvent, trackingInfo]);
 
   const isMultiDataset = Array.isArray(vitessceConfig);
 

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -118,7 +118,7 @@ function Visualization({
 
   const expandVisualization = useCallback(() => {
     expandViz(id);
-    trackEntityPageEvent({ ...trackingInfo, action: `${trackingInfo.action} / Expand Full Screen` });
+    trackEntityPageEvent({ ...trackingInfo, action: `${trackingInfo.action} / Full Screen` });
   }, [expandViz, id, trackEntityPageEvent, trackingInfo]);
 
   const isMultiDataset = Array.isArray(vitessceConfig);

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -148,7 +148,7 @@ function Visualization({
               {hasNotebook && <VisualizationWorkspaceButton />}
               <VisualizationDownloadButton uuid={uuid} hasNotebook={hasNotebook} parentUuid={parentUuid} />
               <VisualizationShareButton />
-              <VisualizationThemeSwitch />
+              <VisualizationThemeSwitch trackingInfo={{ action: 'Vitessce' }} />
               <SecondaryBackgroundTooltip title="Switch to Fullscreen">
                 <ExpandButton size="small" onClick={expandVisualization} variant="contained">
                   <FullscreenRoundedIcon color="primary" />

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -18,6 +18,7 @@ import VisualizationShareButton from 'js/components/detailPage/visualization/Vis
 import VisualizationThemeSwitch from 'js/components/detailPage/visualization/VisualizationThemeSwitch';
 import VisualizationFooter from 'js/components/detailPage/visualization/VisualizationFooter';
 import VisualizationTracker from 'js/components/detailPage/visualization/VisualizationTracker';
+import { EventWithOptionalCategory } from 'js/components/types';
 
 import BodyExpandedCSS from 'js/components/detailPage/visualization/BodyExpandedCSS';
 import { useCanvasScrollFix, useCollapseViz, useFirefoxWarning, useVitessceConfig } from './hooks';
@@ -42,6 +43,7 @@ const visualizationStoreSelector = (state: VisualizationStore) => ({
 
 interface VisualizationProps {
   vitData: object | object[];
+  trackingInfo: EventWithOptionalCategory;
   uuid?: string;
   hasNotebook: boolean;
   shouldDisplayHeader: boolean;
@@ -51,6 +53,7 @@ interface VisualizationProps {
 
 function Visualization({
   vitData,
+  trackingInfo,
   uuid,
   hasNotebook,
   shouldDisplayHeader,
@@ -147,8 +150,8 @@ function Visualization({
             <Stack direction="row" spacing={1}>
               {hasNotebook && <VisualizationWorkspaceButton />}
               <VisualizationDownloadButton uuid={uuid} hasNotebook={hasNotebook} parentUuid={parentUuid} />
-              <VisualizationShareButton />
-              <VisualizationThemeSwitch trackingInfo={{ action: 'Vitessce' }} />
+              <VisualizationShareButton trackingInfo={trackingInfo} />
+              <VisualizationThemeSwitch trackingInfo={trackingInfo} />
               <SecondaryBackgroundTooltip title="Switch to Fullscreen">
                 <ExpandButton size="small" onClick={expandVisualization} variant="contained">
                   <FullscreenRoundedIcon color="primary" />

--- a/context/app/static/js/components/detailPage/visualization/VisualizationShareButton/VisualizationShareButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationShareButton/VisualizationShareButton.tsx
@@ -8,8 +8,9 @@ import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualiz
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 import IconDropdownMenu from 'js/shared-styles/dropdowns/IconDropdownMenu';
 import { useHandleCopyClick } from 'js/hooks/useCopyText';
-
+import { EventInfo } from 'js/components/types';
 import { IconDropdownMenuItem } from 'js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu';
+
 import { createEmailWithUrl, getUrl } from './utils';
 import { DEFAULT_LONG_URL_WARNING } from './constants';
 
@@ -17,13 +18,17 @@ const visualizationStoreSelector = (state: VisualizationStore) => ({
   vitessceState: state.vitessceState,
 });
 
-function VisualizationShareButton() {
+function VisualizationShareButton({
+  trackingInfo,
+}: {
+  trackingInfo: Omit<EventInfo, 'category'> & { category?: string };
+}) {
   const { vitessceState } = useVisualizationStore(visualizationStoreSelector);
   const trackEntityPageEvent = useTrackEntityPageEvent();
   const handleCopyClick = useHandleCopyClick();
 
   const copyLink = () => {
-    trackEntityPageEvent({ action: 'Vitessce / Share Visualization' });
+    trackEntityPageEvent({ ...trackingInfo, action: `${trackingInfo.action} / Share Visualization` });
 
     let urlIsLong = false;
     const url = getUrl(vitessceState as object, () => {
@@ -43,6 +48,7 @@ function VisualizationShareButton() {
     {
       children: 'Email',
       onClick: () => {
+        trackEntityPageEvent({ ...trackingInfo, action: `${trackingInfo.action} / Share Visualization` });
         createEmailWithUrl(vitessceState as object);
       },
       icon: EmailIcon,

--- a/context/app/static/js/components/detailPage/visualization/VisualizationShareButton/VisualizationShareButton.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationShareButton/VisualizationShareButton.tsx
@@ -8,7 +8,7 @@ import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualiz
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 import IconDropdownMenu from 'js/shared-styles/dropdowns/IconDropdownMenu';
 import { useHandleCopyClick } from 'js/hooks/useCopyText';
-import { EventInfo } from 'js/components/types';
+import { EventWithOptionalCategory } from 'js/components/types';
 import { IconDropdownMenuItem } from 'js/shared-styles/dropdowns/IconDropdownMenu/IconDropdownMenu';
 
 import { createEmailWithUrl, getUrl } from './utils';
@@ -18,11 +18,7 @@ const visualizationStoreSelector = (state: VisualizationStore) => ({
   vitessceState: state.vitessceState,
 });
 
-function VisualizationShareButton({
-  trackingInfo,
-}: {
-  trackingInfo: Omit<EventInfo, 'category'> & { category?: string };
-}) {
+function VisualizationShareButton({ trackingInfo }: { trackingInfo: EventWithOptionalCategory }) {
   const { vitessceState } = useVisualizationStore(visualizationStoreSelector);
   const trackEntityPageEvent = useTrackEntityPageEvent();
   const handleCopyClick = useHandleCopyClick();

--- a/context/app/static/js/components/detailPage/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.spec.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.spec.tsx
@@ -4,7 +4,7 @@ import { render, screen } from 'test-utils/functions';
 import VisualizationThemeSwitch from './VisualizationThemeSwitch';
 
 test('switch emits change from light to dark by click on dark label', () => {
-  render(<VisualizationThemeSwitch />);
+  render(<VisualizationThemeSwitch trackingInfo={{}} />);
   const lightLabel = screen.getByLabelText('Visualization light theme button');
   const darkLabel = screen.getByLabelText('Visualization dark theme button');
   fireEvent.click(darkLabel);

--- a/context/app/static/js/components/detailPage/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.tsx
@@ -5,6 +5,7 @@ import Brightness2Icon from '@mui/icons-material/Brightness2Rounded';
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
 import { TooltipToggleButton } from 'js/shared-styles/buttons';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
+import { EventInfo } from 'js/components/types';
 import { StyledToggleButtonGroup } from './style';
 
 const visualizationStoreSelector = (state: VisualizationStore) => ({
@@ -17,7 +18,11 @@ const buttonIcons = {
   light: WbSunnyIcon,
 };
 
-function VisualizationThemeSwitch() {
+function VisualizationThemeSwitch({
+  trackingInfo,
+}: {
+  trackingInfo: Omit<EventInfo, 'category'> & { category?: string };
+}) {
   const { vizTheme, setVizTheme } = useVisualizationStore(visualizationStoreSelector);
   const trackEntityPageEvent = useTrackEntityPageEvent();
 
@@ -30,10 +35,16 @@ function VisualizationThemeSwitch() {
       onChange={(_, theme: 'light' | 'dark') => {
         // No theme arg means the user clicked on the already active theme.
         if (!theme) {
-          trackEntityPageEvent({ action: 'Vitessce / Selected Already Active Theme' });
+          trackEntityPageEvent({
+            ...trackingInfo,
+            action: `${trackingInfo.action} / Selected Already Active Theme`,
+          });
           return;
         }
-        trackEntityPageEvent({ action: `Vitessce / Toggle ${theme} Theme` });
+        trackEntityPageEvent({
+          ...trackingInfo,
+          action: `${trackingInfo.action} / Toggle ${theme} Theme`,
+        });
         setVizTheme(theme);
       }}
       size="small"

--- a/context/app/static/js/components/detailPage/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationThemeSwitch/VisualizationThemeSwitch.tsx
@@ -5,7 +5,7 @@ import Brightness2Icon from '@mui/icons-material/Brightness2Rounded';
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
 import { TooltipToggleButton } from 'js/shared-styles/buttons';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
-import { EventInfo } from 'js/components/types';
+import { EventWithOptionalCategory } from 'js/components/types';
 import { StyledToggleButtonGroup } from './style';
 
 const visualizationStoreSelector = (state: VisualizationStore) => ({
@@ -18,11 +18,7 @@ const buttonIcons = {
   light: WbSunnyIcon,
 };
 
-function VisualizationThemeSwitch({
-  trackingInfo,
-}: {
-  trackingInfo: Omit<EventInfo, 'category'> & { category?: string };
-}) {
+function VisualizationThemeSwitch({ trackingInfo }: { trackingInfo: EventWithOptionalCategory }) {
   const { vizTheme, setVizTheme } = useVisualizationStore(visualizationStoreSelector);
   const trackEntityPageEvent = useTrackEntityPageEvent();
 

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, useMemo } from 'react';
 
+import { EventWithOptionalCategory } from 'js/components/types';
 import VisualizationErrorBoundary from './VisualizationError';
 import { VizContainerStyleContext } from './ContainerStylingContext';
 import { VisualizationSuspenseFallback } from './VisualizationSuspenseFallback';
@@ -8,6 +9,7 @@ const Visualization = React.lazy(() => import('../Visualization'));
 
 interface VisualizationWrapperProps {
   vitData: object | object[];
+  trackingInfo: EventWithOptionalCategory;
   uuid?: string;
   hasNotebook?: boolean;
   shouldDisplayHeader?: boolean;
@@ -18,6 +20,7 @@ interface VisualizationWrapperProps {
 
 function VisualizationWrapper({
   vitData,
+  trackingInfo,
   uuid,
   hasNotebook = false,
   shouldDisplayHeader = true,
@@ -45,6 +48,7 @@ function VisualizationWrapper({
             shouldDisplayHeader={shouldDisplayHeader}
             shouldMountVitessce={hasBeenMounted}
             markerGene={markerGene}
+            trackingInfo={trackingInfo}
           />
         </Suspense>
       </VisualizationErrorBoundary>

--- a/context/app/static/js/components/genes/Organs/Visualization.tsx
+++ b/context/app/static/js/components/genes/Organs/Visualization.tsx
@@ -30,6 +30,7 @@ export function AzimuthVisualization({ organ }: AzimuthVisualizationProps) {
       <ReferenceBasedAnalysis modalities={azimuth.modalities} nunit={azimuth.nunit} dataref={azimuth.dataref} />
       <VisualizationWrapper
         vitData={azimuth.vitessce_conf}
+        trackingInfo={{ action: 'Reference Based Analysis' }}
         uuid={azimuth.title}
         hasBeenMounted
         hasNotebook={false}

--- a/context/app/static/js/components/home/HuBMAPDatasetsChart/HuBMAPDatasetsChart.tsx
+++ b/context/app/static/js/components/home/HuBMAPDatasetsChart/HuBMAPDatasetsChart.tsx
@@ -8,6 +8,7 @@ import { useChartPalette } from 'js/shared-styles/charts/HorizontalStackedBarCha
 import { ChartArea } from 'js/shared-styles/charts/HorizontalStackedBarChart/style';
 import { useBandScale, useLinearScale, useOrdinalScale } from 'js/shared-styles/charts/hooks';
 import Skeleton from '@mui/material/Skeleton';
+import { trackEvent } from 'js/helpers/trackers';
 import { TooltipData } from 'js/shared-styles/charts/types';
 import Typography from '@mui/material/Typography';
 import { AnyD3Scale } from '@visx/scale';
@@ -228,6 +229,12 @@ function HuBMAPDatasetsChart() {
             getY={getOrgan}
             showTooltipAndHover
             TooltipContent={HuBMAPDatasetsChartTooltip}
+            onBarClick={() => {
+              trackEvent({
+                category: 'Homepage',
+                action: 'HuBMAP Datasets Graph/Bar Links',
+              });
+            }}
             getBarHref={selectedColor.getBarHref}
             getAriaLabel={selectedColor.getAriaLabel}
           />

--- a/context/app/static/js/components/organ/Assays/Assays.tsx
+++ b/context/app/static/js/components/organ/Assays/Assays.tsx
@@ -13,6 +13,7 @@ import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
 import { OrganPageIds } from 'js/components/organ/types';
 import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
+import { useOrganContext } from 'js/components/organ/contexts';
 import { getSearchURL } from '../utils';
 
 interface AssaysProps {
@@ -22,13 +23,22 @@ interface AssaysProps {
 
 function Assays({ organTerms, bucketData }: AssaysProps) {
   const assayTypeMap = useDatasetTypeMap();
+  const {
+    organ: { name },
+  } = useOrganContext();
 
   return (
     <OrganDetailSection
       id={OrganPageIds.assaysId}
       title="Assays"
       iconTooltipText="Experiments related to this organ"
-      action={<ViewEntitiesButton entityType="Dataset" filters={{ organTerms }} />}
+      action={
+        <ViewEntitiesButton
+          entityType="Dataset"
+          filters={{ organTerms }}
+          trackingInfo={{ action: 'Assays', label: name }}
+        />
+      }
     >
       <Paper>
         <EntitiesTable

--- a/context/app/static/js/components/organ/Assays/Assays.tsx
+++ b/context/app/static/js/components/organ/Assays/Assays.tsx
@@ -14,6 +14,8 @@ import { OrganPageIds } from 'js/components/organ/types';
 import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { useOrganContext } from 'js/components/organ/contexts';
+import { useEventCallback } from '@mui/material';
+import { trackEvent } from 'js/helpers/trackers';
 import { getSearchURL } from '../utils';
 
 interface AssaysProps {
@@ -26,6 +28,14 @@ function Assays({ organTerms, bucketData }: AssaysProps) {
   const {
     organ: { name },
   } = useOrganContext();
+
+  const handleSelectTrack = useEventCallback((assay: string) => {
+    trackEvent({
+      category: 'Organ Page',
+      action: 'Assays / Select Assay From Table',
+      label: `${name} ${assay}`,
+    });
+  });
 
   return (
     <OrganDetailSection
@@ -53,6 +63,7 @@ function Assays({ organTerms, bucketData }: AssaysProps) {
               <TableCell>
                 <InternalLink
                   href={getSearchURL({ entityType: 'Dataset', organTerms, mappedAssay: bucket.key, assayTypeMap })}
+                  onClick={() => handleSelectTrack(bucket.key)}
                   variant="body2"
                 >
                   {bucket.key}

--- a/context/app/static/js/components/organ/Assays/Assays.tsx
+++ b/context/app/static/js/components/organ/Assays/Assays.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 
 import EntitiesTable from 'js/shared-styles/tables/EntitiesTable';
 import { InternalLink } from 'js/shared-styles/Links';

--- a/context/app/static/js/components/organ/Assays/Assays.tsx
+++ b/context/app/static/js/components/organ/Assays/Assays.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import Paper from '@mui/material/Paper';
+import useEventCallback from '@mui/material/utils/useEventCallback';
 
 import EntitiesTable from 'js/shared-styles/tables/EntitiesTable';
 import { InternalLink } from 'js/shared-styles/Links';
@@ -14,7 +15,6 @@ import { OrganPageIds } from 'js/components/organ/types';
 import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { useOrganContext } from 'js/components/organ/contexts';
-import { useEventCallback } from '@mui/material';
 import { trackEvent } from 'js/helpers/trackers';
 import { getSearchURL } from '../utils';
 
@@ -29,7 +29,7 @@ function Assays({ organTerms, bucketData }: AssaysProps) {
     organ: { name },
   } = useOrganContext();
 
-  const handleSelectTrack = useEventCallback((assay: string) => {
+  const trackClick = useEventCallback((assay: string) => {
     trackEvent({
       category: 'Organ Page',
       action: 'Assays / Select Assay From Table',
@@ -63,7 +63,7 @@ function Assays({ organTerms, bucketData }: AssaysProps) {
               <TableCell>
                 <InternalLink
                   href={getSearchURL({ entityType: 'Dataset', organTerms, mappedAssay: bucket.key, assayTypeMap })}
-                  onClick={() => handleSelectTrack(bucket.key)}
+                  onClick={() => trackClick(bucket.key)}
                   variant="body2"
                 >
                   {bucket.key}

--- a/context/app/static/js/components/organ/Assays/Assays.tsx
+++ b/context/app/static/js/components/organ/Assays/Assays.tsx
@@ -11,21 +11,21 @@ import { HeaderCell } from 'js/shared-styles/tables';
 import { useDatasetTypeMap } from 'js/components/home/HuBMAPDatasetsChart/hooks';
 import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
 import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
+import { OrganPageIds } from 'js/components/organ/types';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { getSearchURL } from '../utils';
 
 interface AssaysProps {
   organTerms: string[];
   bucketData: { key: string; doc_count: number }[];
-  id: string;
 }
 
-function Assays({ organTerms, bucketData, id: sectionId }: AssaysProps) {
+function Assays({ organTerms, bucketData }: AssaysProps) {
   const assayTypeMap = useDatasetTypeMap();
 
   return (
     <CollapsibleDetailPageSection
-      id={sectionId}
+      id={OrganPageIds.assaysId}
       title="Assays"
       iconTooltipText="Experiments related to this organ"
       action={<ViewEntitiesButton entityType="Dataset" filters={{ organTerms }} />}

--- a/context/app/static/js/components/organ/Assays/Assays.tsx
+++ b/context/app/static/js/components/organ/Assays/Assays.tsx
@@ -10,8 +10,8 @@ import DatasetsBarChart from 'js/components/organ/OrganDatasetsChart';
 import { HeaderCell } from 'js/shared-styles/tables';
 import { useDatasetTypeMap } from 'js/components/home/HuBMAPDatasetsChart/hooks';
 import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
-import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import { OrganPageIds } from 'js/components/organ/types';
+import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { getSearchURL } from '../utils';
 
@@ -24,7 +24,7 @@ function Assays({ organTerms, bucketData }: AssaysProps) {
   const assayTypeMap = useDatasetTypeMap();
 
   return (
-    <CollapsibleDetailPageSection
+    <OrganDetailSection
       id={OrganPageIds.assaysId}
       title="Assays"
       iconTooltipText="Experiments related to this organ"
@@ -54,7 +54,7 @@ function Assays({ organTerms, bucketData }: AssaysProps) {
         />
       </Paper>
       <DatasetsBarChart search={organTerms} />
-    </CollapsibleDetailPageSection>
+    </OrganDetailSection>
   );
 }
 

--- a/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
+++ b/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
@@ -3,32 +3,35 @@ import Stack from '@mui/material/Stack';
 
 import OutboundLinkButton from 'js/shared-styles/Links/OutboundLinkButton';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper';
-
 import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
+import { useOrganContext } from 'js/components/organ/contexts';
+import { OrganPageIds } from 'js/components/organ/types';
 import ReferenceBasedAnalysis from './ReferenceBasedAnalysis';
-import { AzimuthConfig } from '../types';
 
-interface AzimuthProps {
-  config: AzimuthConfig;
-  id: string;
-}
+function Azimuth() {
+  const {
+    organ: { azimuth },
+  } = useOrganContext();
 
-function Azimuth({ config, id }: AzimuthProps) {
+  if (!azimuth) {
+    return null;
+  }
+
   return (
     <CollapsibleDetailPageSection
-      id={id}
+      id={OrganPageIds.referenceId}
       title="Reference-Based Analysis"
       iconTooltipText="Analysis provided by Azimuth that uses an annotated reference dataset to automate the processing, analysis and interpretation of a single-cell RNA-seq experiment."
       action={
-        <OutboundLinkButton href={config.applink} component="a">
+        <OutboundLinkButton href={azimuth.applink} component="a">
           Open Azimuth App
         </OutboundLinkButton>
       }
     >
       <Stack dir="column" gap={1}>
-        <ReferenceBasedAnalysis {...config} wrapped />
-        <VisualizationWrapper vitData={config.vitessce_conf} shouldDisplayHeader={false} />
+        <ReferenceBasedAnalysis {...azimuth} wrapped />
+        <VisualizationWrapper vitData={azimuth.vitessce_conf} shouldDisplayHeader={false} />
       </Stack>
     </CollapsibleDetailPageSection>
   );

--- a/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
+++ b/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Stack from '@mui/material/Stack';
+import useEventCallback from '@mui/material/utils/useEventCallback';
 
 import OutboundLinkButton from 'js/shared-styles/Links/OutboundLinkButton';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper';
@@ -7,14 +8,23 @@ import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { useOrganContext } from 'js/components/organ/contexts';
 import { OrganPageIds } from 'js/components/organ/types';
 import OrganDetailSection from 'js/components/organ/OrganDetailSection';
+import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 import ReferenceBasedAnalysis from './ReferenceBasedAnalysis';
 
 const title = 'Reference-Based Analysis';
 
 function Azimuth() {
   const {
-    organ: { azimuth },
+    organ: { azimuth, name },
   } = useOrganContext();
+
+  const trackEntityPageEvent = useTrackEntityPageEvent('Organ Page');
+  const handleTrack = useEventCallback(() => {
+    trackEntityPageEvent({
+      action: 'Reference Based Analysis / Open Azimuth',
+      label: name,
+    });
+  });
 
   if (!azimuth) {
     return null;
@@ -26,14 +36,22 @@ function Azimuth() {
       title={title}
       iconTooltipText="Analysis provided by Azimuth that uses an annotated reference dataset to automate the processing, analysis and interpretation of a single-cell RNA-seq experiment."
       action={
-        <OutboundLinkButton href={azimuth.applink} component="a">
+        <OutboundLinkButton href={azimuth.applink} component="a" onClick={handleTrack}>
           Open Azimuth App
         </OutboundLinkButton>
       }
     >
       <Stack dir="column" gap={1}>
         <ReferenceBasedAnalysis {...azimuth} wrapped />
-        <VisualizationWrapper vitData={azimuth.vitessce_conf} shouldDisplayHeader={false} />
+        <VisualizationWrapper
+          vitData={azimuth.vitessce_conf}
+          shouldDisplayHeader={false}
+          trackingInfo={{
+            category: 'Organ Page',
+            action: 'Reference Based Analysis',
+            label: name,
+          }}
+        />
       </Stack>
     </OrganDetailSection>
   );

--- a/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
+++ b/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
@@ -3,11 +3,13 @@ import Stack from '@mui/material/Stack';
 
 import OutboundLinkButton from 'js/shared-styles/Links/OutboundLinkButton';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper';
-import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { useOrganContext } from 'js/components/organ/contexts';
 import { OrganPageIds } from 'js/components/organ/types';
+import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 import ReferenceBasedAnalysis from './ReferenceBasedAnalysis';
+
+const title = 'Reference-Based Analysis';
 
 function Azimuth() {
   const {
@@ -19,9 +21,9 @@ function Azimuth() {
   }
 
   return (
-    <CollapsibleDetailPageSection
+    <OrganDetailSection
       id={OrganPageIds.referenceId}
-      title="Reference-Based Analysis"
+      title={title}
       iconTooltipText="Analysis provided by Azimuth that uses an annotated reference dataset to automate the processing, analysis and interpretation of a single-cell RNA-seq experiment."
       action={
         <OutboundLinkButton href={azimuth.applink} component="a">
@@ -33,7 +35,7 @@ function Azimuth() {
         <ReferenceBasedAnalysis {...azimuth} wrapped />
         <VisualizationWrapper vitData={azimuth.vitessce_conf} shouldDisplayHeader={false} />
       </Stack>
-    </CollapsibleDetailPageSection>
+    </OrganDetailSection>
   );
 }
 

--- a/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
+++ b/context/app/static/js/components/organ/Azimuth/Azimuth.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Stack from '@mui/material/Stack';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 
 import OutboundLinkButton from 'js/shared-styles/Links/OutboundLinkButton';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper';

--- a/context/app/static/js/components/organ/CellPop/CellPopActions.tsx
+++ b/context/app/static/js/components/organ/CellPop/CellPopActions.tsx
@@ -6,7 +6,8 @@ import FullscreenRoundedIcon from '@mui/icons-material/FullscreenRounded';
 import VisualizationThemeSwitch from 'js/components/detailPage/visualization/VisualizationThemeSwitch';
 import { SpacedSectionButtonRow } from 'js/shared-styles/sections/SectionButtonRow';
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
-import { trackEvent } from 'js/helpers/trackers';
+import { useOrganContext } from 'js/components/organ/contexts';
+import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
 
 interface CellPopActionsProps {
   id: string;
@@ -17,16 +18,21 @@ function visualizationSelector(store: VisualizationStore) {
 }
 
 export default function CellPopActions({ id }: CellPopActionsProps) {
+  const {
+    organ: { name },
+  } = useOrganContext();
+  const trackEntityPageEvent = useTrackEntityPageEvent('Organ Page');
+
   const expandViz = useVisualizationStore(visualizationSelector);
   const expand = useCallback(() => {
-    trackEvent({ category: 'Organ Page', action: 'Expand Cell Population Plot' });
+    trackEntityPageEvent({ action: 'Expand Cell Population Plot', label: name });
     expandViz(id);
-  }, [expandViz, id]);
+  }, [expandViz, id, name, trackEntityPageEvent]);
   return (
     <SpacedSectionButtonRow
       buttons={
         <Stack direction="row" spacing={1}>
-          <VisualizationThemeSwitch />
+          <VisualizationThemeSwitch trackingInfo={{ category: 'Organ Page', action: 'Cellpop', label: name }} />
           <SecondaryBackgroundTooltip title="Switch to Fullscreen">
             <ExpandButton size="small" onClick={expand} variant="contained">
               <FullscreenRoundedIcon color="primary" />

--- a/context/app/static/js/components/organ/CellPop/CellPopulationPlot.tsx
+++ b/context/app/static/js/components/organ/CellPop/CellPopulationPlot.tsx
@@ -8,12 +8,12 @@ import { ExpandableDiv } from 'js/components/detailPage/visualization/Visualizat
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
 import lightTheme, { darkTheme } from 'js/theme/theme';
 import BodyExpandedCSS from 'js/components/detailPage/visualization/BodyExpandedCSS';
+import { OrganPageIds } from 'js/components/organ/types';
 import CellPopDescription from './CellPopDescription';
 import CellPopActions from './CellPopActions';
 import { useTrackCellpop } from './hooks';
 
 interface CellPopulationPlotProps {
-  id: string;
   uuids: string[];
 }
 
@@ -24,16 +24,18 @@ function visualizationSelector(store: VisualizationStore) {
   };
 }
 
-function CellPopulationPlot({ id, uuids }: CellPopulationPlotProps) {
+const { cellpopId } = OrganPageIds;
+
+function CellPopulationPlot({ uuids }: CellPopulationPlotProps) {
   const { fullscreenVizId, theme } = useVisualizationStore(visualizationSelector);
-  const vizIsFullscreen = fullscreenVizId === id;
+  const vizIsFullscreen = fullscreenVizId === cellpopId;
 
   const trackEvent = useTrackCellpop();
 
   return (
-    <CollapsibleDetailPageSection title="Cell Population Plot" id={id} icon={CellTypeIcon}>
+    <CollapsibleDetailPageSection title="Cell Population Plot" id={cellpopId} icon={CellTypeIcon}>
       <CellPopDescription />
-      <CellPopActions id={id} />
+      <CellPopActions id={cellpopId} />
       <Paper>
         <ExpandableDiv $isExpanded={vizIsFullscreen} $theme={theme} $nonExpandedHeight={1000}>
           <CellPopHuBMAPLoader
@@ -71,7 +73,7 @@ function CellPopulationPlot({ id, uuids }: CellPopulationPlotProps) {
             disabledControls={['theme']}
             trackEvent={trackEvent}
           />
-          <BodyExpandedCSS id={id} />
+          <BodyExpandedCSS id={cellpopId} />
         </ExpandableDiv>
       </Paper>
     </CollapsibleDetailPageSection>

--- a/context/app/static/js/components/organ/CellPop/CellPopulationPlot.tsx
+++ b/context/app/static/js/components/organ/CellPop/CellPopulationPlot.tsx
@@ -1,4 +1,3 @@
-import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import React from 'react';
 import { CellPopHuBMAPLoader } from 'cellpop';
@@ -8,6 +7,7 @@ import { ExpandableDiv } from 'js/components/detailPage/visualization/Visualizat
 import useVisualizationStore, { VisualizationStore } from 'js/stores/useVisualizationStore';
 import lightTheme, { darkTheme } from 'js/theme/theme';
 import BodyExpandedCSS from 'js/components/detailPage/visualization/BodyExpandedCSS';
+import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 import { OrganPageIds } from 'js/components/organ/types';
 import CellPopDescription from './CellPopDescription';
 import CellPopActions from './CellPopActions';
@@ -33,7 +33,7 @@ function CellPopulationPlot({ uuids }: CellPopulationPlotProps) {
   const trackEvent = useTrackCellpop();
 
   return (
-    <CollapsibleDetailPageSection title="Cell Population Plot" id={cellpopId} icon={CellTypeIcon}>
+    <OrganDetailSection title="Cell Population Plot" id={cellpopId} icon={CellTypeIcon}>
       <CellPopDescription />
       <CellPopActions id={cellpopId} />
       <Paper>
@@ -76,7 +76,7 @@ function CellPopulationPlot({ uuids }: CellPopulationPlotProps) {
           <BodyExpandedCSS id={cellpopId} />
         </ExpandableDiv>
       </Paper>
-    </CollapsibleDetailPageSection>
+    </OrganDetailSection>
   );
 }
 

--- a/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
+++ b/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
@@ -18,8 +18,9 @@ import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink'
 import { InternalLink } from 'js/shared-styles/Links';
 import { getFileName } from 'js/helpers/functions';
 import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
-import { OrganDataProducts } from 'js/components/organ/types';
+import { OrganDataProducts, OrganPageIds } from 'js/components/organ/types';
 import { trackEvent } from 'js/helpers/trackers';
+import { useOrganContext } from 'js/components/organ/contexts';
 
 const description = [
   'Download HuBMAP-wide data products that contain consolidated data for datasets of a particular assay type and tissue, aggregated across multiple datasets. You can also explore the datasets that contribute to each data product.',
@@ -41,14 +42,16 @@ const headerCells = [
 ));
 
 interface DataProductsProps {
-  id: string;
   dataProducts: OrganDataProducts[];
-  organName: string;
   isLateral?: boolean;
   isLoading?: boolean;
 }
 
-function DataProducts({ id, organName, dataProducts, isLateral, isLoading }: DataProductsProps) {
+function DataProducts({ dataProducts, isLateral, isLoading }: DataProductsProps) {
+  const {
+    organ: { name },
+  } = useOrganContext();
+
   const handleTrack = useEventCallback(
     ({
       action,
@@ -70,21 +73,21 @@ function DataProducts({ id, organName, dataProducts, isLateral, isLoading }: Dat
       trackEvent({
         category: 'Organ Detail Page: Data Products',
         action: `Data Products / ${action}`,
-        label: `${organName}${laterality}${assay}${file}`,
+        label: `${name}${laterality}${assay}${file}`,
       });
     },
   );
 
   if (isLoading) {
     return (
-      <CollapsibleDetailPageSection id={id} title="Data Products">
+      <CollapsibleDetailPageSection id={OrganPageIds.dataProductsId} title="Data Products">
         <Skeleton variant="rectangular" height={400} />
       </CollapsibleDetailPageSection>
     );
   }
 
   return (
-    <CollapsibleDetailPageSection id={id} title="Data Products">
+    <CollapsibleDetailPageSection id={OrganPageIds.dataProductsId} title="Data Products">
       <Stack spacing={1}>
         <Description>
           <Stack spacing={1} direction="column">

--- a/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
+++ b/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
@@ -9,7 +9,6 @@ import Stack from '@mui/material/Stack';
 import Skeleton from '@mui/material/Skeleton';
 import { useEventCallback } from '@mui/material/utils';
 
-import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import Description from 'js/shared-styles/sections/Description';
 import EntitiesTable from 'js/shared-styles/tables/EntitiesTable';
@@ -19,8 +18,9 @@ import { InternalLink } from 'js/shared-styles/Links';
 import { getFileName } from 'js/helpers/functions';
 import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
 import { OrganDataProducts, OrganPageIds } from 'js/components/organ/types';
-import { trackEvent } from 'js/helpers/trackers';
 import { useOrganContext } from 'js/components/organ/contexts';
+import OrganDetailSection from 'js/components/organ/OrganDetailSection';
+import { trackEvent } from 'js/helpers/trackers';
 
 const description = [
   'Download HuBMAP-wide data products that contain consolidated data for datasets of a particular assay type and tissue, aggregated across multiple datasets. You can also explore the datasets that contribute to each data product.',
@@ -80,14 +80,14 @@ function DataProducts({ dataProducts, isLateral, isLoading }: DataProductsProps)
 
   if (isLoading) {
     return (
-      <CollapsibleDetailPageSection id={OrganPageIds.dataProductsId} title="Data Products">
+      <OrganDetailSection id={OrganPageIds.dataProductsId} title="Data Products">
         <Skeleton variant="rectangular" height={400} />
-      </CollapsibleDetailPageSection>
+      </OrganDetailSection>
     );
   }
 
   return (
-    <CollapsibleDetailPageSection id={OrganPageIds.dataProductsId} title="Data Products">
+    <OrganDetailSection id={OrganPageIds.dataProductsId} title="Data Products">
       <Stack spacing={1}>
         <Description>
           <Stack spacing={1} direction="column">
@@ -163,7 +163,7 @@ function DataProducts({ dataProducts, isLateral, isLoading }: DataProductsProps)
           />
         </Paper>
       </Stack>
-    </CollapsibleDetailPageSection>
+    </OrganDetailSection>
   );
 }
 

--- a/context/app/static/js/components/organ/Description/Description.tsx
+++ b/context/app/static/js/components/organ/Description/Description.tsx
@@ -1,34 +1,33 @@
 import React, { PropsWithChildren } from 'react';
 
-import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
-
-import DetailPageSection from 'js/components/detailPage/DetailPageSection';
-import { DetailSectionPaper } from 'js/shared-styles/surfaces';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
+
+import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+import DetailPageSection from 'js/components/detailPage/DetailPageSection';
+import { DetailSectionPaper } from 'js/shared-styles/surfaces';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
+import { useOrganContext } from 'js/components/organ/contexts';
+import { OrganPageIds } from 'js/components/organ/types';
 
-interface DescriptionProps extends PropsWithChildren {
-  uberonIri: string;
-  uberonShort: string;
-  asctbId?: string;
-  id: string;
-}
+function Description({ children }: PropsWithChildren) {
+  const {
+    organ: { uberon, uberon_short, asctb },
+  } = useOrganContext();
 
-function Description({ children, uberonIri, uberonShort, asctbId, id }: DescriptionProps) {
   return (
-    <DetailPageSection id={id}>
+    <DetailPageSection id={OrganPageIds.summaryId}>
       <DetailSectionPaper>
         <Stack spacing={1}>
           <Typography variant="body1">{children}</Typography>
           <Typography variant="body1">
-            Uberon: <OutboundIconLink href={uberonIri}>{uberonShort}</OutboundIconLink>
+            Uberon: <OutboundIconLink href={uberon}>{uberon_short}</OutboundIconLink>
           </Typography>
-          {asctbId && (
+          {asctb && (
             <Typography variant="body1">
               Visit the{' '}
               <OutboundIconLink
-                href={`https://hubmapconsortium.github.io/ccf-asct-reporter/vis?selectedOrgans=${asctbId}&playground=false`}
+                href={`https://hubmapconsortium.github.io/ccf-asct-reporter/vis?selectedOrgans=${asctb}&playground=false`}
               >
                 ASCT+B Reporter
               </OutboundIconLink>

--- a/context/app/static/js/components/organ/Description/Description.tsx
+++ b/context/app/static/js/components/organ/Description/Description.tsx
@@ -1,4 +1,4 @@
-import React, { PropsWithChildren } from 'react';
+import React from 'react';
 
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
@@ -10,16 +10,16 @@ import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { useOrganContext } from 'js/components/organ/contexts';
 import { OrganPageIds } from 'js/components/organ/types';
 
-function Description({ children }: PropsWithChildren) {
+function Description() {
   const {
-    organ: { uberon, uberon_short, asctb },
+    organ: { description, uberon, uberon_short, asctb },
   } = useOrganContext();
 
   return (
     <DetailPageSection id={OrganPageIds.summaryId}>
       <DetailSectionPaper>
         <Stack spacing={1}>
-          <Typography variant="body1">{children}</Typography>
+          <Typography variant="body1">{description}</Typography>
           <Typography variant="body1">
             Uberon: <OutboundIconLink href={uberon}>{uberon_short}</OutboundIconLink>
           </Typography>

--- a/context/app/static/js/components/organ/HumanReferenceAtlas/HumanReferenceAtlas.tsx
+++ b/context/app/static/js/components/organ/HumanReferenceAtlas/HumanReferenceAtlas.tsx
@@ -5,21 +5,22 @@ import Paper from '@mui/material/Paper';
 import CCFOrganInfo from 'js/components/HRA/CCFOrganInfo';
 import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
+import { useOrganContext } from 'js/components/organ/contexts';
+import { OrganPageIds } from 'js/components/organ/types';
 
-interface HumanReferenceAtlasProps {
-  uberonIri: string;
-  id: string;
-}
+function HumanReferenceAtlas() {
+  const {
+    organ: { uberon },
+  } = useOrganContext();
 
-function HumanReferenceAtlas({ uberonIri, id }: HumanReferenceAtlasProps) {
   return (
     <CollapsibleDetailPageSection
-      id={id}
+      id={OrganPageIds.humanReferenceAtlasId}
       title="Human Reference Atlas"
       iconTooltipText="Atlas provided by the Common Coordinate Framework (CCF)."
     >
       <Paper>
-        <CCFOrganInfo uberonIri={uberonIri} />
+        <CCFOrganInfo uberonIri={uberon} />
       </Paper>
     </CollapsibleDetailPageSection>
   );

--- a/context/app/static/js/components/organ/HumanReferenceAtlas/HumanReferenceAtlas.tsx
+++ b/context/app/static/js/components/organ/HumanReferenceAtlas/HumanReferenceAtlas.tsx
@@ -8,8 +8,6 @@ import { useOrganContext } from 'js/components/organ/contexts';
 import { OrganPageIds } from 'js/components/organ/types';
 import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 
-const title = 'Human Reference Atlas';
-
 function HumanReferenceAtlas() {
   const {
     organ: { uberon },
@@ -17,8 +15,8 @@ function HumanReferenceAtlas() {
 
   return (
     <OrganDetailSection
-      id={OrganPageIds.humanReferenceAtlasId}
-      title={title}
+      id={OrganPageIds.hraId}
+      title="Human Reference Atlas"
       iconTooltipText="Atlas provided by the Common Coordinate Framework (CCF)."
     >
       <Paper>

--- a/context/app/static/js/components/organ/HumanReferenceAtlas/HumanReferenceAtlas.tsx
+++ b/context/app/static/js/components/organ/HumanReferenceAtlas/HumanReferenceAtlas.tsx
@@ -3,10 +3,12 @@ import React from 'react';
 import Paper from '@mui/material/Paper';
 
 import CCFOrganInfo from 'js/components/HRA/CCFOrganInfo';
-import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { useOrganContext } from 'js/components/organ/contexts';
 import { OrganPageIds } from 'js/components/organ/types';
+import OrganDetailSection from 'js/components/organ/OrganDetailSection';
+
+const title = 'Human Reference Atlas';
 
 function HumanReferenceAtlas() {
   const {
@@ -14,15 +16,15 @@ function HumanReferenceAtlas() {
   } = useOrganContext();
 
   return (
-    <CollapsibleDetailPageSection
+    <OrganDetailSection
       id={OrganPageIds.humanReferenceAtlasId}
-      title="Human Reference Atlas"
+      title={title}
       iconTooltipText="Atlas provided by the Common Coordinate Framework (CCF)."
     >
       <Paper>
         <CCFOrganInfo uberonIri={uberon} />
       </Paper>
-    </CollapsibleDetailPageSection>
+    </OrganDetailSection>
   );
 }
 

--- a/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.tsx
+++ b/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.tsx
@@ -10,6 +10,8 @@ import { includeOnlyDatasetsClause } from 'js/helpers/queries';
 import { useBandScale, useLinearScale, useOrdinalScale } from 'js/shared-styles/charts/hooks';
 import { useDatasetTypeMap } from 'js/components/home/HuBMAPDatasetsChart/hooks';
 import { mustHaveOrganClause } from 'js/pages/Organ/queries';
+import { trackEvent } from 'js/helpers/trackers';
+import { useOrganContext } from 'js/components/organ/contexts';
 import { OrganFile } from '../types';
 import { datasetTypeForOrganTermsQuery, DatasetTypeOrganQueryAggs } from './queries';
 import { getSearchURL } from '../utils';
@@ -26,6 +28,9 @@ function OrganDatasetsChart({ search }: Pick<OrganFile, 'search'>) {
   );
 
   const datasetTypeMap = useDatasetTypeMap();
+  const {
+    organ: { name },
+  } = useOrganContext();
 
   const { searchData: assayOrganTypeData } = useSearchData<unknown, DatasetTypeOrganQueryAggs>(updatedQuery);
 
@@ -80,6 +85,13 @@ function OrganDatasetsChart({ search }: Pick<OrganFile, 'search'>) {
           assayTypeMap: datasetTypeMap,
         })
       }
+      onBarClick={(d) => {
+        trackEvent({
+          category: 'Organ Page',
+          action: 'Assays / Select Assay From Graphic',
+          label: `${name} ${d?.bar?.data?.datasetType}`,
+        });
+      }}
       getAriaLabel={(d) => {
         const organ = d?.key;
         const assay = d?.bar?.data.datasetType;

--- a/context/app/static/js/components/organ/OrganDetailSection.tsx
+++ b/context/app/static/js/components/organ/OrganDetailSection.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import {
+  CollapsibleDetailPageSection,
+  CollapsibleDetailPageSectionProps,
+} from 'js/components/detailPage/DetailPageSection';
+import { useOrganContext } from 'js/components/organ/contexts';
+import { OrganEventCategories } from 'js/components/organ/types';
+
+function OrganDetailSection({ title, ...rest }: CollapsibleDetailPageSectionProps) {
+  const {
+    organ: { name },
+  } = useOrganContext();
+
+  return (
+    <CollapsibleDetailPageSection
+      trackingInfo={{ category: OrganEventCategories.OrganPage, label: `${name} ${title}` }}
+      title={title}
+      {...rest}
+    />
+  );
+}
+
+export default OrganDetailSection;

--- a/context/app/static/js/components/organ/OrganDetailSection.tsx
+++ b/context/app/static/js/components/organ/OrganDetailSection.tsx
@@ -4,7 +4,6 @@ import {
   CollapsibleDetailPageSectionProps,
 } from 'js/components/detailPage/DetailPageSection';
 import { useOrganContext } from 'js/components/organ/contexts';
-import { OrganEventCategories } from 'js/components/organ/types';
 
 function OrganDetailSection({ title, ...rest }: CollapsibleDetailPageSectionProps) {
   const {
@@ -13,7 +12,7 @@ function OrganDetailSection({ title, ...rest }: CollapsibleDetailPageSectionProp
 
   return (
     <CollapsibleDetailPageSection
-      trackingInfo={{ category: OrganEventCategories.OrganPage, label: `${name} ${title}` }}
+      trackingInfo={{ category: 'Organ Page', label: `${name} ${title}` }}
       title={title}
       {...rest}
     />

--- a/context/app/static/js/components/organ/Samples/Samples.tsx
+++ b/context/app/static/js/components/organ/Samples/Samples.tsx
@@ -13,10 +13,10 @@ import {
   parentDonorSex,
   parentDonorRace,
 } from 'js/shared-styles/tables/columns';
-import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { OrganPageIds } from 'js/components/organ/types';
+import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 
 const columns = [hubmapID, parentDonorAge, parentDonorSex, parentDonorRace, datasetDescendants, createdTimestamp];
 
@@ -52,7 +52,7 @@ function Samples({ organTerms }: OrganSamplesProps) {
   );
 
   return (
-    <CollapsibleDetailPageSection
+    <OrganDetailSection
       id={OrganPageIds.samplesId}
       title="Samples"
       action={
@@ -63,7 +63,7 @@ function Samples({ organTerms }: OrganSamplesProps) {
       }
     >
       <EntitiesTables<SampleDocument> entities={[{ query, columns, entityType: 'Sample' }]} />
-    </CollapsibleDetailPageSection>
+    </OrganDetailSection>
   );
 }
 

--- a/context/app/static/js/components/organ/Samples/Samples.tsx
+++ b/context/app/static/js/components/organ/Samples/Samples.tsx
@@ -16,15 +16,15 @@ import {
 import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
+import { OrganPageIds } from 'js/components/organ/types';
 
 const columns = [hubmapID, parentDonorAge, parentDonorSex, parentDonorRace, datasetDescendants, createdTimestamp];
 
 interface OrganSamplesProps {
   organTerms: string[];
-  id: string;
 }
 
-function Samples({ organTerms, id }: OrganSamplesProps) {
+function Samples({ organTerms }: OrganSamplesProps) {
   const query = useMemo(
     () => ({
       post_filter: {
@@ -53,7 +53,7 @@ function Samples({ organTerms, id }: OrganSamplesProps) {
 
   return (
     <CollapsibleDetailPageSection
-      id={id}
+      id={OrganPageIds.samplesId}
       title="Samples"
       action={
         <Stack direction="row" spacing={1}>

--- a/context/app/static/js/components/organ/Samples/Samples.tsx
+++ b/context/app/static/js/components/organ/Samples/Samples.tsx
@@ -17,6 +17,7 @@ import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { OrganPageIds } from 'js/components/organ/types';
 import OrganDetailSection from 'js/components/organ/OrganDetailSection';
+import { useOrganContext } from 'js/components/organ/contexts';
 
 const columns = [hubmapID, parentDonorAge, parentDonorSex, parentDonorRace, datasetDescendants, createdTimestamp];
 
@@ -51,13 +52,21 @@ function Samples({ organTerms }: OrganSamplesProps) {
     [organTerms],
   );
 
+  const {
+    organ: { name },
+  } = useOrganContext();
+
   return (
     <OrganDetailSection
       id={OrganPageIds.samplesId}
       title="Samples"
       action={
         <Stack direction="row" spacing={1}>
-          <ViewEntitiesButton entityType="Sample" filters={{ organTerms }} />
+          <ViewEntitiesButton
+            entityType="Sample"
+            filters={{ organTerms }}
+            trackingInfo={{ action: 'Samples', label: name }}
+          />
           <SaveEntitiesButtonFromSearch entity_type="Sample" />
         </Stack>
       }

--- a/context/app/static/js/components/organ/Samples/Samples.tsx
+++ b/context/app/static/js/components/organ/Samples/Samples.tsx
@@ -71,7 +71,10 @@ function Samples({ organTerms }: OrganSamplesProps) {
         </Stack>
       }
     >
-      <EntitiesTables<SampleDocument> entities={[{ query, columns, entityType: 'Sample' }]} />
+      <EntitiesTables<SampleDocument>
+        entities={[{ query, columns, entityType: 'Sample' }]}
+        trackingInfo={{ category: 'Organ Page', action: 'Samples', label: name }}
+      />
     </OrganDetailSection>
   );
 }

--- a/context/app/static/js/components/organ/ViewEntitiesButton.tsx
+++ b/context/app/static/js/components/organ/ViewEntitiesButton.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import Button, { ButtonProps } from '@mui/material/Button';
+import { useEventCallback } from '@mui/material/utils';
 import { DatasetIcon } from 'js/shared-styles/icons';
 import { SearchURLTypes, getSearchURL } from 'js/components/organ/utils';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
-import { useEventCallback } from '@mui/material';
 import { EventWithOptionalCategory } from 'js/components/types';
 
 interface ViewEntitiesButtonProps extends ButtonProps {

--- a/context/app/static/js/components/organ/ViewEntitiesButton.tsx
+++ b/context/app/static/js/components/organ/ViewEntitiesButton.tsx
@@ -2,18 +2,36 @@ import React from 'react';
 import Button, { ButtonProps } from '@mui/material/Button';
 import { DatasetIcon } from 'js/shared-styles/icons';
 import { SearchURLTypes, getSearchURL } from 'js/components/organ/utils';
+import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
+import { useEventCallback } from '@mui/material';
+import { EventWithOptionalCategory } from 'js/components/types';
 
 interface ViewEntitiesButtonProps extends ButtonProps {
   entityType: 'Donor' | 'Dataset' | 'Sample';
   filters: Omit<SearchURLTypes, 'entityType'>;
+  trackingInfo?: EventWithOptionalCategory;
 }
-function ViewEntitiesButton({ entityType, filters, ...rest }: ViewEntitiesButtonProps) {
+function ViewEntitiesButton({ entityType, filters, trackingInfo, ...rest }: ViewEntitiesButtonProps) {
+  const trackEntityPageEvent = useTrackEntityPageEvent('Organ Page');
+
+  const handleTrack = useEventCallback(() => {
+    if (!trackingInfo) {
+      return;
+    }
+
+    trackEntityPageEvent({
+      ...trackingInfo,
+      action: `${trackingInfo.action} / View ${entityType}s`,
+    });
+  });
+
   return (
     <Button
       color="primary"
       variant="outlined"
       component="a"
       href={getSearchURL({ entityType, ...filters })}
+      onClick={handleTrack}
       startIcon={<DatasetIcon />}
       {...rest}
     >

--- a/context/app/static/js/components/organ/contexts.tsx
+++ b/context/app/static/js/components/organ/contexts.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, PropsWithChildren } from 'react';
+import { OrganFile } from 'js/components/organ/types';
+
+interface OrganContextProps {
+  organ: OrganFile;
+}
+
+export const OrganContext = createContext<OrganContextProps | null>(null);
+
+export const useOrganContext = () => {
+  const context = useContext(OrganContext);
+  if (!context) {
+    throw new Error('Missing OrganContextProvider');
+  }
+  return context;
+};
+
+export function OrganContextProvider({ children, ...props }: PropsWithChildren<OrganContextProps>) {
+  return <OrganContext.Provider value={props}>{children}</OrganContext.Provider>;
+}

--- a/context/app/static/js/components/organ/types.ts
+++ b/context/app/static/js/components/organ/types.ts
@@ -75,3 +75,7 @@ export enum OrganPageIds {
   samplesId = 'samples',
   cellpopId = 'cell-population-plot',
 }
+
+export enum OrganEventCategories {
+  OrganPage = 'Organ Page',
+}

--- a/context/app/static/js/components/organ/types.ts
+++ b/context/app/static/js/components/organ/types.ts
@@ -68,14 +68,10 @@ export interface OrganDataProducts {
 
 export enum OrganPageIds {
   summaryId = 'summary',
-  humanReferenceAtlasId = 'human-reference-atlas',
+  hraId = 'human-reference-atlas',
   referenceId = 'reference-based-analysis',
   assaysId = 'assays',
   dataProductsId = 'data-products',
   samplesId = 'samples',
   cellpopId = 'cell-population-plot',
-}
-
-export enum OrganEventCategories {
-  OrganPage = 'Organ Page',
 }

--- a/context/app/static/js/components/organ/types.ts
+++ b/context/app/static/js/components/organ/types.ts
@@ -65,3 +65,13 @@ export interface OrganDataProducts {
   processed_cell_type_counts: Record<string, number>;
   datasetUUIDs?: string[];
 }
+
+export enum OrganPageIds {
+  summaryId = 'summary',
+  humanReferenceAtlasId = 'human-reference-atlas',
+  referenceId = 'reference-based-analysis',
+  assaysId = 'assays',
+  dataProductsId = 'data-products',
+  samplesId = 'samples',
+  cellpopId = 'cell-population-plot',
+}

--- a/context/app/static/js/components/savedLists/CreateListDialog/CreateListDialog.tsx
+++ b/context/app/static/js/components/savedLists/CreateListDialog/CreateListDialog.tsx
@@ -1,6 +1,6 @@
 import React, { ChangeEvent, useState } from 'react';
 import Button from '@mui/material/Button';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 import useSavedLists from 'js/components/savedLists/hooks';
 import OptDisabledButton from 'js/shared-styles/buttons/OptDisabledButton';
 import DialogModal from 'js/shared-styles/DialogModal';

--- a/context/app/static/js/components/savedLists/SaveEntitiesButton/SaveEntitiesButton.tsx
+++ b/context/app/static/js/components/savedLists/SaveEntitiesButton/SaveEntitiesButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SvgIcon from '@mui/material/SvgIcon';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 
 import { useAppContext, useFlaskDataContext } from 'js/components/Contexts';
 import useSavedLists from 'js/components/savedLists/hooks';

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -5,6 +5,7 @@ export interface EventInfo {
   category: string;
   action?: string;
   label?: string | number;
+  value?: string | number;
 }
 
 export type DonorEntityType = 'Donor';

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -1,6 +1,7 @@
 import { ContributorAPIResponse, ContactAPIResponse } from './detailPage/ContributorsTable/utils';
 import { UnprocessedFile } from './detailPage/files/types';
 
+// Interface intended for use in tracking events via trackEvent, which requires a category.
 export interface EventInfo {
   category: string;
   action?: string;
@@ -8,6 +9,8 @@ export interface EventInfo {
   value?: string | number;
 }
 
+// Interface intended for use in tracking events via trackEntityPageEvent, which takes care of
+// adding the category to the event.
 export interface EventWithOptionalCategory extends Omit<EventInfo, 'category'> {
   category?: string;
 }

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -8,6 +8,10 @@ export interface EventInfo {
   value?: string | number;
 }
 
+export interface EventWithOptionalCategory extends Omit<EventInfo, 'category'> {
+  category?: string;
+}
+
 export type DonorEntityType = 'Donor';
 export type SampleEntityType = 'Sample';
 export type DatasetEntityType = 'Dataset';

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -1,6 +1,12 @@
 import { ContributorAPIResponse, ContactAPIResponse } from './detailPage/ContributorsTable/utils';
 import { UnprocessedFile } from './detailPage/files/types';
 
+export interface EventInfo {
+  category: string;
+  action?: string;
+  label?: string | number;
+}
+
 export type DonorEntityType = 'Donor';
 export type SampleEntityType = 'Sample';
 export type DatasetEntityType = 'Dataset';

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -116,7 +116,6 @@ function formatEvent(event, id) {
 
 function trackEvent(event, id) {
   const formattedEvent = formatEvent(event, id);
-  // console.log(formattedEvent);
   tracker.trackEvent(formattedEvent);
   ReactGA.event(formattedEvent);
   const category = formattedEvent.category.replace(/ /g, '_');

--- a/context/app/static/js/helpers/trackers.js
+++ b/context/app/static/js/helpers/trackers.js
@@ -116,6 +116,7 @@ function formatEvent(event, id) {
 
 function trackEvent(event, id) {
   const formattedEvent = formatEvent(event, id);
+  // console.log(formattedEvent);
   tracker.trackEvent(formattedEvent);
   ReactGA.event(formattedEvent);
   const category = formattedEvent.category.replace(/ /g, '_');

--- a/context/app/static/js/pages/Organ/Organ.tsx
+++ b/context/app/static/js/pages/Organ/Organ.tsx
@@ -17,7 +17,7 @@ interface OrganProps {
   organ: OrganFile;
 }
 
-const { summaryId, humanReferenceAtlasId, cellpopId, referenceId, assaysId, dataProductsId, samplesId } = OrganPageIds;
+const { summaryId, hraId, cellpopId, referenceId, assaysId, dataProductsId, samplesId } = OrganPageIds;
 
 function Organ({ organ }: OrganProps) {
   const searchItems = useMemo(
@@ -32,7 +32,7 @@ function Organ({ organ }: OrganProps) {
 
   const shouldDisplaySection: Record<string, boolean> = {
     [summaryId]: Boolean(organ?.description),
-    [humanReferenceAtlasId]: Boolean(organ.has_iu_component),
+    [hraId]: Boolean(organ.has_iu_component),
     [cellpopId]: labeledDatasetUuids.length > 0,
     [referenceId]: Boolean(organ?.azimuth),
     [assaysId]: assayBuckets.length > 0,
@@ -50,7 +50,7 @@ function Organ({ organ }: OrganProps) {
           {organ.name}
         </Typography>
         <Description shouldDisplay={shouldDisplaySection[summaryId]} />
-        <HumanReferenceAtlas shouldDisplay={shouldDisplaySection[humanReferenceAtlasId]} />
+        <HumanReferenceAtlas shouldDisplay={shouldDisplaySection[hraId]} />
         <CellPopulationPlot uuids={labeledDatasetUuids} shouldDisplay={shouldDisplaySection[cellpopId]} />
         <Azimuth shouldDisplay={shouldDisplaySection[referenceId]} />
         <Assays organTerms={searchItems} bucketData={assayBuckets} shouldDisplay={shouldDisplaySection[assaysId]} />

--- a/context/app/static/js/pages/Organ/Organ.tsx
+++ b/context/app/static/js/pages/Organ/Organ.tsx
@@ -6,23 +6,18 @@ import Assays from 'js/components/organ/Assays';
 import Description from 'js/components/organ/Description';
 import HumanReferenceAtlas from 'js/components/organ/HumanReferenceAtlas';
 import Samples from 'js/components/organ/Samples';
-import { OrganFile } from 'js/components/organ/types';
+import { OrganFile, OrganPageIds } from 'js/components/organ/types';
 import DetailLayout from 'js/components/detailPage/DetailLayout';
 import CellPopulationPlot from 'js/components/organ/CellPop';
 import DataProducts from 'js/components/organ/DataProducts';
+import { OrganContextProvider } from 'js/components/organ/contexts';
 import { useAssayBucketsQuery, useDataProducts, useHasSamplesQuery, useLabelledDatasetsQuery } from './hooks';
 
 interface OrganProps {
   organ: OrganFile;
 }
 
-const summaryId = 'summary';
-const hraId = 'human-reference-atlas';
-const referenceId = 'reference-based-analysis';
-const assaysId = 'assays';
-const dataProductsId = 'data-products';
-const samplesId = 'samples';
-const cellpopId = 'cell-population-plot';
+const { summaryId, humanReferenceAtlasId, cellpopId, referenceId, assaysId, dataProductsId, samplesId } = OrganPageIds;
 
 function Organ({ organ }: OrganProps) {
   const searchItems = useMemo(
@@ -37,7 +32,7 @@ function Organ({ organ }: OrganProps) {
 
   const shouldDisplaySection: Record<string, boolean> = {
     [summaryId]: Boolean(organ?.description),
-    [hraId]: Boolean(organ.has_iu_component),
+    [humanReferenceAtlasId]: Boolean(organ.has_iu_component),
     [cellpopId]: labeledDatasetUuids.length > 0,
     [referenceId]: Boolean(organ?.azimuth),
     [assaysId]: assayBuckets.length > 0,
@@ -46,41 +41,28 @@ function Organ({ organ }: OrganProps) {
   };
 
   return (
-    <DetailLayout sections={shouldDisplaySection} isLoading={isLoading}>
-      <Typography variant="subtitle1" component="h1" color="primary" data-testid="entity-title">
-        Organ
-      </Typography>
-      <Typography variant="h1" component="h2">
-        {organ.name}
-      </Typography>
-      <Description
-        id={summaryId}
-        uberonIri={organ.uberon}
-        uberonShort={organ.uberon_short}
-        asctbId={organ.asctb}
-        shouldDisplay={shouldDisplaySection[summaryId]}
-      >
-        {organ.description}
-      </Description>
-      <HumanReferenceAtlas id={hraId} uberonIri={organ.uberon} shouldDisplay={shouldDisplaySection[hraId]} />
-      <CellPopulationPlot id={cellpopId} uuids={labeledDatasetUuids} shouldDisplay={shouldDisplaySection[cellpopId]} />
-      <Azimuth id={referenceId} config={organ.azimuth!} shouldDisplay={shouldDisplaySection[referenceId]} />
-      <Assays
-        id={assaysId}
-        organTerms={searchItems}
-        bucketData={assayBuckets}
-        shouldDisplay={shouldDisplaySection[assaysId]}
-      />
-      <DataProducts
-        id={dataProductsId}
-        dataProducts={dataProducts}
-        organName={organ.name}
-        isLateral={isLateral}
-        isLoading={isLoading}
-        shouldDisplay={shouldDisplaySection[dataProductsId]}
-      />
-      <Samples id={samplesId} organTerms={searchItems} shouldDisplay={shouldDisplaySection[samplesId]} />
-    </DetailLayout>
+    <OrganContextProvider organ={organ}>
+      <DetailLayout sections={shouldDisplaySection} isLoading={isLoading}>
+        <Typography variant="subtitle1" component="h1" color="primary" data-testid="entity-title">
+          Organ
+        </Typography>
+        <Typography variant="h1" component="h2">
+          {organ.name}
+        </Typography>
+        <Description shouldDisplay={shouldDisplaySection[summaryId]}>{organ.description}</Description>
+        <HumanReferenceAtlas shouldDisplay={shouldDisplaySection[humanReferenceAtlasId]} />
+        <CellPopulationPlot uuids={labeledDatasetUuids} shouldDisplay={shouldDisplaySection[cellpopId]} />
+        <Azimuth shouldDisplay={shouldDisplaySection[referenceId]} />
+        <Assays organTerms={searchItems} bucketData={assayBuckets} shouldDisplay={shouldDisplaySection[assaysId]} />
+        <DataProducts
+          dataProducts={dataProducts}
+          isLateral={isLateral}
+          isLoading={isLoading}
+          shouldDisplay={shouldDisplaySection[dataProductsId]}
+        />
+        <Samples organTerms={searchItems} shouldDisplay={shouldDisplaySection[samplesId]} />
+      </DetailLayout>
+    </OrganContextProvider>
   );
 }
 

--- a/context/app/static/js/pages/Organ/Organ.tsx
+++ b/context/app/static/js/pages/Organ/Organ.tsx
@@ -49,7 +49,7 @@ function Organ({ organ }: OrganProps) {
         <Typography variant="h1" component="h2">
           {organ.name}
         </Typography>
-        <Description shouldDisplay={shouldDisplaySection[summaryId]}>{organ.description}</Description>
+        <Description shouldDisplay={shouldDisplaySection[summaryId]} />
         <HumanReferenceAtlas shouldDisplay={shouldDisplaySection[humanReferenceAtlasId]} />
         <CellPopulationPlot uuids={labeledDatasetUuids} shouldDisplay={shouldDisplaySection[cellpopId]} />
         <Azimuth shouldDisplay={shouldDisplaySection[referenceId]} />

--- a/context/app/static/js/shared-styles/Links/OutboundLinkButton.tsx
+++ b/context/app/static/js/shared-styles/Links/OutboundLinkButton.tsx
@@ -6,8 +6,16 @@ import StyledOpenInNewRoundedIcon from './StyledOpenInNewRoundedIcon';
 
 type OutboundLinkButtonProps = React.ComponentProps<typeof Button<'a'>>;
 
-function OutboundLinkButton({ children, ...props }: OutboundLinkButtonProps) {
-  const handleClick = useTrackOutboundLink();
+function OutboundLinkButton({ children, onClick, ...props }: OutboundLinkButtonProps) {
+  const trackClick = useTrackOutboundLink();
+
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    trackClick(e);
+    if (onClick) {
+      onClick(e);
+    }
+  };
+
   return (
     <Button
       {...props}

--- a/context/app/static/js/shared-styles/charts/HorizontalStackedBarChart/HorizontalStackedBarChart.tsx
+++ b/context/app/static/js/shared-styles/charts/HorizontalStackedBarChart/HorizontalStackedBarChart.tsx
@@ -56,6 +56,12 @@ interface HorizontalStackedBarChartProps<Datum, XAxisScale extends AnyD3Scale, Y
       key: string;
     },
   ) => string;
+  onBarClick: (
+    d: Omit<BarGroupBar<string>, 'key' | 'value'> & {
+      bar: SeriesPoint<Datum>;
+      key: string;
+    },
+  ) => void;
   getAriaLabel?: (d: TooltipData<Datum>) => string;
 }
 
@@ -80,6 +86,7 @@ function HorizontalStackedBarChart<Datum, XAxisScale extends AnyD3Scale, YAxisSc
   // getTickValues,
   showTooltipAndHover = true,
   getBarHref,
+  onBarClick,
   getAriaLabel,
   srOnlyLabels,
 }: HorizontalStackedBarChartProps<Datum, XAxisScale, YAxisScale>) {
@@ -143,6 +150,7 @@ function HorizontalStackedBarChart<Datum, XAxisScale extends AnyD3Scale, YAxisSc
                         key={`${bar.key}-${bar.index}`}
                         direction="horizontal"
                         bar={bar}
+                        onClick={() => onBarClick(bar)}
                         href={getBarHref?.(bar)}
                         ariaLabelText={getAriaLabel?.(bar)}
                         hoverProps={

--- a/context/app/static/js/shared-styles/charts/StackedBar/StackedBar.tsx
+++ b/context/app/static/js/shared-styles/charts/StackedBar/StackedBar.tsx
@@ -39,7 +39,7 @@ const propMap: Record<Direction, MappableProps> = {
   },
 };
 
-function StackedBar({ direction = 'vertical', bar, hoverProps, href, ariaLabelText }: StackedBarProps) {
+function StackedBar({ direction = 'vertical', bar, hoverProps, href, ariaLabelText, ...rest }: StackedBarProps) {
   const maxBarThickness = 65;
 
   const { length, thickness, discreteAxis, categoricalAxis } = propMap[direction];
@@ -52,7 +52,13 @@ function StackedBar({ direction = 'vertical', bar, hoverProps, href, ariaLabelTe
   };
 
   const rect = (
-    <StyledRect fill={bar.color} {...mappedProps} $showHover={Boolean(hoverProps) || Boolean(href)} {...hoverProps} />
+    <StyledRect
+      fill={bar.color}
+      {...mappedProps}
+      $showHover={Boolean(hoverProps) || Boolean(href)}
+      {...hoverProps}
+      {...rest}
+    />
   );
   if (href) {
     return (

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
@@ -5,7 +5,7 @@ import { useSearchTotalHitsCounts } from 'js/hooks/useSearchData';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 
 import SvgIcon from '@mui/material/SvgIcon';
-import { WorkspacesEventInfo } from 'js/components/workspaces/types';
+import { EventInfo } from 'js/components/types';
 import EntityTable from './EntityTable';
 import { EntitiesTabTypes } from './types';
 import { Tabs, Tab, TabPanel } from '../TableTabs';
@@ -17,7 +17,7 @@ interface EntitiesTablesProps<Doc> {
   entities: EntitiesTabTypes<Doc>[];
   disabledIDs?: Set<string>;
   emptyAlert?: React.ReactNode;
-  trackingInfo?: WorkspacesEventInfo;
+  trackingInfo?: EventInfo;
 }
 
 function EntitiesTables<Doc>({

--- a/context/app/static/js/shared-styles/tables/columns.tsx
+++ b/context/app/static/js/shared-styles/tables/columns.tsx
@@ -18,7 +18,14 @@ function HubmapIDCell({
   return (
     <InternalLink
       href={`/browse/dataset/${uuid}`}
-      onClick={() => trackEvent({ ...trackingInfo, action: 'Navigate to Dataset from Table' })}
+      onClick={() =>
+        trackingInfo &&
+        trackEvent({
+          ...trackingInfo,
+          action: trackingInfo.action ? `${trackingInfo.action} / Select Sample` : 'Navigate to Dataset from Table',
+          label: `${trackingInfo.label} ${hubmap_id}`,
+        })
+      }
       variant="body2"
     >
       {hubmap_id}


### PR DESCRIPTION
## Summary

Adds analytics to organ pages (not including tracking for the Data Products section, which was implemented in #3714).

## Design Documentation/Original Tickets

[Jira CAT-1240 ticket](https://hms-dbmi.atlassian.net/browse/CAT-1240?atlOrigin=eyJpIjoiMzU5ZWEyZWEwZDcyNDAxYmExZWM3MWZlN2FmOWJlYzgiLCJwIjoiaiJ9)

[Trackable Events doc](https://docs.google.com/spreadsheets/d/18hF0VDrepN58GiDX22_jJ6vsnfGwKE_GiL8hdD_Art4/edit?gid=126226029#gid=126226029)

## Testing

Tested by logging all events to the console and verifying against the Trackable Events doc.

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
