### PR TITLE
NickAkhmetov/CAT-1106 Add Cell Types table to organ page

### DIFF
--- a/CHANGELOG-cat-1106.md
+++ b/CHANGELOG-cat-1106.md
@@ -1,0 +1,1 @@
+- Add table of indexed cell types found in a given organ to organ pages.

--- a/context/app/static/js/api/scfind/useLabelToCLID.ts
+++ b/context/app/static/js/api/scfind/useLabelToCLID.ts
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { fetcher } from 'js/helpers/swr';
+import { fetcher, multiFetcher } from 'js/helpers/swr';
 import { useAppContext } from 'js/components/Contexts';
 import { createScFindKey } from './utils';
 
@@ -23,4 +23,11 @@ export default function useLabelToCLID(props: CellTypeToCLIDParams) {
   const { scFindEndpoint } = useAppContext();
   const key = createCLIDtoLabelKey(scFindEndpoint, props);
   return useSWR<CellTypeToCLID, unknown, CellTypeToCLIDKey>(key, (url) => fetcher({ url }));
+}
+
+export function useLabelsToCLIDs(cellTypes: string[]) {
+  const { scFindEndpoint } = useAppContext();
+  const keys = cellTypes.map((cellType) => createCLIDtoLabelKey(scFindEndpoint, { cellType }));
+
+  return useSWR<CellTypeToCLID[], unknown, CellTypeToCLIDKey[]>(keys, (urls) => multiFetcher({ urls }));
 }

--- a/context/app/static/js/components/Routes/Routes.jsx
+++ b/context/app/static/js/components/Routes/Routes.jsx
@@ -39,7 +39,7 @@ const Tutorials = lazy(() => import('js/pages/Tutorials'));
 const Tutorial = lazy(() => import('js/pages/Tutorial'));
 const Profile = lazy(() => import('js/pages/Profile'));
 
-function Routes({ flaskData }) {
+function Routes({ flaskData } = {}) {
   const {
     entity,
     vitessce_conf,
@@ -358,10 +358,6 @@ Routes.propTypes = {
     redirected: PropTypes.bool,
     type: PropTypes.string,
   }),
-};
-
-Routes.defaultProps = {
-  flaskData: {},
 };
 
 export default Routes;

--- a/context/app/static/js/components/organ/Azimuth/ReferenceBasedAnalysis.tsx
+++ b/context/app/static/js/components/organ/Azimuth/ReferenceBasedAnalysis.tsx
@@ -15,10 +15,10 @@ interface ReferenceBasedAnalysisProps {
 }
 
 function MarkdownParagraph({
-  key,
   children,
 }: ClassAttributes<HTMLParagraphElement> & HTMLAttributes<HTMLParagraphElement> & ExtraProps) {
-  return <React.Fragment key={key}>{children}</React.Fragment>;
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{children}</>;
 }
 
 export default function ReferenceBasedAnalysis({ modalities, nunit, dataref, wrapped }: ReferenceBasedAnalysisProps) {

--- a/context/app/static/js/components/organ/OrganCellTypes/CellTypes.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/CellTypes.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import withShouldDisplay from 'js/helpers/withShouldDisplay';
+import Description from 'js/shared-styles/sections/Description';
+import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+import OrganDetailSection from '../OrganDetailSection';
+import IndexedDatasetsSummary from './IndexedDatasetsSummary';
+import CellTypesTable from './CellTypesTable';
+
+interface CellTypesProps {
+  cellTypes: string[];
+}
+
+function CellTypes({ cellTypes }: CellTypesProps) {
+  return (
+    <OrganDetailSection title="Cell Types" id="cell-types">
+      <Description belowTheFold={<IndexedDatasetsSummary />}>
+        These cell types have been identified in datasets from this organ using the{' '}
+        <OutboundIconLink href="https://www.nature.com/articles/s41592-021-01076-9">scFind method</OutboundIconLink>.
+      </Description>
+      <CellTypesTable cellTypes={cellTypes} />
+    </OrganDetailSection>
+  );
+}
+
+export default withShouldDisplay(CellTypes);

--- a/context/app/static/js/components/organ/OrganCellTypes/CellTypesTable.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/CellTypesTable.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
+import { InternalLink } from 'js/shared-styles/Links';
+import ExpandableRow from 'js/shared-styles/tables/ExpandableRow';
+import { StyledTableContainer } from 'js/shared-styles/tables';
+import Paper from '@mui/material/Paper';
+import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+import Stack from '@mui/material/Stack';
+import Skeleton from '@mui/material/Skeleton';
+import Typography from '@mui/material/Typography';
+import { useCellTypeOntologyDetail } from 'js/hooks/useUBKG';
+import DownloadButton from 'js/shared-styles/buttons/DownloadButton';
+import ExpandableRowCell from 'js/shared-styles/tables/ExpandableRowCell';
+import useFindDatasetForCellTypes from 'js/api/scfind/useFindDatasetForCellTypes';
+import { percent } from 'js/helpers/number-format';
+import { useIndexedDatasetsForOrgan } from 'js/pages/Organ/hooks';
+import ViewEntitiesButton from '../ViewEntitiesButton';
+import { useCLID, useFormattedCellTypeName, useUUIDsFromHubmapIds } from '../hooks';
+
+interface CellTypesTableProps {
+  cellTypes: string[];
+}
+
+interface CellTypeProps {
+  cellType: string;
+}
+
+function CellTypeLink({ cellType }: CellTypeProps) {
+  const clid = useCLID(cellType);
+
+  if (!clid) return cellType;
+
+  return <InternalLink href={`/cell-types/${clid}`}>{cellType}</InternalLink>;
+}
+
+// TODO: Remove this when the cell types detail page is ready
+const enableLinks = false;
+
+function CellTypeCell({ cellType }: CellTypeProps) {
+  if (!enableLinks) {
+    return cellType;
+  }
+
+  return <CellTypeLink cellType={cellType} />;
+}
+
+interface CLIDCellProps {
+  clid: string | undefined;
+}
+
+function CLIDCell({ clid }: CLIDCellProps) {
+  if (!clid) return <Skeleton variant="text" width={100} />;
+  return (
+    <OutboundIconLink href={`https://www.ebi.ac.uk/ols4/search?q=${clid}&ontology=cl&exactMatch=true`}>
+      {clid}
+    </OutboundIconLink>
+  );
+}
+
+function MatchedDatasetsCell({ cellType }: CellTypeProps) {
+  const { datasets: indexedDatasets, isLoading: isLoadingAllIndexed } = useIndexedDatasetsForOrgan();
+  const formattedCellName = useFormattedCellTypeName(cellType);
+  const { data: datasetsCountWithCellType, isLoading: isLoadingCellType } = useFindDatasetForCellTypes({
+    cellTypes: [formattedCellName],
+  });
+
+  const isLoading = isLoadingAllIndexed || isLoadingCellType;
+
+  if (isLoading) {
+    return <Skeleton variant="text" width={150} />;
+  }
+
+  const totalIndexedDatasets = indexedDatasets.length;
+  const matchedDatasetsCount = datasetsCountWithCellType?.[0]?.datasets?.length ?? 0;
+
+  return `${matchedDatasetsCount}/${totalIndexedDatasets} (${percent.format(matchedDatasetsCount / totalIndexedDatasets)})`;
+}
+
+function ViewDatasetsCell({ cellType }: CellTypeProps) {
+  const formattedCellName = useFormattedCellTypeName(cellType);
+  const { data: [{ datasets: hubmapIds }] = [{ datasets: [] }], isLoading: isLoadingCellType } =
+    useFindDatasetForCellTypes({
+      cellTypes: [formattedCellName],
+    });
+
+  const { datasetUUIDs, isLoading: isLoadingUUIDs } = useUUIDsFromHubmapIds(hubmapIds);
+
+  const isLoading = isLoadingCellType || isLoadingUUIDs;
+
+  if (isLoading) {
+    return <Skeleton variant="text" width={150} />;
+  }
+
+  return <ViewEntitiesButton entityType="Dataset" filters={{ datasetUUIDs }} />;
+}
+
+function CellTypeDescription({ clid }: CLIDCellProps) {
+  const cellIdWithoutPrefix = clid ? clid.replace('CL:', '') : undefined;
+  const { data, error } = useCellTypeOntologyDetail(cellIdWithoutPrefix);
+  const description = data?.cell_type.definition;
+
+  if (error) {
+    return (
+      <Typography variant="body2" sx={{ p: 2 }}>
+        Error loading description for cell type {clid}.
+      </Typography>
+    );
+  }
+
+  return (
+    <Typography variant="body2" sx={{ p: 2 }}>
+      {description ?? <Skeleton variant="text" sx={{ p: 2 }} />}
+    </Typography>
+  );
+}
+
+function CellTypeRow({ cellType }: CellTypeProps) {
+  const clid = useCLID(cellType);
+  return (
+    <ExpandableRow numCells={5} expandedContent={<CellTypeDescription clid={clid} />}>
+      <ExpandableRowCell>
+        <CellTypeCell cellType={cellType} />
+      </ExpandableRowCell>
+      <ExpandableRowCell>
+        <CLIDCell clid={clid} />
+      </ExpandableRowCell>
+      <ExpandableRowCell>
+        <MatchedDatasetsCell cellType={cellType} />
+      </ExpandableRowCell>
+      <ExpandableRowCell>
+        <ViewDatasetsCell cellType={cellType} />
+      </ExpandableRowCell>
+    </ExpandableRow>
+  );
+}
+
+function CellTypesTable({ cellTypes }: CellTypesTableProps) {
+  return (
+    <StyledTableContainer component={Paper}>
+      <Table stickyHeader>
+        <TableHead>
+          <TableRow>
+            {/* <TableCell>&nbsp; Expansion column </TableCell> */}
+            <TableCell>Cell Type</TableCell>
+            <TableCell>Cell Ontology ID</TableCell>
+            <TableCell>Matched Datasets</TableCell>
+            <TableCell colSpan={2}>
+              <Stack alignItems="end">
+                <DownloadButton tooltip="Download table in TSV format." sx={{ right: 1 }} />
+              </Stack>
+            </TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {cellTypes.map((cellType) => (
+            <CellTypeRow key={cellType} cellType={cellType} />
+          ))}
+        </TableBody>
+      </Table>
+    </StyledTableContainer>
+  );
+}
+
+export default CellTypesTable;

--- a/context/app/static/js/components/organ/OrganCellTypes/CellTypesTableCells.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/CellTypesTableCells.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { InternalLink } from 'js/shared-styles/Links';
+import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+import Skeleton from '@mui/material/Skeleton';
+import ViewEntitiesButton from '../ViewEntitiesButton';
+import { useCLID, useUUIDsFromHubmapIds } from '../hooks';
+import { CellTypeProps, CellTypeRowProps, CLIDCellProps } from './types';
+
+function CellTypeLink({ cellType }: CellTypeProps) {
+  const clid = useCLID(cellType);
+
+  if (!clid) return cellType;
+
+  return <InternalLink href={`/cell-types/${clid}`}>{cellType}</InternalLink>;
+}
+
+// TODO: Remove this when the cell types detail page is ready
+const enableLinks = false;
+
+export function CellTypeCell({ cellType }: CellTypeProps) {
+  if (!enableLinks) {
+    return cellType;
+  }
+
+  return <CellTypeLink cellType={cellType} />;
+}
+
+export function CLIDCell({ clid }: CLIDCellProps) {
+  if (!clid) return <Skeleton variant="text" width={100} />;
+  return (
+    <OutboundIconLink href={`https://www.ebi.ac.uk/ols4/search?q=${clid}&ontology=cl&exactMatch=true`}>
+      {clid}
+    </OutboundIconLink>
+  );
+}
+
+export function MatchedDatasetsCell({
+  totalIndexedDatasets,
+  matchedDatasets,
+  percentage,
+}: Pick<CellTypeRowProps, 'matchedDatasets' | 'totalIndexedDatasets' | 'clid' | 'percentage'>) {
+  const matchedDatasetsCount = matchedDatasets?.length ?? 0;
+
+  if (!totalIndexedDatasets) {
+    return <Skeleton variant="text" width={150} />;
+  }
+
+  return `${matchedDatasetsCount}/${totalIndexedDatasets} (${percentage})`;
+}
+
+export function ViewDatasetsCell({ matchedDatasets }: Pick<CellTypeRowProps, 'matchedDatasets'>) {
+  const { datasetUUIDs, isLoading } = useUUIDsFromHubmapIds(matchedDatasets ?? []);
+
+  if (isLoading) {
+    return <Skeleton variant="text" width={150} />;
+  }
+
+  return <ViewEntitiesButton entityType="Dataset" filters={{ datasetUUIDs }} />;
+}

--- a/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
@@ -2,13 +2,13 @@ import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useIndexedDatasetsForOrgan } from 'js/pages/Organ/hooks';
-import DetailsAccordion from 'js/shared-styles/accordions/DetailsAccordion';
 import OutlinedLinkButton from 'js/shared-styles/buttons/OutlinedLinkButton';
 import { DatasetIcon } from 'js/shared-styles/icons';
 import React from 'react';
 import Skeleton from '@mui/material/Skeleton';
 import { useUUIDsFromHubmapIds } from '../hooks';
 import { getSearchURL } from '../utils';
+import { StyledDetailsAccordion } from './styles';
 
 function IndexedDatasetsSummary() {
   const { datasets, isLoading: isLoadingSCFind, datasetTypes } = useIndexedDatasetsForOrgan();
@@ -18,7 +18,7 @@ function IndexedDatasetsSummary() {
 
   return (
     <Stack spacing={2} sx={{ marginTop: 2 }}>
-      <DetailsAccordion
+      <StyledDetailsAccordion
         summary={
           <Typography variant="subtitle1" component="span">
             Indexed Datasets Summary
@@ -30,16 +30,6 @@ function IndexedDatasetsSummary() {
             component: 'div',
           },
         }}
-        sx={{
-          '& .MuiAccordionSummary-root': {
-            flexDirection: 'row',
-            justifyContent: 'start',
-          },
-          '& .MuiAccordionDetails-root': {
-            padding: 0,
-            spacing: 2,
-          },
-        }}
       >
         <Typography variant="body2" component="div">
           These results are derived from RNAseq datasets that were indexed by the scFind method to identify the cell
@@ -47,7 +37,7 @@ function IndexedDatasetsSummary() {
           differences in data modalities or the availability of cell annotations. This section gives a summary of the
           datasets that are used to compute these results, and only datasets from this organ are included.
         </Typography>
-        <DetailsAccordion
+        <StyledDetailsAccordion
           summary={
             <Stack direction="row" spacing={1} alignItems="center">
               <DatasetIcon />
@@ -56,21 +46,9 @@ function IndexedDatasetsSummary() {
               </Typography>
             </Stack>
           }
-          summaryProps={{
-            sx: {
-              justifyContent: 'start',
-              flexDirection: 'row',
-              alignItems: 'center',
-            },
-          }}
           slotProps={{
             heading: {
               component: 'div',
-            },
-          }}
-          sx={{
-            '& .MuiAccordionSummary-root': {
-              flexDirection: 'row',
             },
           }}
           defaultExpanded
@@ -82,8 +60,8 @@ function IndexedDatasetsSummary() {
               </Typography>
             ))}
           </Stack>
-        </DetailsAccordion>
-      </DetailsAccordion>
+        </StyledDetailsAccordion>
+      </StyledDetailsAccordion>
       <Box>
         {isLoading ? (
           <Skeleton variant="rectangular" width={200} height={40} />

--- a/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
@@ -1,0 +1,105 @@
+import Box from '@mui/material/Box';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import { useIndexedDatasetsForOrgan } from 'js/pages/Organ/hooks';
+import DetailsAccordion from 'js/shared-styles/accordions/DetailsAccordion';
+import OutlinedLinkButton from 'js/shared-styles/buttons/OutlinedLinkButton';
+import { DatasetIcon } from 'js/shared-styles/icons';
+import React from 'react';
+import Skeleton from '@mui/material/Skeleton';
+import { useUUIDsFromHubmapIds } from '../hooks';
+import { getSearchURL } from '../utils';
+
+function IndexedDatasetsSummary() {
+  const { datasets, isLoading: isLoadingSCFind, datasetTypes } = useIndexedDatasetsForOrgan();
+  const { datasetUUIDs, isLoading: isLoadingUUIDs } = useUUIDsFromHubmapIds(datasets);
+
+  const isLoading = isLoadingSCFind || isLoadingUUIDs;
+
+  return (
+    <Stack spacing={2} sx={{ marginTop: 2 }}>
+      <DetailsAccordion
+        summary={
+          <Typography variant="subtitle1" component="span">
+            Indexed Datasets Summary
+          </Typography>
+        }
+        defaultExpanded
+        slotProps={{
+          heading: {
+            component: 'div',
+          },
+        }}
+        sx={{
+          '& .MuiAccordionSummary-root': {
+            flexDirection: 'row',
+            justifyContent: 'start',
+          },
+          '& .MuiAccordionDetails-root': {
+            padding: 0,
+            spacing: 2,
+          },
+        }}
+      >
+        <Typography variant="body2" component="div">
+          These results are derived from RNAseq datasets that were indexed by the scFind method to identify the cell
+          types associated with this organ. Not all HuBMAP datasets are currently compatible with this method due to
+          differences in data modalities or the availability of cell annotations. This section gives a summary of the
+          datasets that are used to compute these results, and only datasets from this organ are included.
+        </Typography>
+        <DetailsAccordion
+          summary={
+            <Stack direction="row" spacing={1} alignItems="center">
+              <DatasetIcon />
+              <Typography variant="subtitle2" component="span">
+                Data Types
+              </Typography>
+            </Stack>
+          }
+          summaryProps={{
+            sx: {
+              justifyContent: 'start',
+              flexDirection: 'row',
+              alignItems: 'center',
+            },
+          }}
+          slotProps={{
+            heading: {
+              component: 'div',
+            },
+          }}
+          sx={{
+            '& .MuiAccordionSummary-root': {
+              flexDirection: 'row',
+            },
+          }}
+          defaultExpanded
+        >
+          <Stack direction="row" spacing={1} alignItems="center">
+            {datasetTypes.map(({ key, doc_count }, idx) => (
+              <Typography variant="body2" component="span" key={key}>
+                {key} ({doc_count}){idx < datasetTypes.length - 1 ? ', ' : ''}
+              </Typography>
+            ))}
+          </Stack>
+        </DetailsAccordion>
+      </DetailsAccordion>
+      <Box>
+        {isLoading ? (
+          <Skeleton variant="rectangular" width={200} height={40} />
+        ) : (
+          <OutlinedLinkButton
+            link={getSearchURL({
+              entityType: 'Dataset',
+              datasetUUIDs,
+            })}
+          >
+            View Indexed Datasets
+          </OutlinedLinkButton>
+        )}
+      </Box>
+    </Stack>
+  );
+}
+
+export default IndexedDatasetsSummary;

--- a/context/app/static/js/components/organ/OrganCellTypes/hooks.ts
+++ b/context/app/static/js/components/organ/OrganCellTypes/hooks.ts
@@ -1,0 +1,49 @@
+import { useMemo } from 'react';
+
+import useFindDatasetForCellTypes from 'js/api/scfind/useFindDatasetForCellTypes';
+import { percent } from 'js/helpers/number-format';
+import { useIndexedDatasetsForOrgan } from 'js/pages/Organ/hooks';
+import { useLabelsToCLIDs } from 'js/api/scfind/useLabelToCLID';
+import { useFormattedCellTypeNames } from '../hooks';
+
+export function useMatchedDatasets(cellTypes: string[]) {
+  const { data: matchedDatasets, isLoading } = useFindDatasetForCellTypes({
+    cellTypes,
+  });
+  const matchedDatasetsCounts = matchedDatasets?.map(({ datasets }) => datasets.length) ?? [];
+  return {
+    matchedDatasets,
+    matchedDatasetsCounts,
+    isLoading,
+  };
+}
+
+export function useCellTypeRows(cellTypes: string[]) {
+  const formattedCellNames = useFormattedCellTypeNames(cellTypes);
+  const { data: clids, isLoading: isLoadingClids } = useLabelsToCLIDs(formattedCellNames);
+  const { matchedDatasets, isLoading: isLoadingMatchedDatasets } = useMatchedDatasets(formattedCellNames);
+  const { datasets: totalIndexedDatasets, isLoading: isLoadingTotalDatasets } = useIndexedDatasetsForOrgan();
+
+  const rows = useMemo(() => {
+    return cellTypes.map((cellType, index) => {
+      const matches = matchedDatasets?.[index]?.datasets ?? [];
+      const matchedDatasetsCount = matches.length;
+      const percentage = percent.format(matchedDatasetsCount / totalIndexedDatasets.length);
+
+      return {
+        cellType,
+        clid: clids?.[index].CLIDs?.[0],
+        matchedDatasets: matches,
+        totalIndexedDatasets: totalIndexedDatasets.length,
+        percentage,
+      };
+    });
+  }, [cellTypes, clids, matchedDatasets, totalIndexedDatasets.length]);
+
+  const isLoading = isLoadingClids || isLoadingMatchedDatasets || isLoadingTotalDatasets;
+
+  return {
+    rows,
+    isLoading,
+  };
+}

--- a/context/app/static/js/components/organ/OrganCellTypes/hooks.ts
+++ b/context/app/static/js/components/organ/OrganCellTypes/hooks.ts
@@ -25,19 +25,24 @@ export function useCellTypeRows(cellTypes: string[]) {
   const { datasets: totalIndexedDatasets, isLoading: isLoadingTotalDatasets } = useIndexedDatasetsForOrgan();
 
   const rows = useMemo(() => {
-    return cellTypes.map((cellType, index) => {
-      const matches = matchedDatasets?.[index]?.datasets ?? [];
-      const matchedDatasetsCount = matches.length;
-      const percentage = percent.format(matchedDatasetsCount / totalIndexedDatasets.length);
+    return (
+      cellTypes
+        .map((cellType, index) => {
+          const matches = matchedDatasets?.[index]?.datasets ?? [];
+          const matchedDatasetsCount = matches.length;
+          const percentage = percent.format(matchedDatasetsCount / totalIndexedDatasets.length);
 
-      return {
-        cellType,
-        clid: clids?.[index].CLIDs?.[0],
-        matchedDatasets: matches,
-        totalIndexedDatasets: totalIndexedDatasets.length,
-        percentage,
-      };
-    });
+          return {
+            cellType,
+            clid: clids?.[index].CLIDs?.[0],
+            matchedDatasets: matches,
+            totalIndexedDatasets: totalIndexedDatasets.length,
+            percentage,
+          };
+        })
+        // Hide the "other" cell type annotation
+        .filter((row) => row.cellType.toLowerCase() !== 'other')
+    );
   }, [cellTypes, clids, matchedDatasets, totalIndexedDatasets.length]);
 
   const isLoading = isLoadingClids || isLoadingMatchedDatasets || isLoadingTotalDatasets;

--- a/context/app/static/js/components/organ/OrganCellTypes/index.ts
+++ b/context/app/static/js/components/organ/OrganCellTypes/index.ts
@@ -1,0 +1,3 @@
+import CellTypes from './CellTypes';
+
+export default CellTypes;

--- a/context/app/static/js/components/organ/OrganCellTypes/styles.ts
+++ b/context/app/static/js/components/organ/OrganCellTypes/styles.ts
@@ -1,0 +1,13 @@
+import { styled } from '@mui/material/styles';
+import DetailsAccordion from 'js/shared-styles/accordions/DetailsAccordion';
+
+export const StyledDetailsAccordion = styled(DetailsAccordion)({
+  '& .MuiAccordionSummary-root': {
+    flexDirection: 'row',
+    justifyContent: 'start',
+  },
+  '& .MuiAccordionDetails-root': {
+    padding: 0,
+    spacing: 2,
+  },
+});

--- a/context/app/static/js/components/organ/OrganCellTypes/types.ts
+++ b/context/app/static/js/components/organ/OrganCellTypes/types.ts
@@ -1,0 +1,15 @@
+export interface CellTypesTableProps {
+  cellTypes: string[];
+}
+
+export interface CellTypeRowProps {
+  cellType: string;
+  clid?: string;
+  matchedDatasets?: string[];
+  percentage?: string;
+  totalIndexedDatasets?: number;
+}
+
+export type CellTypeProps = Pick<CellTypeRowProps, 'cellType'>;
+
+export type CLIDCellProps = Pick<CellTypeRowProps, 'clid'>;

--- a/context/app/static/js/components/organ/hooks.ts
+++ b/context/app/static/js/components/organ/hooks.ts
@@ -28,6 +28,11 @@ export function useFormattedCellTypeName(cellType: string) {
   return `${organ.name.toLowerCase()}.${cellType}`;
 }
 
+export function useFormattedCellTypeNames(cellTypes: string[]) {
+  const { organ } = useOrganContext();
+  return cellTypes.map((cellType) => `${organ.name.toLowerCase()}.${cellType}`);
+}
+
 export function useCLID(cellType: string) {
   const { organ } = useOrganContext();
   const scFindKey = `${organ.name.toLowerCase()}.${cellType}`;

--- a/context/app/static/js/components/organ/hooks.ts
+++ b/context/app/static/js/components/organ/hooks.ts
@@ -1,0 +1,40 @@
+import { useSearchHits } from 'js/hooks/useSearchData';
+import useLabelToCLID from 'js/api/scfind/useLabelToCLID';
+import { useOrganContext } from './contexts';
+
+export function useUUIDsFromHubmapIds(hubmapIds: string[]) {
+  const { searchHits: datasets, isLoading } = useSearchHits({
+    query: {
+      bool: {
+        must: [
+          {
+            terms: {
+              'hubmap_id.keyword': hubmapIds,
+            },
+          },
+        ],
+      },
+    },
+  });
+  if (!datasets) {
+    return { datasetUUIDs: [], isLoading };
+  }
+  const datasetUUIDs = datasets.map((hit) => hit._id);
+  return { datasetUUIDs, isLoading };
+}
+
+export function useFormattedCellTypeName(cellType: string) {
+  const { organ } = useOrganContext();
+  return `${organ.name.toLowerCase()}.${cellType}`;
+}
+
+export function useCLID(cellType: string) {
+  const { organ } = useOrganContext();
+  const scFindKey = `${organ.name.toLowerCase()}.${cellType}`;
+
+  const { data } = useLabelToCLID({ cellType: scFindKey });
+
+  const clid = data?.CLIDs?.[0];
+
+  return clid;
+}

--- a/context/app/static/js/components/organ/types.ts
+++ b/context/app/static/js/components/organ/types.ts
@@ -74,4 +74,5 @@ export enum OrganPageIds {
   dataProductsId = 'data-products',
   samplesId = 'samples',
   cellpopId = 'cell-population-plot',
+  cellTypesId = 'cell-types',
 }

--- a/context/app/static/js/hooks/useUBKG.ts
+++ b/context/app/static/js/hooks/useUBKG.ts
@@ -40,7 +40,10 @@ const useUbkg = () => {
       get proteinList() {
         return `${ubkgEndpoint}/proteins-info`;
       },
-      cellTypeDetail(cellTypeId: string) {
+      cellTypeDetail(cellTypeId?: string) {
+        if (!cellTypeId) {
+          return null;
+        }
         return `${ubkgEndpoint}/celltypes/${cellTypeId.toUpperCase()}`;
       },
       get cellTypeList() {
@@ -251,8 +254,8 @@ export const useGeneOntologyList = (starts_with: string) => {
   });
 };
 
-export const useCellTypeOntologyDetail = (cellTypeId: string) => {
-  const { data, error, ...swr } = useSWR<[CellTypeDetail], SWRError>(
+export const useCellTypeOntologyDetail = (cellTypeId?: string) => {
+  const { data, ...swr } = useSWR<[CellTypeDetail], SWRError>(
     useUbkg().cellTypeDetail(cellTypeId),
     (url: string) =>
       fetcher<[CellTypeDetail]>({
@@ -265,10 +268,6 @@ export const useCellTypeOntologyDetail = (cellTypeId: string) => {
       revalidateOnFocus: false,
     },
   );
-  // Throw an error if the cell type is not found
-  if (error) {
-    throw error;
-  }
   return { data: data?.[0], ...swr };
 };
 interface Description {

--- a/context/app/static/js/pages/Organ/hooks.ts
+++ b/context/app/static/js/pages/Organ/hooks.ts
@@ -5,7 +5,24 @@ import { multiFetcher } from 'js/helpers/swr/fetchers';
 import useSearchData, { useSearchHits } from 'js/hooks/useSearchData';
 import { useAppContext } from 'js/components/Contexts';
 import { OrganDataProducts, OrganFile } from 'js/components/organ/types';
+import useCellTypeNames from 'js/api/scfind/useCellTypeNames';
+import useIndexedDatasets from 'js/api/scfind/useIndexedDatasets';
+import { useOrganContext } from 'js/components/organ/contexts';
 import { mustHaveOrganClause } from './queries';
+
+export function useSearchItems(organ: OrganFile) {
+  const searchItems = useMemo(
+    () => (organ.search.length > 0 ? organ.search : [organ.name]),
+    [organ.search, organ.name],
+  );
+
+  return searchItems;
+}
+
+export function useSearchItemsFromContext() {
+  const { organ } = useOrganContext();
+  return useSearchItems(organ);
+}
 
 export function useHasSamplesQuery(searchItems: string[]) {
   const samplesQuery = useMemo(
@@ -179,4 +196,83 @@ export function useDataProducts(organ: OrganFile) {
   }));
 
   return { dataProducts: dataProductsWithUUIDs, isLoading, isLateral };
+}
+
+/**
+ * Returns a list of cell type names indexed in scFind for the current organ.
+ * @param organ The organ to filter cell types by, e.g., 'kidney', 'liver'.
+ * @returns {string[]} A list of cell type names for the specified organ.
+ */
+export function useCellTypesOfOrgan(organ: string) {
+  const { data } = useCellTypeNames();
+  return useMemo(() => {
+    if (!data) {
+      return [];
+    }
+    return data.cellTypeNames
+      .filter((cellTypeName) => cellTypeName.toLowerCase().startsWith(`${organ.toLowerCase()}.`))
+      .map((cellTypeName) => cellTypeName.split('.')[1]);
+  }, [data, organ]);
+}
+
+interface IndexedDatasetsForOrganAggs {
+  datasetTypes: {
+    buckets: {
+      key: string;
+      doc_count: number;
+    }[];
+  };
+}
+
+/**
+ * Returns a list of the dataset IDs indexed in scFind for the current organ.
+ * @param organ
+ * @returns
+ */
+export function useIndexedDatasetsForOrgan() {
+  const searchItems = useSearchItemsFromContext();
+  const { data = { datasets: [] }, isLoading: isLoadingIndexed, ...rest } = useIndexedDatasets();
+
+  const { searchData, isLoading: isLoadingDatasets } = useSearchData<unknown, IndexedDatasetsForOrganAggs>({
+    query: {
+      bool: {
+        must: [
+          {
+            terms: {
+              'hubmap_id.keyword': data.datasets ?? [],
+            },
+          },
+          {
+            terms: {
+              'origin_samples_unique_mapped_organs.keyword': searchItems,
+            },
+          },
+        ],
+      },
+    },
+    aggs: {
+      datasetTypes: {
+        terms: {
+          field: 'raw_dataset_type.keyword',
+          order: {
+            _term: 'asc',
+          },
+          size: 10000,
+        },
+      },
+    },
+    size: 10000,
+    _source: ['hubmap_id'],
+  });
+
+  const datasetUUIDs = searchData?.hits?.hits.map((h) => h._id) ?? [];
+
+  const datasetTypes = searchData?.aggregations?.datasetTypes?.buckets ?? [];
+
+  return {
+    datasets: datasetUUIDs,
+    isLoading: isLoadingIndexed || isLoadingDatasets,
+    datasetTypes,
+    ...rest,
+  };
 }

--- a/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
+++ b/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
@@ -71,7 +71,7 @@ function ChartWrapper({
                 {labels.map((label) => {
                   const isMultiple = label.text === 'Multiple';
                   return (
-                    <>
+                    <React.Fragment key={label.text}>
                       <LegendItem key={`legend-${label.text}`} margin="0 15px 0 0">
                         <svg width="1em" height="1em" style={{ borderRadius: '4px' }}>
                           {isMultiple && (
@@ -114,7 +114,7 @@ function ChartWrapper({
                         </LegendLabel>
                       </LegendItem>
                       {isMultiple && <Divider sx={{ marginY: 1 }} />}
-                    </>
+                    </React.Fragment>
                   );
                 })}
               </div>

--- a/context/app/static/js/shared-styles/icons/sectionIconMap.ts
+++ b/context/app/static/js/shared-styles/icons/sectionIconMap.ts
@@ -49,6 +49,7 @@ export const sectionIconMap: Record<string, typeof SvgIcon> = {
   assays: DatasetIcon,
   samples: SampleIcon,
   'cell-population-plot': CellTypeIcon,
+  'cell-types': CellTypeIcon,
   'sent-invitations-status': SentIcon,
   templates: WorkspacesIcon,
 } as const;

--- a/context/app/static/js/shared-styles/sections/Description/Description.tsx
+++ b/context/app/static/js/shared-styles/sections/Description/Description.tsx
@@ -2,19 +2,25 @@ import React from 'react';
 import Typography from '@mui/material/Typography';
 
 import { PaperProps } from '@mui/material/Paper';
-import { StyledPaper, StyledInfoIcon } from './style';
+import Stack from '@mui/material/Stack';
+import { InfoIcon } from 'js/shared-styles/icons';
+import { StyledPaper } from './style';
 
 interface DescriptionProps extends PaperProps {
   noIcon?: boolean;
+  belowTheFold?: React.ReactNode;
 }
 
-function Description({ children, noIcon = false, ...props }: DescriptionProps) {
+function Description({ children, noIcon = false, belowTheFold, ...props }: DescriptionProps) {
   return (
     <StyledPaper {...props}>
-      {!noIcon && <StyledInfoIcon color="primary" />}
-      <Typography variant="body1" component="div">
-        {children}
-      </Typography>
+      <Stack direction="row" alignItems="start" spacing={2}>
+        {!noIcon && <InfoIcon fontSize="1.25rem" color="primary" />}
+        <Typography variant="body1" component="div">
+          {children}
+        </Typography>
+      </Stack>
+      {belowTheFold}
     </StyledPaper>
   );
 }

--- a/context/app/static/js/shared-styles/sections/Description/style.ts
+++ b/context/app/static/js/shared-styles/sections/Description/style.ts
@@ -1,14 +1,11 @@
 import { styled } from '@mui/material/styles';
-import InfoIcon from '@mui/icons-material/Info';
 import Paper from '@mui/material/Paper';
 
 const StyledPaper = styled(Paper)(({ theme }) => ({
   display: 'flex',
-  padding: theme.spacing(3),
+  flexDirection: 'column',
+  alignItems: 'start',
+  padding: theme.spacing(2),
 }));
 
-const StyledInfoIcon = styled(InfoIcon)(({ theme }) => ({
-  marginRight: theme.spacing(2),
-}));
-
-export { StyledPaper, StyledInfoIcon };
+export { StyledPaper };

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
@@ -5,82 +5,19 @@ import TableHead from '@mui/material/TableHead';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableRow from '@mui/material/TableRow';
-import Button from '@mui/material/Button';
 import Paper from '@mui/material/Paper';
 import LinearProgress from '@mui/material/LinearProgress';
-import { useEventCallback } from '@mui/material/utils';
 
 import { StyledTableContainer, HeaderCell } from 'js/shared-styles/tables';
 import SelectableHeaderCell from 'js/shared-styles/tables/SelectableHeaderCell';
 import SelectableRowCell from 'js/shared-styles/tables/SelectableRowCell';
-import { OrderIcon } from 'js/components/searchPage/SortingTableHead/SortingTableHead';
 import useScrollTable from 'js/hooks/useScrollTable';
-import { SortState } from 'js/hooks/useSortState';
 import NumSelectedHeader from 'js/shared-styles/tables/NumSelectedHeader';
 import { Entity, EventInfo } from 'js/components/types';
-import { trackEvent } from 'js/helpers/trackers';
-import { Column, EntitiesTabTypes } from './types';
+import { EntitiesTabTypes } from './types';
 import ExpandableRow from '../ExpandableRow';
 import ExpandableRowCell from '../ExpandableRowCell';
-
-interface EntityHeaderCellTypes<Doc> {
-  column: Column<Doc>;
-  setSort: (columnId: string) => void;
-  sortState: SortState;
-  trackingInfo?: EventInfo;
-}
-
-function EntityHeaderCell<Doc>({ column, setSort, sortState, trackingInfo }: EntityHeaderCellTypes<Doc>) {
-  const handleClick = useEventCallback(() => {
-    if (trackingInfo) {
-      trackEvent({
-        ...trackingInfo,
-        action: `${trackingInfo.action} / Sort Table`,
-        label: `${trackingInfo.label} ${column.label}`,
-      });
-    }
-    setSort(column.id);
-  });
-
-  if (column.noSort) {
-    return (
-      <HeaderCell key={column.id} sx={({ palette }) => ({ backgroundColor: palette.background.paper })}>
-        {column.label}
-      </HeaderCell>
-    );
-  }
-
-  // This is a workaround to ensure the header cell control is accessible with consistent keyboard navigation
-  // and appearance. The header cell contains a disabled, hidden button that is the full width of the cell. This
-  // allows us to set the header cell to position: relative and create another button that is absolutely positioned
-  // within the cell. The absolute button is the one that is visible and clickable, and takes up the full width of
-  // the cell, which is guaranteed to be wide enough to contain the column label.
-  return (
-    <HeaderCell key={column.id} sx={({ palette }) => ({ backgroundColor: palette.background.paper })}>
-      <Button sx={{ visibility: 'hidden', whiteSpace: 'nowrap', py: 0 }} fullWidth disabled>
-        {column.label}
-      </Button>
-      <Button
-        variant="text"
-        onClick={handleClick}
-        disableTouchRipple
-        sx={{
-          justifyContent: 'flex-start',
-          whiteSpace: 'nowrap',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          pl: 2,
-        }}
-        endIcon={<OrderIcon order={sortState.columnId === column.id ? sortState.direction : undefined} />}
-      >
-        {column.label}
-      </Button>
-    </HeaderCell>
-  );
-}
+import EntityHeaderCell from './EntityTableHeaderCell';
 
 function TablePaddingRow({ padding }: { padding: number }) {
   return (
@@ -102,6 +39,7 @@ interface EntityTableProps<Doc extends Entity>
   maxHeight?: number;
   onSelectAllChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onSelectChange?: (event: React.ChangeEvent<HTMLInputElement>, id: string) => void;
+  reverseExpandIndicator?: boolean;
 }
 
 const headerRowHeight = 60;
@@ -120,6 +58,7 @@ function EntityTable<Doc extends Entity>({
   numSelected,
   onSelectAllChange,
   onSelectChange,
+  reverseExpandIndicator,
 }: EntityTableProps<Doc>) {
   const columnNameMapping = columns.reduce((acc, column) => ({ ...acc, [column.id]: column.sort }), {});
   const isExpandable = Boolean(ExpandedContent);
@@ -213,6 +152,7 @@ function EntityTable<Doc extends Entity>({
                         expandTooltip,
                         collapseTooltip,
                         disabledTooltipTitle,
+                        reverse: reverseExpandIndicator,
                       }
                     : {})}
                 >

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
@@ -200,16 +200,21 @@ function EntityTable<Doc extends Entity>({
             const hit = searchHits[virtualRow.index];
             if (hit) {
               return (
+                // @ts-expect-error `numCells` and the other props are only provided when `ExpandedContent` is defined
                 <TableRowComponent
                   sx={{ height: virtualRow.size }}
-                  numCells={columns.length + (isSelectable ? 1 : 0) + 1}
                   key={hit?._id}
-                  // @ts-expect-error the expanded content's props should be the same as the hit's _source
-                  expandedContent={ExpandedContent ? <ExpandedContent {...hit?._source} /> : undefined}
-                  isExpandedToStart={virtualRow.index === 0}
-                  expandTooltip={expandTooltip}
-                  collapseTooltip={collapseTooltip}
-                  disabledTooltipTitle={disabledTooltipTitle}
+                  {...(ExpandedContent
+                    ? {
+                        // @ts-expect-error the expanded content's props should be the same as the hit's _source
+                        expandedContent: <ExpandedContent {...hit?._source} />,
+                        isExpandedToStart: virtualRow.index === 0,
+                        numCells: columns.length + (isSelectable ? 2 : 1),
+                        expandTooltip,
+                        collapseTooltip,
+                        disabledTooltipTitle,
+                      }
+                    : {})}
                 >
                   {isSelectable && (
                     <SelectableRowCell

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import Button from '@mui/material/Button';
+import { useEventCallback } from '@mui/material/utils';
+
+import { HeaderCell } from 'js/shared-styles/tables';
+import { OrderIcon } from 'js/components/searchPage/SortingTableHead/SortingTableHead';
+import { SortState } from 'js/hooks/useSortState';
+import { EventInfo } from 'js/components/types';
+import { trackEvent } from 'js/helpers/trackers';
+import { Column } from './types';
+
+interface EntityHeaderCellTypes<Doc> {
+  column: Column<Doc>;
+  setSort: (columnId: string) => void;
+  sortState: SortState;
+  trackingInfo?: EventInfo;
+}
+
+export default function EntityHeaderCell<Doc>({
+  column,
+  setSort,
+  sortState,
+  trackingInfo,
+}: EntityHeaderCellTypes<Doc>) {
+  const handleClick = useEventCallback(() => {
+    if (trackingInfo) {
+      trackEvent({
+        ...trackingInfo,
+        action: `${trackingInfo.action} / Sort Table`,
+        label: `${trackingInfo.label} ${column.label}`,
+      });
+    }
+    setSort(column.id);
+  });
+
+  if (column.noSort) {
+    return (
+      <HeaderCell key={column.id} sx={({ palette }) => ({ backgroundColor: palette.background.paper })}>
+        {column.label}
+      </HeaderCell>
+    );
+  }
+
+  // This is a workaround to ensure the header cell control is accessible with consistent keyboard navigation
+  // and appearance. The header cell contains a disabled, hidden button that is the full width of the cell. This
+  // allows us to set the header cell to position: relative and create another button that is absolutely positioned
+  // within the cell. The absolute button is the one that is visible and clickable, and takes up the full width of
+  // the cell, which is guaranteed to be wide enough to contain the column label.
+  return (
+    <HeaderCell key={column.id} sx={({ palette }) => ({ backgroundColor: palette.background.paper })}>
+      <Button sx={{ visibility: 'hidden', whiteSpace: 'nowrap', py: 0 }} fullWidth disabled>
+        {column.label}
+      </Button>
+      <Button
+        variant="text"
+        onClick={handleClick}
+        disableTouchRipple
+        sx={{
+          justifyContent: 'flex-start',
+          whiteSpace: 'nowrap',
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          pl: 2,
+        }}
+        endIcon={<OrderIcon order={sortState.columnId === column.id ? sortState.direction : undefined} />}
+      >
+        {column.label}
+      </Button>
+    </HeaderCell>
+  );
+}

--- a/context/app/static/js/shared-styles/tables/ExpandableRow/ExpandableRow.tsx
+++ b/context/app/static/js/shared-styles/tables/ExpandableRow/ExpandableRow.tsx
@@ -15,6 +15,7 @@ interface ExpandableRowChildProps extends PropsWithChildren, TableRowProps {
   expandTooltip?: string;
   collapseTooltip?: string;
   disabledTooltipTitle?: string;
+  reverse?: boolean;
 }
 
 function ExpandableRowChild({
@@ -25,23 +26,29 @@ function ExpandableRowChild({
   expandTooltip = '',
   collapseTooltip = '',
   disabledTooltipTitle,
+  reverse = false,
   ...rest
 }: ExpandableRowChildProps) {
   const { isExpanded, toggleIsExpanded } = useExpandableRowStore();
 
   const tooltipTitle = isExpanded ? collapseTooltip : expandTooltip;
 
+  const expandableCell = (
+    <ExpandableRowCell>
+      <SecondaryBackgroundTooltip title={disabled ? disabledTooltipTitle : tooltipTitle}>
+        <span>
+          <StyledExpandCollapseIcon isExpanded={isExpanded} color={disabled ? 'disabled' : 'primary'} />
+        </span>
+      </SecondaryBackgroundTooltip>
+    </ExpandableRowCell>
+  );
+
   return (
     <>
       <ClickableRow {...rest} onClick={toggleIsExpanded} disabled={disabled} label="expand row">
+        {reverse ? expandableCell : null}
         {children}
-        <ExpandableRowCell>
-          <SecondaryBackgroundTooltip title={disabled ? disabledTooltipTitle : tooltipTitle}>
-            <span>
-              <StyledExpandCollapseIcon isExpanded={isExpanded} color={disabled ? 'disabled' : 'primary'} />
-            </span>
-          </SecondaryBackgroundTooltip>
-        </ExpandableRowCell>
+        {reverse ? null : expandableCell}
       </ClickableRow>
       <ExpandedRow $isExpanded={isExpanded}>
         <ExpandedCell colSpan={numCells} $isExpanded={isExpanded}>

--- a/context/app/static/js/shared-styles/tables/columns.tsx
+++ b/context/app/static/js/shared-styles/tables/columns.tsx
@@ -19,7 +19,10 @@ function HubmapIDCell({
   trackingInfo,
   openLinksInNewTab,
 }: CellContentProps<EntityDocument> & { trackingInfo: EventInfo; openLinksInNewTab?: boolean }) {
-  const isNotPublic = mapped_status !== 'Published' || mapped_data_access_level !== 'Public';
+  const isNotPublic =
+    mapped_status &&
+    mapped_data_access_level &&
+    (mapped_status !== 'Published' || mapped_data_access_level !== 'Public');
   const markerGene = useOptionalGeneContext();
 
   const href = useMemo(() => {


### PR DESCRIPTION
## Summary

This PR
* Resolves some minor sitewide issues which clogged the console (e.g. complaints about using default values with proptypes instead of using the built-in JS functionality, missing keys where they were necessary, extraneous keys where they were not needed)
* Adds the Cell Types section/table to the organ page
* Adds the ability to reverse the existing `ExpandableRow` component
* Moves the entity table header cell functionality into its own component/file for reuse
* Fixes a minor issue with entity table ID cells displaying empty parentheses for non-dataset entities

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1106
https://hms-dbmi.atlassian.net/browse/CAT-1169

## Testing

* local testing with kidney/lung organ pages

## Screenshots/Video

![image](https://github.com/user-attachments/assets/fb2acb57-400b-4f51-b751-836cf212412c)


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
