### PR TITLE
NickAkhmetov/CAT-1306 fix biomarkers search

### DIFF
--- a/CHANGELOG-cat-1306.md
+++ b/CHANGELOG-cat-1306.md
@@ -1,0 +1,1 @@
+- Fix genes-info endpoint parameters.

--- a/context/app/static/js/hooks/useUBKG.ts
+++ b/context/app/static/js/hooks/useUBKG.ts
@@ -243,7 +243,7 @@ export const useGeneOntologyList = (starts_with: string) => {
   const apiUrls = useUbkg();
   const query = useMemo(
     () => ({
-      genesperpage: '10',
+      genes_per_page: '10',
       starts_with,
     }),
     [starts_with],


### PR DESCRIPTION
## Summary

This PR updates the `genesperpage` param to `genes_per_page` in order to restore the functionality of the biomarkers landing page.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1306

## Testing

Manually tested by loading the biomarkers page.

## Screenshots/Video

<img width="1280" height="779" alt="image" src="https://github.com/user-attachments/assets/7f9f74c2-6a7d-4f7f-bb92-f022793046b0" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
