### PR TITLE
Austenem/CAT-1298 Add init workspace state

### DIFF
--- a/CHANGELOG-add-init-workspace-state.md
+++ b/CHANGELOG-add-init-workspace-state.md
@@ -1,0 +1,1 @@
+- Add support for new "initializing" workspace state.

--- a/context/app/static/js/components/workspaces/statusCodes.ts
+++ b/context/app/static/js/components/workspaces/statusCodes.ts
@@ -1,12 +1,15 @@
 // Workspaces:
 
-export type WorkspaceStatus = 'active' | 'idle' | 'deleting' | 'error';
+export type WorkspaceStatus = 'active' | 'idle' | 'initializing' | 'deleting' | 'error';
 
 const workspaceStatuses: Record<WorkspaceStatus, { isDone: boolean }> = {
   active: {
     isDone: false,
   },
   idle: {
+    isDone: false,
+  },
+  initializing: {
     isDone: false,
   },
   deleting: {

--- a/context/app/static/js/shared-styles/icons/workspaceStatusIconMap.ts
+++ b/context/app/static/js/shared-styles/icons/workspaceStatusIconMap.ts
@@ -4,6 +4,7 @@ import { SuccessIcon, ErrorIcon, InfoIcon } from './icons';
 export const workspaceStatusIconMap: Record<string, { icon: typeof SvgIcon; color: SvgIconProps['color'] }> = {
   active: { icon: SuccessIcon, color: 'success' },
   idle: { icon: InfoIcon, color: 'info' },
+  initializing: { icon: InfoIcon, color: 'info' },
   deleting: { icon: InfoIcon, color: 'info' },
   error: { icon: ErrorIcon, color: 'error' },
 } as const;


### PR DESCRIPTION
## Summary

Adds support for new "initializing" workspace state.

## Design Documentation/Original Tickets

[CAT-1298 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1298?atlOrigin=eyJpIjoiM2Y4NmQyNDI2NmQxNDA0OTlkNWI0MmJkNzNiYTMwNDMiLCJwIjoiaiJ9)

## Screenshots/Video

<img width="1110" alt="Screenshot 2025-06-23 at 1 18 42 PM" src="https://github.com/user-attachments/assets/ff42b513-9d34-4ccc-9364-c77b11e18763" />

## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
