### PR TITLE
CAT-1295: Fixes typo on Workspaces Sharing dialog

### DIFF
--- a/CHANGELOG-Workspaces-sharing-dialog-typo.md
+++ b/CHANGELOG-Workspaces-sharing-dialog-typo.md
@@ -1,0 +1,1 @@
+Fix typo on Workspaces Sharing dialog.

--- a/context/app/static/js/components/workspaces/ShareWorkspacesDialog/ShareWorkspacesDialog.tsx
+++ b/context/app/static/js/components/workspaces/ShareWorkspacesDialog/ShareWorkspacesDialog.tsx
@@ -58,7 +58,7 @@ export default function ShareWorkspacesDialog({ handleClose, selectedWorkspaceId
         necessary workspace permissions will appear in the list. If someone lacks these permissions, they must contact
         the <ContactUsLink>HuBMAP help desk</ContactUsLink> for assistance.
       </Typography>,
-      'You can search for recipients by first name, last name, or email address. This is not a synchronous sharing feature, so recipients will receive a copy of the workspace at it exists at the time of sharing. When sharing multiple workspaces or sharing to multiple recipients, each invitation is sent separately.',
+      'You can search for recipients by first name, last name, or email address. This is not a synchronous sharing feature, so recipients will receive a copy of the workspace as it exists at the time of sharing. When sharing multiple workspaces or sharing to multiple recipients, each invitation is sent separately.',
     ],
     [selectedWorkspaceNames],
   );


### PR DESCRIPTION
## Summary

Fix minor typo on Workspaces Sharing dialog to change 'copy of the workspace at it exists' to 'copy of the workspace as it exists'.

## Design Documentation/Original Tickets

[CAT-1295](https://hms-dbmi.atlassian.net/browse/CAT-1295)

## Testing

Manual test.


## Checklist

- [x ] Code follows the project's coding standards
  - [ x] Lint checks pass locally
  - [x ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x ] Unit tests covering the new feature have been added
- [x ] All existing tests pass
- [x ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

None


[CAT-1295]: https://hms-dbmi.atlassian.net/browse/CAT-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ