### PR TITLE
NickAkhmetov/CAT-1397 fix remaining organ links

### DIFF
--- a/CHANGELOG-cat-1397.md
+++ b/CHANGELOG-cat-1397.md
@@ -1,0 +1,1 @@
+- Remove remaining references to legacy `/organ` route in favor of `/organs`.

--- a/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
+++ b/context/app/static/js/components/Header/staticLinks/staticLinks.tsx
@@ -131,7 +131,7 @@ export const dataLinks: DrawerSection[] = [
         label: 'Organs',
         description:
           'Explore an organ through spatial visualizations, reference-based analysis and other relevant data.',
-        href: '/organ',
+        href: '/organs',
         icon: <OrganIcon color="primary" />,
       },
       {

--- a/context/app/static/js/components/home/Hero/const.tsx
+++ b/context/app/static/js/components/home/Hero/const.tsx
@@ -109,7 +109,7 @@ export const HOME_TIMELINE_ITEMS: TimelineData[] = [
   },
   {
     title: 'Global Data Products Now Available on Organ Pages',
-    titleHref: '/organ',
+    titleHref: '/organs',
     description:
       'Download HuBMAP-wide data products for an organ of interest that contain consolidated data for datasets of a particular assay type and tissue, aggregated across multiple datasets. Both raw and processed data products may be available.',
     date: 'March 2025',


### PR DESCRIPTION
## Summary

This PR corrects the remaining references to the old `/organ` URL in constants files - I missed these on my previous passes, but redirects are present, so I didn't want to block the release any further.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1397
