### PR TITLE
NickAkhmetov/CAT-1344 Display dataset overview chart with stripes to indicate matched status

### DIFF
--- a/CHANGELOG-cat-1344.md
+++ b/CHANGELOG-cat-1344.md
@@ -1,0 +1,2 @@
+- Display grouped stacked bar charts with stripes to indicate matched values.
+- Improve legend width consistency.

--- a/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
+++ b/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
@@ -58,7 +58,7 @@ function ChartWrapper(
           "x-axis       x-axis       x-axis       legend"
         `,
         overflow: 'none',
-        gridTemplateColumns: 'auto auto auto minmax(175px, fit-content)',
+        gridTemplateColumns: 'auto auto auto minmax(175px, max-content)',
         gridTemplateRows: 'auto auto minmax(0, auto) 500px minmax(0, auto)',
       }}
       ref={ref}
@@ -73,7 +73,7 @@ function ChartWrapper(
       <Box sx={{ gridArea: 'x-axis', p: xAxisDropdown ? 1 : 0 }}>{xAxisDropdown}</Box>
       <Box sx={{ gridArea: 'legend', display: 'grid', maxHeight: '100%', overflow: 'none' }}>
         <Stack direction="column" pl={1}>
-          {dropdown && <Box sx={{ marginY: 1, minWidth: 0 }}>{dropdown}</Box>}
+          {dropdown && <Box sx={{ marginY: 1, width: '100%', minWidth: 'fit-content' }}>{dropdown}</Box>}
           <Box sx={{ flex: 1, overflowY: 'auto', gridArea: 'legend', mt: dropdown ? 0 : 2 }} tabIndex={0}>
             {colorScale && (
               <LegendOrdinal scale={colorScale} domain={domain}>

--- a/context/app/static/js/shared-styles/charts/StackedBar/StackedBar.tsx
+++ b/context/app/static/js/shared-styles/charts/StackedBar/StackedBar.tsx
@@ -58,8 +58,23 @@ function Fill({
   const barKey = bar.key;
   const barKeys = String(barKey).split(', ');
 
+  // Check if this is a "matched" element that should have stripes
+  const isMatched = String(barKey).includes('matched') && !String(barKey).includes('unmatched');
+
   // If it's a single-key bar or a separate scale is not provided, the pattern should just reflect the color
   if (barKeys.length === 1 || !colorScale || !canBeMultipleKeys) {
+    if (isMatched) {
+      // Create diagonal stripes for matched elements
+      return (
+        <defs>
+          <pattern id={id} patternUnits="userSpaceOnUse" width="8" height="8" patternTransform="rotate(45)">
+            <rect width="100%" height="100%" fill={bar.color} />
+            <rect width="4" height="8" fill={bar.color} fillOpacity="0.7" />
+            <rect x="4" width="4" height="8" fill="black" fillOpacity="0.3" />
+          </pattern>
+        </defs>
+      );
+    }
     return (
       <defs>
         <pattern id={id} patternUnits="userSpaceOnUse" width="1.5" height="1.5" patternTransform="rotate(90)">


### PR DESCRIPTION
## Summary

This PR updates the dataset overview chart to display "matched" values with stripes instead of using completely different colors for the matched and unmatched segments of each bar.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1344

## Testing

Manually tested, including PNG export functionality.

## Screenshots/Video

<img width="1256" height="724" alt="image" src="https://github.com/user-attachments/assets/01705f3c-966f-4927-93ef-c3002c5466f4" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

I also improved the sizing for the legend to be less squished.
