### PR TITLE
John conroy/easy hierarchical links

### DIFF
--- a/CHANGELOG-easy-hierarchical-links.md
+++ b/CHANGELOG-easy-hierarchical-links.md
@@ -1,0 +1,1 @@
+- Enable easy links to the search page with hierarchical facets selected.

--- a/context/app/static/js/components/search/Facets/FilterChips.tsx
+++ b/context/app/static/js/components/search/Facets/FilterChips.tsx
@@ -56,36 +56,35 @@ interface HierarchicalChip {
   parentField: string;
   parentValue: string;
   value: string;
-  isParentChip?: boolean;
 }
 
-function useDeleteHierarchicalChip({ parentField, parentValue, value, isParentChip }: HierarchicalChip) {
-  const filterHierarchicalChildTerm = useSearchStore((state) => state.filterHierarchicalChildTerm);
+const HierarchicalParentChip = React.memo(function HierarchicalTermChip({
+  parentField,
+  parentValue,
+  value,
+}: HierarchicalChip) {
+  const getFieldLabel = useGetFieldLabel();
   const filterHierarchicalParentTerm = useSearchStore((state) => state.filterHierarchicalParentTerm);
 
-  const filterParent = useCallback(
+  const onDelete = useCallback(
     () => filterHierarchicalParentTerm({ term: parentField, value: parentValue, childValues: [] }),
     [parentField, parentValue, filterHierarchicalParentTerm],
   );
 
-  const filterChild = useCallback(
-    () => filterHierarchicalChildTerm({ parentTerm: parentField, parentValue, value }),
-    [parentField, value, parentValue, filterHierarchicalChildTerm],
-  );
+  return <FilterChip label={`${getFieldLabel(parentField)}: ${value}`} key={value} onDelete={onDelete} />;
+});
 
-  if (isParentChip) {
-    return filterParent;
-  }
-  return filterChild;
-}
 const HierarchichalTermChip = React.memo(function HierarchicalTermChip({
   parentField,
   parentValue,
   value,
-  isParentChip,
 }: HierarchicalChip) {
   const getFieldLabel = useGetFieldLabel();
-  const onDelete = useDeleteHierarchicalChip({ parentField, parentValue, value, isParentChip });
+  const filterHierarchicalChildTerm = useSearchStore((state) => state.filterHierarchicalChildTerm);
+  const onDelete = useCallback(
+    () => filterHierarchicalChildTerm({ parentTerm: parentField, parentValue, value }),
+    [parentField, value, parentValue, filterHierarchicalChildTerm],
+  );
   return <FilterChip label={`${getFieldLabel(parentField)}: ${value}`} key={value} onDelete={onDelete} />;
 });
 
@@ -159,15 +158,7 @@ function FilterChips() {
             }
             return parentValues.map(([parent, children]) => {
               if (!children?.size) {
-                return (
-                  <HierarchichalTermChip
-                    key={parent}
-                    parentField={field}
-                    value={parent}
-                    parentValue={parent}
-                    isParentChip
-                  />
-                );
+                return <HierarchicalParentChip key={parent} parentField={field} value={parent} parentValue={parent} />;
               }
               return [...children].map((child) => (
                 <HierarchichalTermChip

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -124,7 +124,9 @@ export function buildQuery({
           const childValues = Object.values(filter.values)
             .map((v) => [...v])
             .flat();
-          draft[childPortalField] = esb.termsQuery(childPortalField, childValues);
+          if (childValues.length) {
+            draft[childPortalField] = esb.termsQuery(childPortalField, childValues);
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

The team working on the ingest portal needs to easy link to the search page with hierarchical facets selected. This PR enables easy links to the search page with hierarchical facets selected.

The child terms won't all be selected, but this is a quick start.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added