### PR TITLE
John conroy/fix workflow links

### DIFF
--- a/CHANGELOG-fix-workflow-links.md
+++ b/CHANGELOG-fix-workflow-links.md
@@ -1,0 +1,1 @@
+- Fix bug where links in dataset workflow details could not be clicked.


### PR DESCRIPTION
## Summary

- Fix bug where links in dataset workflow details could not be clicked.
- Conditionally display workflow steps and collapse button.

## Screenshots/Video

Workflow description and version defined. Input parameters exist.

<img width="1223" height="687" alt="Screenshot 2025-07-18 at 12 11 58 PM" src="https://github.com/user-attachments/assets/7f40fe6d-d146-4125-b3f1-8e021bd3d745" />


Workflow description and version undefined. Input parameters do not exist.

<img width="1235" height="613" alt="Screenshot 2025-07-18 at 11 33 44 AM" src="https://github.com/user-attachments/assets/ba92f8da-f0b5-4e9a-9acd-c3852c418be3" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
