### PR TITLE
CAT-1337 NickAkhmetov/Fix disparities with organ page data inclusion

### DIFF
--- a/CHANGELOG-organs.md
+++ b/CHANGELOG-organs.md
@@ -1,0 +1,1 @@
+- Fix disparities with displaying all organs' data in organ pages.

--- a/context/app/organ/bronchus.yaml
+++ b/context/app/organ/bronchus.yaml
@@ -7,4 +7,6 @@ asctb: Lung-v1.2
 description: The upper conducting airways of the lung; these airways arise from the
   terminus of the trachea.
 icon: https://cdn.jsdelivr.net/gh/cns-iu/md-icons@main/other-icons/organs/ico-organs-lung.svg
-search: []
+search:
+  - Bronchus (Left)
+  - Bronchus (Right)

--- a/context/app/organ/lung.yaml
+++ b/context/app/organ/lung.yaml
@@ -8,7 +8,8 @@ description: Respiration organ that develops as an outpocketing of the esophagus
 icon: https://cdn.jsdelivr.net/gh/cns-iu/md-icons@main/other-icons/organs/ico-organs-lung.svg
 has_iu_component: true
 search:
-- Lung (Right)
+  - Lung (Right)
+  - Lung (Left)
 azimuth:
   title: Human - Lung v1
   uberon_iri: http://purl.obolibrary.org/obo/UBERON_0002048
@@ -35,10 +36,10 @@ azimuth:
 
     '
   annotations:
-  - name: annotation.l1
-    file: lung_l1.csv
-  - name: annotation.l2
-    file: lung_l2.csv
+    - name: annotation.l1
+      file: lung_l1.csv
+    - name: annotation.l2
+      file: lung_l2.csv
   mapped:
     unit: Cells
     nunit: 916,876
@@ -60,35 +61,35 @@ azimuth:
     version: 1.0.0
     name: Human Lung
     datasets:
-    - uid: human-lung
-      name: Human Lung
-      files:
-      - type: cells
-        fileType: anndata-cells.zarr
-        url: https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-lung/vitessce_ref.zarr
-        options:
-          mappings:
-            UMAP:
-              key: obsm/X_umap
-              dims:
-              - 0
-              - 1
-          factors:
-          - obs/annotation.l1
-          - obs/annotation.l2
-      - type: cell-sets
-        fileType: anndata-cell-sets.zarr
-        url: https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-lung/vitessce_ref.zarr
-        options:
-        - groupName: annotation.l1
-          setName: obs/annotation.l1
-        - groupName: annotation.l2
-          setName: obs/annotation.l2
-      - type: expression-matrix
-        fileType: anndata-expression-matrix.zarr
-        url: https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-lung/vitessce_ref.zarr
-        options:
-          matrix: X
+      - uid: human-lung
+        name: Human Lung
+        files:
+          - type: cells
+            fileType: anndata-cells.zarr
+            url: https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-lung/vitessce_ref.zarr
+            options:
+              mappings:
+                UMAP:
+                  key: obsm/X_umap
+                  dims:
+                    - 0
+                    - 1
+              factors:
+                - obs/annotation.l1
+                - obs/annotation.l2
+          - type: cell-sets
+            fileType: anndata-cell-sets.zarr
+            url: https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-lung/vitessce_ref.zarr
+            options:
+              - groupName: annotation.l1
+                setName: obs/annotation.l1
+              - groupName: annotation.l2
+                setName: obs/annotation.l2
+          - type: expression-matrix
+            fileType: anndata-expression-matrix.zarr
+            url: https://azimuth-vitessce.s3.us-west-2.amazonaws.com/human-lung/vitessce_ref.zarr
+            options:
+              matrix: X
     initStrategy: auto
     coordinationSpace:
       embeddingType:
@@ -100,25 +101,25 @@ azimuth:
       embeddingCellSetLabelSize:
         UMAP: 10
     layout:
-    - component: cellSets
-      h: 3
-      w: 3
-      x: 9
-      y: 0
-      coordinationScopes: {}
-    - component: genes
-      h: 3
-      w: 3
-      x: 9
-      y: 3
-      coordinationScopes: {}
-    - component: scatterplot
-      h: 6
-      w: 9
-      x: 0
-      y: 0
-      coordinationScopes:
-        embeddingType: UMAP
-        embeddingCellRadius: UMAP
-        embeddingCellSetLabelsVisible: UMAP
-        embeddingCellSetLabelSize: UMAP
+      - component: cellSets
+        h: 3
+        w: 3
+        x: 9
+        y: 0
+        coordinationScopes: {}
+      - component: genes
+        h: 3
+        w: 3
+        x: 9
+        y: 3
+        coordinationScopes: {}
+      - component: scatterplot
+        h: 6
+        w: 9
+        x: 0
+        y: 0
+        coordinationScopes:
+          embeddingType: UMAP
+          embeddingCellRadius: UMAP
+          embeddingCellSetLabelsVisible: UMAP
+          embeddingCellSetLabelSize: UMAP

--- a/context/app/static/js/components/organ/Assays/Assays.tsx
+++ b/context/app/static/js/components/organ/Assays/Assays.tsx
@@ -74,7 +74,9 @@ function Assays({ organTerms, bucketData }: AssaysProps) {
           ))}
         />
       </Paper>
-      <DatasetsBarChart search={organTerms} />
+      <Paper sx={{ mt: 2 }}>
+        <DatasetsBarChart search={organTerms} />
+      </Paper>
     </OrganDetailSection>
   );
 }

--- a/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.tsx
+++ b/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.tsx
@@ -16,7 +16,7 @@ import { OrganFile } from '../types';
 import { datasetTypeForOrganTermsQuery, DatasetTypeOrganQueryAggs } from './queries';
 import { getSearchURL } from '../utils';
 
-const margin = { top: 40, right: 10, bottom: 100, left: 10 };
+const margin = { top: 40, right: 10, bottom: 40, left: 10 };
 
 function OrganDatasetsChart({ search }: Pick<OrganFile, 'search'>) {
   const updatedQuery = useMemo(

--- a/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
+++ b/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
@@ -6,6 +6,7 @@ import Box from '@mui/material/Box';
 import { TitleWrapper } from 'js/shared-styles/charts/style';
 import InfoTextTooltip from 'js/shared-styles/tooltips/InfoTextTooltip';
 import Divider from '@mui/material/Divider';
+import Stack from '@mui/material/Stack';
 import { OrdinalScale } from '../hooks';
 
 interface ChartWrapperProps extends PropsWithChildren {
@@ -70,86 +71,88 @@ function ChartWrapper(
       <Box sx={{ gridArea: 'y-axis', p: yAxisDropdown ? 1 : 0 }}>{yAxisDropdown}</Box>
       <Box sx={{ gridArea: 'chart' }}>{children}</Box>
       <Box sx={{ gridArea: 'x-axis', p: xAxisDropdown ? 1 : 0 }}>{xAxisDropdown}</Box>
-      <Box sx={{ gridArea: 'legend', display: 'flex', flexDirection: 'column', maxHeight: '100%', overflow: 'none' }}>
-        {dropdown && <Box sx={{ marginY: 1, minWidth: 0 }}>{dropdown}</Box>}
-        <Box sx={{ flex: 1, overflowY: 'auto', gridArea: 'legend' }} tabIndex={0}>
-          {colorScale && (
-            <LegendOrdinal scale={colorScale} domain={domain}>
-              {(labels) => (
-                <div style={{ display: 'flex', flexDirection: 'column' }}>
-                  {labels.map((label, idx) => {
-                    const isMultiple = label.text === 'Multiple';
-                    return (
-                      <React.Fragment key={label.text}>
-                        <LegendItem key={`legend-${label.text}`} margin="0 15px 0 0">
-                          <svg width="1em" height="1em" style={{ borderRadius: '4px' }}>
-                            {isMultiple && (
-                              <defs>
-                                <pattern
-                                  id={`pattern-${label.text}`}
-                                  patternUnits="userSpaceOnUse"
-                                  width={domain.length}
-                                  height="2.5"
-                                  patternTransform="rotate(90)"
+      <Box sx={{ gridArea: 'legend', display: 'grid', maxHeight: '100%', overflow: 'none' }}>
+        <Stack direction="column" pl={1}>
+          {dropdown && <Box sx={{ marginY: 1, minWidth: 0 }}>{dropdown}</Box>}
+          <Box sx={{ flex: 1, overflowY: 'auto', gridArea: 'legend', mt: dropdown ? 0 : 2 }} tabIndex={0}>
+            {colorScale && (
+              <LegendOrdinal scale={colorScale} domain={domain}>
+                {(labels) => (
+                  <div style={{ display: 'flex', flexDirection: 'column' }}>
+                    {labels.map((label, idx) => {
+                      const isMultiple = label.text === 'Multiple';
+                      return (
+                        <React.Fragment key={label.text}>
+                          <LegendItem key={`legend-${label.text}`} margin="0 15px 0 0">
+                            <svg width="1em" height="1em" style={{ borderRadius: '4px' }}>
+                              {isMultiple && (
+                                <defs>
+                                  <pattern
+                                    id={`pattern-${label.text}`}
+                                    patternUnits="userSpaceOnUse"
+                                    width={domain.length}
+                                    height="2.5"
+                                    patternTransform="rotate(90)"
+                                  >
+                                    {domain.map((key, index) => (
+                                      <line
+                                        key={key}
+                                        x1={index + 0.5}
+                                        y1="0"
+                                        x2={index + 0.5}
+                                        y2="2.5"
+                                        stroke={colorScale(key)}
+                                        strokeWidth="1"
+                                      />
+                                    ))}
+                                  </pattern>
+                                </defs>
+                              )}
+                              <rect
+                                fill={!isMultiple ? colorScale(label.text) : `url(#pattern-${label.text})`}
+                                width="1em"
+                                height="1em"
+                              />
+                            </svg>
+                            <LegendLabel align="left" margin="0 0 0 4px">
+                              {isMultiple ? (
+                                <InfoTextTooltip tooltipTitle="This data has multiple categories">
+                                  {label.text}
+                                </InfoTextTooltip>
+                              ) : (
+                                label.text
+                              )}
+                              {labelValueMap[label.text] && (
+                                <Typography
+                                  component="span"
+                                  variant="caption"
+                                  color="textSecondary"
+                                  display="inline-block"
+                                  ml={1}
                                 >
-                                  {domain.map((key, index) => (
-                                    <line
-                                      key={key}
-                                      x1={index + 0.5}
-                                      y1="0"
-                                      x2={index + 0.5}
-                                      y2="2.5"
-                                      stroke={colorScale(key)}
-                                      strokeWidth="1"
-                                    />
-                                  ))}
-                                </pattern>
-                              </defs>
-                            )}
-                            <rect
-                              fill={!isMultiple ? colorScale(label.text) : `url(#pattern-${label.text})`}
-                              width="1em"
-                              height="1em"
-                            />
-                          </svg>
-                          <LegendLabel align="left" margin="0 0 0 4px">
-                            {isMultiple ? (
-                              <InfoTextTooltip tooltipTitle="This data has multiple categories">
-                                {label.text}
-                              </InfoTextTooltip>
-                            ) : (
-                              label.text
-                            )}
-                            {labelValueMap[label.text] && (
-                              <Typography
-                                component="span"
-                                variant="caption"
-                                color="textSecondary"
-                                display="inline-block"
-                                ml={1}
-                              >
-                                ({labelValueMap[label.text]})
-                              </Typography>
-                            )}
-                          </LegendLabel>
-                        </LegendItem>
-                        {(isMultiple || (dividersInLegend && idx !== labels.length - 1)) && (
-                          <Divider sx={{ marginY: 1 }} />
-                        )}
-                      </React.Fragment>
-                    );
-                  })}
-                </div>
-              )}
-            </LegendOrdinal>
-          )}
-          {allKeysScale && (
-            /* This is used to prevent content shift when toggling between different sets of data */
-            <Box sx={{ height: 0, speak: 'none', overflow: 'hidden' }}>
-              <LegendOrdinal scale={allKeysScale} domain={allKeysDomain} />
-            </Box>
-          )}
-        </Box>
+                                  ({labelValueMap[label.text]})
+                                </Typography>
+                              )}
+                            </LegendLabel>
+                          </LegendItem>
+                          {(isMultiple || (dividersInLegend && idx !== labels.length - 1)) && (
+                            <Divider sx={{ marginY: 1 }} />
+                          )}
+                        </React.Fragment>
+                      );
+                    })}
+                  </div>
+                )}
+              </LegendOrdinal>
+            )}
+            {allKeysScale && (
+              /* This is used to prevent content shift when toggling between different sets of data */
+              <Box sx={{ height: 0, speak: 'none', overflow: 'hidden' }}>
+                <LegendOrdinal scale={allKeysScale} domain={allKeysDomain} />
+              </Box>
+            )}
+          </Box>
+        </Stack>
       </Box>
       <Box sx={{ gridArea: 'top-controls' }}>{additionalControls}</Box>
     </Box>


### PR DESCRIPTION
## Summary

This PR adds missing search terms to ensure that all lateral organs' data is included on organ pages.

It also fixes the display of the assays graph on the organs page

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1337

## Testing

Checked organ pages after updating yamls.

## Screenshots/Video

<img width="1326" height="554" alt="image" src="https://github.com/user-attachments/assets/084a28f5-969e-45ed-a926-bcf4f3cef475" />

<img width="1372" height="593" alt="image" src="https://github.com/user-attachments/assets/557be157-2d3f-4940-8027-a0f8df082c1c" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
