### PR TITLE
NickAkhmetov/CAT-1302 Fix organ assay chart ticks displaying fractions of datasets

### DIFF
--- a/CHANGELOG-cat-1302.md
+++ b/CHANGELOG-cat-1302.md
@@ -1,0 +1,1 @@
+- Fix organ assay chart ticks displaying fractions of datasets.

--- a/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.tsx
+++ b/context/app/static/js/components/organ/OrganDatasetsChart/OrganDatasetsChart.tsx
@@ -77,6 +77,9 @@ function OrganDatasetsChart({ search }: Pick<OrganFile, 'search'>) {
       xAxisLabel="Number of Datasets"
       srOnlyLabels
       showTooltipAndHover={hasMultipleSearchTerms}
+      // Only display integers - there is no such thing as half of a dataset
+      xTickValues={xScale.ticks(10).filter((d) => d % 1 === 0)}
+      xTickFormat={(value) => value.toString()}
       getBarHref={(d) =>
         getSearchURL({
           entityType: 'Dataset',

--- a/context/app/static/js/shared-styles/charts/HorizontalStackedBarChart/HorizontalStackedBarChart.tsx
+++ b/context/app/static/js/shared-styles/charts/HorizontalStackedBarChart/HorizontalStackedBarChart.tsx
@@ -65,6 +65,8 @@ interface HorizontalStackedBarChartProps<Datum, XAxisScale extends AnyD3Scale, Y
   ) => void;
   getAriaLabel?: (d: TooltipData<Datum>) => string;
   canBeMultipleKeys?: boolean;
+  xTickFormat?: (value: number) => string;
+  xTickValues?: number[];
 }
 
 function HorizontalStackedBarChart<Datum, XAxisScale extends AnyD3Scale, YAxisScale extends AnyD3Scale>({
@@ -92,6 +94,8 @@ function HorizontalStackedBarChart<Datum, XAxisScale extends AnyD3Scale, YAxisSc
   getAriaLabel,
   srOnlyLabels,
   canBeMultipleKeys = false,
+  xTickFormat,
+  xTickValues,
 }: HorizontalStackedBarChartProps<Datum, XAxisScale, YAxisScale>) {
   const { xWidth, yHeight, updatedMargin, longestLabelSize } = useHorizontalChart({
     margin,
@@ -191,6 +195,8 @@ function HorizontalStackedBarChart<Datum, XAxisScale extends AnyD3Scale, YAxisSc
             stroke="black"
             tickStroke="black"
             label={xAxisLabel}
+            tickValues={xTickValues}
+            tickFormat={xTickFormat}
             labelProps={axisLabelProps}
             tickLabelProps={() => ({
               fill: 'black',


### PR DESCRIPTION
## Summary

This PR fixes #2280. Organ page graphs with fewer than 10 datasets no longer display tick labels corresponding to half of a dataset.

## Design Documentation/Original Tickets

#2280 
https://hms-dbmi.atlassian.net/browse/CAT-1302

## Testing

Manual testing

## Screenshots/Video

<img width="1285" height="781" alt="image" src="https://github.com/user-attachments/assets/be6b99c5-de6f-4f5c-af69-9c0cf84b81a9" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
