### PR TITLE
Austenem/CAT-1303 Fix user list names

### DIFF
--- a/CHANGELOG-fix-user-list-names.md
+++ b/CHANGELOG-fix-user-list-names.md
@@ -1,0 +1,1 @@
+- Prevent workspaces and lists from being named with only whitespace, which breaks links.

--- a/context/app/static/js/components/savedLists/CreateListDialog/CreateListDialog.tsx
+++ b/context/app/static/js/components/savedLists/CreateListDialog/CreateListDialog.tsx
@@ -50,7 +50,7 @@ function CreateListDialog({ secondaryText, dialogIsOpen, setDialogIsOpen }: Crea
       <Button onClick={handleClose} color="primary">
         Cancel
       </Button>
-      <OptDisabledButton onClick={handleSubmit} color="primary" disabled={title.length === 0}>
+      <OptDisabledButton onClick={handleSubmit} color="primary" disabled={title.trim().length === 0}>
         Save
       </OptDisabledButton>
     </>

--- a/context/app/static/js/components/savedLists/EditListDialog/EditListDialog.tsx
+++ b/context/app/static/js/components/savedLists/EditListDialog/EditListDialog.tsx
@@ -64,7 +64,7 @@ function EditListDialog({ dialogIsOpen, setDialogIsOpen, listDescription, listTi
           <Button onClick={handleClose} color="primary">
             Cancel
           </Button>
-          <OptDisabledButton onClick={handleSubmit} color="primary" disabled={title.length === 0}>
+          <OptDisabledButton onClick={handleSubmit} color="primary" disabled={title.trim().length === 0}>
             Save
           </OptDisabledButton>
         </>

--- a/context/app/static/js/components/workspaces/workspaceFormFields.ts
+++ b/context/app/static/js/components/workspaces/workspaceFormFields.ts
@@ -1,12 +1,11 @@
 import { z } from 'zod';
 import { withCustomMessage } from 'js/helpers/zod/withCustomMessage';
 
+const nameMessage = 'A workspace name is required. Please enter a workspace name.';
 const workspaceNameField = {
-  'workspace-name': z
-    .string({ errorMap: withCustomMessage('A workspace name is required. Please enter a workspace name.') })
-    .refine((val) => val.trim().length > 0, {
-      message: 'A workspace name is required. Please enter a workspace name.',
-    }),
+  'workspace-name': z.string({ errorMap: withCustomMessage(nameMessage) }).refine((val) => val.trim().length > 0, {
+    message: nameMessage,
+  }),
 };
 
 const workspaceDescriptionField = {

--- a/context/app/static/js/components/workspaces/workspaceFormFields.ts
+++ b/context/app/static/js/components/workspaces/workspaceFormFields.ts
@@ -4,7 +4,9 @@ import { withCustomMessage } from 'js/helpers/zod/withCustomMessage';
 const workspaceNameField = {
   'workspace-name': z
     .string({ errorMap: withCustomMessage('A workspace name is required. Please enter a workspace name.') })
-    .min(1),
+    .refine((val) => val.trim().length > 0, {
+      message: 'A workspace name is required. Please enter a workspace name.',
+    }),
 };
 
 const workspaceDescriptionField = {


### PR DESCRIPTION
## Summary

Prevent workspaces and lists from being named with only whitespace, which breaks links.

## Design Documentation/Original Tickets

[CAT-1303 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1303?atlOrigin=eyJpIjoiZmQwMTZlMmNjNTE0NGFiMzlkZGJjNzZmMDQ3MDYwZTQiLCJwIjoiaiJ9)

## Screenshots/Video

Examples of broken links on prod:

<img width="966" height="309" alt="Screenshot 2025-07-21 at 3 32 09 PM" src="https://github.com/user-attachments/assets/88c00f40-f226-48d9-82e8-c3b498ca2136" />
<img width="1253" height="195" alt="Screenshot 2025-07-21 at 3 38 07 PM" src="https://github.com/user-attachments/assets/6123741e-fd90-49f7-9765-4b38299b114a" />


## Checklist

- [X] Code follows the project's coding standards
    - [X] Lint checks pass locally
    - [X] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [X] Unit tests covering the new feature have been added
- [X] All existing tests pass
- [X] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [X] Any new functionalities have appropriate analytics functionalities added
