### PR TITLE
NickAkhmetov/Fix publication detail page to correctly display related datasets

### DIFF
--- a/CHANGELOG-publication-data-section-fixes.md
+++ b/CHANGELOG-publication-data-section-fixes.md
@@ -1,0 +1,1 @@
+- Fix the publication detail page Data section showing the wrong number of related datasets. All entities referenced by a publication's `ancestor_ids` are now loaded, including older dataset versions that have a `next_revision_uuid`.

--- a/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.tsx
+++ b/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.tsx
@@ -60,9 +60,21 @@ interface IntegratedDataTablesProps {
   entities: Entity[];
   tableTooltips?: Partial<Record<IntegratedEntityTypes, string>>;
   isLoading?: boolean;
+  /**
+   * Whether queries built by this table should apply the default-query restriction
+   * (which excludes documents with `next_revision_uuid` or `sub_status`). Defaults
+   * to true for compatibility with general detail-page surfaces. Publications pass
+   * `false` because they reference specific older dataset versions.
+   */
+  useDefaultQuery?: boolean;
 }
 
-function IntegratedDataTables({ entities: entityList, tableTooltips, isLoading }: IntegratedDataTablesProps) {
+function IntegratedDataTables({
+  entities: entityList,
+  tableTooltips,
+  isLoading,
+  useDefaultQuery = true,
+}: IntegratedDataTablesProps) {
   const entitiesTableConfig: EntitiesTabTypes<Entity>[] = useMemo(() => {
     const integratedEntityList = entityList.filter(isIntegratedEntity);
 
@@ -146,6 +158,7 @@ function IntegratedDataTables({ entities: entityList, tableTooltips, isLoading }
       resetSelectionOnTabChange
       maxHeight={600}
       isLoading={isLoading}
+      useDefaultQuery={useDefaultQuery}
     />
   );
 }

--- a/context/app/static/js/components/publications/PublicationsDataSection/PublicationsDataSection.tsx
+++ b/context/app/static/js/components/publications/PublicationsDataSection/PublicationsDataSection.tsx
@@ -9,14 +9,14 @@ import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPag
 import { useEntitiesData } from 'js/hooks/useEntityData';
 
 interface PublicationsDataSectionProps {
-  datasetUUIDs: string[];
+  ancestorIds: string[];
   associatedCollectionUUID?: string;
 }
 
 function useEffectiveDatasetUUIDs({
-  datasetUUIDs = [],
+  ancestorIds = [],
   associatedCollectionUUID,
-}: Pick<PublicationsDataSectionProps, 'datasetUUIDs' | 'associatedCollectionUUID'>) {
+}: Pick<PublicationsDataSectionProps, 'ancestorIds' | 'associatedCollectionUUID'>) {
   const collectionQuery = associatedCollectionUUID
     ? {
         query: getIDsQuery(associatedCollectionUUID),
@@ -39,7 +39,7 @@ function useEffectiveDatasetUUIDs({
 
   return {
     collections,
-    datasetUUIDs: datasetUUIDs.filter(Boolean),
+    datasetUUIDs: ancestorIds.filter(Boolean),
     isLoading,
   };
 }
@@ -58,6 +58,9 @@ function useAllAncestors(datasetUUIDs: string[], isLoadingDatasetUUIDs: boolean)
         },
       },
       _source: 'ancestor_ids',
+      // Without an explicit size, ES caps results at 10. Publications can reference
+      // hundreds of ancestors, so all of them must be fetched.
+      size: 10000,
     }),
     [datasetUUIDs],
   );
@@ -79,14 +82,14 @@ function useAllAncestors(datasetUUIDs: string[], isLoadingDatasetUUIDs: boolean)
   };
 }
 
-function PublicationsDataSection({ datasetUUIDs, associatedCollectionUUID }: PublicationsDataSectionProps) {
+function PublicationsDataSection({ ancestorIds, associatedCollectionUUID }: PublicationsDataSectionProps) {
   // Extract dataset UUIDs from collection or use provided ones
   const {
     collections,
     datasetUUIDs: effectiveDatasetUUIDs,
     isLoading: isLoadingEffectiveDatasetUUIDs,
   } = useEffectiveDatasetUUIDs({
-    datasetUUIDs,
+    ancestorIds,
     associatedCollectionUUID,
   });
 
@@ -105,7 +108,12 @@ function PublicationsDataSection({ datasetUUIDs, associatedCollectionUUID }: Pub
 
   return (
     <CollapsibleDetailPageSection id="data" title="Data">
-      <IntegratedDataTables entities={allEntities} isLoading={loadingTableEntities} />
+      {/*
+        Publications reference specific dataset versions, including older ones whose
+        next_revision_uuid points to newer versions. Disable the default-query filter
+        so those referenced versions aren't dropped from the table.
+      */}
+      <IntegratedDataTables entities={allEntities} isLoading={loadingTableEntities} useDefaultQuery={false} />
       {associatedCollectionUUID && <PublicationCollections collectionsData={collections} isCollectionPublication />}
     </CollapsibleDetailPageSection>
   );

--- a/context/app/static/js/hooks/useColumnFilters.ts
+++ b/context/app/static/js/hooks/useColumnFilters.ts
@@ -29,9 +29,15 @@ interface UseColumnFiltersProps<Doc> {
   columns: Column<Doc>[];
   baseQuery: SearchRequest;
   enabled?: boolean;
+  useDefaultQuery?: boolean;
 }
 
-export function useColumnFilters<Doc>({ columns, baseQuery, enabled = true }: UseColumnFiltersProps<Doc>) {
+export function useColumnFilters<Doc>({
+  columns,
+  baseQuery,
+  enabled = true,
+  useDefaultQuery = true,
+}: UseColumnFiltersProps<Doc>) {
   const [filters, setFilters] = useState<ColumnFilterState>({});
 
   const filterableColumns = useMemo(() => columns.filter((col) => col.filterable && col.sort), [columns]);
@@ -125,6 +131,7 @@ export function useColumnFilters<Doc>({ columns, baseQuery, enabled = true }: Us
     aggregationsQuery ?? { query: { match_all: {} } },
     {
       shouldFetch: Boolean(aggregationsQuery),
+      useDefaultQuery,
     },
   );
 

--- a/context/app/static/js/hooks/useScrollTable.ts
+++ b/context/app/static/js/hooks/useScrollTable.ts
@@ -56,6 +56,13 @@ interface ScrollTableTypes<Doc> {
   isExpandable?: boolean;
   /** Height estimate for expanded content in pixels (default: 200px) */
   estimatedExpandedRowHeight?: number;
+  /**
+   * Whether to apply the default ES query restriction (excludes documents with
+   * `next_revision_uuid` or `sub_status`). Defaults to true. Set false when the
+   * caller passes specific entity IDs that should not be re-filtered — e.g.,
+   * publications that reference older dataset versions.
+   */
+  useDefaultQuery?: boolean;
 }
 
 interface UseScrollSearchHitsTypes<Document> {
@@ -74,8 +81,9 @@ function useScrollTable<Document>({
   columns,
   isExpandable = false,
   estimatedExpandedRowHeight = 200,
+  useDefaultQuery = true,
 }: ScrollTableTypes<Document>) {
-  const { allSearchIDs } = useAllSearchIDs(query) as AllSearchIDsTypes;
+  const { allSearchIDs } = useAllSearchIDs(query, { useDefaultQuery }) as AllSearchIDsTypes;
 
   const { sortState, setSort, sort } = useSortState(columnNameMapping, initialSortState);
 
@@ -101,13 +109,15 @@ function useScrollTable<Document>({
     columns,
     baseQuery: queryWithSort,
     enabled: true,
+    useDefaultQuery,
   });
 
   // Use different data fetching strategies based on sort type
-  const scrollData = useScrollSearchHits(filteredQuery, {}) as UseScrollSearchHitsTypes<Document>;
+  const scrollData = useScrollSearchHits(filteredQuery, { useDefaultQuery }) as UseScrollSearchHitsTypes<Document>;
 
   const { searchHits: allSearchHits, isLoading: allDataLoading } = useSearchHits<Document>(filteredQuery, {
     shouldFetch: isCustomSort,
+    useDefaultQuery,
   });
 
   // Apply custom sorting when needed

--- a/context/app/static/js/hooks/useSearchData.ts
+++ b/context/app/static/js/hooks/useSearchData.ts
@@ -97,8 +97,9 @@ export async function fetchSearchData<Documents, Aggs>(
   query: SearchRequest,
   url: string,
   token: string,
+  useDefaultQuery: boolean = true,
 ): Promise<SearchResponseBody<Documents, Aggs>> {
-  const body = createSearchRequestBody({ query, useDefaultQuery: true });
+  const body = createSearchRequestBody({ query, useDefaultQuery });
   const requestInit = buildSearchRequestInit({ body, authHeader: getAuthHeader(token) });
   const searchResponse = await fetch<SearchResponseBody<Documents, Aggs> & Response>({
     url,
@@ -240,6 +241,7 @@ async function* fetchAllPages(
   elasticsearchEndpoint: string,
   groupsToken: string,
   numberOfPagesToRequest: number,
+  useDefaultQuery: boolean,
 ) {
   const q = query;
 
@@ -248,7 +250,7 @@ async function* fetchAllPages(
     while (i < numberOfPagesToRequest) {
       // disabling eslint rule because that's the whole point of this generator
 
-      const firstPageResults = await fetchSearchData(q, elasticsearchEndpoint, groupsToken);
+      const firstPageResults = await fetchSearchData(q, elasticsearchEndpoint, groupsToken, useDefaultQuery);
       yield firstPageResults;
       q.search_after = getSearchAfterSort(firstPageResults.hits.hits);
       i += 1;
@@ -281,11 +283,16 @@ async function fetchAllIDs({
   useDefaultQuery: boolean;
   numberOfPagesToRequest: number;
 }) {
-  const query = useDefaultQuery ? addRestrictionsToQuery(q) : q;
   const ids = new Set<string>();
   // For await loop is the clearest way to fetch all pages sequentially.
 
-  for await (const results of fetchAllPages(query, elasticsearchEndpoint, groupsToken, numberOfPagesToRequest)) {
+  for await (const results of fetchAllPages(
+    q,
+    elasticsearchEndpoint,
+    groupsToken,
+    numberOfPagesToRequest,
+    useDefaultQuery,
+  )) {
     extractIDs(results).forEach((id) => ids.add(id));
   }
   return Array.from(ids);
@@ -314,11 +321,16 @@ async function fetchAllHits<Documents>({
   useDefaultQuery: boolean;
   numberOfPagesToRequest: number;
 }) {
-  const query = useDefaultQuery ? addRestrictionsToQuery(q) : q;
   const hits: Required<SearchHit<Documents>>[] = [];
   // For await loop is the clearest way to fetch all pages sequentially.
 
-  for await (const results of fetchAllPages(query, elasticsearchEndpoint, groupsToken, numberOfPagesToRequest)) {
+  for await (const results of fetchAllPages(
+    q,
+    elasticsearchEndpoint,
+    groupsToken,
+    numberOfPagesToRequest,
+    useDefaultQuery,
+  )) {
     const pageHits = (results?.hits?.hits ?? []) as Required<SearchHit<Documents>>[];
     hits.push(...pageHits);
   }
@@ -488,8 +500,7 @@ export function useScrollSearchHits<Doc, Aggs>(
     SWRError
   >(
     getKey,
-    (args: [SearchRequest, string, string, boolean, number]) =>
-      fetcher(...args) as Promise<SearchResponseBody<Doc, Aggs>>,
+    (args: [SearchRequest, string, string, boolean]) => fetcher(...args) as Promise<SearchResponseBody<Doc, Aggs>>,
     {
       fallbackData: [],
       revalidateAll: false,

--- a/context/app/static/js/pages/Publication/Publication.tsx
+++ b/context/app/static/js/pages/Publication/Publication.tsx
@@ -52,7 +52,7 @@ function Publication({ publication, vignette_json }: PublicationProps) {
     <DetailContextProvider uuid={uuid} hubmap_id={hubmap_id} mapped_data_access_level="Public" entityType="Publication">
       <DetailLayout sections={shouldDisplaySection}>
         <PublicationSummary />
-        <PublicationsDataSection datasetUUIDs={ancestor_ids} associatedCollectionUUID={associatedCollectionUUID} />
+        <PublicationsDataSection ancestorIds={ancestor_ids} associatedCollectionUUID={associatedCollectionUUID} />
         {shouldDisplaySection.visualizations && (
           <PublicationsVisualizationSection vignette_json={vignette_json} uuid={uuid} />
         )}

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
@@ -29,6 +29,7 @@ interface EntitiesTablesProps<Doc extends Entity> {
   onSelectAllChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   resetSelectionOnTabChange?: boolean;
   isLoading?: boolean;
+  useDefaultQuery?: boolean;
 }
 
 /**
@@ -131,6 +132,7 @@ interface EntitiesTablesBodiesProps<Doc extends Entity>
       | 'trackingInfo'
       | 'disabledIDs'
       | 'isSelectable'
+      | 'useDefaultQuery'
     > {}
 
 function EntitiesTablesBodies<Doc extends Entity>({
@@ -139,6 +141,7 @@ function EntitiesTablesBodies<Doc extends Entity>({
   emptyAlert,
   isLoading,
   totalHitsCounts,
+  useDefaultQuery,
   ...restSharedProps
 }: EntitiesTablesBodiesProps<Doc>) {
   return (
@@ -174,7 +177,7 @@ function EntitiesTablesBodies<Doc extends Entity>({
 
         return (
           <TabPanel key={entityType} value={openTabIndex} index={i}>
-            <EntityTable query={query} {...entityTableProps} {...restSharedProps} />
+            <EntityTable query={query} useDefaultQuery={useDefaultQuery} {...entityTableProps} {...restSharedProps} />
           </TabPanel>
         );
       })}
@@ -187,12 +190,14 @@ function EntitiesTables<Doc extends Entity>({
   entities,
   resetSelectionOnTabChange = false,
   isLoading,
+  useDefaultQuery = true,
   ...rest
 }: EntitiesTablesProps<Doc>) {
   const { openTabIndex, handleTabChange } = useTabs(initialTabIndex);
 
   const { totalHitsCounts, isLoading: isLoadingHitCounts } = useSearchTotalHitsCounts(
     entities.map(({ query }) => query),
+    { useDefaultQuery },
   ) as {
     totalHitsCounts: number[];
     isLoading: boolean;
@@ -212,6 +217,7 @@ function EntitiesTables<Doc extends Entity>({
         handleTabChange={handleTabChange}
         isLoading={isLoading || isLoadingHitCounts}
         totalHitsCounts={totalHitsCounts}
+        useDefaultQuery={useDefaultQuery}
         {...rest}
       />
       {resetSelectionOnTabChange && <TabChangeSelectionHandler openTabIndex={openTabIndex} />}

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntityTable.tsx
@@ -45,6 +45,7 @@ interface EntityTableProps<Doc extends Entity>
   estimatedExpandedRowHeight?: number;
   initialSortState?: { columnId: string; direction: 'asc' | 'desc' };
   headerActions?: React.ReactNode;
+  useDefaultQuery?: boolean;
 }
 
 const headerRowHeight = 60;
@@ -73,6 +74,7 @@ function EntityTable<Doc extends Entity>({
   estimatedExpandedRowHeight,
   initialSortState = { columnId: 'last_modified_timestamp', direction: 'desc' },
   headerActions,
+  useDefaultQuery = true,
 }: EntityTableProps<Doc>) {
   const columnNameMapping = columns.reduce((acc, column) => ({ ...acc, [column.id]: column.sort }), {});
   const isExpandable = Boolean(ExpandedContent);
@@ -104,6 +106,7 @@ function EntityTable<Doc extends Entity>({
     columns,
     isExpandable,
     estimatedExpandedRowHeight,
+    useDefaultQuery,
   });
 
   // Create a combined onExpand handler that tracks expansion state and calls the external callback


### PR DESCRIPTION
## Summary

The list of related datasets was being truncated by:
* `useAllAncestorIds` excluded `size` parameter -> limited to only 10 entities
* `useDefaultQuery` was `true`, which excluded datasets with new versions