### PR TITLE
NickAkhmetov/CAT-1360 Add support for configuring SCFind index version as an environment variable

### DIFF
--- a/CHANGELOG-cat-1360.md
+++ b/CHANGELOG-cat-1360.md
@@ -1,0 +1,1 @@
+- Add support for configuring SCFind index version as an environment variable.

--- a/context/app/default_config.py
+++ b/context/app/default_config.py
@@ -43,6 +43,7 @@ class DefaultConfig(object):
     SOFT_ASSAY_ENDPOINT = 'should-be-overridden'
     UKV_ENDPOINT = 'should-be-overridden'
     SCFIND_ENDPOINT = 'should-be-overridden'
+    SCFIND_DEFAULT_INDEX_VERSION = ''
     DATA_PRODUCTS_ENDPOINT = 'should-be-overridden'
 
     SECRET_KEY = 'should-be-overridden'

--- a/context/app/static/js/api/scfind/useCLIDToLabel.ts
+++ b/context/app/static/js/api/scfind/useCLIDToLabel.ts
@@ -16,14 +16,20 @@ type CellTypeCountForTissueKey = string;
 export function createCLIDtoLabelKey(
   scFindEndpoint: string,
   { clid }: CellTypeLabelsForCLIDParams,
+  scFindIndexVersion?: string,
 ): CellTypeCountForTissueKey {
-  return createScFindKey(scFindEndpoint, 'CLID2CellType', {
-    CLID_label: clid,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'CLID2CellType',
+    {
+      CLID_label: clid,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useCLIDToLabel(props: CellTypeLabelsForCLIDParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCLIDtoLabelKey(scFindEndpoint, props);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCLIDtoLabelKey(scFindEndpoint, props, scFindIndexVersion);
   return useSWR<CellTypeLabelsForCLID, unknown, CellTypeCountForTissueKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useCellTypeCountForDataset.ts
+++ b/context/app/static/js/api/scfind/useCellTypeCountForDataset.ts
@@ -21,14 +21,20 @@ type CellTypeCountForDatasetKey = string;
 export function createCellTypeCountForDatasetKey(
   scFindEndpoint: string,
   { dataset }: CellTypeCountForDatasetParams,
+  scFindIndexVersion?: string,
 ): CellTypeCountForDatasetKey {
-  return createScFindKey(scFindEndpoint, 'cellTypeCountForDataset', {
-    dataset,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'cellTypeCountForDataset',
+    {
+      dataset,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useCellTypeCountForDataset(props: CellTypeCountForDatasetParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCellTypeCountForDatasetKey(scFindEndpoint, props);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCellTypeCountForDatasetKey(scFindEndpoint, props, scFindIndexVersion);
   return useSWR<CellTypeCountsForDataset, unknown, CellTypeCountForDatasetKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useCellTypeCountForTissue.ts
+++ b/context/app/static/js/api/scfind/useCellTypeCountForTissue.ts
@@ -21,25 +21,31 @@ type CellTypeCountForTissueKey = string | null;
 export function createCellTypeCountForTissueKey(
   scFindEndpoint: string,
   { tissue }: CellTypeCountForTissueParams,
+  scFindIndexVersion?: string,
 ): CellTypeCountForTissueKey | null {
   if (!tissue || tissue.length === 0) {
     return null;
   }
-  return createScFindKey(scFindEndpoint, 'cellTypeCountForTissue', {
-    tissue,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'cellTypeCountForTissue',
+    {
+      tissue,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useCellTypeCountForTissue(props: CellTypeCountForTissueParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCellTypeCountForTissueKey(scFindEndpoint, props);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCellTypeCountForTissueKey(scFindEndpoint, props, scFindIndexVersion);
   return useSWR<CellTypeCountsForTissue, unknown, CellTypeCountForTissueKey>(key, (url) => fetcher({ url }));
 }
 
 export function useCellTypeCountForTissues(tissues: string[]) {
-  const { scFindEndpoint } = useAppContext();
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
   const keys = tissues
-    .map((tissue) => createCellTypeCountForTissueKey(scFindEndpoint, { tissue }))
+    .map((tissue) => createCellTypeCountForTissueKey(scFindEndpoint, { tissue }, scFindIndexVersion))
     .filter((key): key is string => key !== null);
 
   return useSWR<CellTypeCountsForTissue[], unknown, NonNullable<CellTypeCountForTissueKey>[]>(keys, (urls: string[]) =>

--- a/context/app/static/js/api/scfind/useCellTypeExpression.ts
+++ b/context/app/static/js/api/scfind/useCellTypeExpression.ts
@@ -22,28 +22,34 @@ type GeneExpressionBinKey = string | null;
 export function createGeneExpressionBinKey(
   scFindEndpoint: string,
   { geneList, datasetName, bin }: GeneExpressionKeyParams,
+  scFindIndexVersion?: string,
 ): GeneExpressionBinKey {
   const base = bin ? 'getCellTypeExpressionBinData' : 'getCellTypeExpression';
   if (!geneList) {
     return null;
   }
-  return createScFindKey(scFindEndpoint, base, {
-    gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
-    // this is weird but it is how the API works - e.g. `HBM762-RPDR-282.HBM762.RPDR.282`
-    cell_type: `${datasetName.replaceAll('.', '-')}.${datasetName}`,
-    ...(bin ? { bin_length: '1' } : {}),
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    base,
+    {
+      gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
+      // this is weird but it is how the API works - e.g. `HBM762-RPDR-282.HBM762.RPDR.282`
+      cell_type: `${datasetName.replaceAll('.', '-')}.${datasetName}`,
+      ...(bin ? { bin_length: '1' } : {}),
+    },
+    scFindIndexVersion,
+  );
 }
 
 export function useCellTypeExpression(params: GeneExpressionParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createGeneExpressionBinKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createGeneExpressionBinKey(scFindEndpoint, params, scFindIndexVersion);
   // TODO: Update with correct response type once the API is fixed
   return useSWR<GeneExpressionBinsResponse, unknown, GeneExpressionBinKey>(key, (url) => fetcher({ url }));
 }
 
 export default function useCellTypeExpressionBins(params: GeneExpressionParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createGeneExpressionBinKey(scFindEndpoint, { ...params, bin: true });
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createGeneExpressionBinKey(scFindEndpoint, { ...params, bin: true }, scFindIndexVersion);
   return useSWR<GeneExpressionBinsResponse, unknown, GeneExpressionBinKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useCellTypeMarkers.ts
+++ b/context/app/static/js/api/scfind/useCellTypeMarkers.ts
@@ -33,17 +33,23 @@ interface CellTypeMarkersResponse {
 export function createCellTypeMarkersKey(
   scFindEndpoint: string,
   { cellTypes, topK, backgroundCellTypes, sortField, includePrefix }: CellTypeMarkersParams,
+  scFindIndexVersion?: string,
 ): CellTypeMarkersKey {
   if (!cellTypes || cellTypes.length === 0) {
     return null;
   }
-  return createScFindKey(scFindEndpoint, 'cellTypeMarkers', {
-    cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
-    background_cell_types: Array.isArray(backgroundCellTypes) ? backgroundCellTypes.join(',') : backgroundCellTypes,
-    top_k: topK ? topK.toString() : undefined,
-    include_prefix: includePrefix ? String(includePrefix) : undefined,
-    sort_field: sortField,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'cellTypeMarkers',
+    {
+      cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
+      background_cell_types: Array.isArray(backgroundCellTypes) ? backgroundCellTypes.join(',') : backgroundCellTypes,
+      top_k: topK ? topK.toString() : undefined,
+      include_prefix: includePrefix ? String(includePrefix) : undefined,
+      sort_field: sortField,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useCellTypeMarkers({
@@ -52,7 +58,11 @@ export default function useCellTypeMarkers({
   includePrefix = true,
   ...params
 }: CellTypeMarkersParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCellTypeMarkersKey(scFindEndpoint, { topK, sortField, includePrefix, ...params });
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCellTypeMarkersKey(
+    scFindEndpoint,
+    { topK, sortField, includePrefix, ...params },
+    scFindIndexVersion,
+  );
   return useSWR<CellTypeMarkersResponse, unknown, CellTypeMarkersKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useCellTypeNames.ts
+++ b/context/app/static/js/api/scfind/useCellTypeNames.ts
@@ -11,13 +11,13 @@ interface CellTypeNamesResponse {
   cellTypeNames: string[];
 }
 
-export function createCellTypeNamesKey(scFindEndpoint: string): CellTypeNamesKey {
-  return createScFindKey(scFindEndpoint, 'cellTypeNames', {});
+export function createCellTypeNamesKey(scFindEndpoint: string, scFindIndexVersion?: string): CellTypeNamesKey {
+  return createScFindKey(scFindEndpoint, 'cellTypeNames', {}, scFindIndexVersion);
 }
 
 export default function useCellTypeNames() {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCellTypeNamesKey(scFindEndpoint);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCellTypeNamesKey(scFindEndpoint, scFindIndexVersion);
   const { data, ...rest } = useSWR<CellTypeNamesResponse, unknown, CellTypeNamesKey>(key, (url) => fetcher({ url }));
 
   const filteredData = useMemo(() => {

--- a/context/app/static/js/api/scfind/useEvaluateMarkers.ts
+++ b/context/app/static/js/api/scfind/useEvaluateMarkers.ts
@@ -20,18 +20,24 @@ interface EvaluateMarkersResponse {
 export function createCellTypeMarkersKey(
   scFindEndpoint: string,
   { geneList, cellTypes, backgroundCellTypes, sortField, includePrefix }: EvaluateMarkersParams,
+  scFindIndexVersion?: string,
 ): EvaluateMarkersKey {
-  return createScFindKey(scFindEndpoint, 'evaluateMarkers', {
-    gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
-    cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
-    background_cell_types: Array.isArray(backgroundCellTypes) ? backgroundCellTypes.join(',') : backgroundCellTypes,
-    sort_field: sortField,
-    include_prefix: includePrefix !== undefined ? String(includePrefix) : undefined,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'evaluateMarkers',
+    {
+      gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
+      cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
+      background_cell_types: Array.isArray(backgroundCellTypes) ? backgroundCellTypes.join(',') : backgroundCellTypes,
+      sort_field: sortField,
+      include_prefix: includePrefix !== undefined ? String(includePrefix) : undefined,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useEvaluateMarkers(params: EvaluateMarkersParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCellTypeMarkersKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCellTypeMarkersKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<EvaluateMarkersResponse, unknown, EvaluateMarkersKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useFindCellTypeSpecificities.ts
+++ b/context/app/static/js/api/scfind/useFindCellTypeSpecificities.ts
@@ -19,17 +19,23 @@ interface FindCellTypeSpecificitiesResponse {
 export function createCellTypeSpecificitiesKey(
   scFindEndpoint: string,
   { geneList, datasets, minCells, minFraction }: FindCellTypeSpecificitiesParams,
+  scFindIndexVersion?: string,
 ): CellTypeSpecificitiesKey {
-  return createScFindKey(scFindEndpoint, 'findCellTypeSpecificities', {
-    gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
-    datasets: Array.isArray(datasets) ? datasets.join(',') : datasets,
-    min_cells: minCells ? String(minCells) : undefined,
-    min_fraction: minFraction ? String(minFraction) : undefined,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'findCellTypeSpecificities',
+    {
+      gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
+      datasets: Array.isArray(datasets) ? datasets.join(',') : datasets,
+      min_cells: minCells ? String(minCells) : undefined,
+      min_fraction: minFraction ? String(minFraction) : undefined,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useFindCellTypeSpecificities(params: FindCellTypeSpecificitiesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCellTypeSpecificitiesKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCellTypeSpecificitiesKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<FindCellTypeSpecificitiesResponse, unknown, CellTypeSpecificitiesKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useFindDatasetForCellTypes.ts
+++ b/context/app/static/js/api/scfind/useFindDatasetForCellTypes.ts
@@ -16,11 +16,17 @@ export interface FindDatasetForCellTypeResponse {
 export function createFindDatasetForCellTypeKey(
   scFindEndpoint: string,
   { cellType }: FindDatasetForCellTypeParams,
+  scFindIndexVersion?: string,
 ): FindDatasetForCellTypeKey {
   if (typeof cellType !== 'string' || cellType.length === 0) return null;
-  return createScFindKey(scFindEndpoint, 'findDatasetForCellType', {
-    cell_type: cellType,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'findDatasetForCellType',
+    {
+      cell_type: cellType,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export interface FindDatasetForCellTypesParams {
@@ -35,8 +41,10 @@ type FindDatasetForCellTypesKey = FindDatasetForCellTypeKey[];
  * @returns A list of HBM dataset IDs that contain the given cell types.
  */
 export default function useFindDatasetForCellTypes({ cellTypes }: FindDatasetForCellTypesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = cellTypes.map((cellType) => createFindDatasetForCellTypeKey(scFindEndpoint, { cellType }));
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = cellTypes.map((cellType) =>
+    createFindDatasetForCellTypeKey(scFindEndpoint, { cellType }, scFindIndexVersion),
+  );
   return useSWR<FindDatasetForCellTypeResponse[], unknown, FindDatasetForCellTypesKey>(
     key,
     (urls) =>

--- a/context/app/static/js/api/scfind/useFindDatasetForGenes.ts
+++ b/context/app/static/js/api/scfind/useFindDatasetForGenes.ts
@@ -16,20 +16,26 @@ type DatasetsForGenesKey = string | null;
 export function createFindDatasetForGenesKey(
   scFindEndpoint: string,
   { geneList }: DatasetsForGenesParams,
+  scFindIndexVersion?: string,
 ): DatasetsForGenesKey {
   if (
     (Array.isArray(geneList) && geneList.length === 0) ||
     (typeof geneList === 'string' && geneList.trim().length === 0)
   )
     return null;
-  return createScFindKey(scFindEndpoint, 'findDatasets', {
-    gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'findDatasets',
+    {
+      gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useFindDatasetForGenes(props: DatasetsForGenesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createFindDatasetForGenesKey(scFindEndpoint, props);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createFindDatasetForGenesKey(scFindEndpoint, props, scFindIndexVersion);
   return useSWR<DatasetsForGenesResponse, Error, DatasetsForGenesKey>(
     key,
     (url) =>

--- a/context/app/static/js/api/scfind/useFindGeneSignatures.ts
+++ b/context/app/static/js/api/scfind/useFindGeneSignatures.ts
@@ -18,16 +18,22 @@ interface FindGeneSignaturesResponse {
 export function createFindGeneSignaturesKey(
   scFindEndpoint: string,
   { cellTypes, minCells, minFraction }: FindGeneSignaturesParams,
+  scFindIndexVersion?: string,
 ): FindGeneSignaturesKey {
-  return createScFindKey(scFindEndpoint, 'findGeneSignatures', {
-    cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
-    min_cells: minCells ? String(minCells) : undefined,
-    min_fraction: minFraction ? String(minFraction) : undefined,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'findGeneSignatures',
+    {
+      cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
+      min_cells: minCells ? String(minCells) : undefined,
+      min_fraction: minFraction ? String(minFraction) : undefined,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useFindGeneSignatures(params: FindGeneSignaturesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createFindGeneSignaturesKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createFindGeneSignaturesKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<FindGeneSignaturesResponse, unknown, FindGeneSignaturesKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useFindHouseKeepingGenes.ts
+++ b/context/app/static/js/api/scfind/useFindHouseKeepingGenes.ts
@@ -18,16 +18,22 @@ interface FindHouseKeepingGenesResponse {
 export function createFindHouseKeepingGenesKey(
   scFindEndpoint: string,
   { cellTypes, minRecall, maxGenes }: FindHouseKeepingGenesParams,
+  scFindIndexVersion?: string,
 ): FindHouseKeepingGenesKey {
-  return createScFindKey(scFindEndpoint, 'findHouseKeepingGenes', {
-    cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
-    min_recall: minRecall ? String(minRecall) : undefined,
-    max_genes: maxGenes ? String(maxGenes) : undefined,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'findHouseKeepingGenes',
+    {
+      cell_types: Array.isArray(cellTypes) ? cellTypes.join(',') : cellTypes,
+      min_recall: minRecall ? String(minRecall) : undefined,
+      max_genes: maxGenes ? String(maxGenes) : undefined,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useFindHouseKeepingGenes(params: FindHouseKeepingGenesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createFindHouseKeepingGenesKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createFindHouseKeepingGenesKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<FindHouseKeepingGenesResponse, unknown, FindHouseKeepingGenesKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useFindSimilarGenes.ts
+++ b/context/app/static/js/api/scfind/useFindSimilarGenes.ts
@@ -18,16 +18,22 @@ interface FindSimilarGenesResponse {
 export function createFindSimilarGenesKey(
   scFindEndpoint: string,
   { geneList, datasetName, topK }: FindSimilarGenesParams,
+  scFindIndexVersion?: string,
 ): FindSimilarGenesKey {
-  return createScFindKey(scFindEndpoint, 'findSimilarGenes', {
-    gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
-    dataset_name: Array.isArray(datasetName) ? datasetName.join(',') : datasetName,
-    top_k: topK ? topK.toString() : undefined,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'findSimilarGenes',
+    {
+      gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
+      dataset_name: Array.isArray(datasetName) ? datasetName.join(',') : datasetName,
+      top_k: topK ? topK.toString() : undefined,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useFindSimilarGenes(params: FindSimilarGenesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createFindSimilarGenesKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createFindSimilarGenesKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<FindSimilarGenesResponse, unknown, FindSimilarGenesKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useFindTissueSpecificities.ts
+++ b/context/app/static/js/api/scfind/useFindTissueSpecificities.ts
@@ -17,15 +17,21 @@ interface FindTissueSpecificitiesResponse {
 export function FindTissueSpecificitiesKey(
   scFindEndpoint: string,
   { geneList, minCells }: FindTissueSpecificitiesParams,
+  scFindIndexVersion?: string,
 ): FindTissueSpecificitiesKey {
-  return createScFindKey(scFindEndpoint, 'findTissueSpecificities', {
-    gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
-    min_cells: minCells ? String(minCells) : undefined,
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'findTissueSpecificities',
+    {
+      gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
+      min_cells: minCells ? String(minCells) : undefined,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useFindTissueSpecificities(params: FindTissueSpecificitiesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = FindTissueSpecificitiesKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = FindTissueSpecificitiesKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<FindTissueSpecificitiesResponse, unknown, FindTissueSpecificitiesKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useHyperQueryCellTypes.ts
+++ b/context/app/static/js/api/scfind/useHyperQueryCellTypes.ts
@@ -26,16 +26,22 @@ type HyperQueryCellTypesKey = string;
 export function createCellTypeNamesKey(
   scFindEndpoint: string,
   { geneList, datasetName, includePrefix }: HyperQueryCellTypesParams,
+  scFindIndexVersion?: string,
 ): HyperQueryCellTypesKey {
-  return createScFindKey(scFindEndpoint, 'hyperQueryCellTypes', {
-    gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
-    dataset_name: Array.isArray(datasetName) ? datasetName.join(',') : datasetName,
-    include_prefix: includePrefix ? 'true' : 'false',
-  });
+  return createScFindKey(
+    scFindEndpoint,
+    'hyperQueryCellTypes',
+    {
+      gene_list: Array.isArray(geneList) ? geneList.join(',') : geneList,
+      dataset_name: Array.isArray(datasetName) ? datasetName.join(',') : datasetName,
+      include_prefix: includePrefix ? 'true' : 'false',
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useHyperQueryCellTypes(params: HyperQueryCellTypesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCellTypeNamesKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCellTypeNamesKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<CellTypeNamesResponse, unknown, HyperQueryCellTypesKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/useIndexedDatasets.ts
+++ b/context/app/static/js/api/scfind/useIndexedDatasets.ts
@@ -9,13 +9,13 @@ interface IndexedDatasetsResponse {
   datasets: string[];
 }
 
-export function createIndexedDatasetsKey(scFindEndpoint: string): IndexedDatasetsKey {
-  return createScFindKey(scFindEndpoint, 'getDatasets', {});
+export function createIndexedDatasetsKey(scFindEndpoint: string, scFindIndexVersion?: string): IndexedDatasetsKey {
+  return createScFindKey(scFindEndpoint, 'getDatasets', {}, scFindIndexVersion);
 }
 
 export default function useIndexedDatasets() {
-  const { scFindEndpoint } = useAppContext();
-  const key = createIndexedDatasetsKey(scFindEndpoint);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createIndexedDatasetsKey(scFindEndpoint, scFindIndexVersion);
   const swr = useSWR<IndexedDatasetsResponse, Error, IndexedDatasetsKey>(key, (url) => fetcher({ url }));
 
   return swr;

--- a/context/app/static/js/api/scfind/useLabelToCLID.ts
+++ b/context/app/static/js/api/scfind/useLabelToCLID.ts
@@ -14,21 +14,30 @@ export interface CellTypeToCLIDParams {
 
 type CellTypeToCLIDKey = string;
 
-export function createCLIDtoLabelKey(scFindEndpoint: string, { cellType }: CellTypeToCLIDParams): CellTypeToCLIDKey {
-  return createScFindKey(scFindEndpoint, 'CellType2CLID', {
-    cell_type: cellType,
-  });
+export function createCLIDtoLabelKey(
+  scFindEndpoint: string,
+  { cellType }: CellTypeToCLIDParams,
+  scFindIndexVersion?: string,
+): CellTypeToCLIDKey {
+  return createScFindKey(
+    scFindEndpoint,
+    'CellType2CLID',
+    {
+      cell_type: cellType,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useLabelToCLID(props: CellTypeToCLIDParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createCLIDtoLabelKey(scFindEndpoint, props);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createCLIDtoLabelKey(scFindEndpoint, props, scFindIndexVersion);
   return useSWR<CellTypeToCLID, unknown, CellTypeToCLIDKey>(key, (url) => fetcher({ url }));
 }
 
 export function useLabelsToCLIDs(cellTypes: string[]) {
-  const { scFindEndpoint } = useAppContext();
-  const keys = cellTypes.map((cellType) => createCLIDtoLabelKey(scFindEndpoint, { cellType }));
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const keys = cellTypes.map((cellType) => createCLIDtoLabelKey(scFindEndpoint, { cellType }, scFindIndexVersion));
 
   return useSWR<CellTypeToCLID[], unknown, CellTypeToCLIDKey[]>(keys, (urls) => multiFetcher({ urls }));
 }

--- a/context/app/static/js/api/scfind/useMarkerGenes.ts
+++ b/context/app/static/js/api/scfind/useMarkerGenes.ts
@@ -12,15 +12,24 @@ export interface MarkerGenesParams {
   datasetName?: string;
 }
 
-function createMarkerGenesKey(scFindApiUrl: string, { markerGenes, datasetName }: MarkerGenesParams): MarkerGenesKey {
-  return createScFindKey(scFindApiUrl, 'marker_genes', {
-    marker_genes: Array.isArray(markerGenes) ? markerGenes.join(',') : markerGenes,
-    dataset_name: datasetName,
-  });
+function createMarkerGenesKey(
+  scFindApiUrl: string,
+  { markerGenes, datasetName }: MarkerGenesParams,
+  scFindIndexVersion?: string,
+): MarkerGenesKey {
+  return createScFindKey(
+    scFindApiUrl,
+    'marker_genes',
+    {
+      marker_genes: Array.isArray(markerGenes) ? markerGenes.join(',') : markerGenes,
+      dataset_name: datasetName,
+    },
+    scFindIndexVersion,
+  );
 }
 
 export default function useMarkerGenes(params: MarkerGenesParams) {
-  const { scFindEndpoint } = useAppContext();
-  const key = createMarkerGenesKey(scFindEndpoint, params);
+  const { scFindEndpoint, scFindIndexVersion } = useAppContext();
+  const key = createMarkerGenesKey(scFindEndpoint, params, scFindIndexVersion);
   return useSWR<MarkerGenesResponse, unknown, MarkerGenesKey>(key, (url) => fetcher({ url }));
 }

--- a/context/app/static/js/api/scfind/utils.ts
+++ b/context/app/static/js/api/scfind/utils.ts
@@ -12,6 +12,7 @@ export function createScFindKey(
   scFindApiUrl: string,
   endpoint: string,
   params: Record<string, string | undefined>,
+  indexVersion?: string,
 ): string {
   const urlParams = new URLSearchParams();
   // Filter out undefined values from url params
@@ -19,8 +20,9 @@ export function createScFindKey(
     .filter(([, value]) => value)
     .forEach(([key, value]) => urlParams.append(key, value!));
 
-  // TODO: Once we add switching between index versions, update this to be dynamically set
-  urlParams.append('index_version', '2025-08-07');
+  if (indexVersion) {
+    urlParams.append('index_version', indexVersion);
+  }
   const fullUrl = new URL(`${scFindApiUrl}/api/${endpoint}?${urlParams.toString()}`);
   return fullUrl.toString();
 }

--- a/context/app/static/js/components/Contexts.tsx
+++ b/context/app/static/js/components/Contexts.tsx
@@ -39,6 +39,7 @@ interface AppContextType {
   userTemplatesEndpoint: string;
   ubkgEndpoint: string;
   scFindEndpoint: string;
+  scFindIndexVersion?: string;
   ukvEndpoint: string;
   dataProductsEndpoint: string;
   protocolsClientToken: string;

--- a/context/app/utils.py
+++ b/context/app/utils.py
@@ -47,6 +47,7 @@ def get_default_flask_data():
             'ukvEndpoint': current_app.config['UKV_ENDPOINT'],
             'dataProductsEndpoint': current_app.config['DATA_PRODUCTS_ENDPOINT'],
             'scFindEndpoint': current_app.config['SCFIND_ENDPOINT'],
+            'scFindIndexVersion': current_app.config['SCFIND_DEFAULT_INDEX_VERSION']
         },
         'globalAlertMd': current_app.config.get('GLOBAL_ALERT_MD')
     }

--- a/example-app.conf
+++ b/example-app.conf
@@ -65,3 +65,5 @@ DATA_PRODUCTS_ENDPOINT =    'https://data-products.cmu.hubmapconsortium.org'
 # UKV_ENDPOINT =            'https://ukv.api.hubmapconsortium.org'
 # SCFIND_ENDPOINT =         'https://scfind.hubmapconsortium.org'
 # DATA_PRODUCTS_ENDPOINT =  'https://data-products.cmu.hubmapconsortium.org'
+
+SCFIND_DEFAULT_INDEX_VERSION = '2025-08-15'


### PR DESCRIPTION
## Summary

This PR updates the index version handling for scFind to be configured via an environment variable to enable resolution of any future index version-related regressions.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1360

## Testing/Screenshots

<img width="1304" height="892" alt="image" src="https://github.com/user-attachments/assets/fae0571d-7a73-46c1-aad1-7ecbf1d785a1" />

Tested with both `2025-08-15` and empty string.

<img width="459" height="47" alt="image" src="https://github.com/user-attachments/assets/a74668bf-2394-4647-bfa1-a2927f59c215" />

<img width="456" height="147" alt="image" src="https://github.com/user-attachments/assets/18e8443b-98d5-43d8-8ad1-2e89a5593f78" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
