### PR TITLE
NickAkhmetov/Gene Detail Page Fixes

### DIFF
--- a/CHANGELOG-gene-detail-page-fixes.md
+++ b/CHANGELOG-gene-detail-page-fixes.md
@@ -1,0 +1,3 @@
+- Restore summary link to gene detail page table of contents.
+- Remove `other` cells from gene detail page.
+- Fix incorrect `biomarkers` link.

--- a/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
@@ -236,6 +236,7 @@ function CellTypesTable() {
       return 0;
     });
     return sortedCellTypes.filter((cellType) => {
+      if (cellType.cell_type.endsWith('other')) return false; // Hide 'other' cell types
       if (!selectedOrgan) return true; // Show all if no organ is selected
       return cellType.cell_type.startsWith(`${selectedOrgan}.`);
     });

--- a/context/app/static/js/components/genes/Summary/Summary.tsx
+++ b/context/app/static/js/components/genes/Summary/Summary.tsx
@@ -9,6 +9,7 @@ import RelevantPagesSection from 'js/shared-styles/sections/RelevantPagesSection
 import { trackEvent } from 'js/helpers/trackers';
 import { useGeneOntology, useGenePageContext } from '../hooks';
 import KnownReferences from './KnownReferences';
+import { pageSectionIDs } from '../constants';
 
 function SummarySkeleton() {
   return (
@@ -30,7 +31,7 @@ const trackRelevantPageClick = (label: string) => {
 
 const relevantPages = [
   {
-    link: '/genes',
+    link: '/biomarkers',
     children: 'Biomarkers',
   },
   {
@@ -66,7 +67,7 @@ function Summary() {
   }, [data?.approved_symbol, geneSymbolUpper]);
 
   return (
-    <DetailPageSection id="summary">
+    <DetailPageSection id={pageSectionIDs.summary}>
       <SummaryPaper>
         <LabelledSectionText label="Description" bottomSpacing={1} iconTooltipText="Gene description from NCBI Gene.">
           {data?.summary ?? <SummarySkeleton />}

--- a/context/app/static/js/components/genes/constants.ts
+++ b/context/app/static/js/components/genes/constants.ts
@@ -9,6 +9,7 @@ export const cellTypes = {
 };
 
 export const pageSectionIDs = {
+  summary: 'summary',
   datasets: datasets.id,
   cellTypes: cellTypes.id,
 };

--- a/context/app/static/js/pages/Genes/Genes.tsx
+++ b/context/app/static/js/pages/Genes/Genes.tsx
@@ -10,9 +10,10 @@ import Datasets from 'js/components/genes/Datasets';
 import { pageSectionIDs } from 'js/components/genes/constants';
 import CellTypes from 'js/components/genes/CellTypes/GeneCellTypes';
 
-const { datasets, cellTypes } = pageSectionIDs;
+const { datasets, cellTypes, summary } = pageSectionIDs;
 
 const shouldDisplaySection = {
+  [summary]: true,
   [cellTypes]: true,
   [datasets]: true,
 };


### PR DESCRIPTION
## Summary

This PR fixes CAT-1285, CAT-1286, and CAT-1287 after minor issues with the gene detail page implementation were surfaced during QA. 

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1285
https://hms-dbmi.atlassian.net/browse/CAT-1286
https://hms-dbmi.atlassian.net/browse/CAT-1287

## Testing

Manual testing

## Screenshots/Video


Restored summary section:

![image](https://github.com/user-attachments/assets/7b6178ce-4422-4eca-97ea-8c78bd14ad74)


No more `other` cells in table:
![image](https://github.com/user-attachments/assets/0adbe3f1-7195-4bca-bd46-ec3fd0e651d7)

Correct link from `biomarkers` button: 
![image](https://github.com/user-attachments/assets/ba5227e1-b526-4acc-9411-6b7360e9a05d)



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [ x New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added 