### PR TITLE
Austenem/CAT-1343 Fix protected datasets tracking bug

### DIFF
--- a/CHANGELOG-fix-protected-datasets-bug.md
+++ b/CHANGELOG-fix-protected-datasets-bug.md
@@ -1,0 +1,1 @@
+- Fix protected datasets analytics tracking bug.

--- a/context/app/static/js/components/bulkDownload/BulkDownloadDialog/BulkDownloadDialog.tsx
+++ b/context/app/static/js/components/bulkDownload/BulkDownloadDialog/BulkDownloadDialog.tsx
@@ -20,6 +20,7 @@ import RelevantPagesSection from 'js/shared-styles/sections/RelevantPagesSection
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
 import { Alert } from 'js/shared-styles/alerts';
 import ErrorOrWarningMessages from 'js/shared-styles/alerts/ErrorOrWarningMessages';
+import { trackEvent } from 'js/helpers/trackers';
 
 function DownloadDescription() {
   return (
@@ -72,6 +73,13 @@ function RestrictedDatasetsSection({
         restrictedHubmapIds={restrictedHubmapIds}
         removeRestrictedDatasets={removeRestrictedDatasets}
         restrictedRows={restrictedRows}
+        trackEventHelper={(numRestrictedDatasets) => {
+          trackEvent({
+            category: 'Bulk Download',
+            action: 'Protected datasets selected',
+            value: numRestrictedDatasets,
+          });
+        }}
       />
     </Stack>
   );

--- a/context/app/static/js/components/bulkDownload/hooks.ts
+++ b/context/app/static/js/components/bulkDownload/hooks.ts
@@ -11,7 +11,6 @@ import { useSearchHits } from 'js/hooks/useSearchData';
 import { useRestrictedDatasetsForm } from 'js/hooks/useRestrictedDatasets';
 import { createDownloadUrl } from 'js/helpers/functions';
 import { checkAndDownloadFile, postAndDownloadFile } from 'js/helpers/download';
-import { trackEvent } from 'js/helpers/trackers';
 import { getIDsQuery } from 'js/helpers/queries';
 import { restrictedDatasetsErrorMessage } from 'js/components/bulkDownload/bulkDownloadDatasetMessaging';
 
@@ -99,13 +98,6 @@ function useBulkDownloadDialog(deselectRows?: (uuids: string[]) => void) {
     selectedRows: new Set(uuids),
     deselectRows: removeUuidsOrRows,
     restrictedDatasetsErrorMessage,
-    trackEventHelper: (numRestrictedDatasets) => {
-      trackEvent({
-        category: 'Bulk Download',
-        action: 'Protected datasets selected',
-        value: numRestrictedDatasets,
-      });
-    },
   });
 
   const downloadMetadata = useCallback(

--- a/context/app/static/js/components/workspaces/AddDatasetsFromSearchDialog/AddDatasetsFromSearchDialog.tsx
+++ b/context/app/static/js/components/workspaces/AddDatasetsFromSearchDialog/AddDatasetsFromSearchDialog.tsx
@@ -11,6 +11,7 @@ import AccordionSteps from 'js/shared-styles/accordions/AccordionSteps';
 import { useAccordionStep } from 'js/shared-styles/accordions/StepAccordion';
 import { AccordionStepsProvider } from 'js/shared-styles/accordions/AccordionSteps/store';
 import { isWorkspaceAtDatasetLimit } from 'js/helpers/functions';
+import { trackEvent } from 'js/helpers/trackers';
 import { EditWorkspaceDialogContent } from '../EditWorkspaceDialog';
 import AddDatasetsTable from '../AddDatasetsTable';
 import { useAddDatasetsFromSearchDialog } from './hooks';
@@ -18,7 +19,7 @@ import { useWorkspacesList } from '../hooks';
 import WorkspaceListItem from '../WorkspaceListItem';
 import { StopWorkspaceAlert } from '../WorkspaceLaunchStopButtons';
 import RemoveRestrictedDatasetsFormField from '../RemoveRestrictedDatasetsFormField';
-import { MergedWorkspace } from '../types';
+import { MergedWorkspace, WorkspacesEventCategories } from '../types';
 
 function SearchDialogWorkspaceListItem({
   workspace,
@@ -134,6 +135,13 @@ function AddDatasetsStep({
         restrictedHubmapIds={restrictedHubmapIds}
         removeRestrictedDatasets={removeRestrictedDatasets}
         restrictedRows={restrictedRows}
+        trackEventHelper={(numProtectedRows: number) => {
+          trackEvent({
+            category: WorkspacesEventCategories.Workspaces,
+            action: 'Create Workspace / Protected datasets selected',
+            value: numProtectedRows,
+          });
+        }}
       />
       <AddDatasetsTable {...rest} />
     </Stack>

--- a/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
+++ b/context/app/static/js/components/workspaces/NewWorkspaceDialog/NewWorkspaceDialogFromSelections.tsx
@@ -20,7 +20,6 @@ function NewWorkspaceDialogFromSelections() {
     restrictedRows,
     restrictedHubmapIds,
     removeRestrictedDatasets,
-    ...restWorkspaceDatasets
   } = useCreateWorkspaceDatasets();
 
   const { deselectRows } = useSelectableTableStore();
@@ -67,7 +66,13 @@ function NewWorkspaceDialogFromSelections() {
               removeDatasets(restrictedRows);
             }}
             restrictedRows={restrictedRows}
-            {...restWorkspaceDatasets}
+            trackEventHelper={(numProtectedRows: number) => {
+              trackEvent({
+                category: WorkspacesEventCategories.Workspaces,
+                action: 'Create Workspace / Protected datasets selected',
+                value: numProtectedRows,
+              });
+            }}
           />
         </Box>
       </NewWorkspaceDialog>

--- a/context/app/static/js/components/workspaces/RemoveRestrictedDatasetsFormField/RemoveRestrictedDatasetsFormField.tsx
+++ b/context/app/static/js/components/workspaces/RemoveRestrictedDatasetsFormField/RemoveRestrictedDatasetsFormField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
@@ -15,15 +15,27 @@ type Props<FormType extends FieldValues> = {
   control: Control<FormType>;
 } & Pick<
   ReturnType<typeof useWorkspacesRestrictedDatasetsForm>,
-  'restrictedHubmapIds' | 'removeRestrictedDatasets' | 'restrictedRows'
+  'restrictedHubmapIds' | 'removeRestrictedDatasets' | 'restrictedRows' | 'trackEventHelper'
 >;
 function RemoveRestrictedDatasetsFormField<FormType extends FieldValues>({
   control,
   restrictedHubmapIds,
   removeRestrictedDatasets,
   restrictedRows,
+  trackEventHelper,
 }: Props<FormType>) {
   const handleCopyClick = useHandleCopyClick();
+  const reportedRestrictedRows = useRef(false);
+
+  if (restrictedHubmapIds.length < 1) {
+    return null;
+  }
+
+  if (!reportedRestrictedRows.current) {
+    reportedRestrictedRows.current = true;
+    trackEventHelper(restrictedHubmapIds.length);
+  }
+
   const hubmapIdsString = generateCommaList(restrictedHubmapIds);
 
   return (

--- a/context/app/static/js/components/workspaces/RemoveRestrictedDatasetsFormField/RemoveRestrictedDatasetsFormField.tsx
+++ b/context/app/static/js/components/workspaces/RemoveRestrictedDatasetsFormField/RemoveRestrictedDatasetsFormField.tsx
@@ -16,9 +16,10 @@ const trackedSignatures = new Set<string>();
 
 type Props<FormType extends FieldValues> = {
   control: Control<FormType>;
+  trackEventHelper: (numRestrictedDatasets: number) => void;
 } & Pick<
   ReturnType<typeof useWorkspacesRestrictedDatasetsForm>,
-  'restrictedHubmapIds' | 'removeRestrictedDatasets' | 'restrictedRows' | 'trackEventHelper'
+  'restrictedHubmapIds' | 'removeRestrictedDatasets' | 'restrictedRows'
 >;
 function RemoveRestrictedDatasetsFormField<FormType extends FieldValues>({
   control,

--- a/context/app/static/js/components/workspaces/formHooks.ts
+++ b/context/app/static/js/components/workspaces/formHooks.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useRef } from 'react';
 import { trackEvent } from 'js/helpers/trackers';
 import { EXCESSIVE_NUMBER_OF_WORKSPACE_DATASETS, MAX_NUMBER_OF_WORKSPACE_DATASETS } from 'js/components/workspaces/api';
 import { WorkspacesEventCategories } from 'js/components/workspaces/types';
@@ -12,19 +12,10 @@ function useWorkspacesRestrictedDatasetsForm({
   selectedRows: Set<string>;
   deselectRows?: (rowKeys: string[]) => void;
 }) {
-  const trackEventHelper = useCallback((numProtectedRows: number) => {
-    trackEvent({
-      category: WorkspacesEventCategories.Workspaces,
-      action: 'Create Workspace / Protected datasets selected',
-      value: numProtectedRows,
-    });
-  }, []);
-
   return useRestrictedDatasetsForm({
     selectedRows,
     deselectRows,
     restrictedDatasetsErrorMessage,
-    trackEventHelper,
   });
 }
 

--- a/context/app/static/js/hooks/useRestrictedDatasets.tsx
+++ b/context/app/static/js/hooks/useRestrictedDatasets.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useWorkspaceToasts } from 'js/components/workspaces/toastHooks';
 import useHubmapIds from 'js/hooks/useHubmapIds';
 import { useDatasetsAccess } from 'js/hooks/useDatasetPermissions';
@@ -35,18 +35,11 @@ function useRestrictedDatasetsForm({
   const restrictedRows = useGetRestrictedDatasets(selectedRows);
   const { hubmapIds: restrictedHubmapIds } = useHubmapIds(restrictedRows);
 
-  const reportedRestrictedRows = useRef(false);
-
   const errorMessages = useMemo(() => {
     if (restrictedHubmapIds.length === 0) return [];
 
-    if (!reportedRestrictedRows.current) {
-      reportedRestrictedRows.current = true;
-      trackEventHelper(restrictedHubmapIds.length);
-    }
-
     return [restrictedDatasetsErrorMessage(restrictedHubmapIds)];
-  }, [restrictedHubmapIds, restrictedDatasetsErrorMessage, trackEventHelper]);
+  }, [restrictedHubmapIds, restrictedDatasetsErrorMessage]);
 
   const removeRestrictedDatasets = useCallback(() => {
     deselectRows?.(restrictedRows);
@@ -59,6 +52,7 @@ function useRestrictedDatasetsForm({
     removeRestrictedDatasets,
     restrictedRows,
     selectedRows,
+    trackEventHelper,
   };
 }
 

--- a/context/app/static/js/hooks/useRestrictedDatasets.tsx
+++ b/context/app/static/js/hooks/useRestrictedDatasets.tsx
@@ -22,13 +22,11 @@ interface useRestrictedDatasetsFormProps {
   selectedRows: Set<string>;
   deselectRows?: (uuids: string[]) => void;
   restrictedDatasetsErrorMessage: (restrictedRows: string[]) => string;
-  trackEventHelper: (numProtectedDatasets: number) => void;
 }
 function useRestrictedDatasetsForm({
   selectedRows,
   deselectRows,
   restrictedDatasetsErrorMessage,
-  trackEventHelper,
 }: useRestrictedDatasetsFormProps) {
   const { toastSuccessRemoveRestrictedDatasets } = useWorkspaceToasts();
   // Restricted rows are those that the current user does not have access to in a workspace or bulk download.
@@ -52,7 +50,6 @@ function useRestrictedDatasetsForm({
     removeRestrictedDatasets,
     restrictedRows,
     selectedRows,
-    trackEventHelper,
   };
 }
 


### PR DESCRIPTION
## Summary

Fix protected datasets analytics tracking bug, which was caused by protected dataset detail page visits always triggering a "Protected Datasets Selected" event.

## Design Documentation/Original Tickets

[CAT-1343 Jira ticket](https://hms-dbmi.atlassian.net/browse/CAT-1343?atlOrigin=eyJpIjoiNjYxYjQ3NWY4ZTI5NGRhNzk1ZGJiNjc0YzQwNzA1OGMiLCJwIjoiaiJ9)

## Testing

Tested by logging events to the console.

