### PR TITLE
NickAkhmetov/SCFind Fixes 

### DIFF
--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -2,3 +2,4 @@
 - Add tooltips to Biomarkers table columns on Cell Type Detail pages.
 - Increase bottom margin of cell type chart in cell type search results to avoid clipping of axis and tick labels.
 - Fix icons in cell type search result tabs.
+- Improve autocomplete instruction text when there are no options loaded.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -1,3 +1,4 @@
 - Add links to cell type landing page graph.
 - Add tooltips to Biomarkers table columns on Cell Type Detail pages.
 - Increase bottom margin of cell type chart in cell type search results to avoid clipping of axis and tick labels.
+- Fix icons in cell type search result tabs.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -3,3 +3,4 @@
 - Increase bottom margin of cell type chart in cell type search results to avoid clipping of axis and tick labels.
 - Fix icons in cell type search result tabs.
 - Improve autocomplete instruction text when there are no options loaded.
+- Remove "beta" from biomarker landing page and molecular data query page.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -1,2 +1,3 @@
 - Add links to cell type landing page graph.
 - Add tooltips to Biomarkers table columns on Cell Type Detail pages.
+- Increase bottom margin of cell type chart in cell type search results to avoid clipping of axis and tick labels.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -1,0 +1,1 @@
+- Add links to cell type landing page graph.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -1,1 +1,2 @@
 - Add links to cell type landing page graph.
+- Add tooltips to Biomarkers table columns on Cell Type Detail pages.

--- a/context/app/static/js/api/scfind/useLabelToCLID.ts
+++ b/context/app/static/js/api/scfind/useLabelToCLID.ts
@@ -1,6 +1,7 @@
 import useSWR from 'swr';
 import { fetcher, multiFetcher } from 'js/helpers/swr';
 import { useAppContext } from 'js/components/Contexts';
+import { useMemo } from 'react';
 import { createScFindKey } from './utils';
 
 interface CellTypeToCLID {
@@ -33,19 +34,20 @@ export function useLabelsToCLIDs(cellTypes: string[]) {
 }
 
 export function useLabelToCLIDMap(cellTypes: string[]) {
-  const { data, error } = useLabelsToCLIDs(cellTypes);
-  const isLoading = !data && !error;
+  const { data, error, isLoading } = useLabelsToCLIDs(cellTypes);
 
-  const labelToCLIDMap: Record<string, string[]> = {};
-  if (data) {
-    data.forEach((item, idx) => {
-      labelToCLIDMap[cellTypes[idx]] = item.CLIDs;
-    });
-  }
+  return useMemo(() => {
+    const labelToCLIDMap: Record<string, string[]> = {};
 
-  return {
-    labelToCLIDMap,
-    isLoading,
-    error,
-  };
+    if (isLoading || error) {
+      return { labelToCLIDMap, isLoading, error };
+    }
+
+    if (data) {
+      data.forEach((item, idx) => {
+        labelToCLIDMap[cellTypes[idx]] = item.CLIDs;
+      });
+    }
+    return { labelToCLIDMap, isLoading, error };
+  }, [isLoading, error, data, cellTypes]);
 }

--- a/context/app/static/js/api/scfind/useLabelToCLID.ts
+++ b/context/app/static/js/api/scfind/useLabelToCLID.ts
@@ -31,3 +31,21 @@ export function useLabelsToCLIDs(cellTypes: string[]) {
 
   return useSWR<CellTypeToCLID[], unknown, CellTypeToCLIDKey[]>(keys, (urls) => multiFetcher({ urls }));
 }
+
+export function useLabelToCLIDMap(cellTypes: string[]) {
+  const { data, error } = useLabelsToCLIDs(cellTypes);
+  const isLoading = !data && !error;
+
+  const labelToCLIDMap: Record<string, string[]> = {};
+  if (data) {
+    data.forEach((item, idx) => {
+      labelToCLIDMap[cellTypes[idx]] = item.CLIDs;
+    });
+  }
+
+  return {
+    labelToCLIDMap,
+    isLoading,
+    error,
+  };
+}

--- a/context/app/static/js/api/scfind/useLabelToCLID.ts
+++ b/context/app/static/js/api/scfind/useLabelToCLID.ts
@@ -44,9 +44,10 @@ export function useLabelToCLIDMap(cellTypes: string[]) {
     }
 
     if (data) {
-      data.forEach((item, idx) => {
-        labelToCLIDMap[cellTypes[idx]] = item.CLIDs;
-      });
+      data.reduce((acc, item, idx) => {
+        acc[cellTypes[idx]] = item.CLIDs;
+        return acc;
+      }, labelToCLIDMap);
     }
     return { labelToCLIDMap, isLoading, error };
   }, [isLoading, error, data, cellTypes]);

--- a/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
+++ b/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
@@ -117,7 +117,7 @@ export const dataLinks: DrawerSection[] = [
         icon: <entityIconMap.Dataset color="primary" />,
       },
       {
-        label: 'Biomarker & Cell Type Search (Beta)',
+        label: 'Biomarker & Cell Type Search',
         description: 'Find datasets by biomarker abundance or cell types.',
         href: '/cells',
         icon: <SearchIcon color="primary" />,
@@ -135,7 +135,7 @@ export const dataLinks: DrawerSection[] = [
         icon: <OrganIcon color="primary" />,
       },
       {
-        label: 'Biomarkers (Beta)',
+        label: 'Biomarkers',
         description: 'Explore biomarkers and find detailed information on associated organs, cell types, and datasets.',
         href: '/biomarkers',
         icon: <entityIconMap.Gene color="primary" />,

--- a/context/app/static/js/components/biomarkers/BiomarkersPanelItem.tsx
+++ b/context/app/static/js/components/biomarkers/BiomarkersPanelItem.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 
-import Stack from '@mui/material/Stack';
 import Chip from '@mui/material/Chip';
 import { styled } from '@mui/material/styles';
 
 import LineClamp from 'js/shared-styles/text/LineClamp';
 import { InternalLink } from 'js/shared-styles/Links';
 import { useIsMobile } from 'js/hooks/media-queries';
-import SelectableChip from 'js/shared-styles/chips/SelectableChip';
-import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { BodyCell, HeaderCell, StackTemplate } from 'js/shared-styles/panels/ResponsivePanelCells';
-import { useBiomarkersSearchActions, useBiomarkersSearchState } from './BiomarkersSearchContext';
 
 const desktopConfig = {
   name: {
@@ -72,37 +68,9 @@ function BiomarkerPanelItem({ name, href, description, type }: BiomarkerPanelIte
   );
 }
 
-const UnroundedFilterChip = styled(SelectableChip)(({ theme }) => ({
-  borderRadius: theme.spacing(1),
-  '&.MuiChip-outlined': {
-    borderRadius: theme.spacing(1),
-  },
-}));
-
-function BiomarkerPanelFilters() {
-  const { toggleFilterByGenes, toggleFilterByProteins } = useBiomarkersSearchActions();
-  const { filterType } = useBiomarkersSearchState();
-  return (
-    <Stack direction="row" spacing={1}>
-      <UnroundedFilterChip label="Filter by Genes" isSelected={filterType === 'gene'} onClick={toggleFilterByGenes} />
-      <SecondaryBackgroundTooltip title="Coming soon">
-        <span>
-          <UnroundedFilterChip
-            label="Filter by Proteins"
-            isSelected={filterType === 'protein'}
-            onClick={toggleFilterByProteins}
-            disabled
-          />
-        </span>
-      </SecondaryBackgroundTooltip>
-    </Stack>
-  );
-}
-
 const BiomarkerPanel = {
   Header: BiomarkerHeaderPanel,
   Item: BiomarkerPanelItem,
-  Filters: BiomarkerPanelFilters,
 };
 
 export default BiomarkerPanel;

--- a/context/app/static/js/components/biomarkers/BiomarkersPanelList.tsx
+++ b/context/app/static/js/components/biomarkers/BiomarkersPanelList.tsx
@@ -58,11 +58,6 @@ export default function BiomarkersPanelList() {
     }
     const propsList: PanelProps[] = [
       {
-        key: 'filters',
-        noHover: true,
-        children: <BiomarkerPanel.Filters />,
-      },
-      {
         key: 'header',
         noPadding: true,
         children: <BiomarkerPanel.Header />,

--- a/context/app/static/js/components/biomarkers/BiomarkersSearchContext.tsx
+++ b/context/app/static/js/components/biomarkers/BiomarkersSearchContext.tsx
@@ -1,18 +1,12 @@
 import React, { Dispatch, PropsWithChildren, useMemo, useState } from 'react';
 import { createContext, useContext } from 'js/helpers/context';
-import { useTrackBiomarkerLandingPage } from './hooks';
-
-type FilterType = 'gene' | 'protein';
 
 interface BiomarkersSearchStateContext {
   search: string;
-  filterType?: FilterType;
 }
 
 interface BiomarkersSearchActionsContext {
   setSearch: Dispatch<React.SetStateAction<string>>;
-  toggleFilterByGenes: () => void;
-  toggleFilterByProteins: () => void;
 }
 
 const BiomarkersSearchStateContext = createContext<BiomarkersSearchStateContext>('BiomarkersSearchContext');
@@ -20,37 +14,19 @@ const BiomarkersSearchActionsContext = createContext<BiomarkersSearchActionsCont
 
 function BiomarkersSearchProvider({ children }: PropsWithChildren) {
   const [search, setSearch] = useState('');
-  const [filterType, setFilterType] = useState<FilterType>();
-
-  const track = useTrackBiomarkerLandingPage();
 
   const searchState = useMemo(
     () => ({
       search,
-      filterType,
     }),
-    [search, filterType],
+    [search],
   );
 
   const searchActions = useMemo(
     () => ({
       setSearch,
-      toggleFilterByGenes: () => {
-        setFilterType((c) => (c === 'gene' ? undefined : 'gene'));
-        track({
-          action: 'Select Table Filter',
-          label: 'Filter by Genes',
-        });
-      },
-      toggleFilterByProteins: () => {
-        setFilterType((c) => (c === 'protein' ? undefined : 'protein'));
-        track({
-          action: 'Select Table Filter',
-          label: 'Filter by Proteins',
-        });
-      },
     }),
-    [track],
+    [],
   );
 
   return (

--- a/context/app/static/js/components/cell-types/CellTypesBiomarkersTable.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesBiomarkersTable.tsx
@@ -90,9 +90,29 @@ const cellContent = () => null;
 const columns = [
   { id: 'name', label: 'Name', sort: 'name', cellContent },
   { id: 'description', label: 'Description', sort: 'description', cellContent },
-  { id: 'precision', label: 'Precision', sort: 'precision', cellContent },
-  { id: 'recall', label: 'Recall', sort: 'recall', cellContent },
-  { id: 'f1', label: 'F1 Score', sort: 'f1', cellContent },
+  {
+    id: 'precision',
+    label: 'Precision',
+    sort: 'precision',
+    cellContent,
+    tooltipText:
+      'Statistical metric measuring the proportion of correctly identified positive cases and predicted positive cases. Higher precision indicates fewer false positives.',
+  },
+  {
+    id: 'recall',
+    label: 'Recall',
+    sort: 'recall',
+    cellContent,
+    tooltipText:
+      'Statistical metric measuring the proportion of actual positive cases and true positives. Higher recall indicates fewer false negatives.',
+  },
+  {
+    id: 'f1',
+    label: 'F1 Score',
+    sort: 'f1',
+    cellContent,
+    tooltipText: 'Statistical metric balancing precision and recall. A higher F1 score indicates better performance.',
+  },
 ];
 
 function BiomarkersTable() {

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
@@ -25,6 +25,7 @@ interface MultiOrganCellTypeDistributionChartProps {
   cellTypes: string[];
   organs: string[];
   hideLegend?: boolean;
+  hideLinks?: boolean;
 }
 
 function ChartControls() {
@@ -152,6 +153,7 @@ function MultiOrganCellTypeDistributionChart({
   cellTypes,
   organs,
   hideLegend,
+  hideLinks = false,
 }: MultiOrganCellTypeDistributionChartProps) {
   const {
     cellTypeCountsRecord,
@@ -237,6 +239,9 @@ function MultiOrganCellTypeDistributionChart({
             getTickValues={getTickValues}
             yTickFormat={yTickFormat}
             getBarHref={(d) => {
+              if (hideLinks) {
+                return undefined;
+              }
               const { key, bar } = d;
               const fullKey = `${bar.data.organ}.${key}`;
               if (labelToCLIDMap[fullKey]) {
@@ -244,6 +249,7 @@ function MultiOrganCellTypeDistributionChart({
               }
               return undefined;
             }}
+            order="ascending"
           />
         </ChartWrapper>
       </Paper>

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
@@ -12,6 +12,7 @@ import { ScaleContinuousNumeric } from 'd3';
 import Skeleton from '@mui/material/Skeleton';
 import { unselectedCellColors } from 'js/components/cells/CellTypeDistributionChart/utils';
 import { trackEvent } from 'js/helpers/trackers';
+import { useLabelToCLIDMap } from 'js/api/scfind/useLabelToCLID';
 import { useCellTypeCountData, useYScale } from './hooks';
 import CellTypesDistributionChartContextProvider, {
   useCellTypesDistributionChartContext,
@@ -194,6 +195,8 @@ function MultiOrganCellTypeDistributionChart({
   const yAxisLabel = showPercentages ? 'Cell Fraction' : 'Cell Count';
   const yTickFormat = usePercentageYScaleFormat(showPercentages);
 
+  const { labelToCLIDMap } = useLabelToCLIDMap(cellTypes);
+
   if (isLoading) {
     return <Skeleton variant="rectangular" width="100%" height={500} />;
   }
@@ -233,6 +236,14 @@ function MultiOrganCellTypeDistributionChart({
             // @ts-expect-error Annoying type error with scale types
             getTickValues={getTickValues}
             yTickFormat={yTickFormat}
+            getBarHref={(d) => {
+              const { key, bar } = d;
+              const fullKey = `${bar.data.organ}.${key}`;
+              if (labelToCLIDMap[fullKey]) {
+                return `/cell-types/${labelToCLIDMap[fullKey][0]}`;
+              }
+              return undefined;
+            }}
           />
         </ChartWrapper>
       </Paper>

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/hooks.ts
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/hooks.ts
@@ -55,11 +55,11 @@ export function useCellTypeCountData(organs: string[], cellTypes: string[]) {
     const formattedCellTypes = Array.from(new Set(cellTypes.map((name) => formatCellTypeName(name))));
     const allOtherCellTypes = Array.from(
       new Set(
-        data
-          .flatMap((item) =>
-            item.cellTypeCounts.filter((count) => !cellTypes.includes(count.index)).map((count) => count.index),
-          )
-          .map((name) => formatCellTypeName(name)),
+        data.flatMap((item) =>
+          item.cellTypeCounts
+            .filter((count) => !cellTypes.includes(count.index))
+            .map((count) => formatCellTypeName(count.index)),
+        ),
       ),
     );
 

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/hooks.ts
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/hooks.ts
@@ -52,7 +52,9 @@ export function useCellTypeCountData(organs: string[], cellTypes: string[]) {
   const { data = [], isLoading } = useCellTypeCountForTissues(organs);
 
   const [targetCellTypeKeys, otherCellTypeKeys, allCellTypeKeys] = useMemo(() => {
-    const formattedCellTypes = cellTypes.map((name) => formatCellTypeName(name));
+    const formattedCellTypes = cellTypes
+      .map((name) => formatCellTypeName(name))
+      .filter((name, idx, arr) => name && arr.indexOf(name) === idx);
     const allOtherCellTypes = data
       .flatMap((item) =>
         item.cellTypeCounts.filter((count) => !cellTypes.includes(count.index)).map((count) => count.index),

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/hooks.ts
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/hooks.ts
@@ -52,19 +52,18 @@ export function useCellTypeCountData(organs: string[], cellTypes: string[]) {
   const { data = [], isLoading } = useCellTypeCountForTissues(organs);
 
   const [targetCellTypeKeys, otherCellTypeKeys, allCellTypeKeys] = useMemo(() => {
-    const formattedCellTypes = cellTypes
-      .map((name) => formatCellTypeName(name))
-      .filter((name, idx, arr) => name && arr.indexOf(name) === idx);
-    const allOtherCellTypes = data
-      .flatMap((item) =>
-        item.cellTypeCounts.filter((count) => !cellTypes.includes(count.index)).map((count) => count.index),
-      )
-      .map((name) => formatCellTypeName(name))
-      .filter((name, idx, arr) => name && arr.indexOf(name) === idx);
-
-    const allCellTypes = [...formattedCellTypes, ...allOtherCellTypes].filter(
-      (name, idx, arr) => name && arr.indexOf(name) === idx,
+    const formattedCellTypes = Array.from(new Set(cellTypes.map((name) => formatCellTypeName(name))));
+    const allOtherCellTypes = Array.from(
+      new Set(
+        data
+          .flatMap((item) =>
+            item.cellTypeCounts.filter((count) => !cellTypes.includes(count.index)).map((count) => count.index),
+          )
+          .map((name) => formatCellTypeName(name)),
+      ),
     );
+
+    const allCellTypes = Array.from(new Set([...formattedCellTypes, ...allOtherCellTypes]));
 
     return [formattedCellTypes, allOtherCellTypes, allCellTypes];
   }, [cellTypes, data]);

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/index.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/index.tsx
@@ -34,7 +34,7 @@ function Chart() {
 
   if (organs.length > 1) {
     // Stacked bar chart
-    return <MultiOrganCellTypeDistributionChart organs={organs} cellTypes={cellTypes} />;
+    return <MultiOrganCellTypeDistributionChart organs={organs} cellTypes={cellTypes} hideLinks />;
   }
   // fraction chart
   return (

--- a/context/app/static/js/components/cells/CellsCharts/CellTypesChart.tsx
+++ b/context/app/static/js/components/cells/CellsCharts/CellTypesChart.tsx
@@ -43,6 +43,13 @@ interface CellTypesChartProps {
   title?: React.ReactNode;
 }
 
+const margin = {
+  top: 20,
+  right: 20,
+  bottom: 220,
+  left: 80,
+} as const;
+
 function CellTypesChart({ totalCells, cellTypeCounts, isLoading, cellNames, title }: CellTypesChartProps) {
   return (
     <Box p={2} width="100%">
@@ -59,14 +66,7 @@ function CellTypesChart({ totalCells, cellTypeCounts, isLoading, cellNames, titl
               highlightedKeys={cellNames}
               yAxisLabel="Count"
               xAxisLabel="Cell Type"
-              margin={
-                {
-                  top: 20,
-                  right: 20,
-                  bottom: 20,
-                  left: 80,
-                } as const
-              }
+              margin={margin}
               TooltipContent={CellTypesChartTooltip}
             />
           </ChartLoader>

--- a/context/app/static/js/components/cells/DatasetsOverview/DatasetsOverview.tsx
+++ b/context/app/static/js/components/cells/DatasetsOverview/DatasetsOverview.tsx
@@ -16,9 +16,16 @@ interface DatasetsOverviewProps extends React.PropsWithChildren {
   datasets: string[];
   belowTheFold?: React.ReactNode;
   trackingInfo?: EventInfo;
+  tableTabDescription?: React.ReactNode;
 }
 
-export default function DatasetsOverview({ datasets, children, belowTheFold, trackingInfo }: DatasetsOverviewProps) {
+export default function DatasetsOverview({
+  datasets,
+  children,
+  belowTheFold,
+  trackingInfo,
+  tableTabDescription,
+}: DatasetsOverviewProps) {
   const { data: indexedDatasets, isLoading, error } = useIndexedDatasets();
   const indexed = useDatasetsOverview(indexedDatasets?.datasets ?? []);
   const all = useDatasetsOverview();
@@ -75,6 +82,7 @@ export default function DatasetsOverview({ datasets, children, belowTheFold, tra
         <DatasetsOverviewChart matched={matched} indexed={indexed} all={all} trackingInfo={trackingInfo} />
       </TabPanel>
       <TabPanel value={openTabIndex} index={1}>
+        {tableTabDescription && <Description>{tableTabDescription}</Description>}
         <DatasetsOverviewTable matched={matched} indexed={indexed} all={all} />
       </TabPanel>
     </>

--- a/context/app/static/js/components/cells/MolecularDataQueryForm/AutocompleteEntity/AutocompleteEntity.tsx
+++ b/context/app/static/js/components/cells/MolecularDataQueryForm/AutocompleteEntity/AutocompleteEntity.tsx
@@ -148,6 +148,9 @@ function AutocompleteEntity<T extends QueryType>({ targetEntity, defaultValue }:
       }}
       limitTags={limitTags}
       getLimitTagsText={LimitCount()}
+      noOptionsText={
+        substring ? 'No results found' : `Start typing to search for ${queryTypes[targetEntity].label.toLowerCase()}s.`
+      }
       renderTags={(value, getTagProps) =>
         value.map((option, index) => {
           const tagProps = getTagProps({ index });

--- a/context/app/static/js/components/cells/SCFindResults/SCFindCellTypeQueryResults.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/SCFindCellTypeQueryResults.tsx
@@ -181,7 +181,7 @@ const CellTypeCategoryTab = forwardRef(function CellTypeCategoryTab(
   const formattedVariant = variant ? ` (${variant})` : '';
   const isCellType = stringIsCellType(cellTypeCategory);
   const label = isCellType ? `${name}${formattedVariant} in ${capitalize(tissue)}` : cellTypeCategory;
-  const icon = isCellType ? <CellTypeIcon /> : <OrganIcon organName={cellTypeCategory} aria-label={cellTypeCategory} />;
+  const icon = isCellType ? <OrganIcon organName={tissue} aria-label={tissue} /> : <CellTypeIcon />;
 
   return (
     <Tab

--- a/context/app/static/js/components/cells/SCFindResults/SCFindCellTypeQueryResults.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/SCFindCellTypeQueryResults.tsx
@@ -155,11 +155,19 @@ function OrganCellTypeDistributionCharts({ trackingInfo }: { trackingInfo?: Even
           <Typography variant="subtitle1" component="p">
             Datasets Overview
           </Typography>
-          <DatasetsOverview datasets={datasetsByTissue[tissue]} trackingInfo={trackingInfo}>
+          <DatasetsOverview
+            datasets={datasetsByTissue[tissue]}
+            trackingInfo={trackingInfo}
+            tableTabDescription={
+              <>
+                The table below summarizes the number of matched datasets and the proportions relative to scFind-indexed
+                datasets and total HuBMAP datasets.
+              </>
+            }
+          >
             These results are derived from RNAseq datasets that were indexed by the <SCFindLink />. Not all HuBMAP
             datasets are currently compatible with this method due to data modalities or the availability of cell
-            annotations. The table below summarizes the number of matched datasets and the proportions relative to
-            scFind-indexed datasets and total HuBMAP datasets.
+            annotations.
           </DatasetsOverview>
         </TabPanel>
       ))}

--- a/context/app/static/js/components/genes/Summary/Summary.tsx
+++ b/context/app/static/js/components/genes/Summary/Summary.tsx
@@ -70,11 +70,12 @@ function Summary() {
     <DetailPageSection id={pageSectionIDs.summary}>
       <SummaryPaper>
         <LabelledSectionText label="Description" bottomSpacing={1} iconTooltipText="Gene description from NCBI Gene.">
-          {(data?.summary ?? isLoading) ? (
-            <SummarySkeleton />
-          ) : (
-            'No description available. Please view additional information in the Known References section.'
-          )}
+          {data?.summary ??
+            (isLoading ? (
+              <SummarySkeleton />
+            ) : (
+              'No description available. Please view additional information in the Known References section.'
+            ))}
         </LabelledSectionText>
         <LabelledSectionText
           label="Known References"

--- a/context/app/static/js/components/genes/Summary/Summary.tsx
+++ b/context/app/static/js/components/genes/Summary/Summary.tsx
@@ -70,12 +70,16 @@ function Summary() {
     <DetailPageSection id={pageSectionIDs.summary}>
       <SummaryPaper>
         <LabelledSectionText label="Description" bottomSpacing={1} iconTooltipText="Gene description from NCBI Gene.">
-          {data?.summary ??
-            (isLoading ? (
-              <SummarySkeleton />
-            ) : (
-              'No description available. Please view additional information in the Known References section.'
-            ))}
+          {
+            // Since summary can be an empty string, prefer this to nullish coalescing
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            data?.summary ||
+              (isLoading ? (
+                <SummarySkeleton />
+              ) : (
+                'No description available. Please view additional information in the Known References section.'
+              ))
+          }
         </LabelledSectionText>
         <LabelledSectionText
           label="Known References"

--- a/context/app/static/js/components/genes/Summary/Summary.tsx
+++ b/context/app/static/js/components/genes/Summary/Summary.tsx
@@ -41,7 +41,7 @@ const relevantPages = [
 ];
 
 function Summary() {
-  const { data } = useGeneOntology();
+  const { data, isLoading } = useGeneOntology();
   const { geneSymbolUpper } = useGenePageContext();
 
   const setAssayMetadata = useEntityStore((s) => s.setAssayMetadata);
@@ -70,7 +70,11 @@ function Summary() {
     <DetailPageSection id={pageSectionIDs.summary}>
       <SummaryPaper>
         <LabelledSectionText label="Description" bottomSpacing={1} iconTooltipText="Gene description from NCBI Gene.">
-          {data?.summary ?? <SummarySkeleton />}
+          {(data?.summary ?? isLoading) ? (
+            <SummarySkeleton />
+          ) : (
+            'No description available. Please view additional information in the Known References section.'
+          )}
         </LabelledSectionText>
         <LabelledSectionText
           label="Known References"

--- a/context/app/static/js/components/home/Hero/const.tsx
+++ b/context/app/static/js/components/home/Hero/const.tsx
@@ -63,12 +63,12 @@ export const HOME_TIMELINE_ITEMS: TimelineData[] = [
     img: <OrganIcon {...timelineIconProps} />,
   },
   {
-    title: 'Improved Molecular & Cellular Data Query (Beta)',
+    title: 'Improved Molecular & Cellular Data Query',
     titleHref: '/cells',
     description: (
       <>
-        Explore the improved <InternalLink href="/cells">Molecular & Cellular Data Query (Beta)</InternalLink> with a
-        new scFind-powered search method, gene pathway-based queries, and enhanced visualizations for gene and cell type
+        Explore the improved <InternalLink href="/cells">Molecular & Cellular Data Query</InternalLink> with a new
+        scFind-powered search method, gene pathway-based queries, and enhanced visualizations for gene and cell type
         results.
       </>
     ),

--- a/context/app/static/js/pages/Biomarkers/Biomarkers.tsx
+++ b/context/app/static/js/pages/Biomarkers/Biomarkers.tsx
@@ -27,7 +27,7 @@ export default function Biomarkers() {
               pages={[
                 {
                   link: '/cells',
-                  children: 'Molecular & Cellular Data Query (BETA)',
+                  children: 'Molecular & Cellular Data Query',
                   external: false,
                   onClick: () => {
                     track({ action: 'Select Relevant Page button', label: 'Molecular & Cellular Data Query' });

--- a/context/app/static/js/pages/Cells/Cells.tsx
+++ b/context/app/static/js/pages/Cells/Cells.tsx
@@ -14,7 +14,7 @@ function Cells() {
   return (
     <>
       <PageTitle data-testid="molecular-data-queries-title" color="primary">
-        Molecular and Cellular Data Query (BETA)
+        Molecular and Cellular Data Query
       </PageTitle>
       <Stack component={SectionPaper} direction="column" spacing={2}>
         <LabelledSectionText label="What is the molecular and cellular data query?">

--- a/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
+++ b/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
@@ -5,7 +5,7 @@ import { withParentSize } from '@visx/responsive';
 import Typography from '@mui/material/Typography';
 import type { WithParentSizeProvidedProps } from '@visx/responsive/lib/enhancers/withParentSize';
 import type { AnyD3Scale, ScaleInput } from '@visx/scale';
-import type { Accessor, SeriesPoint } from '@visx/shape/lib/types';
+import type { Accessor, BarGroupBar, SeriesPoint } from '@visx/shape/lib/types';
 
 import { type OrdinalScale, useChartTooltip, useVerticalChart } from 'js/shared-styles/charts/hooks';
 import StackedBar from 'js/shared-styles/charts/StackedBar';
@@ -47,6 +47,12 @@ interface VerticalStackedBarChartProps<
   order?: BarStackProps<Datum, YAxisKey, XAxisScale, YAxisScale>['order'];
   valueAccessor?: (d: Datum, key: YAxisKey) => number;
   yTickFormat?: (value: number) => string;
+  getBarHref?: (
+    d: Omit<BarGroupBar<string>, 'key' | 'value'> & {
+      bar: SeriesPoint<Datum>;
+      key: string;
+    },
+  ) => string | undefined;
 }
 
 function VerticalStackedBarChart<
@@ -78,6 +84,7 @@ function VerticalStackedBarChart<
   order,
   valueAccessor,
   yTickFormat = (value) => value.toString(),
+  getBarHref,
 }: VerticalStackedBarChartProps<Datum, XAxisKey, YAxisKey, XAxisScale, YAxisScale>) {
   const { xWidth, yHeight, updatedMargin, longestLabelSize } = useVerticalChart({
     margin,
@@ -134,6 +141,7 @@ function VerticalStackedBarChart<
                           key={`${bar.key}-${bar.index}`}
                           direction="vertical"
                           bar={bar}
+                          href={getBarHref?.(bar)}
                           ariaLabelText={getAriaLabel?.(bar)}
                           hoverProps={{
                             onMouseEnter: handleMouseEnter(bar),

--- a/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
+++ b/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
@@ -45,7 +45,6 @@ interface VerticalStackedBarChartProps<
   getTickValues?: (yScale: YAxisScale) => number[];
   getAriaLabel?: (d: TooltipData<Datum>) => string;
   order?: BarStackProps<Datum, YAxisKey, XAxisScale, YAxisScale>['order'];
-  valueAccessor?: (d: Datum, key: YAxisKey) => number;
   yTickFormat?: (value: number) => string;
   getBarHref?: (
     d: Omit<BarGroupBar<string>, 'key' | 'value'> & {
@@ -82,7 +81,6 @@ function VerticalStackedBarChart<
   getTickValues,
   getAriaLabel,
   order,
-  valueAccessor,
   yTickFormat = (value) => value.toString(),
   getBarHref,
 }: VerticalStackedBarChartProps<Datum, XAxisKey, YAxisKey, XAxisScale, YAxisScale>) {
@@ -130,7 +128,6 @@ function VerticalStackedBarChart<
               y1={y1}
               y0={y0}
               order={order}
-              value={valueAccessor}
             >
               {(barStacks) => {
                 return barStacks.map((barStack) =>

--- a/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
+++ b/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
@@ -46,6 +46,15 @@ interface VerticalStackedBarChartProps<
   getAriaLabel?: (d: TooltipData<Datum>) => string;
   order?: BarStackProps<Datum, YAxisKey, XAxisScale, YAxisScale>['order'];
   yTickFormat?: (value: number) => string;
+  /**
+   * A function to generate a URL for a given bar in the chart.
+   * 
+   * @param d - An object representing the bar, including its data point (`bar`) and key (`key`).
+   * @returns A string representing the URL for the bar, or `undefined` if no URL is applicable.
+   * 
+   * This function is called for each bar in the chart to determine its associated hyperlink.
+   * The returned URL can be used to navigate to a detailed view or related resource for the bar.
+   */
   getBarHref?: (
     d: Omit<BarGroupBar<string>, 'key' | 'value'> & {
       bar: SeriesPoint<Datum>;

--- a/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
+++ b/context/app/static/js/shared-styles/charts/VerticalStackedBarChart/VerticalStackedBarChart.tsx
@@ -48,10 +48,10 @@ interface VerticalStackedBarChartProps<
   yTickFormat?: (value: number) => string;
   /**
    * A function to generate a URL for a given bar in the chart.
-   * 
+   *
    * @param d - An object representing the bar, including its data point (`bar`) and key (`key`).
    * @returns A string representing the URL for the bar, or `undefined` if no URL is applicable.
-   * 
+   *
    * This function is called for each bar in the chart to determine its associated hyperlink.
    * The returned URL can be used to navigate to a detailed view or related resource for the bar.
    */

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 
-import Button from '@mui/material/Button';
 import { useEventCallback } from '@mui/material/utils';
 
 import { HeaderCell } from 'js/shared-styles/tables';
-import { OrderIcon } from 'js/components/searchPage/SortingTableHead/SortingTableHead';
 import { SortState } from 'js/hooks/useSortState';
 import { EventInfo } from 'js/components/types';
 import { trackEvent } from 'js/helpers/trackers';
 import InfoTextTooltip from 'js/shared-styles/tooltips/InfoTextTooltip';
+import TableSortLabel from '@mui/material/TableSortLabel';
 import { Column } from './types';
 
 interface EntityHeaderCellTypes<Doc> {
@@ -35,48 +34,39 @@ export default function EntityHeaderCell<Doc>({
     setSort(column.id);
   });
 
+  const { id } = column;
+
   const label = tooltipText ? (
-    <InfoTextTooltip tooltipTitle={tooltipText}>{column.label}</InfoTextTooltip>
+    <InfoTextTooltip infoIconSize="medium" tooltipTitle={tooltipText}>
+      {column.label}
+    </InfoTextTooltip>
   ) : (
     column.label
   );
 
   if (column.noSort) {
     return (
-      <HeaderCell key={column.id} sx={{ backgroundColor: 'background.paper' }}>
+      <HeaderCell key={id} sx={{ backgroundColor: 'background.paper' }}>
         {label}
       </HeaderCell>
     );
   }
 
-  // This is a workaround to ensure the header cell control is accessible with consistent keyboard navigation
-  // and appearance. The header cell contains a disabled, hidden button that is the full width of the cell. This
-  // allows us to set the header cell to position: relative and create another button that is absolutely positioned
-  // within the cell. The absolute button is the one that is visible and clickable, and takes up the full width of
-  // the cell, which is guaranteed to be wide enough to contain the column label.
   return (
-    <HeaderCell key={column.id} sx={{ backgroundColor: 'background.paper' }}>
-      <Button sx={{ visibility: 'hidden', whiteSpace: 'nowrap', py: 0 }} fullWidth disabled>
-        {column.label}
-      </Button>
-      <Button
-        variant="text"
+    <HeaderCell key={id} sx={{ backgroundColor: 'background.paper' }}>
+      <TableSortLabel
+        active={sortState.columnId === id}
+        direction={sortState.direction}
         onClick={handleClick}
-        disableTouchRipple
         sx={{
-          justifyContent: 'flex-start',
           whiteSpace: 'nowrap',
-          position: 'absolute',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          pl: 2,
+          '& .MuiTableSortLabel-icon': {
+            opacity: 0.5,
+          },
         }}
-        endIcon={<OrderIcon order={sortState.columnId === column.id ? sortState.direction : undefined} />}
       >
         {label}
-      </Button>
+      </TableSortLabel>
     </HeaderCell>
   );
 }

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
@@ -52,16 +52,18 @@ export default function EntityHeaderCell<Doc>({
     );
   }
 
+  const active = sortState.columnId === id;
+
   return (
     <HeaderCell key={id} sx={{ backgroundColor: 'background.paper' }}>
       <TableSortLabel
-        active={sortState.columnId === id}
-        direction={sortState.direction}
+        active={active}
+        direction={active ? sortState.direction : undefined}
         onClick={handleClick}
         sx={{
           whiteSpace: 'nowrap',
-          '& .MuiTableSortLabel-icon': {
-            opacity: 0.5,
+          '> .MuiTableSortLabel-icon': {
+            opacity: 0.25,
           },
         }}
       >


### PR DESCRIPTION
## Summary

Consolidating a few small closely related items into one PR.

* CAT-1322 Cell type landing page bars lead to cell type detail page on click
  * Added links to target cell types.
* CAT-1323 Handle mismatch between scFind-indexed and UBKG-indexed genes
  * Added handling for genes without a description. Was not able to reproduce cases where the description re-attempts to load after failing. Related design ticket for genes without scFind-indexed data (CAT-1330) is in progress.
* CAT-1324 Add tooltips to biomarkers table column headers on cell type detail page
  * Took the opportunity to also get rid of the hacky workaround I had originally implemented before finding out that TableSortLabel exists.
* CAT-1326 Fix icon for cell type search tab
* CAT-1327 Add bottom margin to expanded cell type row view
  * Increased bottom margin to 200px to account for long label names
* CAT-1328 Remove "filter by genes"/"filter by proteins" chips from biomarkers page
* CAT-1329 Remove (Beta) from biomarkers and molecular data query
* CAT-1331 Sort stacked cell type charts by count instead of alphabetical
* CAT-1332 Hide "no options" display when combobox input is empty
  * Added instruction text to start typing if the search string is empty

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1322
https://hms-dbmi.atlassian.net/browse/CAT-1323
https://hms-dbmi.atlassian.net/browse/CAT-1324
https://hms-dbmi.atlassian.net/browse/CAT-1326
https://hms-dbmi.atlassian.net/browse/CAT-1327
https://hms-dbmi.atlassian.net/browse/CAT-1328
https://hms-dbmi.atlassian.net/browse/CAT-1329
https://hms-dbmi.atlassian.net/browse/CAT-1331
https://hms-dbmi.atlassian.net/browse/CAT-1332

## Testing

Manually tested

## Screenshots/Video
### CAT-1322 Cell type landing page bars lead to cell type detail page on click
<img width="1174" height="371" alt="image" src="https://github.com/user-attachments/assets/bbdfec05-0960-454e-b352-64935e7598ff" />


### CAT-1323 Handle mismatch between scFind-indexed and UBKG-indexed genes
<img width="762" height="364" alt="image" src="https://github.com/user-attachments/assets/cc86777b-36d6-49db-9e9c-0436059b913e" />

### CAT-1324 Add tooltips to biomarkers table column headers on cell type detail page
<img width="1309" height="422" alt="image" src="https://github.com/user-attachments/assets/343b1626-6a71-4be1-ab3f-87a95497cb96" />

### CAT-1326 Fix icons for cell type search tabs
<img width="1284" height="155" alt="image" src="https://github.com/user-attachments/assets/0d3ff399-4e65-4b12-bf17-c7c3b0eae1ca" />

### CAT-1327 Add bottom margin for cell type search result graphs
<img width="1252" height="786" alt="image" src="https://github.com/user-attachments/assets/dcb75e28-0eab-4e4f-939f-369ea15786c2" />

### CAT-1328 Remove filter chips from biomarker landing page
<img width="1309" height="430" alt="image" src="https://github.com/user-attachments/assets/d81cfc56-e769-40c3-8b32-74cdc17e8c34" />


### CAT-1329 Remove "Beta" from biomarkers and molecular data query
<img width="855" height="416" alt="image" src="https://github.com/user-attachments/assets/0381ea95-8248-4624-a2ec-2b20275db9ee" />
<img width="419" height="206" alt="image" src="https://github.com/user-attachments/assets/f951dcb4-a907-4c26-b685-dcc6e2f4aff7" />
<img width="701" height="344" alt="image" src="https://github.com/user-attachments/assets/2e10383d-c521-451b-9f74-60078118ecdd" />


### CAT-1331 Sort stacked cell type charts by count
<img width="1279" height="641" alt="image" src="https://github.com/user-attachments/assets/725eb2de-6373-43bc-9c10-3decac6f224b" />

### CAT-1332 Hide "no options" display when combobox input is empty
<img width="364" height="174" alt="image" src="https://github.com/user-attachments/assets/e7aa50dd-ec0d-4ddd-b1c2-4fa52a9c410c" />
<img width="318" height="206" alt="image" src="https://github.com/user-attachments/assets/956d5697-d723-42b1-994c-8be1e41424bd" />
<img width="341" height="188" alt="image" src="https://github.com/user-attachments/assets/66e3909c-5bfb-498b-b288-f447455d0055" />

Searching for non-existent terms still shows "no options": 
<img width="193" height="163" alt="image" src="https://github.com/user-attachments/assets/592c7c68-f441-4780-b6f8-9bf5552582fa" />



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
