### PR TITLE
NickAkhmetov/CAT-1408 CAT-1409 Datasets Overview Chart Fixes

### DIFF
--- a/CHANGELOG-cat-1408-1409.md
+++ b/CHANGELOG-cat-1408-1409.md
@@ -1,0 +1,1 @@
+- Add scFind documentation link to dataset overview chart caption.

--- a/CHANGELOG-cat-1408-1409.md
+++ b/CHANGELOG-cat-1408-1409.md
@@ -1,1 +1,2 @@
 - Add scFind documentation link to dataset overview chart caption.
+- Fix Dataset Overview Graph comparison toggle.

--- a/context/app/static/js/components/cells/DatasetsOverview/DatasetsOverviewChart.tsx
+++ b/context/app/static/js/components/cells/DatasetsOverview/DatasetsOverviewChart.tsx
@@ -20,6 +20,7 @@ import { useDownloadImage } from 'js/hooks/useDownloadImage';
 import DownloadButton from 'js/shared-styles/buttons/DownloadButton';
 import Box from '@mui/material/Box';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import SCFindLink from 'js/shared-styles/Links/SCFindLink';
 import {
   ageBucketLabels,
   DatasetsOverviewDigest,
@@ -341,7 +342,7 @@ export default function DatasetsOverviewChart({ matched, indexed, all, trackingI
         dividersInLegend={compareBy === 'Race'}
         caption={
           <>
-            This chart shows the distribution of HuBMAP datasets that are compatible with the scFind method. The
+            This chart shows the distribution of HuBMAP datasets that are compatible with the <SCFindLink />. The
             distribution is based on the number of unique donors and the average age of donors in each dataset.
             {showComparison && (
               <> Striped segments represent matched datasets, while solid segments represent unmatched datasets.</>

--- a/context/app/static/js/components/cells/DatasetsOverview/hooks.ts
+++ b/context/app/static/js/components/cells/DatasetsOverview/hooks.ts
@@ -468,24 +468,25 @@ const getFormattedDataFromBuckets = (
       yAxis,
       matchBucket?.buckets.find((b) => String(b.key) === String(group)),
     );
-    const unmatched = getYValue(
+    const total = getYValue(
       yAxis,
       comparisonBucket.buckets.find((b) => String(b.key) === String(group)),
     );
 
     if (isPercentage) {
-      if (unmatched === 0) {
+      if (total === 0) {
         acc[group] = { matched: 0, unmatched: 0 }; // Avoid division by zero
       } else {
+        const unmatchedCount = calculateUnmatched(matched, total, showComparison);
         acc[group] = {
-          matched: matched / unmatched,
-          unmatched: calculateUnmatched(unmatched, matched, showComparison),
+          matched: matched / total,
+          unmatched: unmatchedCount / total,
         };
       }
     } else {
       acc[group] = {
         matched,
-        unmatched: calculateUnmatched(unmatched, matched, showComparison),
+        unmatched: calculateUnmatched(matched, total, showComparison),
       };
     }
 

--- a/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
@@ -365,6 +365,12 @@ interface DatasetGeneAggregations {
       doc_count: number;
     }[];
   };
+  organs: {
+    buckets: {
+      key: string;
+      doc_count: number;
+    }[];
+  };
 }
 
 const useIndexedDatasetsForGene = () => {
@@ -402,6 +408,11 @@ const useIndexedDatasetsForGene = () => {
           size: 10000,
         },
       },
+      organs: {
+        terms: {
+          field: 'origin_samples_unique_mapped_organs.keyword',
+        },
+      },
     },
     size: 10000,
     _source: ['hubmap_id'],
@@ -411,12 +422,15 @@ const useIndexedDatasetsForGene = () => {
 
   const datasetTypes = searchData?.aggregations?.datasetTypes?.buckets ?? [];
 
+  const organs = searchData?.aggregations?.organs?.buckets ?? [];
+
   return {
     datasets: datasetUUIDs,
     datasetTypes,
     scFindParams: {
       genes: [geneSymbol],
     },
+    organs,
     isLoading: isLoadingDatasets || isLoadingDatasetTypes,
   };
 };

--- a/end-to-end/cypress/e2e/portal/pages/genes.cy.js
+++ b/end-to-end/cypress/e2e/portal/pages/genes.cy.js
@@ -1,0 +1,159 @@
+const geneSymbol = "MMRN1";
+const geneName = "Multimerin 1"
+const genePath = `/genes/${geneSymbol}`;
+
+describe("Gene Detail Page", () => {
+      beforeEach(() => {
+        cy.viewport("macbook-15");
+      });
+  context("macbook-size", () => {
+    // Group tests that don't require navigation or state changes
+    context("page content and structure", () => {
+      beforeEach(() => {
+        // Ensure we're always on the correct page before each test
+        cy.url().then((url) => {
+          if (!url.includes(genePath)) {
+            cy.visit(genePath);
+          }
+        });
+        
+        // Wait for the page to fully load before running tests
+        cy.findByRole("heading", { level: 1 }, { timeout: 10000 }).should("contain", geneSymbol);
+        cy.get("#summary", { timeout: 10000 }).should("exist");
+        cy.get("#cell-types", { timeout: 15000 }).should("exist");
+        
+        // Scroll to ensure the datasets section is visible and wait for it to load
+        cy.get("#datasets", { timeout: 15000 }).should("exist").scrollIntoView();
+      });
+
+      it("displays the correct page title and gene name", () => {
+        // Test that the gene full name and symbol appear in h1 element
+        cy.findByRole("heading", { level: 1 }).should("contain", geneName).and("contain", geneSymbol);
+        
+        // Test that the page title is set correctly
+        cy.title().should("include", geneSymbol);
+        cy.title().should("include", "HuBMAP");
+      });
+
+      it("displays the summary section with gene description and references", () => {
+        // Check that summary section exists
+        cy.get("#summary").should("exist").within(() => {
+          // Check for gene description section
+          cy.findByText("Description").should("exist");
+
+          // Check for known references section
+          cy.findByText("Known References").should("exist");
+          
+          // Check for relevant pages section with biomarkers and search links
+          cy.findByText("Biomarkers").should("exist");
+          cy.findByText("Biomarker and Cell Type Search").should("exist");
+          
+          // Verify the links are clickable and point to correct URLs (but don't click them)
+          cy.contains("a", "Biomarkers").should("have.attr", "href", "/biomarkers");
+          cy.contains("a", "Biomarker and Cell Type Search").should("have.attr", "href", "/search/biomarkers-cell-types");
+        });
+      });
+
+      it("displays the indexed datasets summary with organs and data types", () => {
+        // Check that the cell types section exists with indexed datasets summary
+        cy.get("#cell-types").should("exist").within(() => {
+          cy.findByText(`Cell Types with ${geneSymbol} as Marker Gene`).should("exist");
+
+          // Check for indexed datasets summary content
+          cy.findByText("Organs").should("exist");
+          cy.findByText("Data Types").should("exist");
+          cy.findByText("View Indexed Datasets").should("exist");
+          
+          // Look for table headers
+          cy.findByText("Cell Type").should("exist");
+          cy.findByText("Cell Ontology ID").should("exist");
+          cy.findByText("Cells Hit / Total Cells (%)").should("exist");
+          cy.findByText("p-value").should("exist");
+          
+          // Check that there are cell type rows (at least one row should exist)
+          cy.get("tbody tr").should("have.length.at.least", 1);
+        });
+      });
+
+      it("displays the datasets overview section with interactive controls", () => {
+        // Scroll to and check that datasets section exists
+        cy.get("#datasets").should("exist").scrollIntoView().within(() => {
+          cy.findByText(`Datasets with ${geneSymbol}`).should("exist");
+          
+          // Look for overview section
+          cy.findByText("Datasets Overview").should("exist").scrollIntoView();
+          
+          // Check for interactive controls (but don't interact with them)
+          cy.findByText("Plot Type").should("exist");
+          cy.findByText("Comparison Group").should("exist");
+          cy.findByText("Display As").should("exist");
+          
+          // Check for axis selectors
+          cy.findAllByText("X-Axis").should("exist");
+          cy.findAllByText("Y-Axis").should("exist");
+          cy.findAllByText("Compare by").should("exist");
+        });
+      });
+
+
+      it("displays the datasets list", () => {
+        cy.get("#datasets").should("exist").scrollIntoView().within(() => {
+          // Check for datasets list section
+          cy.findByText("Datasets").should("exist");
+          
+          // Check for table with dataset rows
+          cy.get("tbody tr").should("have.length.at.least", 1);
+        });
+      });
+
+      it("displays the explore with biomarker tool button in datasets section", () => {
+        cy.get("#datasets").should("exist").scrollIntoView().within(() => {
+          cy.findByText("Explore with Biomarker and Cell Type Search Tool").should("exist");
+          // Check the href attribute but don't click the link
+          cy.contains("a", "Explore with Biomarker and Cell Type Search Tool")
+            .should("have.attr", "href", "/search/biomarkers-cell-types");
+        });
+      });
+    });
+
+    // Group tests that require navigation (each needs a fresh page load)
+    context("navigation functionality", () => {
+
+      it("has working navigation to biomarker and cell type search page", () => {
+        cy.visit(genePath);
+        
+        // Click on the biomarker search link from summary section
+        cy.contains("a", "Biomarker and Cell Type Search").click();
+        
+        // Verify navigation to search page
+        cy.url().should("include", "/search/biomarkers-cell-types");
+        cy.title().should("include", "Biomarker");
+      });
+
+      it("has working navigation to biomarkers page", () => {
+        cy.visit(genePath);
+        
+        // Click on the biomarkers link from summary section
+        cy.contains("a", "Biomarkers").click();
+        
+        // Verify navigation to biomarkers page
+        cy.url().should("include", "/biomarkers");
+      });
+    });
+
+    // Test for loading states - separate since it explicitly tests loading behavior
+    context("loading and error handling", () => {
+
+      it("handles loading states gracefully", () => {
+        // Visit the gene page and check that skeleton loaders don't persist indefinitely
+        cy.visit(genePath);
+        
+        // Main content should load within reasonable time
+        cy.findByRole("heading", { level: 1 }, { timeout: 10000 }).should("contain", geneSymbol);
+        cy.get("#summary", { timeout: 10000 }).should("exist");
+        cy.get("#cell-types", { timeout: 15000 }).should("exist");
+        cy.get("#datasets", { timeout: 15000 }).should("exist").scrollIntoView();
+      });
+    });
+  });
+});

--- a/end-to-end/cypress/e2e/portal/pages/genes.cy.js
+++ b/end-to-end/cypress/e2e/portal/pages/genes.cy.js
@@ -1,5 +1,5 @@
 const geneSymbol = "MMRN1";
-const geneName = "Multimerin 1"
+const geneName = "Multimerin 1";
 const genePath = `/genes/${geneSymbol}`;
 
 describe("Gene Detail Page", () => {


### PR DESCRIPTION
## Summary

This PR:
* Fixes the dataset overview chart not showing the `unmatched` data in the comparison
* Adds a link to the scfind documentation to the dataset overview chart caption
* Fixes the missing "organs" list on the indexed datasets summary of the gene page

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1408
https://hms-dbmi.atlassian.net/browse/CAT-1409

## Testing

Manually tested to confirm functionality is restored, added cypress tests for basic gene page functionalities.

## Screenshots/Video

<details><summary>Dataset Overview Chart Fixes</summary>
<p>

with comparison turned off:
<img width="1270" height="711" alt="image" src="https://github.com/user-attachments/assets/9786d4af-a764-4a6b-a4eb-c32da277d79b" />

with comparison turned on:
<img width="1261" height="731" alt="image" src="https://github.com/user-attachments/assets/5d717168-d2e2-48c3-9aed-05d4c16a7d18" />

with comparison turned on/percentage enabled:
<img width="1281" height="719" alt="image" src="https://github.com/user-attachments/assets/cae947ae-6c68-4860-a568-4164ca5b1b46" />

with comparison turned on/compare to all enabled:
<img width="1301" height="718" alt="image" src="https://github.com/user-attachments/assets/86191a59-168d-496c-9463-052ce2d7e875" />

with comparison turned on/compare to all and percentage mode enabled:
<img width="1257" height="718" alt="image" src="https://github.com/user-attachments/assets/68fe0b76-ce5e-4598-a332-1b96f6440273" />

</p>
</details> 

<details><summary>Fixed gene page organs list</summary>
<p>

<img width="1320" height="247" alt="image" src="https://github.com/user-attachments/assets/82b0f9e4-5805-4f67-97bd-c152b1a4e108" />

</p>
</details> 


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Exploring the possibility of adding cypress tests for the gene detail page; will open past draft state once the feasibility is clear.