### PR TITLE
John conroy/clt protected CAT-1262

### DIFF
--- a/CHANGELOG-clt-protected.md
+++ b/CHANGELOG-clt-protected.md
@@ -1,0 +1,1 @@
+- Allow users to generate bulk download manifests for the HuBMAP CLT which include protected datasets.

--- a/context/app/static/js/components/bulkDownload/BulkDownloadDialog/BulkDownloadDialog.tsx
+++ b/context/app/static/js/components/bulkDownload/BulkDownloadDialog/BulkDownloadDialog.tsx
@@ -8,10 +8,8 @@ import Typography from '@mui/material/Typography';
 
 import { LINKS, PAGES } from 'js/components/bulkDownload/constants';
 import { BulkDownloadFormTypes, useBulkDownloadDialog } from 'js/components/bulkDownload/hooks';
-import RemoveProtectedDatasetsFormField from 'js/components/workspaces/RemoveProtectedDatasetsFormField';
 import BulkDownloadOptionsField from 'js/components/bulkDownload/BulkDownloadOptionsField';
 import BulkDownloadMetadataField from 'js/components/bulkDownload/BulkDownloadMetadataField';
-import { DatasetAccessLevelHits } from 'js/hooks/useProtectedDatasets';
 import SummaryPaper from 'js/shared-styles/sections/SectionPaper';
 import DialogModal from 'js/shared-styles/dialogs/DialogModal';
 import { SectionDescription } from 'js/shared-styles/sections/SectionDescription';
@@ -20,7 +18,6 @@ import { OutboundLink } from 'js/shared-styles/Links';
 import RelevantPagesSection from 'js/shared-styles/sections/RelevantPagesSection';
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
 import { Alert } from 'js/shared-styles/alerts';
-import ErrorOrWarningMessages from 'js/shared-styles/alerts/ErrorOrWarningMessages';
 
 function DownloadDescription() {
   return (
@@ -44,37 +41,6 @@ function DownloadDescription() {
         <RelevantPagesSection pages={PAGES} />
       </Stack>
     </SectionDescription>
-  );
-}
-
-interface ProtectedDatasetsSectionProps {
-  control: Control<BulkDownloadFormTypes>;
-  errorMessages: string[];
-  protectedHubmapIds: string;
-  protectedRows: DatasetAccessLevelHits;
-  removeProtectedDatasets: () => void;
-}
-function ProtectedDatasetsSection({
-  control,
-  errorMessages,
-  protectedHubmapIds,
-  protectedRows,
-  removeProtectedDatasets,
-}: ProtectedDatasetsSectionProps) {
-  if (errorMessages.length === 0) {
-    return null;
-  }
-
-  return (
-    <Stack paddingY={1}>
-      <ErrorOrWarningMessages errorMessages={errorMessages} />
-      <RemoveProtectedDatasetsFormField
-        control={control}
-        protectedHubmapIds={protectedHubmapIds}
-        removeProtectedDatasets={removeProtectedDatasets}
-        protectedRows={protectedRows}
-      />
-    </Stack>
   );
 }
 
@@ -105,20 +71,9 @@ interface DownloadOptionsSectionProps {
     label: string;
   }[];
   isLoading: boolean;
-  errorMessages: string[];
-  protectedHubmapIds: string;
-  protectedRows: DatasetAccessLevelHits;
-  removeProtectedDatasets: () => void;
 }
-function DownloadOptionsSection({
-  control,
-  downloadOptions,
-  isLoading,
-  errorMessages,
-  protectedHubmapIds,
-  protectedRows,
-  removeProtectedDatasets,
-}: DownloadOptionsSectionProps) {
+
+function DownloadOptionsSection({ control, downloadOptions, isLoading }: DownloadOptionsSectionProps) {
   if (isLoading) {
     return (
       <>
@@ -140,13 +95,6 @@ function DownloadOptionsSection({
   return (
     <Box>
       <Step title="Download Options" hideRequiredText>
-        <ProtectedDatasetsSection
-          control={control}
-          errorMessages={errorMessages}
-          protectedHubmapIds={protectedHubmapIds}
-          protectedRows={protectedRows}
-          removeProtectedDatasets={removeProtectedDatasets}
-        />
         <DownloadOptionsDescription />
         <SummaryPaper>
           <Stack direction="column" spacing={2}>
@@ -161,22 +109,9 @@ function DownloadOptionsSection({
 
 const formId = 'bulk-download-form';
 
-interface BulkDownloadDialogProps {
-  deselectRows?: (uuids: string[]) => void;
-}
-function BulkDownloadDialog({ deselectRows }: BulkDownloadDialogProps) {
-  const {
-    handleSubmit,
-    onSubmit,
-    handleClose,
-    isOpen,
-    errors,
-    control,
-    isLoading,
-    downloadOptions,
-    errorMessages,
-    ...rest
-  } = useBulkDownloadDialog(deselectRows);
+function BulkDownloadDialog() {
+  const { handleSubmit, onSubmit, handleClose, isOpen, errors, control, isLoading, downloadOptions, ...rest } =
+    useBulkDownloadDialog();
 
   return (
     <DialogModal
@@ -191,7 +126,6 @@ function BulkDownloadDialog({ deselectRows }: BulkDownloadDialogProps) {
               control={control}
               downloadOptions={downloadOptions}
               isLoading={isLoading}
-              errorMessages={errorMessages}
               {...rest}
             />
           </Stack>
@@ -204,12 +138,7 @@ function BulkDownloadDialog({ deselectRows }: BulkDownloadDialogProps) {
           <Button type="button" onClick={handleClose}>
             Cancel
           </Button>
-          <Button
-            type="submit"
-            variant="contained"
-            form={formId}
-            disabled={Object.keys(errors).length > 0 || errorMessages.length > 0}
-          >
+          <Button type="submit" variant="contained" form={formId} disabled={Object.keys(errors).length > 0}>
             Generate Download Manifest
           </Button>
         </Stack>

--- a/context/app/static/js/components/bulkDownload/buttons/BulkDownloadButton/BulkDownloadButton.tsx
+++ b/context/app/static/js/components/bulkDownload/buttons/BulkDownloadButton/BulkDownloadButton.tsx
@@ -11,10 +11,9 @@ import { trackEvent } from 'js/helpers/trackers';
 interface BulkDownloadButtonProps extends ButtonProps {
   tooltip: string;
   uuids: Set<string>;
-  deselectRows?: (uuids: string[]) => void;
   trackingInfo?: EventInfo;
 }
-function BulkDownloadButton({ uuids, deselectRows, disabled, trackingInfo, ...rest }: BulkDownloadButtonProps) {
+function BulkDownloadButton({ uuids, disabled, trackingInfo, ...rest }: BulkDownloadButtonProps) {
   const { openDialog, isOpen } = useBulkDownloadDialog();
 
   return (
@@ -31,7 +30,7 @@ function BulkDownloadButton({ uuids, deselectRows, disabled, trackingInfo, ...re
       >
         <SvgIcon color={disabled ? 'disabled' : 'primary'} component={Download} />
       </DownloadButton>
-      {isOpen && <BulkDownloadDialog deselectRows={deselectRows} />}
+      {isOpen && <BulkDownloadDialog />}
     </>
   );
 }

--- a/context/app/static/js/components/bulkDownload/buttons/BulkDownloadButtonFromSearch/BulkDownloadButtonFromSearch.tsx
+++ b/context/app/static/js/components/bulkDownload/buttons/BulkDownloadButtonFromSearch/BulkDownloadButtonFromSearch.tsx
@@ -11,7 +11,7 @@ interface BulkDownloadButtonFromSearchProps {
 }
 
 function BulkDownloadButtonFromSearch({ type, trackingInfo }: BulkDownloadButtonFromSearchProps) {
-  const { selectedRows, deselectRows } = useSelectableTableStore();
+  const { selectedRows } = useSelectableTableStore();
 
   const disabled = selectedRows.size === 0;
   const isDatasetSearch = type.toLowerCase() === 'dataset';
@@ -23,7 +23,6 @@ function BulkDownloadButtonFromSearch({ type, trackingInfo }: BulkDownloadButton
   return (
     <BulkDownloadButton
       tooltip={disabled ? 'Select datasets for download.' : tooltip}
-      deselectRows={deselectRows}
       uuids={selectedRows}
       disabled={disabled}
       trackingInfo={trackingInfo}

--- a/context/app/static/js/components/bulkDownload/hooks.ts
+++ b/context/app/static/js/components/bulkDownload/hooks.ts
@@ -8,10 +8,8 @@ import useBulkDownloadToasts from 'js/components/bulkDownload/toastHooks';
 import { ALL_BULK_DOWNLOAD_OPTIONS } from 'js/components/bulkDownload/constants';
 import { BulkDownloadDataset, useBulkDownloadStore } from 'js/stores/useBulkDownloadStore';
 import { useSearchHits } from 'js/hooks/useSearchData';
-import { useProtectedDatasetsForm } from 'js/hooks/useProtectedDatasets';
 import { createDownloadUrl } from 'js/helpers/functions';
 import { checkAndDownloadFile, postAndDownloadFile } from 'js/helpers/download';
-import { trackEvent } from 'js/helpers/trackers';
 import { getIDsQuery } from 'js/helpers/queries';
 
 const schema = z
@@ -54,7 +52,7 @@ function useBulkDownloadForm() {
   };
 }
 
-function useBulkDownloadDialog(deselectRows?: (uuids: string[]) => void) {
+function useBulkDownloadDialog() {
   const { isOpen, uuids, open, close, setUuids, setDownloadSuccess } = useBulkDownloadStore();
   const { control, handleSubmit, errors, reset, trigger } = useBulkDownloadForm();
   const { toastErrorDownloadFile, toastSuccessDownloadFile } = useBulkDownloadToasts();
@@ -82,31 +80,6 @@ function useBulkDownloadDialog(deselectRows?: (uuids: string[]) => void) {
       }).filter((option) => option.count > 0),
     [datasets],
   );
-
-  // Remove selected uuids from the list and deselect them in the table if needed
-  const removeUuidsOrRows = useCallback(
-    (uuidsToRemove: string[]) => {
-      if (deselectRows) {
-        deselectRows(uuidsToRemove);
-      }
-      setUuids(new Set([...uuids].filter((uuid) => !uuidsToRemove.includes(uuid))));
-    },
-    [deselectRows, setUuids, uuids],
-  );
-
-  const protectedDatasetsFields = useProtectedDatasetsForm({
-    selectedRows: new Set(uuids),
-    deselectRows: removeUuidsOrRows,
-    protectedDatasetsErrorMessage: (protectedDatasets) =>
-      `You have selected ${protectedDatasets.length} protected datasets.`,
-    trackEventHelper: (numProtectedDatasets) => {
-      trackEvent({
-        category: 'Bulk Download',
-        action: 'Protected datasets selected',
-        value: numProtectedDatasets,
-      });
-    },
-  });
 
   const downloadMetadata = useCallback(
     (datasetsToDownload: BulkDownloadDataset[]) => {
@@ -195,7 +168,6 @@ function useBulkDownloadDialog(deselectRows?: (uuids: string[]) => void) {
     openDialog,
     downloadManifest,
     downloadMetadata,
-    ...protectedDatasetsFields,
   };
 }
 


### PR DESCRIPTION
## Summary

- Allow users to generate bulk download manifests for the HuBMAP CLT which include protected datasets.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
