### PR TITLE
NickAkhmetov/Big batch of small scFind Fixes

### DIFF
--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -1,3 +1,4 @@
 - Move the description below the "datasets" header in the scFind gene query results.
 - Fix visibility for X axis labels in vertical bar charts.
 - Highlight missing genes, do not display dataset overview when no results are available for genes query.
+- Add gene pathway name to scFind parameters display when viewing results of molecular query.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -1,1 +1,3 @@
 - Move the description below the "datasets" header in the scFind gene query results.
+- Fix visibility for X axis labels in vertical bar charts.
+- Highlight missing genes, do not display dataset overview when no results are available for genes query.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -2,3 +2,4 @@
 - Fix visibility for X axis labels in vertical bar charts.
 - Highlight missing genes, do not display dataset overview when no results are available for genes query.
 - Add gene pathway name to scFind parameters display when viewing results of molecular query.
+- Fix Cell Ontology ID column name on cell types landing page for consistency.

--- a/CHANGELOG-scfind-fixes.md
+++ b/CHANGELOG-scfind-fixes.md
@@ -1,0 +1,1 @@
+- Move the description below the "datasets" header in the scFind gene query results.

--- a/context/app/static/js/components/cell-types-landing/CellTypesPanelItem.tsx
+++ b/context/app/static/js/components/cell-types-landing/CellTypesPanelItem.tsx
@@ -80,7 +80,7 @@ function CellTypesHeaderPanel() {
           sx={{ width: '100%' }}
           data-testid="cell-types-header-clid"
         >
-          CLID
+          Cell Ontology ID
         </TableSortLabel>
       </HeaderCell>
       <HeaderCell {...desktopConfig.organs} pl={2}>

--- a/context/app/static/js/components/cells/MolecularDataQueryForm/CurrentQueryParametersDisplay.tsx
+++ b/context/app/static/js/components/cells/MolecularDataQueryForm/CurrentQueryParametersDisplay.tsx
@@ -8,6 +8,7 @@ export default function CurrentQueryParametersDisplay() {
   const cellVariableNames = useCellVariableNames();
   const expressionLevel = watch('minimumExpressionLevel');
   const threshold = watch('minimumCellPercentage');
+  const pathway = watch('pathway');
 
   if (!formState.isSubmitted || !formState.isSubmitSuccessful || formState.isLoading) {
     return null;
@@ -18,8 +19,9 @@ export default function CurrentQueryParametersDisplay() {
   switch (queryType) {
     case 'gene':
       if (queryMethod === 'scFind') {
-        // TODO: Once we add pathways, the pathway name should be present here too
-        // return `${queryMethod} | ${pathway} | ${variables}`;
+        if (pathway) {
+          return `${queryMethod} | ${pathway.full} | ${variables}`;
+        }
         return `${queryMethod} | ${variables}`;
       }
       return (

--- a/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
@@ -106,6 +106,7 @@ function DatasetListSection() {
 
   return (
     <Stack spacing={1} pt={2}>
+      <DatasetListHeader />
       <Description>
         Datasets expressing each selected gene are listed below. The number of datasets for each gene is shown in
         parentheses.
@@ -116,7 +117,6 @@ function DatasetListSection() {
           </>
         )}
       </Description>
-      <DatasetListHeader />
       <Tabs onChange={handleTabChange} value={openTabIndex} variant={order.length > 10 ? 'scrollable' : 'fullWidth'}>
         {order.map((gene, idx) => (
           <Tab key={gene} label={`${gene} (${categorizedResults[gene]?.length ?? 0})`} index={idx} />

--- a/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
@@ -86,6 +86,20 @@ function SCFindGeneQueryDatasetList({ datasetIds }: SCFindQueryResultsListProps)
   );
 }
 
+function NoMatchesText({ emptyResults }: { emptyResults: string[] }) {
+  return (
+    <Stack spacing={1} pt={2}>
+      <Description>
+        No datasets were found for the selected genes:{' '}
+        <Typography component="span" color="warning">
+          {emptyResults.join(', ')}
+        </Typography>
+        .
+      </Description>
+    </Stack>
+  );
+}
+
 function DatasetListSection() {
   const { openTabIndex, handleTabChange } = useTabs();
   const genes = useCellVariableNames();
@@ -96,12 +110,8 @@ function DatasetListSection() {
     return <Skeleton variant="rectangular" width="100%" height={800} />;
   }
 
-  if (error || !order) {
-    return (
-      <Stack spacing={1} pt={2}>
-        <Description>No datasets were found for any of the selected genes: {emptyResults.join(', ')}.</Description>
-      </Stack>
-    );
+  if (error || !order || emptyResults.length === order.length) {
+    return <NoMatchesText emptyResults={genes} />;
   }
 
   return (
@@ -111,10 +121,17 @@ function DatasetListSection() {
         Datasets expressing each selected gene are listed below. The number of datasets for each gene is shown in
         parentheses.
         {emptyResults.length > 0 && (
-          <>
-            <br />
-            No datasets were found for {emptyResults.length} of the selected genes: {emptyResults.join(', ')}.
-          </>
+          <div>
+            No datasets were found for{' '}
+            <Typography component="span" color="warning">
+              {emptyResults.length}
+            </Typography>{' '}
+            of the selected genes:{' '}
+            <Typography component="span" color="warning">
+              {emptyResults.join(', ')}
+            </Typography>
+            .
+          </div>
         )}
       </Description>
       <Tabs onChange={handleTabChange} value={openTabIndex} variant={order.length > 10 ? 'scrollable' : 'fullWidth'}>
@@ -143,7 +160,7 @@ interface SCFindGeneQueryResultsLoaderProps {
 function SCFindGeneQueryResultsLoader({ trackingInfo }: SCFindGeneQueryResultsLoaderProps) {
   const { setResults } = useResultsProvider();
 
-  const { datasets, isLoading, error, datasetToGeneMap } = useSCFindGeneResults();
+  const { datasets, isLoading, error, datasetToGeneMap, noResults } = useSCFindGeneResults();
 
   const deduplicatedResults = useDeduplicatedResults(datasets?.findDatasets);
 
@@ -158,25 +175,30 @@ function SCFindGeneQueryResultsLoader({ trackingInfo }: SCFindGeneQueryResultsLo
 
   return (
     <MatchingGeneContextProvider value={datasetToGeneMap}>
-      <Typography variant="subtitle1" component="p" gutterBottom>
-        Datasets Overview
-      </Typography>
-      <DatasetsOverview
-        datasets={deduplicatedResults}
-        belowTheFold={
-          <ViewIndexedDatasetsButton
-            scFindParams={{
-              scFindOnly: true,
-            }}
-            isLoading={false}
-          />
-        }
-        trackingInfo={trackingInfo}
-      >
-        This overview provides a summary of the matched datasets and their proportions relative to both indexed datasets
-        and the total HuBMAP datasets. The summary is available in two formats: a visualization view and a tabular view.
-        Both views can be downloaded, with the visualization available as a PNG and the table as a TSV file.
-      </DatasetsOverview>
+      {!noResults && (
+        <>
+          <Typography variant="subtitle1" component="p" gutterBottom>
+            Datasets Overview
+          </Typography>
+          <DatasetsOverview
+            datasets={deduplicatedResults}
+            belowTheFold={
+              <ViewIndexedDatasetsButton
+                scFindParams={{
+                  scFindOnly: true,
+                }}
+                isLoading={false}
+              />
+            }
+            trackingInfo={trackingInfo}
+          >
+            This overview provides a summary of the matched datasets and their proportions relative to both indexed
+            datasets and the total HuBMAP datasets. The summary is available in two formats: a visualization view and a
+            tabular view. Both views can be downloaded, with the visualization available as a PNG and the table as a TSV
+            file.
+          </DatasetsOverview>
+        </>
+      )}
       <DatasetListSection />
     </MatchingGeneContextProvider>
   );

--- a/context/app/static/js/components/cells/SCFindResults/hooks.ts
+++ b/context/app/static/js/components/cells/SCFindResults/hooks.ts
@@ -46,7 +46,7 @@ export function useSCFindGeneResults() {
   // - Union of all results for genes in the same pathway, with pathway name as the key
   // - If the intersection of the genes in the same pathway is not empty, it is also a category
   // - Any genes that do not have a result are separately listed
-  const { categorizedResults, emptyResults, order, datasetToGeneMap } = useMemo(() => {
+  const { categorizedResults, emptyResults, order, datasetToGeneMap, noResults } = useMemo(() => {
     return processGeneQueryResults({
       data,
       genes,
@@ -62,6 +62,7 @@ export function useSCFindGeneResults() {
     isLoading: isLoadingDatasets || isLoadingPathwayGenes,
     emptyResults,
     order,
+    noResults,
     ...results,
   };
 }

--- a/context/app/static/js/components/cells/SCFindResults/utils.ts
+++ b/context/app/static/js/components/cells/SCFindResults/utils.ts
@@ -80,6 +80,7 @@ interface ProcessedGeneQueryResults {
   emptyResults: string[];
   order: string[];
   datasetToGeneMap: Record<string, Set<string>>;
+  noResults: boolean;
 }
 
 /**
@@ -180,6 +181,7 @@ const noDataResults: ProcessedGeneQueryResults = {
   emptyResults: [],
   order: [],
   datasetToGeneMap: {},
+  noResults: true,
 };
 
 /**
@@ -221,10 +223,13 @@ export function processGeneQueryResults({
     }
   });
 
+  const noResults = emptyResults.length === genes.length;
+
   return {
     categorizedResults,
     emptyResults,
     order,
     datasetToGeneMap,
+    noResults,
   };
 }

--- a/context/app/static/js/shared-styles/buttons/DownloadButton/DownloadButton.tsx
+++ b/context/app/static/js/shared-styles/buttons/DownloadButton/DownloadButton.tsx
@@ -7,7 +7,9 @@ import { TooltipButtonProps } from 'js/shared-styles/buttons/TooltipButton';
 function DownloadButton({ disabled, ...rest }: TooltipButtonProps) {
   return (
     <WhiteBackgroundIconTooltipButton disabled={disabled} {...rest}>
-      <SvgIcon color={disabled ? 'disabled' : 'primary'} component={Download} />
+      <span>
+        <SvgIcon color={disabled ? 'disabled' : 'primary'} component={Download} />
+      </span>
     </WhiteBackgroundIconTooltipButton>
   );
 }

--- a/context/app/static/js/shared-styles/charts/hooks.ts
+++ b/context/app/static/js/shared-styles/charts/hooks.ts
@@ -101,7 +101,7 @@ function useVerticalChart({
     labels: xAxisTickLabels,
     labelFontSize: tickLabelSize,
   });
-  const updatedMargin = { ...margin, bottom: Math.max(margin.bottom, longestLabelSize + 24) };
+  const updatedMargin = { ...margin, bottom: Math.max(margin.bottom, longestLabelSize + 48) };
 
   const { xWidth, yHeight } = getChartDimensions(parentWidth, parentHeight, updatedMargin);
 


### PR DESCRIPTION
This PR contains fixes for some of the easier issues identified during the last round of QA:

* CAT-1346 Moves the description below the "datasets" header in the scFind gene query results.
* CAT-1347 / CAT-1353 / CAT-1355 Fixes the cut-off X axis labels on vertical bar charts.
* CAT-1349 Adds a "warning" color highlight for any genes not found in results, handles gene queries with no results whatsoever.
* CAT-1350 Adds pathway name to the accordion header if a pathway is selected
* CAT-1354 Corrects CLID column name on cell types landing page to "Cell Ontology ID"

## Design Documentation/Original Tickets
https://hms-dbmi.atlassian.net/browse/CAT-1346
https://hms-dbmi.atlassian.net/browse/CAT-1347
https://hms-dbmi.atlassian.net/browse/CAT-1349
https://hms-dbmi.atlassian.net/browse/CAT-1350
https://hms-dbmi.atlassian.net/browse/CAT-1353
https://hms-dbmi.atlassian.net/browse/CAT-1354
https://hms-dbmi.atlassian.net/browse/CAT-1355

## Testing

Describe how the feature has been tested, including both automated and manual testing strategies.

## Screenshots/Video

<details><summary>CAT-1346</summary>
<p>

<img width="1324" height="383" alt="image" src="https://github.com/user-attachments/assets/dd64f260-79d8-49a3-896d-b7de8f6960ca" />

</p>
</details> 

<details><summary>CAT-1347</summary>
<p>

<img width="1302" height="684" alt="image" src="https://github.com/user-attachments/assets/db60294a-3386-4384-985c-19f97519ee7a" />


</p>
</details> 

<details><summary>CAT-1353</summary>
<p>

<img width="1294" height="647" alt="image" src="https://github.com/user-attachments/assets/57da2943-c00a-43cf-923f-5f718ad0456c" />


</p>
</details> 

<details><summary>CAT-1349</summary>
<p>

With no results available whatsoever:
<img width="1327" height="261" alt="image" src="https://github.com/user-attachments/assets/7f6a4767-e4dd-4316-9f09-b90ac0461b28" />


With present results for other genes:

<img width="1334" height="1121" alt="image" src="https://github.com/user-attachments/assets/2de9014a-5b92-4f7f-8125-b780ee52a917" />


</p>
</details> 

<details><summary>CAT-1350</summary>
<p>

Query with Pathway:
<img width="959" height="247" alt="image" src="https://github.com/user-attachments/assets/71b20b9d-e6f3-481d-b646-8b9dfb970058" />

Query without Pathway (for regression check):
<img width="1268" height="791" alt="image" src="https://github.com/user-attachments/assets/6eebb68f-184d-4772-9d75-43911caade05" />

</p>
</details> 

<details><summary>CAT-1354</summary>
<p>

<img width="1268" height="791" alt="image" src="https://github.com/user-attachments/assets/544d8815-3548-4eea-a9f7-ee2c9288e6b8" />


</p>
</details> 

<details><summary>CAT-1355</summary>
<p>

<img width="1312" height="999" alt="image" src="https://github.com/user-attachments/assets/20585085-1bdc-40af-9bdd-8c1f41706376" />


</p>
</details> 

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Additional work to be done in follow-up branches due to scope of changes:
* CAT-1345 - fixing jittery scrolling on entity tables will require defining fixed widths for columns
* CAT-1344 - adjusting the color scales for the grouped stacked bar chart may be challenging given the difficulties experienced with the initial implementation, so I didn't want to hold up the rest of the changes with that aspect.