### PR TITLE
Austenem/CAT-1274 Fix table sizing

### DIFF
--- a/CHANGELOG-fix-table-sizing.md
+++ b/CHANGELOG-fix-table-sizing.md
@@ -1,0 +1,1 @@
+- Fix search table sizing issues on Publication and Collection pages.

--- a/context/app/static/js/shared-styles/panels/PanelList/style.ts
+++ b/context/app/static/js/shared-styles/panels/PanelList/style.ts
@@ -7,6 +7,7 @@ const PanelScrollBox = styled(Paper)(({ theme }) => {
     [media]: {
       flexGrow: 1,
       overflowY: 'scroll',
+      maxHeight: '400px',
     },
   };
 });

--- a/context/app/static/js/shared-styles/panels/PanelListLandingPage/style.ts
+++ b/context/app/static/js/shared-styles/panels/PanelListLandingPage/style.ts
@@ -1,12 +1,9 @@
 import { styled } from '@mui/material/styles';
-
 import Description from 'js/shared-styles/sections/Description';
-import { headerHeight } from 'js/components/Header/HeaderAppBar/style';
 
 const PageWrapper = styled('div')(({ theme }) => ({
   marginBottom: theme.spacing(5),
   [theme.breakpoints.up('md')]: {
-    height: `calc(100vh - ${headerHeight + 24}px)`,
     display: 'flex',
     flexDirection: 'column',
   },


### PR DESCRIPTION
## Summary

Fix search table sizing issues on Publication and Collection pages.

## Design Documentation/Original Tickets

[CAT-1274 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1274?atlOrigin=eyJpIjoiYTU1OWNmZDUxYWM4NGUwYjk1MjM4NWMzNDUxZjEyNjUiLCJwIjoiaiJ9)

## Testing

Tested on multiple devices with varying browser sizes.

## Screenshots/Video

Local:

![on-local](https://github.com/user-attachments/assets/bd608857-8d04-41bd-a21b-5b87add0b97e)

Prod (same browser height):

![on-prod](https://github.com/user-attachments/assets/b8d42c55-507a-421f-9260-a3ed9adcf5ef)

## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
