### PR TITLE
NickAkhmetov/CAT-1351 Add "—" keys in metadata table that don't have corresponding values.

### DIFF
--- a/CHANGELOG-cat-1351.md
+++ b/CHANGELOG-cat-1351.md
@@ -1,0 +1,1 @@
+- Add "—" keys in metadata table that don't have corresponding values.

--- a/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
+++ b/context/app/static/js/components/detailPage/MetadataTable/MetadataTable.tsx
@@ -37,7 +37,7 @@ function MetadataTable({ tableRows = [] as MetadataTableRow[], columns = default
                   {row.key.endsWith('age_value') ? (
                     <DonorAgeTooltip donorAge={row.value}>{row.value}</DonorAgeTooltip>
                   ) : (
-                    row.value
+                    row.value || '—'
                   )}
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
## Summary

This PR handles empty values in metadata tables by falling back to a hyphen if the value is an empty string.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1351

## Testing

Tested on CyTOF dataset linked in original ticket.

## Screenshots/Video
Prod:
<img width="1343" height="578" alt="image" src="https://github.com/user-attachments/assets/c76fd8cf-869d-4800-b114-f9fd5ab01061" />

Fixed:
<img width="1305" height="598" alt="image" src="https://github.com/user-attachments/assets/ffbb2892-3c7f-4167-be9a-2e522cb7ec39" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
