### PR TITLE
NIckAkhmetov/CAT-1277 Fix gene pathways effect causing molecular data queries to fail

### DIFF
--- a/CHANGELOG-cat-1277.md
+++ b/CHANGELOG-cat-1277.md
@@ -1,0 +1,1 @@
+- Fix gene pathways effect causing molecular data queries to fail.

--- a/context/app/static/js/components/cells/MolecularDataQueryForm/AutocompleteEntity/hooks.ts
+++ b/context/app/static/js/components/cells/MolecularDataQueryForm/AutocompleteEntity/hooks.ts
@@ -129,7 +129,11 @@ export function useSelectedPathwayParticipants() {
 
   // Update the selected genes on pathway change
   useEffect(() => {
-    if (selectedPathway && pathway && !formState.isSubmitted) {
+    if (formState.isSubmitted) {
+      // If the form has been submitted, do not update the genes.
+      return;
+    }
+    if (selectedPathway && pathway) {
       // If a new pathway is selected, set the genes to the new pathway.
       previousSelectedPathway.current = pathway;
       const genes = getParticipantsFromPathway(pathway).map((gene) => ({


### PR DESCRIPTION
## Summary

This PR adjusts the condition for the effect which updates the set of genes to fetch when querying with a selected gene pathway or deselecting a pathway, as this effect should not run while the form is in a submitted state.

This should fix the regression which causes the query not to run.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1277
 

## Screenshots/Video 

https://github.com/user-attachments/assets/f5e9da9f-94be-430d-bea1-925512f0f1ab



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
