### PR TITLE
Austenem/Add MUI import eslint rule

### DIFF
--- a/CHANGELOG-add-import-eslint-rule.md
+++ b/CHANGELOG-add-import-eslint-rule.md
@@ -1,0 +1,1 @@
+- Add eslint rule for MUI imports.

--- a/context/app/static/js/api/scfind/useCellTypeMarkers.stories.tsx
+++ b/context/app/static/js/api/scfind/useCellTypeMarkers.stories.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack, FormControl, TextField } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useCellTypeMarkers, { CellTypeMarkersParams } from './useCellTypeMarkers';
 

--- a/context/app/static/js/api/scfind/useCellTypeNames.stories.tsx
+++ b/context/app/static/js/api/scfind/useCellTypeNames.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useCellTypeNames from './useCellTypeNames';
 

--- a/context/app/static/js/api/scfind/useEvaluateMarkers.stories.tsx
+++ b/context/app/static/js/api/scfind/useEvaluateMarkers.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useEvaluateMarkers, { EvaluateMarkersParams } from './useEvaluateMarkers';
 

--- a/context/app/static/js/api/scfind/useFindCellTypeSpecificities.stories.tsx
+++ b/context/app/static/js/api/scfind/useFindCellTypeSpecificities.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useFindCellTypeSpecificities, { FindCellTypeSpecificitiesParams } from './useFindCellTypeSpecificities';
 

--- a/context/app/static/js/api/scfind/useFindGeneSignatures.stories.tsx
+++ b/context/app/static/js/api/scfind/useFindGeneSignatures.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useFindGeneSignatures, { FindGeneSignaturesParams } from './useFindGeneSignatures';
 

--- a/context/app/static/js/api/scfind/useFindHouseKeepingGenes.stories.tsx
+++ b/context/app/static/js/api/scfind/useFindHouseKeepingGenes.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useFindHousekeepingGenes, { FindHouseKeepingGenesParams } from './useFindHouseKeepingGenes';
 

--- a/context/app/static/js/api/scfind/useFindSimilarGenes.stories.tsx
+++ b/context/app/static/js/api/scfind/useFindSimilarGenes.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useFindSimilarGenes, { FindSimilarGenesParams } from './useFindSimilarGenes';
 

--- a/context/app/static/js/api/scfind/useFindTissueSpecificities.stories.tsx
+++ b/context/app/static/js/api/scfind/useFindTissueSpecificities.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useFindTissueSpecificities, { FindTissueSpecificitiesParams } from './useFindTissueSpecificities';
 

--- a/context/app/static/js/api/scfind/useHyperQueryCellTypes.stories.tsx
+++ b/context/app/static/js/api/scfind/useHyperQueryCellTypes.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useHyperQueryCellTypes, { HyperQueryCellTypesParams } from './useHyperQueryCellTypes';
 

--- a/context/app/static/js/api/scfind/useMarkerGenes.stories.tsx
+++ b/context/app/static/js/api/scfind/useMarkerGenes.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Typography, Stack } from '@mui/material';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { http, passthrough } from 'msw';
 import useMarkerGenes, { MarkerGenesParams } from './useMarkerGenes';
 

--- a/context/app/static/js/components/detailPage/ContributorsTable/hooks.tsx
+++ b/context/app/static/js/components/detailPage/ContributorsTable/hooks.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
-
-import { Stack } from '@mui/material';
+import Stack from '@mui/material/Stack';
 import EmailIconLink from 'js/shared-styles/Links/iconLinks/EmailIconLink';
 import { ContributorAPIResponse, ContactAPIResponse, normalizeContributor, normalizeContact } from './utils';
 

--- a/context/app/static/js/components/detailPage/files/DataProducts/DownloadFileButton.tsx
+++ b/context/app/static/js/components/detailPage/files/DataProducts/DownloadFileButton.tsx
@@ -1,5 +1,5 @@
-import { IconButton, IconButtonProps } from '@mui/material';
 import React, { PropsWithChildren } from 'react';
+import IconButton, { IconButtonProps } from '@mui/material/IconButton';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { useTrackEntityPageEvent } from 'js/components/detailPage//useTrackEntityPageEvent';
 import { UnprocessedFile } from '../types';

--- a/context/app/static/js/components/detailPage/multi-assay/ComponentAlert/ComponentAlert.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/ComponentAlert/ComponentAlert.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 import Typography from '@mui/material/Typography';
 import Skeleton from '@mui/material/Skeleton';
 import Button from '@mui/material/Button';
+import Stack from '@mui/material/Stack';
 
 import { DetailPageAlert } from 'js/components/detailPage/style';
 import { InternalLink } from 'js/shared-styles/Links';
-import { Stack } from '@mui/material';
 import useRelatedMultiAssayDatasets from '../useRelatedMultiAssayDatasets';
 
 function ComponentAlert() {

--- a/context/app/static/js/components/detailPage/summary/SummaryTitle/SummaryTitle.tsx
+++ b/context/app/static/js/components/detailPage/summary/SummaryTitle/SummaryTitle.tsx
@@ -1,10 +1,10 @@
 import React, { PropsWithChildren, useEffect } from 'react';
 import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
 import { useInView } from 'react-intersection-observer';
 
 import useEntityStore, { EntityStore } from 'js/stores/useEntityStore';
 import InfoTooltipIcon from 'js/shared-styles/icons/TooltipIcon';
-import { Stack } from '@mui/material';
 import { entityIconMap } from 'js/shared-styles/icons/entityIconMap';
 
 const entityStoreSelector = (state: EntityStore) => state.setSummaryComponentObserver;

--- a/context/app/static/js/components/detailPage/visualization/VisualizationTracker/hooks.ts
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationTracker/hooks.ts
@@ -1,7 +1,7 @@
 import React, { useMemo, useRef } from 'react';
+import { useEventCallback } from '@mui/material/utils';
 import useTrackMount from 'js/hooks/useTrackMount';
 import { useFlaskDataContext } from 'js/components/Contexts';
-import { useEventCallback } from '@mui/material';
 import { trackEvent } from 'js/helpers/trackers';
 import { formatEventCategoryAndLabel, getNearestIdentifier, modifierKeys, mouseButtonMap } from './utils';
 

--- a/context/app/static/js/components/genes/Organs/Visualization.tsx
+++ b/context/app/static/js/components/genes/Organs/Visualization.tsx
@@ -4,7 +4,7 @@ import ReferenceBasedAnalysis from 'js/components/organ/Azimuth/ReferenceBasedAn
 import Stack from '@mui/material/Stack';
 import { OrganFile } from 'js/components/organ/types';
 import { DetailPageAlert } from 'js/components/detailPage/style';
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 import InfoTooltipIcon from 'js/shared-styles/icons/TooltipIcon';
 import { useGenePageContext } from '../hooks';
 

--- a/context/app/static/js/components/genes/Summary/KnownReferences.tsx
+++ b/context/app/static/js/components/genes/Summary/KnownReferences.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import Skeleton from '@mui/material/Skeleton';
 
 import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
 import hasKey from 'js/helpers/hasKey';
 import { capitalizeString } from 'js/helpers/functions';
 
-import { Skeleton } from '@mui/material';
 import { useGeneOntology } from '../hooks';
 import { ReferenceList } from './styles';
 

--- a/context/app/static/js/components/home/ExploreTools/ToolsCard.tsx
+++ b/context/app/static/js/components/home/ExploreTools/ToolsCard.tsx
@@ -4,11 +4,11 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import Grid from '@mui/material/Grid2';
+import Box from '@mui/material/Box';
 
 import { animated, useTransition } from '@react-spring/web';
 
 import { useIsDesktop, useIsMobile } from 'js/hooks/media-queries';
-import { Box } from '@mui/material';
 import { useCardGridContext } from './CardGridContext';
 import { StyledImg } from './styles';
 

--- a/context/app/static/js/components/home/Hero/styles.ts
+++ b/context/app/static/js/components/home/Hero/styles.ts
@@ -1,4 +1,4 @@
-import { Box, BoxProps } from '@mui/material';
+import Box, { BoxProps } from '@mui/material/Box';
 import { styled } from '@mui/material/styles';
 
 interface HeroGridContainerProps extends BoxProps {

--- a/context/app/static/js/components/savedLists/hooks.ts
+++ b/context/app/static/js/components/savedLists/hooks.ts
@@ -19,7 +19,7 @@ import { SavedListsSuccessAlertType, useSavedListsAlertsStore } from 'js/stores/
 import { trackEvent } from 'js/helpers/trackers';
 import { useEntitiesData } from 'js/hooks/useEntityData';
 import { useFlaskDataContext } from 'js/components/Contexts';
-import { useEventCallback } from '@mui/material';
+import { useEventCallback } from '@mui/material/utils';
 
 function useGlobalMutateSavedList() {
   const { buildKey } = useBuildUkvSWRKey();

--- a/context/app/static/js/components/search/SearchViewSwitch.tsx
+++ b/context/app/static/js/components/search/SearchViewSwitch.tsx
@@ -3,7 +3,7 @@ import { useShallow } from 'zustand/react/shallow';
 import ListRoundedIcon from '@mui/icons-material/ListRounded';
 import GridOnRoundedIcon from '@mui/icons-material/GridOnRounded';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
-import { SvgIcon } from '@mui/material';
+import SvgIcon from '@mui/material/SvgIcon';
 
 import { TooltipToggleButton } from 'js/shared-styles/buttons';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';

--- a/context/app/static/js/components/workspaces/InvitationTabs.tsx
+++ b/context/app/static/js/components/workspaces/InvitationTabs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Box from '@mui/material/Box';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 
 import InvitationsTable from 'js/components/workspaces/Tables/InvitationsTable';
 import { WorkspaceInvitation } from 'js/components/workspaces/types';

--- a/context/app/static/js/components/workspaces/Tables/WorkspaceItemsTable/hooks.ts
+++ b/context/app/static/js/components/workspaces/Tables/WorkspaceItemsTable/hooks.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 import {
   SortField,
   TableField,

--- a/context/app/static/js/components/workspaces/WorkspaceListItem.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceListItem.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 import Stack from '@mui/material/Stack';
-import styled from '@mui/material/styles/styled';
+import { styled } from '@mui/material/styles';
 import Button, { ButtonProps } from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
 import Radio from '@mui/material/Radio';

--- a/context/app/static/js/components/workspaces/WorkspacesAutocomplete.tsx
+++ b/context/app/static/js/components/workspaces/WorkspacesAutocomplete.tsx
@@ -3,7 +3,7 @@ import Autocomplete, { AutocompleteRenderInputParams } from '@mui/material/Autoc
 import Box from '@mui/material/Box';
 import InputAdornment from '@mui/material/InputAdornment';
 import Typography from '@mui/material/Typography';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 
 import { StyledSearchIcon, StyledTextField } from 'js/components/workspaces/style';
 import { WorkspaceWithCreatorInfo } from 'js/components/workspaces/types';

--- a/context/app/static/js/components/workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu.tsx
+++ b/context/app/static/js/components/workspaces/WorkspacesDropdownMenu/WorkspacesDropdownMenu.tsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from 'react';
 import MenuItem from '@mui/material/MenuItem';
 import SvgIcon from '@mui/material/SvgIcon';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import { useEventCallback } from '@mui/material/utils';
 
 import withDropdownMenuProvider from 'js/shared-styles/dropdowns/DropdownMenuProvider/withDropdownMenuProvider';
 import DropdownMenu from 'js/shared-styles/dropdowns/DropdownMenu';
@@ -11,7 +13,6 @@ import { DialogType, useEditWorkspaceStore } from 'js/stores/useWorkspaceModalSt
 import { AddIcon } from 'js/shared-styles/icons';
 import AddDatasetsFromSearchDialog from 'js/components/workspaces/AddDatasetsFromSearchDialog';
 import WorkspacesIcon from 'assets/svg/workspaces.svg';
-import { ListItemIcon, useEventCallback } from '@mui/material';
 import { trackEvent } from 'js/helpers/trackers';
 import { WorkspacesEventCategories } from 'js/components/workspaces/types';
 import { useSelectableTableStore } from 'js/shared-styles/tables/SelectableTableProvider';

--- a/context/app/static/js/components/workspaces/WorkspacesList.tsx
+++ b/context/app/static/js/components/workspaces/WorkspacesList.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import ShareIcon from '@mui/icons-material/Share';
-import debounce from '@mui/material/utils/debounce';
+import { debounce } from '@mui/material/utils';
 
 import { useSelectItems } from 'js/hooks/useSelectItems';
 import NewWorkspaceDialogFromWorkspaceList from 'js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromWorkspaceList';

--- a/context/app/static/js/hooks/media-queries.tsx
+++ b/context/app/static/js/hooks/media-queries.tsx
@@ -1,4 +1,4 @@
-import useTheme from '@mui/material/styles/useTheme';
+import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
 export function useIsMobile() {

--- a/context/app/static/js/pages/Invitation/Invitation.tsx
+++ b/context/app/static/js/pages/Invitation/Invitation.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { format } from 'date-fns/format';
 import Stack from '@mui/material/Stack';
 import Button from '@mui/material/Button';
-import useEventCallback from '@mui/material/utils/useEventCallback';
+import { useEventCallback } from '@mui/material/utils';
 
 import { useInvitationDetail } from 'js/components/workspaces/hooks';
 import { TemplatesTypes, WorkspaceInvitation, WorkspacesEventCategories } from 'js/components/workspaces/types';

--- a/context/app/static/js/pages/Invitation/style.ts
+++ b/context/app/static/js/pages/Invitation/style.ts
@@ -1,4 +1,4 @@
-import styled from '@mui/material/styles/styled';
+import { styled } from '@mui/material/styles';
 import { Alert } from 'js/shared-styles/alerts';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({

--- a/context/app/static/js/shared-styles/Drawer/NavigationDrawer.tsx
+++ b/context/app/static/js/shared-styles/Drawer/NavigationDrawer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import Stack from '@mui/material/Stack';
 import Divider from '@mui/material/Divider';
-import { IconButton } from '@mui/material';
+import IconButton from '@mui/material/IconButton';
 import CloseRounded from '@mui/icons-material/CloseRounded';
 import { DrawerSection, NavigationDrawerProps } from './types';
 import { DrawerTitle, StyledDrawer } from './styles';

--- a/context/app/static/js/shared-styles/Drawer/types.ts
+++ b/context/app/static/js/shared-styles/Drawer/types.ts
@@ -1,4 +1,4 @@
-import { ListSubheaderProps } from '@mui/material';
+import { ListSubheaderProps } from '@mui/material/ListSubheader';
 import React from 'react';
 
 export interface DrawerItemProps {

--- a/context/app/static/js/shared-styles/Links/StyledOpenInNewRoundedIcon.ts
+++ b/context/app/static/js/shared-styles/Links/StyledOpenInNewRoundedIcon.ts
@@ -1,5 +1,5 @@
 import OpenInNewRoundedIcon from '@mui/icons-material/OpenInNewRounded';
-import styled from '@mui/material/styles/styled';
+import { styled } from '@mui/material/styles';
 
 const StyledOpenInNewRoundedIcon = styled(OpenInNewRoundedIcon)(({ theme }) => ({
   fontSize: '1.1rem',

--- a/context/app/static/js/shared-styles/Links/iconLinks/IconLink/IconLink.tsx
+++ b/context/app/static/js/shared-styles/Links/iconLinks/IconLink/IconLink.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { LinkProps } from '@mui/material';
+import { LinkProps } from '@mui/material/Link';
 
 import OutboundLink from '../../OutboundLink';
 import InternalLink from '../../InternalLink';

--- a/context/app/static/js/shared-styles/accordions/DetailsAccordion/DetailsAccordion.tsx
+++ b/context/app/static/js/shared-styles/accordions/DetailsAccordion/DetailsAccordion.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { AccordionProps } from '@mui/material/Accordion';
 import { AccordionSummaryProps } from '@mui/material/AccordionSummary';
 import { AccordionDetailsProps } from '@mui/material/AccordionDetails';
-import { Typography } from '@mui/material';
+import Typography from '@mui/material/Typography';
 import { Accordion, AccordionDetails, AccordionSummary } from './style';
 
 type DetailAccordionProps = React.PropsWithChildren<{

--- a/context/app/static/js/shared-styles/icons/HeaderIcon.tsx
+++ b/context/app/static/js/shared-styles/icons/HeaderIcon.tsx
@@ -1,4 +1,4 @@
-import styled from '@mui/material/styles/styled';
+import { styled } from '@mui/material/styles';
 import SvgIcon from '@mui/material/SvgIcon';
 
 const HeaderIcon = styled(SvgIcon)(() => ({

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
@@ -7,7 +7,8 @@ import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
 import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
-import { LinearProgress, useEventCallback } from '@mui/material';
+import LinearProgress from '@mui/material/LinearProgress';
+import { useEventCallback } from '@mui/material/utils';
 
 import { StyledTableContainer, HeaderCell } from 'js/shared-styles/tables';
 import SelectableHeaderCell from 'js/shared-styles/tables/SelectableHeaderCell';

--- a/context/app/static/js/shared-styles/tables/ExpandableRowCell/ExpandableRowCell.tsx
+++ b/context/app/static/js/shared-styles/tables/ExpandableRowCell/ExpandableRowCell.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { useExpandableRowStore } from 'js/shared-styles/tables/ExpandableRow/store';
-import { TableCellProps } from '@mui/material';
+import { TableCellProps } from '@mui/material/TableCell';
 import { StyledTableCell } from './style';
 
 function ExpandableRowCell({ children, ...props }: TableCellProps) {

--- a/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/style.ts
+++ b/context/app/static/js/shared-styles/tooltips/InfoTextTooltip/style.ts
@@ -1,4 +1,4 @@
-import { Stack } from '@mui/material';
+import Stack from '@mui/material/Stack';
 import { styled } from '@mui/material/styles';
 import { InfoIcon } from 'js/shared-styles/icons';
 

--- a/context/app/static/js/theme/theme.stories.tsx
+++ b/context/app/static/js/theme/theme.stories.tsx
@@ -1,6 +1,12 @@
 import * as React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { Box, Typography, Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
 import theme from './theme';
 
 interface PaletteColorProps {

--- a/context/eslint.config.mjs
+++ b/context/eslint.config.mjs
@@ -136,6 +136,19 @@ export default [
           ignoreRestSiblings: true,
         },
       ],
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: '@mui/material',
+              message:
+                'Please import directly from @mui/material/[Component], e.g. `import Box from "@mui/material/Box"` to avoid tree-shaking issues.',
+            },
+          ],
+          patterns: ['@mui/material/*/*'],
+        },
+      ],
     },
   },
   ...compat


### PR DESCRIPTION
## Summary

Adds eslint rule for MUI imports, restricting [deep imports](https://mui.com/material-ui/migration/upgrade-to-v7/#package-layout-updated) and imports from the base `@mui/material` package. Cleans up existing files based on eslint errors.