### PR TITLE
Austenem/CAT-1301 Fix up/down icons

### DIFF
--- a/CHANGELOG-fix-up-down-icons.md
+++ b/CHANGELOG-fix-up-down-icons.md
@@ -1,0 +1,1 @@
+- Fix flipped 'up' and 'down' icons across the portal.

--- a/context/app/static/js/shared-styles/icons/icons.tsx
+++ b/context/app/static/js/shared-styles/icons/icons.tsx
@@ -111,9 +111,9 @@ const EmailIcon = withIconStyles(EmailRoundedIcon);
 
 const ListsIcon = withIconStyles(ListAltRoundedIcon);
 
-const DownIcon = withIconStyles(ExpandLess);
+const DownIcon = withIconStyles(ExpandMore);
 
-const UpIcon = withIconStyles(ExpandMore);
+const UpIcon = withIconStyles(ExpandLess);
 
 const AddIcon = withIconStyles(AddRoundedIcon);
 


### PR DESCRIPTION
## Summary

Fix flipped 'up' and 'down' icons across the portal.

## Design Documentation/Original Tickets

[CAT-1301 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1301?atlOrigin=eyJpIjoiMmUzMTQxMmM5MjkwNDlkZjk5MTc0ZDVhYTcwYzk2ZGQiLCJwIjoiaiJ9)

## Screenshots/Video

<img width="1140" alt="Screenshot 2025-06-26 at 1 32 35 PM" src="https://github.com/user-attachments/assets/cdf0ed3d-5691-41aa-99c5-54cd368ee075" />