### PR TITLE
Austenem/CAT-1260 Search by publication

### DIFF
--- a/CHANGELOG-search-by-publication.md
+++ b/CHANGELOG-search-by-publication.md
@@ -1,0 +1,1 @@
+- Add facet to dataset search page to filter datasets to only those linked to a publication.

--- a/context/app/static/js/components/search/Facets/ExistsFacet.tsx
+++ b/context/app/static/js/components/search/Facets/ExistsFacet.tsx
@@ -10,7 +10,7 @@ function ExistsFacet({ filter, field }: { filter: ExistsValues; field: string })
   const analyticsCategory = useSearchStore((state) => state.analyticsCategory);
   const filterExists = useSearchStore((state) => state.filterExists);
 
-  const active = Boolean(filter?.values);
+  const active = filter.values;
   const getFieldLabel = useGetFieldLabel();
   const fieldLabel = getFieldLabel(field);
 

--- a/context/app/static/js/components/search/Facets/ExistsFacet.tsx
+++ b/context/app/static/js/components/search/Facets/ExistsFacet.tsx
@@ -10,7 +10,7 @@ function ExistsFacet({ filter, field }: { filter: ExistsValues; field: string })
   const analyticsCategory = useSearchStore((state) => state.analyticsCategory);
   const filterExists = useSearchStore((state) => state.filterExists);
 
-  const active = filter.values;
+  const active = Boolean(filter?.values);
   const getFieldLabel = useGetFieldLabel();
   const fieldLabel = getFieldLabel(field);
 

--- a/context/app/static/js/components/search/fieldConfigurations.ts
+++ b/context/app/static/js/components/search/fieldConfigurations.ts
@@ -48,6 +48,9 @@ function buildFieldConfigurations(type: SearchStoreState['type']): FieldConfigur
     'descendant_counts.entity_type.Dataset': {
       label: `Show ${type}s Without Datasets`,
     },
+    'descendant_counts.entity_type.Publication': {
+      label: `Show Only ${type}s Linked to Publications`,
+    },
     descendant_ids: {
       label: 'Descendant ID',
     },

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -131,9 +131,16 @@ export function buildQuery({
       }
 
       if (isExistsFilter(filter) && isExistsFacet(facetConfig)) {
-        if (filterHasValues({ filter })) {
-          const existsClause = esb.existsQuery(field);
-          draft[portalField] = facetConfig.invert ? esb.boolQuery().mustNot(existsClause) : existsClause;
+        const hasValues = filterHasValues({ filter });
+        // handle new non-inverted facet use case
+        if (!facetConfig?.invert && hasValues) {
+          draft[portalField] = esb.existsQuery(field);
+        }
+        // preserve original logic for inverted facets
+        else if (facetConfig?.invert) {
+          if (!(hasValues && facetConfig?.invert)) {
+            draft[portalField] = esb.existsQuery(field);
+          }
         }
       }
     });

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -131,8 +131,9 @@ export function buildQuery({
       }
 
       if (isExistsFilter(filter) && isExistsFacet(facetConfig)) {
-        if (!(filterHasValues({ filter }) && facetConfig?.invert)) {
-          draft[portalField] = esb.existsQuery(field);
+        if (filterHasValues({ filter })) {
+          const existsClause = esb.existsQuery(field);
+          draft[portalField] = facetConfig.invert ? esb.boolQuery().mustNot(existsClause) : existsClause;
         }
       }
     });

--- a/context/app/static/js/pages/search/S.tsx
+++ b/context/app/static/js/pages/search/S.tsx
@@ -142,7 +142,12 @@ function buildDatasetFacetGroups(isHubmapUser: boolean) {
         type: FACETS.term,
       },
       { field: 'mapped_status', childField: 'mapped_data_access_level', type: FACETS.hierarchical },
-      { field: 'descendant_counts.entity_type.Publication', type: FACETS.exists, invert: true, default: false },
+      {
+        field: 'descendant_counts.entity_type.Publication',
+        type: FACETS.exists,
+        invert: false,
+        default: false,
+      },
       { field: 'published_timestamp', type: FACETS.date },
       ...(isHubmapUser ? [{ field: 'last_modified_timestamp', type: FACETS.date }] : []),
     ],

--- a/context/app/static/js/pages/search/S.tsx
+++ b/context/app/static/js/pages/search/S.tsx
@@ -142,6 +142,7 @@ function buildDatasetFacetGroups(isHubmapUser: boolean) {
         type: FACETS.term,
       },
       { field: 'mapped_status', childField: 'mapped_data_access_level', type: FACETS.hierarchical },
+      { field: 'descendant_counts.entity_type.Publication', type: FACETS.exists, invert: true, default: false },
       { field: 'published_timestamp', type: FACETS.date },
       ...(isHubmapUser ? [{ field: 'last_modified_timestamp', type: FACETS.date }] : []),
     ],


### PR DESCRIPTION
## Summary

Adds a facet to dataset search page to filter datasets to only those linked to a publication (alternate approach to the search-api update now that the collections edge case will be removed).

## Design Documentation/Original Tickets

[CAT-1260 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1260?atlOrigin=eyJpIjoiOTAwN2RlMGZhNDliNGZmN2I1YjkzNDlkYjY2ZDkwNzQiLCJwIjoiaiJ9)

## Screenshots/Video

![search-page](https://github.com/user-attachments/assets/6bde6f5d-042d-43f4-9bbb-af7671144ab4)

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
