### PR TITLE
NickAkhmetov/Switch Biomarker & Cell Type search to use a MUI stepper instead of accordions

### DIFF
--- a/context/app/static/js/components/cells/MolecularDataQueryForm/MolecularDataQueryFormProvider.tsx
+++ b/context/app/static/js/components/cells/MolecularDataQueryForm/MolecularDataQueryFormProvider.tsx
@@ -19,10 +19,6 @@ export default function MolecularDataQueryFormProvider({ children, initialValues
 
   const queryType = watch('queryType');
   const queryMethod = watch('queryMethod');
-  const threshold = watch('minimumCellPercentage');
-  const genes = watch('genes');
-  const proteins = watch('proteins');
-  const cellTypes = watch('cellTypes');
 
   // Reset selected options when query type changes
   useEffect(() => {
@@ -60,24 +56,6 @@ export default function MolecularDataQueryFormProvider({ children, initialValues
       keepIsSubmitted: false,
     });
   }, [queryMethod, reset]);
-
-  useEffect(() => {
-    // Reset the form submission state when any query fields change
-    // This is to ensure that updating the parameters while the form is submitted
-    // does not immediately trigger a re-query for results
-    // Per the react-hook-form docs, it's recommended to do this reset
-    // in useEffect as execution order matters
-
-    // TODO: With this approach, the query still reruns and gets discarded after the first change since the
-    // form state is reset AFTER the swr hook gets new params. We should investigate if there is a way to
-    // prevent the query from running until the form is submitted again. Maybe switch to a mutation?
-    reset(undefined, {
-      keepIsSubmitted: false,
-      keepIsSubmitSuccessful: false,
-      keepValues: true,
-      keepDirty: false,
-    });
-  }, [threshold, genes, proteins, cellTypes, reset]);
 
   return (
     <FormProvider {...methods}>


### PR DESCRIPTION
This PR improves the biomarker & cell type search page by switching from the accordions currently used to contain the form to MUI's vertical stepper component to improve clarity.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1310

## Testing

Describe how the feature has been tested, including both automated and manual testing strategies.

## Screenshots/Video

Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
