### PR TITLE
Austenem/CAT-1254 Workspace sharing fixes

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -25,10 +25,10 @@ jobs:
           cache-dependency-path: "context/requirements*.txt"
 
       - name: Install python main dependencies
-        run: PIP_CONSTRAINT=context/constraints.txt pip install -r context/requirements.txt --use-deprecated=legacy-resolver
+        run: pip install -r context/requirements.txt --constraint=context/constraints.txt
 
       - name: Install python dev dependencies
-        run: PIP_CONSTRAINT=context/constraints.txt pip install -r context/requirements-dev.txt --use-deprecated=legacy-resolver
+        run: pip install -r context/requirements-dev.txt --constraint=context/constraints.txt
 
       - name: Run test script
         run: etc/test/test-python.sh

--- a/CHANGELOG-workspace-sharing-fixes.md
+++ b/CHANGELOG-workspace-sharing-fixes.md
@@ -1,0 +1,2 @@
+- Fix workspace sharing dialog text.
+- Fix checkbox header styling on workspace landing page.

--- a/context/app/static/js/components/workspaces/ConfirmDeleteInvitationDialog/ConfirmDeleteInvitationDialog.tsx
+++ b/context/app/static/js/components/workspaces/ConfirmDeleteInvitationDialog/ConfirmDeleteInvitationDialog.tsx
@@ -8,7 +8,6 @@ import { useWorkspaceToasts } from 'js/components/workspaces/toastHooks';
 import { useWorkspacesEventContext } from 'js/components/workspaces/contexts';
 import { trackEvent } from 'js/helpers/trackers';
 import { WorkspacesEventCategories } from 'js/components/workspaces/types';
-import { getSharerInfo } from 'js/components/workspaces/utils';
 
 export default function ConfirmDeleteInvitationDialog() {
   const { handleDeleteInvitation } = useInvitationsList();
@@ -21,10 +20,12 @@ export default function ConfirmDeleteInvitationDialog() {
   }
 
   const {
-    shared_workspace_id: { id, name },
+    shared_workspace_id: {
+      id,
+      name,
+      user_id: { first_name, last_name },
+    },
   } = invitation;
-
-  const { first_name, last_name } = getSharerInfo(invitation);
 
   const isFromLandingPage = currentEventCategory === WorkspacesEventCategories.WorkspaceLandingPage;
 

--- a/context/app/static/js/components/workspaces/Tables/WorkspaceItemsTable/components/TableContent.tsx
+++ b/context/app/static/js/components/workspaces/Tables/WorkspaceItemsTable/components/TableContent.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { WorkspaceItem, WorkspaceItemsTableProps } from 'js/components/workspaces/Tables/WorkspaceItemsTable/types';
 import { useWorkspaceItemsTableContent } from 'js/components/workspaces/Tables/WorkspaceItemsTable/hooks';
 import {
-  StyledHeaderCell,
+  StyledCheckboxHeaderCell,
   StyledTable,
   StyledTableBody,
   StyledTableCell,
@@ -44,9 +44,9 @@ function TableContent<T extends WorkspaceItem>(props: WorkspaceItemsTableProps<T
         <StyledTable>
           <StyledTableHead>
             {!!selectedItemIds && (
-              <StyledHeaderCell>
+              <StyledCheckboxHeaderCell>
                 <Checkbox checked={selectedItemIds?.size === items.length} onChange={onToggleAllItems} />
-              </StyledHeaderCell>
+              </StyledCheckboxHeaderCell>
             )}
             <StyledTableCell width="0" />
             <HeaderCells tableFields={tableFields} sortField={sortField} setSortField={setSortField} {...rest} />

--- a/context/app/static/js/components/workspaces/Tables/WorkspaceItemsTable/style.ts
+++ b/context/app/static/js/components/workspaces/Tables/WorkspaceItemsTable/style.ts
@@ -15,6 +15,12 @@ const border = (theme: Theme) => ({
   border: `1px solid ${theme.palette.grey[300]}`,
 });
 
+const checkboxStyles = {
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+};
+
 const ChipWrapper = styled('div')(({ theme }) => ({
   ...border(theme),
   borderTop: 'none',
@@ -84,10 +90,13 @@ const StyledHeaderCell = styled(HeaderCell)({
   whiteSpace: 'nowrap',
 });
 
+const StyledCheckboxHeaderCell = styled(StyledHeaderCell)({
+  ...checkboxStyles,
+  borderBottom: 'none',
+});
+
 const StyledCheckboxCell = styled(StyledTableCell)(({ theme }) => ({
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
+  ...checkboxStyles,
   paddingTop: theme.spacing(1.25),
 }));
 
@@ -138,4 +147,5 @@ export {
   StyledSvgIcon,
   BorderedTableRow,
   StyledDescriptionContainer,
+  StyledCheckboxHeaderCell,
 };


### PR DESCRIPTION
## Summary

Fixes dialog text in the "delete shared workspace invitation" dialog (which named the sharer instead of the sharee), and fixes the checkbox header styling on the workspace landing page.

## Design Documentation/Original Tickets

[CAT-1254 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1254?atlOrigin=eyJpIjoiOGI2Y2M0NDMyMDcxNDUxZThhYWM3OWM4YjRhNGEzODAiLCJwIjoiaiJ9)

## Screenshots/Video

Aligned checkbox header
<img width="988" alt="Screenshot 2025-04-28 at 10 31 55 AM" src="https://github.com/user-attachments/assets/47cae798-0a84-466d-9592-5af0ea660034" />


Corrected dialog text
<img width="641" alt="Screenshot 2025-04-28 at 10 34 54 AM" src="https://github.com/user-attachments/assets/03c1de18-fa76-4ad1-8419-e46777e83b1f" />


## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
