### PR TITLE
 Austenem/CAT-1311 Add data permissions

### DIFF
--- a/CHANGELOG-add-data-permissions.md
+++ b/CHANGELOG-add-data-permissions.md
@@ -1,0 +1,1 @@
+- Check user's access to specific datasets for workspace and bulk download operations using new access endpoint.

--- a/CHANGELOG-fix-data-products.md
+++ b/CHANGELOG-fix-data-products.md
@@ -1,0 +1,1 @@
+- Update data products endpoint.

--- a/CHANGELOG-fix-data-products.md
+++ b/CHANGELOG-fix-data-products.md
@@ -1,1 +1,0 @@
-- Update data products endpoint.

--- a/context/app/static/js/components/bulkDownload/BulkDownloadDialog/BulkDownloadDialog.tsx
+++ b/context/app/static/js/components/bulkDownload/BulkDownloadDialog/BulkDownloadDialog.tsx
@@ -49,7 +49,6 @@ function DownloadDescription() {
 interface RestrictedDatasetsSectionProps {
   control: Control<BulkDownloadFormTypes>;
   errorMessages: string[];
-  warningMessages: string[];
   restrictedHubmapIds: string[];
   restrictedRows: string[];
   removeRestrictedDatasets: () => void;
@@ -57,18 +56,17 @@ interface RestrictedDatasetsSectionProps {
 function RestrictedDatasetsSection({
   control,
   errorMessages,
-  warningMessages,
   restrictedHubmapIds,
   restrictedRows,
   removeRestrictedDatasets,
 }: RestrictedDatasetsSectionProps) {
-  if (errorMessages.length === 0 && warningMessages.length === 0) {
+  if (errorMessages.length === 0) {
     return null;
   }
 
   return (
     <Stack paddingY={1}>
-      <ErrorOrWarningMessages warningMessages={warningMessages} errorMessages={errorMessages} />
+      <ErrorOrWarningMessages errorMessages={errorMessages} />
       <RemoveRestrictedDatasetsFormField
         control={control}
         restrictedHubmapIds={restrictedHubmapIds}
@@ -107,7 +105,6 @@ interface DownloadOptionsSectionProps {
   }[];
   isLoading: boolean;
   errorMessages: string[];
-  warningMessages: string[];
   restrictedHubmapIds: string[];
   restrictedRows: string[];
   removeRestrictedDatasets: () => void;
@@ -117,7 +114,6 @@ function DownloadOptionsSection({
   downloadOptions,
   isLoading,
   errorMessages,
-  warningMessages,
   restrictedHubmapIds,
   restrictedRows,
   removeRestrictedDatasets,
@@ -146,7 +142,6 @@ function DownloadOptionsSection({
         <RestrictedDatasetsSection
           control={control}
           errorMessages={errorMessages}
-          warningMessages={warningMessages}
           restrictedHubmapIds={restrictedHubmapIds}
           restrictedRows={restrictedRows}
           removeRestrictedDatasets={removeRestrictedDatasets}

--- a/context/app/static/js/components/bulkDownload/hooks.ts
+++ b/context/app/static/js/components/bulkDownload/hooks.ts
@@ -13,10 +13,7 @@ import { createDownloadUrl } from 'js/helpers/functions';
 import { checkAndDownloadFile, postAndDownloadFile } from 'js/helpers/download';
 import { trackEvent } from 'js/helpers/trackers';
 import { getIDsQuery } from 'js/helpers/queries';
-import {
-  restrictedDatasetsErrorMessage,
-  protectedDatasetsWarningMessage,
-} from 'js/components/bulkDownload/bulkDownloadDatasetMessaging';
+import { restrictedDatasetsErrorMessage } from 'js/components/bulkDownload/bulkDownloadDatasetMessaging';
 
 const schema = z
   .object({
@@ -101,7 +98,6 @@ function useBulkDownloadDialog(deselectRows?: (uuids: string[]) => void) {
   const restrictedDatasetsFields = useRestrictedDatasetsForm({
     selectedRows: new Set(uuids),
     deselectRows: removeUuidsOrRows,
-    protectedDatasetsWarningMessage,
     restrictedDatasetsErrorMessage,
     trackEventHelper: (numRestrictedDatasets) => {
       trackEvent({

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -14,7 +14,6 @@ import { DialogType } from 'js/stores/useWorkspaceModalStore';
 import AddDatasetsFromDetailDialog from 'js/components/workspaces/AddDatasetsFromDetailDialog';
 import { WorkspacesEventCategories } from 'js/components/workspaces/types';
 import { trackEvent } from 'js/helpers/trackers';
-import { useAppContext } from 'js/components/Contexts';
 import { useDatasetAccess } from 'js/hooks/useDatasetPermissions';
 
 interface ProcessedDataWorkspaceMenuProps {
@@ -96,10 +95,9 @@ function ProcessedDataWorkspaceMenu({ button, hubmap_id, uuid, dialogType }: Pro
     },
   ];
 
-  const { isWorkspacesUser } = useAppContext();
   const { accessAllowed, isLoading } = useDatasetAccess(uuid);
 
-  if (!isWorkspacesUser || !accessAllowed || isLoading) {
+  if (!accessAllowed || isLoading) {
     return null;
   }
 

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataWorkspaceMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useEventCallback } from '@mui/material/utils';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -14,8 +14,8 @@ import { DialogType } from 'js/stores/useWorkspaceModalStore';
 import AddDatasetsFromDetailDialog from 'js/components/workspaces/AddDatasetsFromDetailDialog';
 import { WorkspacesEventCategories } from 'js/components/workspaces/types';
 import { trackEvent } from 'js/helpers/trackers';
-import { useCheckDatasetAccess } from 'js/hooks/useRestrictedDatasets';
 import { useAppContext } from 'js/components/Contexts';
+import { useDatasetAccess } from 'js/hooks/useDatasetPermissions';
 
 interface ProcessedDataWorkspaceMenuProps {
   button: React.ReactNode;
@@ -25,10 +25,10 @@ interface ProcessedDataWorkspaceMenuProps {
 }
 
 function ProcessedDataWorkspaceMenu({ button, hubmap_id, uuid, dialogType }: ProcessedDataWorkspaceMenuProps) {
-  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
   const open = Boolean(anchorEl);
   const track = useTrackEntityPageEvent();
-  const hasWorkspaceAccess = useCheckDatasetAccess();
 
   const handleOpen = (event: React.MouseEvent<HTMLButtonElement>) => {
     track({
@@ -97,8 +97,9 @@ function ProcessedDataWorkspaceMenu({ button, hubmap_id, uuid, dialogType }: Pro
   ];
 
   const { isWorkspacesUser } = useAppContext();
+  const { accessAllowed, isLoading } = useDatasetAccess(uuid);
 
-  if (!isWorkspacesUser || !hasWorkspaceAccess(uuid)) {
+  if (!isWorkspacesUser || !accessAllowed || isLoading) {
     return null;
   }
 

--- a/context/app/static/js/components/workspaces/AddDatasetsFromSearchDialog/hooks.ts
+++ b/context/app/static/js/components/workspaces/AddDatasetsFromSearchDialog/hooks.ts
@@ -84,10 +84,8 @@ function useAddDatasetsFromSearchDialog() {
   const { selectedRows, deselectRows } = useSelectableTableStore();
   const {
     errorMessages: restrictedDatasetsErrorMessages,
-    warningMessages: protectedDatasetsWarningMessages,
     restrictedHubmapIds,
     removeRestrictedDatasets: removeRestrictedDatasetsFromSearchSelections,
-    protectedRows,
     ...restRestrictedDatasets
   } = useWorkspacesRestrictedDatasetsForm({
     selectedRows,
@@ -131,12 +129,6 @@ function useAddDatasetsFromSearchDialog() {
 
   const updateWorkspaceDatasets = useUpdateWorkspaceDatasets({ workspaceId: workspaceIdField.value });
 
-  const removeRestrictedDatasets = useCallback(() => {
-    const protectedUUIDs = protectedRows.filter((uuid): uuid is string => Boolean(uuid));
-    removeRestrictedDatasetsFromSearchSelections();
-    removeDatasets(protectedUUIDs);
-  }, [removeRestrictedDatasetsFromSearchSelections, removeDatasets, protectedRows]);
-
   const submit = useCallback(
     async ({ datasets }: { datasets: string[] }) => {
       const workspaceDatasetsSet = new Set(workspaceDatasets);
@@ -179,7 +171,7 @@ function useAddDatasetsFromSearchDialog() {
 
   const datasetsWarningMessages = buildErrorMessages({
     fieldState: datasetsFieldState,
-    otherErrors: [...protectedDatasetsWarningMessages, ...tooManyDatasetsWarningMessages],
+    otherErrors: [...tooManyDatasetsWarningMessages],
   });
 
   const workspaceIdErrorMessages = buildErrorMessages({
@@ -207,8 +199,7 @@ function useAddDatasetsFromSearchDialog() {
     workspaceIdErrorMessages,
     selectWorkspace,
     restrictedHubmapIds,
-    protectedRows,
-    removeRestrictedDatasets,
+    removeRestrictedDatasets: removeRestrictedDatasetsFromSearchSelections,
     ...restRestrictedDatasets,
   };
 }

--- a/context/app/static/js/components/workspaces/AddDatasetsTable/hooks.ts
+++ b/context/app/static/js/components/workspaces/AddDatasetsTable/hooks.ts
@@ -1,4 +1,4 @@
-import { useState, SyntheticEvent } from 'react';
+import { useState, SyntheticEvent, useMemo } from 'react';
 import { useEventCallback } from '@mui/material/utils';
 
 import { useSearchHits } from 'js/hooks/useSearchData';
@@ -6,7 +6,7 @@ import { Dataset } from 'js/components/types';
 import { useWorkspaceToasts } from 'js/components/workspaces/toastHooks';
 import { trackEvent } from 'js/helpers/trackers';
 import { WorkspacesEventCategories } from 'js/components/workspaces/types';
-import { useCheckDatasetAccess } from 'js/hooks/useRestrictedDatasets';
+import { useDatasetsAccess } from 'js/hooks/useDatasetPermissions';
 
 interface BuildIDPrefixQueryType {
   value: string;
@@ -124,11 +124,17 @@ function useDatasetsAutocomplete({
     uuidsToExclude: allDatasets,
   });
 
-  const checkDatasetAccess = useCheckDatasetAccess();
-  const searchHits = unfilteredSearchHits.filter((hit) => {
-    const uuid = hit._source?.uuid;
-    return uuid && checkDatasetAccess(uuid);
-  });
+  const uuids = unfilteredSearchHits.map((hit) => hit._source?.uuid).filter(Boolean);
+  const { accessibleDatasets, isLoading } = useDatasetsAccess(uuids);
+
+  const searchHits = useMemo(() => {
+    if (isLoading || !accessibleDatasets) return [];
+
+    return unfilteredSearchHits.filter((hit) => {
+      const uuid = hit._source?.uuid;
+      return uuid && accessibleDatasets[uuid]?.access_allowed;
+    });
+  }, [unfilteredSearchHits, accessibleDatasets, isLoading]);
 
   return {
     inputValue,

--- a/context/app/static/js/components/workspaces/AddDatasetsTable/hooks.ts
+++ b/context/app/static/js/components/workspaces/AddDatasetsTable/hooks.ts
@@ -124,7 +124,10 @@ function useDatasetsAutocomplete({
     uuidsToExclude: allDatasets,
   });
 
-  const uuids = unfilteredSearchHits.map((hit) => hit._source?.uuid).filter(Boolean);
+  const uuids = useMemo(
+    () => unfilteredSearchHits.map((hit) => hit._source?.uuid).filter(Boolean),
+    [unfilteredSearchHits],
+  );
   const { accessibleDatasets, isLoading } = useDatasetsAccess(uuids);
 
   const searchHits = useMemo(() => {

--- a/context/app/static/js/components/workspaces/AddDatasetsTable/hooks.ts
+++ b/context/app/static/js/components/workspaces/AddDatasetsTable/hooks.ts
@@ -1,4 +1,4 @@
-import { useState, SyntheticEvent, useMemo } from 'react';
+import { useState, SyntheticEvent } from 'react';
 import { useEventCallback } from '@mui/material/utils';
 
 import { useSearchHits } from 'js/hooks/useSearchData';
@@ -124,20 +124,16 @@ function useDatasetsAutocomplete({
     uuidsToExclude: allDatasets,
   });
 
-  const uuids = useMemo(
-    () => unfilteredSearchHits.map((hit) => hit._source?.uuid).filter(Boolean),
-    [unfilteredSearchHits],
-  );
+  const uuids = unfilteredSearchHits.map((hit) => hit._source?.uuid).filter(Boolean);
   const { accessibleDatasets, isLoading } = useDatasetsAccess(uuids);
 
-  const searchHits = useMemo(() => {
-    if (isLoading || !accessibleDatasets) return [];
-
-    return unfilteredSearchHits.filter((hit) => {
-      const uuid = hit._source?.uuid;
-      return uuid && accessibleDatasets[uuid]?.access_allowed;
-    });
-  }, [unfilteredSearchHits, accessibleDatasets, isLoading]);
+  const searchHits =
+    isLoading || !accessibleDatasets
+      ? []
+      : unfilteredSearchHits.filter((hit) => {
+          const uuid = hit._source?.uuid;
+          return uuid && accessibleDatasets[uuid]?.access_allowed;
+        });
 
   return {
     inputValue,

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -14,8 +14,8 @@ import RemoveRestrictedDatasetsFormField from '../RemoveRestrictedDatasetsFormFi
 
 function NewWorkspaceDialogFromSelections() {
   const {
-    errorMessages,
-    warningMessages,
+    errorMessages: datasetsErrorMessages,
+    warningMessages: datasetsWarningMessages,
     selectedRows,
     restrictedRows,
     restrictedHubmapIds,
@@ -25,7 +25,7 @@ function NewWorkspaceDialogFromSelections() {
 
   const { deselectRows } = useSelectableTableStore();
 
-  const { control, errors, setDialogIsOpen, removeDatasets, ...rest } = useCreateWorkspaceForm({
+  const { control, errors, setDialogIsOpen, removeDatasets, errorMessages, ...rest } = useCreateWorkspaceForm({
     initialRestrictedDatasets: [...restrictedHubmapIds],
     initialSelectedDatasets: [...selectedRows],
   });
@@ -48,6 +48,8 @@ function NewWorkspaceDialogFromSelections() {
         Create New Workspace
       </MenuItem>
       <NewWorkspaceDialog
+        errorMessages={datasetsErrorMessages}
+        warningMessages={datasetsWarningMessages}
         control={control}
         errors={errors}
         removeDatasets={(uuids: string[]) => {

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -17,7 +17,6 @@ function NewWorkspaceDialogFromSelections() {
     errorMessages,
     warningMessages,
     selectedRows,
-    protectedRows,
     restrictedRows,
     restrictedHubmapIds,
     removeRestrictedDatasets,

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/useCreateWorkspaceForm.ts
@@ -170,7 +170,7 @@ function useCreateWorkspaceForm({
     }
   }, [dialogIsOpen, trigger]);
 
-  const { errorMessages, warningMessages } = useWorkspacesRestrictedDatasetsForm({
+  const { errorMessages } = useWorkspacesRestrictedDatasetsForm({
     selectedRows: new Set(allDatasets),
     deselectRows: (uuids) => removeDatasets(uuids),
   });
@@ -183,7 +183,6 @@ function useCreateWorkspaceForm({
     control,
     errors,
     errorMessages,
-    warningMessages,
     onSubmit,
     isSubmitting: isSubmitting || isSubmitSuccessful,
     inputValue,
@@ -200,11 +199,7 @@ function useCreateWorkspaceForm({
 
 function useCreateWorkspaceDatasets() {
   const { selectedRows, deselectRows } = useSelectableTableStore();
-  const {
-    errorMessages: restrictedDatasetsErrorMessages,
-    warningMessages: protectedDatasetsWarningMessages,
-    ...rest
-  } = useWorkspacesRestrictedDatasetsForm({
+  const { errorMessages: restrictedDatasetsErrorMessages, ...rest } = useWorkspacesRestrictedDatasetsForm({
     selectedRows,
     deselectRows,
   });
@@ -214,7 +209,7 @@ function useCreateWorkspaceDatasets() {
 
   return {
     errorMessages: [...restrictedDatasetsErrorMessages, ...tooManyDatasetsErrorMessages],
-    warningMessages: [...protectedDatasetsWarningMessages, ...tooManyDatasetsWarningMessages],
+    warningMessages: [...tooManyDatasetsWarningMessages],
     ...rest,
   };
 }

--- a/context/app/static/js/components/workspaces/formHooks.ts
+++ b/context/app/static/js/components/workspaces/formHooks.ts
@@ -3,11 +3,7 @@ import { trackEvent } from 'js/helpers/trackers';
 import { EXCESSIVE_NUMBER_OF_WORKSPACE_DATASETS, MAX_NUMBER_OF_WORKSPACE_DATASETS } from 'js/components/workspaces/api';
 import { WorkspacesEventCategories } from 'js/components/workspaces/types';
 import { useRestrictedDatasetsForm } from 'js/hooks/useRestrictedDatasets';
-import {
-  errorHelper,
-  restrictedDatasetsErrorMessage,
-  protectedDatasetsWarningMessage,
-} from 'js/components/workspaces/workspaceDatasetMessaging';
+import { errorHelper, restrictedDatasetsErrorMessage } from 'js/components/workspaces/workspaceDatasetMessaging';
 
 function useWorkspacesRestrictedDatasetsForm({
   selectedRows,
@@ -28,7 +24,6 @@ function useWorkspacesRestrictedDatasetsForm({
     selectedRows,
     deselectRows,
     restrictedDatasetsErrorMessage,
-    protectedDatasetsWarningMessage,
     trackEventHelper,
   });
 }

--- a/context/app/static/js/hooks/useDatasetPermissions.tsx
+++ b/context/app/static/js/hooks/useDatasetPermissions.tsx
@@ -1,0 +1,90 @@
+import { useAppContext } from 'js/components/Contexts';
+import { fetcher } from 'js/helpers/swr';
+import { useCallback } from 'react';
+import useSWR from 'swr';
+
+interface DatasetPermissionsRequest {
+  url: string;
+  data: string[];
+  groupsToken: string;
+}
+
+interface DatasetPermission {
+  access_allowed: boolean;
+  valid_id: boolean;
+  uuid: string;
+  hubmap_id: string;
+  entity_type: string;
+  file_system_path: string;
+}
+
+export type DatasetPermissionsResponse = Record<string, DatasetPermission>;
+
+export async function fetchDatasetPermissions({ url, data, groupsToken }: DatasetPermissionsRequest) {
+  return fetcher<DatasetPermissionsResponse>({
+    url: `${url}/entities/accessible-data-directories`,
+    requestInit: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${groupsToken}`,
+      },
+      body: JSON.stringify(data),
+    },
+  });
+}
+
+export function useDatasetsAccess(uuids: string[]) {
+  const { groupsToken, softAssayEndpoint } = useAppContext();
+
+  const shouldFetch = Boolean(uuids && softAssayEndpoint && groupsToken);
+
+  const { data, isLoading } = useSWR(shouldFetch ? ['dataset-access', uuids, groupsToken] : null, () =>
+    fetchDatasetPermissions({
+      url: softAssayEndpoint,
+      data: uuids,
+      groupsToken,
+    }),
+  );
+
+  return {
+    accessibleDatasets: data ?? {},
+    isLoading,
+  };
+}
+
+export function useDatasetAccess(uuid: string) {
+  const { groupsToken, softAssayEndpoint } = useAppContext();
+
+  const shouldFetch = Boolean(uuid && softAssayEndpoint && groupsToken);
+
+  const { data, isLoading } = useSWR(shouldFetch ? ['dataset-access', uuid, groupsToken] : null, () =>
+    fetchDatasetPermissions({
+      url: softAssayEndpoint,
+      data: [uuid],
+      groupsToken,
+    }),
+  );
+
+  return {
+    accessAllowed: data?.[uuid]?.access_allowed ?? false,
+    isLoading,
+  };
+}
+
+export function useCheckDatasetPermissions() {
+  const { groupsToken, softAssayEndpoint } = useAppContext();
+
+  const checkPermissions = useCallback(
+    async (datasetIds: string[]): Promise<DatasetPermissionsResponse> => {
+      return fetchDatasetPermissions({
+        url: softAssayEndpoint,
+        data: datasetIds,
+        groupsToken,
+      });
+    },
+    [groupsToken, softAssayEndpoint],
+  );
+
+  return checkPermissions;
+}

--- a/context/app/static/js/hooks/useRestrictedDatasets.tsx
+++ b/context/app/static/js/hooks/useRestrictedDatasets.tsx
@@ -9,13 +9,11 @@ import { useDatasetsAccess } from 'js/hooks/useDatasetPermissions';
  * @returns A list of restricted dataset UUIDs
  */
 function useGetRestrictedDatasets(datasetUUIDs: Set<string>) {
-  const uuidsArray = useMemo(() => Array.from(datasetUUIDs), [datasetUUIDs]);
+  const uuidsArray = Array.from(datasetUUIDs);
   const { accessibleDatasets, isLoading } = useDatasetsAccess(uuidsArray);
 
-  const protectedDatasetUUIDs = useMemo(() => {
-    if (isLoading || !accessibleDatasets) return [];
-    return uuidsArray.filter((uuid) => !accessibleDatasets[uuid]?.access_allowed);
-  }, [accessibleDatasets, isLoading, uuidsArray]);
+  const protectedDatasetUUIDs =
+    isLoading || !accessibleDatasets ? [] : uuidsArray.filter((uuid) => !accessibleDatasets[uuid]?.access_allowed);
 
   return protectedDatasetUUIDs;
 }

--- a/context/app/static/js/hooks/useRestrictedDatasets.tsx
+++ b/context/app/static/js/hooks/useRestrictedDatasets.tsx
@@ -38,15 +38,17 @@ function useRestrictedDatasetsForm({
   const { hubmapIds: restrictedHubmapIds } = useHubmapIds(restrictedRows);
 
   const reportedRestrictedRows = useRef(false);
-  const errorMessages = [];
 
-  if (restrictedHubmapIds.length > 0) {
-    errorMessages.push(restrictedDatasetsErrorMessage(restrictedHubmapIds));
+  const errorMessages = useMemo(() => {
+    if (restrictedHubmapIds.length === 0) return [];
+
     if (!reportedRestrictedRows.current) {
       reportedRestrictedRows.current = true;
       trackEventHelper(restrictedHubmapIds.length);
     }
-  }
+
+    return [restrictedDatasetsErrorMessage(restrictedHubmapIds)];
+  }, [restrictedHubmapIds, restrictedDatasetsErrorMessage, trackEventHelper]);
 
   const removeRestrictedDatasets = useCallback(() => {
     deselectRows?.(restrictedRows);

--- a/context/app/static/js/hooks/useRestrictedDatasets.tsx
+++ b/context/app/static/js/hooks/useRestrictedDatasets.tsx
@@ -1,11 +1,7 @@
 import { useCallback, useMemo, useRef } from 'react';
-import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
-import { Dataset } from 'js/components/types';
 import { useWorkspaceToasts } from 'js/components/workspaces/toastHooks';
 import useHubmapIds from 'js/hooks/useHubmapIds';
 import { useDatasetsAccess } from 'js/hooks/useDatasetPermissions';
-
-export type DatasetAccessLevelHits = SearchHit<Pick<Dataset, 'hubmap_id' | 'mapped_dataset_access_level' | 'uuid'>>[];
 
 /**
  * Returns a list of dataset UUIDs that the user does not have access to for workspaces or bulk download.

--- a/context/app/static/js/pages/Organ/hooks.ts
+++ b/context/app/static/js/pages/Organ/hooks.ts
@@ -141,7 +141,7 @@ export function useDataProducts(organ: OrganFile) {
   const isLateral = search?.length > 1;
 
   const possibleNames = isLateral ? [`${name} (Right)`, `${name} (Left)`] : [name];
-  const urls = possibleNames.map((n) => `${dataProductsEndpoint}/api/data_products/${n}`);
+  const urls = possibleNames.map((n) => `${dataProductsEndpoint}/api/data_products/tissue/${n}`);
 
   const { data, isLoading } = useSWR<OrganDataProducts[]>(urls, (u: string[]) => multiFetcher({ urls: u }), {
     fallbackData: [],

--- a/context/app/static/js/shared-styles/tables/columns.tsx
+++ b/context/app/static/js/shared-styles/tables/columns.tsx
@@ -8,7 +8,7 @@ import { trackEvent } from 'js/helpers/trackers';
 import { EventInfo } from 'js/components/types';
 import Typography from '@mui/material/Typography';
 import { useOptionalGeneContext } from 'js/components/cells/SCFindResults/CurrentGeneContext';
-import { useCheckDatasetAccess } from 'js/hooks/useRestrictedDatasets';
+import { useDatasetAccess } from 'js/hooks/useDatasetPermissions';
 import { SecondaryBackgroundTooltip } from '../tooltips';
 
 export interface CellContentProps<SearchDoc> {
@@ -20,8 +20,7 @@ function HubmapIDCell({
   trackingInfo,
   openLinksInNewTab,
 }: CellContentProps<EntityDocument> & { trackingInfo: EventInfo; openLinksInNewTab?: boolean }) {
-  const checkDatasetAccess = useCheckDatasetAccess();
-  const isRestricted = !checkDatasetAccess(uuid);
+  const { accessAllowed } = useDatasetAccess(uuid);
 
   const isNotPublic =
     mapped_status &&
@@ -40,10 +39,10 @@ function HubmapIDCell({
 
   const accessTooltip = useMemo(
     () =>
-      isRestricted
+      !accessAllowed
         ? 'This is a protected dataset that cannot be accessed with your current permissions.'
         : 'This is a protected dataset. Access to this dataset depends on your user permissions.',
-    [isRestricted],
+    [accessAllowed],
   );
 
   return (
@@ -65,9 +64,9 @@ function HubmapIDCell({
       >
         {hubmap_id}
       </InternalLink>
-      {(isNotPublic || isRestricted) && (
+      {(isNotPublic || !accessAllowed) && (
         <SecondaryBackgroundTooltip title={accessTooltip}>
-          <Typography variant="caption" color={isRestricted ? 'error' : 'warning'} sx={{ display: 'block', mt: 1 }}>
+          <Typography variant="caption" color={!accessAllowed ? 'error' : 'warning'} sx={{ display: 'block', mt: 1 }}>
             {mapped_status} ({mapped_data_access_level})
           </Typography>
         </SecondaryBackgroundTooltip>

--- a/context/app/static/js/shared-styles/tables/columns.tsx
+++ b/context/app/static/js/shared-styles/tables/columns.tsx
@@ -21,12 +21,6 @@ function HubmapIDCell({
   openLinksInNewTab,
 }: CellContentProps<EntityDocument> & { trackingInfo: EventInfo; openLinksInNewTab?: boolean }) {
   const { accessAllowed } = useDatasetAccess(uuid);
-
-  const isNotPublic =
-    mapped_status &&
-    mapped_data_access_level &&
-    (mapped_status !== 'Published' || mapped_data_access_level !== 'Public');
-
   const markerGene = useOptionalGeneContext();
 
   const href = useMemo(() => {
@@ -36,14 +30,6 @@ function HubmapIDCell({
     }
     return url.toString();
   }, [uuid, markerGene]);
-
-  const accessTooltip = useMemo(
-    () =>
-      !accessAllowed
-        ? 'This is a protected dataset that cannot be accessed with your current permissions.'
-        : 'This is a protected dataset. Access to this dataset depends on your user permissions.',
-    [accessAllowed],
-  );
 
   return (
     <>
@@ -64,8 +50,8 @@ function HubmapIDCell({
       >
         {hubmap_id}
       </InternalLink>
-      {(isNotPublic || !accessAllowed) && (
-        <SecondaryBackgroundTooltip title={accessTooltip}>
+      {!accessAllowed && (
+        <SecondaryBackgroundTooltip title="This is a protected dataset that cannot be accessed with your current permissions.">
           <Typography variant="caption" color={!accessAllowed ? 'error' : 'warning'} sx={{ display: 'block', mt: 1 }}>
             {mapped_status} ({mapped_data_access_level})
           </Typography>


### PR DESCRIPTION
## Summary

Checks a user's access to specific datasets for workspace and bulk download operations using new ingest api access endpoint (which is now on PROD).

Many changes involve removing the previous warning messages that were applied to any action involving protected datasets, as the new endpoint is a single source of truth about whether the user has access to a given dataset.

## Design Documentation/Original Tickets

[CAT-1311 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1311?atlOrigin=eyJpIjoiOGE0NWI5Y2IyNjIzNDIzNWE2ZmUzOTY5ZDZlYjYyN2YiLCJwIjoiaiJ9)

## Testing

Tested by going through workspace and bulk download dialog user flows with both restricted and non-restricted datasets.

## Screenshots/Video

Bulk download dialog:
<img width="1283" height="832" alt="Screenshot 2025-07-21 at 11 10 25 AM" src="https://github.com/user-attachments/assets/df75016a-5908-49b3-8327-9321efc12b53" />

Workspace dialog:
<img width="1287" height="629" alt="Screenshot 2025-07-21 at 11 04 41 AM" src="https://github.com/user-attachments/assets/711e3a0a-c61e-400a-ab4b-288548dda172" />


## Checklist

- [X] Code follows the project's coding standards
  - [X] Lint checks pass locally
  - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added

