### PR TITLE
NickAkhmetov/CAT-1391 Improve organ filter clarity

### DIFF
--- a/CHANGELOG-cat-1391.md
+++ b/CHANGELOG-cat-1391.md
@@ -1,0 +1,1 @@
+- Improve clarity of deslect all organs/select all organs.

--- a/context/app/static/js/components/cell-types-landing/CellTypesPanelItem.tsx
+++ b/context/app/static/js/components/cell-types-landing/CellTypesPanelItem.tsx
@@ -274,7 +274,7 @@ function OrgansCell({ organs }: { organs: string[] }) {
               variant="body2"
               sx={{
                 display: 'inline-block',
-                color: organIsSelected(organ) || filterIsInactive ? 'text.primary' : 'text.secondary',
+                color: organIsSelected(organ) || filterIsInactive ? 'text.primary' : 'text.disabled',
               }}
             >
               {capitalize(organ)}

--- a/context/app/static/js/components/cell-types-landing/CellTypesPanelItem.tsx
+++ b/context/app/static/js/components/cell-types-landing/CellTypesPanelItem.tsx
@@ -272,7 +272,10 @@ function OrgansCell({ organs }: { organs: string[] }) {
           <React.Fragment key={organ}>
             <Typography
               variant="body2"
-              sx={{ display: 'inline-block', color: organIsSelected(organ) ? 'text.primary' : 'text.secondary' }}
+              sx={{
+                display: 'inline-block',
+                color: organIsSelected(organ) || filterIsInactive ? 'text.primary' : 'text.secondary',
+              }}
             >
               {capitalize(organ)}
             </Typography>

--- a/context/app/static/js/components/cell-types-landing/CellTypesSearchContext.tsx
+++ b/context/app/static/js/components/cell-types-landing/CellTypesSearchContext.tsx
@@ -69,7 +69,7 @@ export default function CellTypesSearchProvider({
     () => ({
       search,
       organs,
-      organIsSelected: (organ: string) => organs.length === 0 || organs.includes(organ),
+      organIsSelected: (organ: string) => organs.includes(organ),
       organCount: organs.length,
       sortState,
       get filterIsInactive() {


### PR DESCRIPTION
## Summary

This PR adjusts the logic for the organs filter on the cell type search page.

* The existing approach shows all organs as selected in the dropdown if no organs are selected. This makes the functionality of the select all/deselect all buttons unclear. 
* The updated approach only displays the checkmarks next to selected organs. The clarity for the "no organs selected" case not applying any filtering is maintained by using the `filterIsInactive` state as one of the options for whether to color the text as primary or secondary.
* Filter clarity is further enhanced by setting the color for non-selected organs to `text.disabled` instead of `text.primary`.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1391

## Testing

Manually tested by applying various combinations of filters.

## Screenshots/Video

No organs selected:
<img width="1313" height="536" alt="image" src="https://github.com/user-attachments/assets/4ba05640-155b-4a38-9707-d1c4cfc97695" />

All organs selected:
<img width="1262" height="501" alt="image" src="https://github.com/user-attachments/assets/ec630a33-0f01-4a26-9b0b-11d6d09e6cb9" />

One organ selected:

<img width="1268" height="514" alt="image" src="https://github.com/user-attachments/assets/e3fd3144-fdc5-42a2-baa0-5e7e6814efea" />

Two organs selected:
<img width="1287" height="489" alt="image" src="https://github.com/user-attachments/assets/4666feb8-0ab2-4204-9f8b-260b5d8204b7" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
