### PR TITLE
NickAkhmetov/CAT-1345 Set fixed widths for columns to prevent jittering on scroll

### DIFF
--- a/CHANGELOG-cat-1345.md
+++ b/CHANGELOG-cat-1345.md
@@ -1,0 +1,1 @@
+- Set fixed widths for columns in large viewports to prevent jittering on scroll.

--- a/context/app/static/js/components/cells/SCFindResults/columns.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/columns.tsx
@@ -78,6 +78,7 @@ export const targetCellCountColumn = {
   label: 'Target Cell Count',
   cellContent: TargetCellCountColumn,
   noSort: true,
+  width: 150,
 };
 
 export const totalCellCountColumn = {
@@ -85,6 +86,7 @@ export const totalCellCountColumn = {
   label: 'Total Cell Count',
   cellContent: TotalCellCountColumn,
   noSort: true,
+  width: 150,
 };
 
 function MatchingGeneColumn({ hit }: CellContentProps<DatasetDocument>) {
@@ -113,4 +115,5 @@ export const matchingGeneColumn = {
   label: 'Matching Genes',
   cellContent: MatchingGeneColumn,
   noSort: true,
+  width: 150,
 };

--- a/context/app/static/js/components/organ/Samples/Samples.tsx
+++ b/context/app/static/js/components/organ/Samples/Samples.tsx
@@ -11,6 +11,7 @@ import {
   parentDonorAge,
   parentDonorSex,
   parentDonorRace,
+  anatomy,
 } from 'js/shared-styles/tables/columns';
 import ViewEntitiesButton from 'js/components/organ/ViewEntitiesButton';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
@@ -19,7 +20,15 @@ import { OrganPageIds } from 'js/components/organ/types';
 import OrganDetailSection from 'js/components/organ/OrganDetailSection';
 import { useOrganContext } from 'js/components/organ/contexts';
 
-const columns = [hubmapID, parentDonorAge, parentDonorSex, parentDonorRace, datasetDescendants, createdTimestamp];
+const columns = [
+  hubmapID,
+  anatomy,
+  parentDonorAge,
+  parentDonorSex,
+  parentDonorRace,
+  datasetDescendants,
+  createdTimestamp,
+];
 
 interface OrganSamplesProps {
   organTerms: string[];

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
@@ -173,8 +173,16 @@ function EntityTable<Doc extends Entity>({
                       cellComponent={TableCellComponent}
                     />
                   )}
-                  {columns.map(({ cellContent: CellContent, id }) => (
-                    <TableCellComponent key={id}>
+                  {columns.map(({ cellContent: CellContent, id, width }) => (
+                    <TableCellComponent
+                      key={id}
+                      sx={{
+                        width: {
+                          xs: 'auto',
+                          lg: width ?? 'auto',
+                        },
+                      }}
+                    >
                       <CellContent hit={hit._source} trackingInfo={trackingInfo} />
                     </TableCellComponent>
                   ))}

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTableHeaderCell.tsx
@@ -55,7 +55,16 @@ export default function EntityHeaderCell<Doc>({
   const active = sortState.columnId === id;
 
   return (
-    <HeaderCell key={id} sx={{ backgroundColor: 'background.paper' }}>
+    <HeaderCell
+      key={id}
+      sx={{
+        backgroundColor: 'background.paper',
+        width: {
+          sx: 'auto',
+          lg: column.width ?? 'auto',
+        },
+      }}
+    >
       <TableSortLabel
         active={active}
         direction={active ? sortState.direction : undefined}

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/types.ts
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/types.ts
@@ -9,6 +9,7 @@ export interface Column<Doc> {
   cellContent: ComponentType<{ hit: SearchHit<Doc> }> | ElementType;
   noSort?: boolean;
   tooltipText?: string;
+  width?: number;
 }
 
 export interface EntitiesTabTypes<Doc extends Entity> {

--- a/context/app/static/js/shared-styles/tables/columns.tsx
+++ b/context/app/static/js/shared-styles/tables/columns.tsx
@@ -70,6 +70,7 @@ export const hubmapID = {
   label: 'HuBMAP ID',
   sort: 'hubmap_id.keyword',
   cellContent: HubmapIDCell,
+  width: 180,
 };
 
 export const hubmapIDWithLinksInNewTab = {
@@ -87,6 +88,7 @@ export const lastModifiedTimestamp = {
   id: 'last_modified_timestamp',
   label: 'Last Modified',
   cellContent: LastModifiedTimestampCell,
+  width: 150,
 };
 
 function CreatedTimestampCell({ hit: { created_timestamp } }: CellContentProps<EntityDocument>) {
@@ -108,6 +110,7 @@ export const assayTypes = {
   label: 'Data Type',
   sort: 'mapped_data_types.keyword',
   cellContent: AssayTypesCell,
+  width: 270,
 };
 
 function StatusCell({ hit: { mapped_status, mapped_data_access_level } }: CellContentProps<DatasetDocument>) {
@@ -132,6 +135,7 @@ export const organ = {
   label: 'Organ',
   sort: 'origin_samples.mapped_organ.keyword',
   cellContent: OrganCell,
+  width: 180,
 };
 
 function withParentDonor(Component: ComponentType<{ hit: DonorDocument }>) {
@@ -149,6 +153,7 @@ export const parentDonorAge = {
   label: 'Donor Age',
   sort: 'donor.mapped_metadata.age_value',
   cellContent: withParentDonor(DonorAge),
+  width: 150,
 };
 
 function DonorSex({ hit }: CellContentProps<DonorDocument>) {
@@ -160,6 +165,7 @@ export const parentDonorSex = {
   label: 'Donor Sex',
   sort: 'donor.mapped_metadata.sex.keyword',
   cellContent: withParentDonor(DonorSex),
+  width: 150,
 };
 
 function DonorRace({ hit }: CellContentProps<DonorDocument>) {
@@ -171,6 +177,7 @@ export const parentDonorRace = {
   label: 'Donor Race',
   sort: 'donor.mapped_metadata.race.keyword',
   cellContent: withParentDonor(DonorRace),
+  width: 150,
 };
 
 export const datasetDescendants = {
@@ -178,4 +185,16 @@ export const datasetDescendants = {
   label: 'Derived Dataset Count',
   cellContent: ({ hit: { descendant_counts } }: CellContentProps<EntityDocument>) =>
     descendant_counts?.entity_type?.Dataset ?? 0,
+  width: 150,
+};
+
+export const anatomy = {
+  id: 'anatomy_2',
+  label: 'Anatomy',
+  sort: 'anatomy_2.keyword',
+  cellContent: ({ hit: { anatomy_2, anatomy_1 } }: CellContentProps<SampleDocument>) =>
+    (Array.isArray(anatomy_2) ? anatomy_2.join(', ') : anatomy_2) ||
+    (Array.isArray(anatomy_1) ? anatomy_1.join(', ') : anatomy_1) ||
+    '—',
+  width: 150,
 };

--- a/context/app/static/js/typings/search.ts
+++ b/context/app/static/js/typings/search.ts
@@ -34,6 +34,8 @@ export interface SampleDocument extends EntityDocument, SampleDatasetSharedField
   donor: DonorDocument;
   origin_samples: Omit<SampleDocument, 'descendant_counts' | 'origin_samples'>;
   entity_type: 'Sample';
+  anatomy_1: string | string[];
+  anatomy_2: string | string[];
 }
 
 export interface DatasetDocument extends EntityDocument, SampleDatasetSharedFields {


### PR DESCRIPTION
## Summary

This PR adds fixed widths which are applied to infinite scroll table columns when viewed in a large viewport. This prevents the columns from being resized as the user scrolls through the entity list. The `width` prop is optional and can be omitted when defining a column.

I found that the organ page had some free space available with these sizing adjustments in place; after confirming with Tiffany, I added the `Anatomy` column to the organ page's list of samples to provide more biological context for each sample.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1345

## Testing

Tested on molecular data query page, organ page, and cell/gene pages.

## Screenshots/Video

https://github.com/user-attachments/assets/646b4301-4ca3-45c6-9e90-9ed9110a7473


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
