### PR TITLE
NickAkhmetov/Support scFind results with both UUID and HBM ID outputs

### DIFF
--- a/CHANGELOG-scfind-id-adapter.md
+++ b/CHANGELOG-scfind-id-adapter.md
@@ -1,0 +1,1 @@
+- Support scFind results with both UUID and HBM ID inputs/outputs.

--- a/CHANGELOG-scfind-id-adapter.md
+++ b/CHANGELOG-scfind-id-adapter.md
@@ -1,1 +1,1 @@
-- Support scFind results with both UUID and HBM ID inputs/outputs.
+- Support scFind results with both UUID and HBM ID outputs.

--- a/context/app/static/js/api/scfind/useSCFindIDAdapter.ts
+++ b/context/app/static/js/api/scfind/useSCFindIDAdapter.ts
@@ -1,0 +1,33 @@
+import useSearchData from 'js/hooks/useSearchData';
+import { useMemo } from 'react';
+
+/**
+ * Takes in a list of scFind results. If the results are in HuBMAP ID format (HBM123.ABCD.456)
+ * then a lookup is performed to find the corresponding UUIDs.
+ *
+ * If the results are already in UUID format, they are returned as-is.
+ * @param datasets
+ */
+export default function useSCFindIDAdapter(datasets: string[] = []) {
+  const allAreUUIDs = datasets.every((id) => id.length === 32);
+
+  const uuidQuery = useSearchData(
+    {
+      query: {
+        terms: {
+          'hubmap_id.keyword': datasets,
+        },
+      },
+    },
+    {
+      shouldFetch: !allAreUUIDs,
+    },
+  );
+
+  return useMemo(() => {
+    if (allAreUUIDs) {
+      return datasets;
+    }
+    return uuidQuery.searchData?.hits.hits.map((hit) => hit._id) ?? [];
+  }, [allAreUUIDs, datasets, uuidQuery.searchData]);
+}

--- a/context/app/static/js/components/cell-types/hooks.tsx
+++ b/context/app/static/js/components/cell-types/hooks.tsx
@@ -146,16 +146,23 @@ export function useIndexedDatasetsForCellType({
 
   const ids = useSCFindIDAdapter(scFindIds);
 
-  const { searchData, isLoading: isLoadingSearchApi } = useSearchData<Entity, IndexedDatasetsForCellTypeAggs>({
-    query: {
-      bool: {
-        must: {
-          ids: {
-            values: ids,
+  const query =
+    ids.length > 0
+      ? {
+          bool: {
+            must: [
+              {
+                ids: {
+                  values: ids,
+                },
+              },
+            ],
           },
-        },
-      },
-    },
+        }
+      : undefined;
+
+  const { searchData, isLoading: isLoadingSearchApi } = useSearchData<Entity, IndexedDatasetsForCellTypeAggs>({
+    query,
     aggs: {
       datasetTypes: {
         terms: {

--- a/context/app/static/js/components/cells/CellsCharts/CellTypesChart.tsx
+++ b/context/app/static/js/components/cells/CellsCharts/CellTypesChart.tsx
@@ -122,7 +122,7 @@ export function CrossModalityCellTypesChart({ uuid }: Dataset) {
   );
 }
 
-export function SCFindCellTypesChart({ hubmap_id }: Dataset) {
+export function SCFindCellTypesChart({ hubmap_id, uuid }: Dataset) {
   const { track } = useMolecularDataQueryFormTracking();
 
   useEffect(() => {
@@ -136,7 +136,7 @@ export function SCFindCellTypesChart({ hubmap_id }: Dataset) {
   }, [hubmap_id, track]);
 
   const cellVariableNames = useCellVariableNames();
-  const { data, isLoading } = useCellTypeCountForDataset({ dataset: hubmap_id });
+  const { data, isLoading } = useCellTypeCountForDataset({ dataset: uuid });
   const cellNames = useMemo(() => {
     return cellVariableNames.map((cellTypeName) => cellTypeName.split('.')[1]).filter(Boolean);
   }, [cellVariableNames]);

--- a/context/app/static/js/components/cells/CellsCharts/CellTypesChart.tsx
+++ b/context/app/static/js/components/cells/CellsCharts/CellTypesChart.tsx
@@ -136,6 +136,10 @@ export function SCFindCellTypesChart({ hubmap_id, uuid }: Dataset) {
   }, [hubmap_id, track]);
 
   const cellVariableNames = useCellVariableNames();
+
+  // TODO: Once we are able to switch between index versions, the dataset input will have to be updated accordingly
+  // to handle the first version of the index using HBM IDs and subsequent versions using UUIDs
+  // https://hms-dbmi.atlassian.net/browse/CAT-1339
   const { data, isLoading } = useCellTypeCountForDataset({ dataset: uuid });
   const cellNames = useMemo(() => {
     return cellVariableNames.map((cellTypeName) => cellTypeName.split('.')[1]).filter(Boolean);

--- a/context/app/static/js/components/cells/CellsCharts/SCFindGeneCharts.tsx
+++ b/context/app/static/js/components/cells/CellsCharts/SCFindGeneCharts.tsx
@@ -46,15 +46,15 @@ const margin = {
   left: 80,
 } as const;
 
-function SCFindGeneExpressionLevelDistributionPlot({ hubmap_id }: Dataset) {
+function SCFindGeneExpressionLevelDistributionPlot({ uuid }: Dataset) {
   const gene = useOptionalGeneContext();
 
   const { data, isLoading } = useCellTypeExpressionBins({
     geneList: gene,
-    datasetName: hubmap_id,
+    datasetName: uuid,
   });
 
-  const totalCells = useTotalCells(hubmap_id);
+  const totalCells = useTotalCells(uuid);
 
   const geneData: Record<string, { value: number }> = useMemo(() => {
     if (!data || !gene || !data[gene]) {
@@ -74,8 +74,8 @@ function SCFindGeneExpressionLevelDistributionPlot({ hubmap_id }: Dataset) {
   }, [data, gene, totalCells]);
 
   const GeneExpressionTooltip = useMemo(() => {
-    return GeneExpressionTooltipWithDataset(hubmap_id);
-  }, [hubmap_id]);
+    return GeneExpressionTooltipWithDataset(uuid);
+  }, [uuid]);
 
   // If a gene is not defined, this chart should not be displayed
   // This happens in pathway tabs.

--- a/context/app/static/js/components/cells/CellsCharts/SCFindGeneCharts.tsx
+++ b/context/app/static/js/components/cells/CellsCharts/SCFindGeneCharts.tsx
@@ -46,6 +46,9 @@ const margin = {
   left: 80,
 } as const;
 
+// TODO: Once we are able to switch between index versions, the dataset input will have to be updated accordingly
+// to handle the first version of the index using HBM IDs and subsequent versions using UUIDs
+// https://hms-dbmi.atlassian.net/browse/CAT-1339
 function SCFindGeneExpressionLevelDistributionPlot({ uuid }: Dataset) {
   const gene = useOptionalGeneContext();
 

--- a/context/app/static/js/components/cells/CellsCharts/hooks.ts
+++ b/context/app/static/js/components/cells/CellsCharts/hooks.ts
@@ -80,6 +80,9 @@ function useCellTypesChartsData({ uuid, cellVariableNames: cellNames }: UseCellT
   return { expressionData: data, ...rest };
 }
 
+// TODO: Once we are able to switch between index versions, the dataset input will have to be updated accordingly
+// to handle the first version of the index using HBM IDs and subsequent versions using UUIDs
+// https://hms-dbmi.atlassian.net/browse/CAT-1339
 const useTotalCells = (dataset: string) => {
   const { data: { cellTypeCounts } = { cellTypeCounts: [] } } = useCellTypeCountForDataset({ dataset });
 

--- a/context/app/static/js/components/cells/DatasetsOverview/hooks.ts
+++ b/context/app/static/js/components/cells/DatasetsOverview/hooks.ts
@@ -4,6 +4,7 @@ import { includeOnlyDatasetsClause } from 'js/helpers/queries';
 import useSearchData from 'js/hooks/useSearchData';
 import { decimal, percent } from 'js/helpers/number-format';
 import { BarStackGroup } from 'js/shared-styles/charts/VerticalStackedBarChart/VerticalGroupedStackedBarChart';
+import useSCFindIDAdapter from 'js/api/scfind/useSCFindIDAdapter';
 
 export const Y_AXIS_OPTIONS = ['Datasets', 'Donors'] as const;
 export type YAxisOptions = (typeof Y_AXIS_OPTIONS)[number];
@@ -273,25 +274,25 @@ const aggs: Record<string, AggregationsAggregationContainer> = {
 /**
  * Retrieves the number of unique donors, average donor age, and total datasets for the specified datasets.
  * If no datasets are provided, it retrieves the same information for all datasets.
- * @param hubmap_ids - An array of HuBMAP IDs for the datasets to retrieve information for.
+ * @param scFindIds - An array of IDs returned by scFind for the datasets to retrieve information for.
  * If not provided, retrieves information for all datasets.
  * @returns An object containing the number of unique donors, average donor age, total datasets, and loading state.
  */
-export function useDatasetsOverview(hubmap_ids?: string[]): DatasetsOverviewDigest {
+export function useDatasetsOverview(scFindIds?: string[]): DatasetsOverviewDigest {
+  const ids = useSCFindIDAdapter(scFindIds);
+
   const query: SearchRequest = useMemo(() => {
-    if (hubmap_ids) {
+    if (ids) {
       return {
         size: 0,
         query: {
           bool: {
             ...includeOnlyDatasetsClause.bool,
-            filter: [
-              {
-                terms: {
-                  'hubmap_id.keyword': hubmap_ids,
-                },
+            must: {
+              ids: {
+                values: ids,
               },
-            ],
+            },
           },
         },
         aggs,
@@ -302,7 +303,7 @@ export function useDatasetsOverview(hubmap_ids?: string[]): DatasetsOverviewDige
       query: includeOnlyDatasetsClause,
       aggs,
     };
-  }, [hubmap_ids]);
+  }, [ids]);
 
   const { searchData, isLoading } = useSearchData<unknown, DatasetsOverviewAggs>(query);
 

--- a/context/app/static/js/components/cells/DatasetsOverview/hooks.ts
+++ b/context/app/static/js/components/cells/DatasetsOverview/hooks.ts
@@ -282,17 +282,19 @@ export function useDatasetsOverview(scFindIds?: string[]): DatasetsOverviewDiges
   const ids = useSCFindIDAdapter(scFindIds);
 
   const query: SearchRequest = useMemo(() => {
-    if (ids) {
+    if (ids && ids.length > 0) {
       return {
         size: 0,
         query: {
           bool: {
             ...includeOnlyDatasetsClause.bool,
-            must: {
-              ids: {
-                values: ids,
+            must: [
+              {
+                ids: {
+                  values: ids,
+                },
               },
-            },
+            ],
           },
         },
         aggs,

--- a/context/app/static/js/components/cells/SCFindResults/SCFindCellTypeQueryResults.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/SCFindCellTypeQueryResults.tsx
@@ -16,6 +16,7 @@ import Box from '@mui/material/Box';
 import { CellTypeIcon } from 'js/shared-styles/icons';
 import { decimal, percent } from 'js/helpers/number-format';
 import Divider from '@mui/material/Divider';
+import useSCFindIDAdapter from 'js/api/scfind/useSCFindIDAdapter';
 import { useDeduplicatedResults, useSCFindCellTypeResults, useTableTrackingProps } from './hooks';
 import { useCellVariableNames } from '../MolecularDataQueryForm/hooks';
 import { SCFindCellTypesChart } from '../CellsCharts/CellTypesChart';
@@ -30,6 +31,7 @@ import useSCFindResultsStatisticsStore from './store';
 const columns = [hubmapID, organ, assayTypes, targetCellCountColumn, totalCellCountColumn, lastModifiedTimestamp];
 
 function SCFindCellTypeQueryDatasetList({ datasetIds }: SCFindQueryResultsListProps) {
+  const ids = useSCFindIDAdapter(datasetIds.map(({ hubmap_id }) => hubmap_id));
   return (
     <EntityTable<Dataset>
       maxHeight={800}
@@ -37,8 +39,12 @@ function SCFindCellTypeQueryDatasetList({ datasetIds }: SCFindQueryResultsListPr
       columns={columns}
       query={{
         query: {
-          terms: {
-            'hubmap_id.keyword': datasetIds.map(({ hubmap_id }) => hubmap_id),
+          bool: {
+            must: {
+              ids: {
+                values: ids,
+              },
+            },
           },
         },
         size: 10000,

--- a/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
@@ -18,6 +18,7 @@ import Typography from '@mui/material/Typography';
 import ViewIndexedDatasetsButton from 'js/components/organ/OrganCellTypes/ViewIndexedDatasetsButton';
 import useIndexedDatasets from 'js/api/scfind/useIndexedDatasets';
 import { useUUIDsFromHubmapIds } from 'js/components/organ/hooks';
+import useSCFindIDAdapter from 'js/api/scfind/useSCFindIDAdapter';
 import DatasetsOverview from '../DatasetsOverview';
 
 import { SCFindQueryResultsListProps } from './types';
@@ -48,6 +49,8 @@ function SCFindGeneQueryDatasetList({ datasetIds }: SCFindQueryResultsListProps)
 
   const columnsToUse = genes.length > 1 ? columnsWithMatchingGene : columns;
 
+  const ids = useSCFindIDAdapter(datasetIds.map(({ hubmap_id }) => hubmap_id));
+
   return (
     <EntityTable<Dataset>
       maxHeight={800}
@@ -55,8 +58,12 @@ function SCFindGeneQueryDatasetList({ datasetIds }: SCFindQueryResultsListProps)
       columns={columnsToUse}
       query={{
         query: {
-          terms: {
-            'hubmap_id.keyword': datasetIds.map(({ hubmap_id }) => hubmap_id),
+          bool: {
+            must: {
+              ids: {
+                values: ids,
+              },
+            },
           },
         },
         size: 10000,

--- a/context/app/static/js/components/cells/SCFindResults/columns.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/columns.tsx
@@ -14,8 +14,8 @@ interface CellCountColumnProps {
   renderDisplay: (props: CellTypeCountsForDataset) => React.ReactNode;
 }
 
-function CellCountColumn({ hit: { hubmap_id }, renderDisplay: Display }: CellCountColumnProps) {
-  const { data, isLoading } = useCellTypeCountForDataset({ dataset: hubmap_id });
+function CellCountColumn({ hit: { hubmap_id, uuid }, renderDisplay: Display }: CellCountColumnProps) {
+  const { data, isLoading } = useCellTypeCountForDataset({ dataset: uuid });
 
   if (isLoading) {
     return <Skeleton variant="text" width={100} />;

--- a/context/app/static/js/components/cells/SCFindResults/columns.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/columns.tsx
@@ -15,6 +15,9 @@ interface CellCountColumnProps {
 }
 
 function CellCountColumn({ hit: { hubmap_id, uuid }, renderDisplay: Display }: CellCountColumnProps) {
+  // TODO: Once we are able to switch between index versions, the dataset input will have to be updated accordingly
+  // to handle the first version of the index using HBM IDs and subsequent versions using UUIDs
+  // https://hms-dbmi.atlassian.net/browse/CAT-1339
   const { data, isLoading } = useCellTypeCountForDataset({ dataset: uuid });
 
   if (isLoading) {

--- a/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
@@ -37,6 +37,7 @@ import Description from 'js/shared-styles/sections/Description';
 import Divider from '@mui/material/Divider';
 import SCFindLink from 'js/shared-styles/Links/SCFindLink';
 import { trackEvent } from 'js/helpers/trackers';
+import useSCFindIDAdapter from 'js/api/scfind/useSCFindIDAdapter';
 import ScientificNotationDisplay from './ScientificNotationDisplay';
 import { useGenePageContext, useGeneDetailPageTrackingInfo, useTrackGeneDetailPage } from '../hooks';
 import { cellTypes as cellTypesSection } from '../constants';
@@ -370,16 +371,16 @@ const useIndexedDatasetsForGene = () => {
     geneList: geneSymbol,
   });
 
+  const ids = useSCFindIDAdapter(datasets?.findDatasets[geneSymbol] ?? []);
+
   const { searchData, isLoading: isLoadingDatasetTypes } = useSearchData<unknown, DatasetGeneAggregations>({
     query: {
       bool: {
-        must: [
-          {
-            terms: {
-              'hubmap_id.keyword': datasets?.findDatasets[geneSymbol] ?? [],
-            },
+        must: {
+          ids: {
+            values: ids,
           },
-        ],
+        },
       },
     },
     aggs: {

--- a/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
@@ -373,16 +373,23 @@ const useIndexedDatasetsForGene = () => {
 
   const ids = useSCFindIDAdapter(datasets?.findDatasets[geneSymbol] ?? []);
 
-  const { searchData, isLoading: isLoadingDatasetTypes } = useSearchData<unknown, DatasetGeneAggregations>({
-    query: {
-      bool: {
-        must: {
-          ids: {
-            values: ids,
+  const query =
+    ids.length > 0
+      ? {
+          bool: {
+            must: [
+              {
+                ids: {
+                  values: ids,
+                },
+              },
+            ],
           },
-        },
-      },
-    },
+        }
+      : undefined;
+
+  const { searchData, isLoading: isLoadingDatasetTypes } = useSearchData<unknown, DatasetGeneAggregations>({
+    query,
     aggs: {
       datasetTypes: {
         terms: {

--- a/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
@@ -10,7 +10,7 @@ import { StyledDetailsAccordion } from './styles';
 import ViewIndexedDatasetsButton from './ViewIndexedDatasetsButton';
 
 interface IndexedDatasetsSummaryProps {
-  datasets: string[];
+  datasets?: string[];
   datasetTypes: { key: string; doc_count: number }[];
   organs?: { key: string; doc_count: number }[];
   isLoadingDatasets?: boolean;

--- a/context/app/static/js/pages/Organ/hooks.ts
+++ b/context/app/static/js/pages/Organ/hooks.ts
@@ -8,6 +8,7 @@ import { OrganDataProducts, OrganFile } from 'js/components/organ/types';
 import useCellTypeNames from 'js/api/scfind/useCellTypeNames';
 import useIndexedDatasets from 'js/api/scfind/useIndexedDatasets';
 import { useOrganContext } from 'js/components/organ/contexts';
+import useSCFindIDAdapter from 'js/api/scfind/useSCFindIDAdapter';
 import { mustHaveOrganClause } from './queries';
 
 export function useSearchItems(organ: OrganFile) {
@@ -191,13 +192,15 @@ export function useIndexedDatasetsForOrgan() {
   const searchItems = useSearchItemsFromContext();
   const { data = { datasets: [] }, isLoading: isLoadingIndexed, ...rest } = useIndexedDatasets();
 
+  const ids = useSCFindIDAdapter(data?.datasets);
+
   const { searchData, isLoading: isLoadingDatasets } = useSearchData<unknown, IndexedDatasetsForOrganAggs>({
     query: {
       bool: {
         must: [
           {
-            terms: {
-              'hubmap_id.keyword': data.datasets ?? [],
+            ids: {
+              values: ids,
             },
           },
           {


### PR DESCRIPTION
## Summary

This PR aims to support scFind queries with both HuBMAP IDs and UUIDs.

Getting the inputs to work dynamically as well will require additional effort to track which index is currently being queried against, so I will leave some related todos/make tickets to resolve them.

## Design Documentation/Original Tickets

This is a hotfix for an issue which developed with the last scFind index deploy. A follow-up ticket to handle the inputs has been created: https://hms-dbmi.atlassian.net/browse/CAT-1339 

## Testing

Manually testing each page with scFind-derived elasticsearch queries (cell types, cell type details, genes, gene details, molecular queries for cell types and genes).

## Screenshots/Video

Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

scFind stories will also be updated as part of CAT-1339.
