### PR TITLE
NickAkhmetov/CAT-1352 CAT-1357 Fix missing "matching gene" information and broken organ pages

### DIFF
--- a/CHANGELOG-cat-1352-1357.md
+++ b/CHANGELOG-cat-1352-1357.md
@@ -1,0 +1,2 @@
+- Fix missing "matching gene" information.
+- Fix crashes on organ pages.

--- a/context/app/static/js/components/cells/SCFindResults/columns.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/columns.tsx
@@ -88,7 +88,7 @@ export const totalCellCountColumn = {
 };
 
 function MatchingGeneColumn({ hit }: CellContentProps<DatasetDocument>) {
-  const matchingGenes = useMatchingGeneContext()[hit.hubmap_id] ?? new Set<string>();
+  const matchingGenes = useMatchingGeneContext()[hit.uuid] ?? new Set<string>();
   const numberOfMatchingGenes = matchingGenes.size;
 
   const allGenes = useCellVariableNames();

--- a/context/app/static/js/shared-styles/tables/columns.tsx
+++ b/context/app/static/js/shared-styles/tables/columns.tsx
@@ -22,8 +22,8 @@ function HubmapIDCell({
   const isDataset = entity_type === 'Dataset';
   const markerGene = useOptionalGeneContext();
 
-  const isPublished = mapped_status.toLowerCase() === 'published';
-  const isPublic = mapped_data_access_level.toLowerCase() === 'public';
+  const isPublished = mapped_status && mapped_status.toLowerCase() === 'published';
+  const isPublic = mapped_data_access_level && mapped_data_access_level.toLowerCase() === 'public';
 
   const accessAllowed = isPublished && isPublic;
 


### PR DESCRIPTION
## Summary

This PR fixes a spot I missed during the migration from using hubmap ID's as the returned scfind keys, and resolves crashes from attempting to access mapped_status and mapped_data_access_level on entities which do not have those fields (i.e. in the samples table on the organs page)

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1352
https://hms-dbmi.atlassian.net/browse/CAT-1357

## Testing

Manual testing

## Screenshots/Video

1352: kidney page loads

<img width="1867" height="2091" alt="image" src="https://github.com/user-attachments/assets/cf2ad65e-0568-4b78-ad93-c5fa40316255" />


1357: "matching gene" is non-zero:
<img width="1307" height="354" alt="image" src="https://github.com/user-attachments/assets/edfe1d5a-e745-4a41-867c-60c747415da7" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
