### PR TITLE
NickAkhmetov/CAT-1553 Update Protocols.io links to no longer request latest version

### DIFF
--- a/CHANGELOG-cat-1553.md
+++ b/CHANGELOG-cat-1553.md
@@ -1,0 +1,1 @@
+- Adjust protocol links to point to specific version associated with donor/sample.

--- a/context/app/static/js/components/detailPage/Protocol/Protocol.tsx
+++ b/context/app/static/js/components/detailPage/Protocol/Protocol.tsx
@@ -86,7 +86,7 @@ interface ProtocolProps {
 }
 
 function Protocol({ protocol_url, showHeader }: ProtocolProps) {
-  const protocolUrls = useFormattedProtocolUrls(protocol_url, 1);
+  const protocolUrls = useFormattedProtocolUrls(protocol_url);
 
   const contents = (
     <>

--- a/context/app/static/js/components/detailPage/Protocol/Protocol.tsx
+++ b/context/app/static/js/components/detailPage/Protocol/Protocol.tsx
@@ -15,6 +15,15 @@ import { useTrackEntityPageEvent } from '../useTrackEntityPageEvent';
 const loadingText = 'Protocols are loading. If protocols take a significant time to load, please ';
 const errorText = 'Failed to retrieve protocols. Please ';
 
+function decodeHtmlEntities(str: string): string {
+  const textarea = document.createElement('textarea');
+  textarea.innerHTML = str;
+  const formatted = textarea.value;
+  // clean up the created textarea
+  textarea.remove();
+  return formatted;
+}
+
 interface ProtocolMessageProps {
   isLoading?: boolean;
   isError?: boolean;
@@ -57,7 +66,7 @@ function ProtocolLink({ url, index }: ProtocolLinkProps) {
   }
 
   return (
-    <SectionItem label={data?.payload?.title}>
+    <SectionItem label={data?.payload?.title ? decodeHtmlEntities(data.payload.title) : undefined}>
       {data?.payload && (
         <OutboundIconLink
           onClick={() => {

--- a/context/app/static/js/hooks/useProtocolData.spec.ts
+++ b/context/app/static/js/hooks/useProtocolData.spec.ts
@@ -25,8 +25,8 @@ describe('useFormattedProtocolUrls', () => {
     const result = getResult(protocolUrls);
     expect(result).toEqual({
       protocols: [
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn',
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn/v1',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en/v2',
       ],
       gitHub: [],
     });
@@ -65,8 +65,8 @@ describe('useFormattedProtocolUrls', () => {
     const result = getResult(protocolUrls);
     expect(result).toEqual({
       protocols: [
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn',
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn/v1',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en/v2',
       ],
       gitHub: [],
     });
@@ -76,7 +76,7 @@ describe('useFormattedProtocolUrls', () => {
     const protocolUrls = 'dx.doi.org/10.17504/protocols.io.btnfnmbn/v1';
     const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn/v1'],
       gitHub: [],
     });
   });
@@ -185,7 +185,7 @@ describe('useFormattedProtocolUrls', () => {
       expect(result).toEqual({
         protocols: [
           'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn',
-          'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en',
+          'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en/v1',
         ],
         gitHub: ['https://github.com/user/repo1', 'https://github.com/user/repo2'],
       });

--- a/context/app/static/js/hooks/useProtocolData.spec.ts
+++ b/context/app/static/js/hooks/useProtocolData.spec.ts
@@ -2,9 +2,9 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import { useFormattedProtocolUrls, isGithubUrl } from './useProtocolData';
 
-const getResult = (protocols: string, lastVersion: number) => {
-  const { result } = renderHook(({ urls, version }) => useFormattedProtocolUrls(urls, version), {
-    initialProps: { urls: protocols, version: lastVersion },
+const getResult = (protocols: string) => {
+  const { result } = renderHook(({ urls }) => useFormattedProtocolUrls(urls), {
+    initialProps: { urls: protocols },
   });
   return result.current;
 };
@@ -12,10 +12,9 @@ const getResult = (protocols: string, lastVersion: number) => {
 describe('useFormattedProtocolUrls', () => {
   it('should format a single URL with no version number', () => {
     const protocolUrls = 'https://dx.doi.org/10.17504/protocols.io.btnfnmbn';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
@@ -23,12 +22,11 @@ describe('useFormattedProtocolUrls', () => {
   it('should format multiple URLs with version numbers', () => {
     const protocolUrls =
       'https://dx.doi.org/10.17504/protocols.io.btnfnmbn/v1, https://dx.doi.org/10.17504/protocols.io.7d5h6en/v2';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
       protocols: [
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1',
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en?last_version=1',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en',
       ],
       gitHub: [],
     });
@@ -36,30 +34,27 @@ describe('useFormattedProtocolUrls', () => {
 
   it('should handle URLs with http:// prefix', () => {
     const protocolUrls = 'http://dx.doi.org/10.17504/protocols.io.btnfnmbn';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
 
   it('should handle URLs with https:// prefix', () => {
     const protocolUrls = 'https://dx.doi.org/10.17504/protocols.io.btnfnmbn';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
 
   it('should handle URLs with dx.doi.org/ prefix', () => {
     const protocolUrls = 'dx.doi.org/10.17504/protocols.io.btnfnmbn';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
@@ -67,12 +62,11 @@ describe('useFormattedProtocolUrls', () => {
   it('should handle URLs with multiple prefixes', () => {
     const protocolUrls =
       'https://dx.doi.org/10.17504/protocols.io.btnfnmbn/v1,http://dx.doi.org/10.17504/protocols.io.7d5h6en/v2';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
       protocols: [
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1',
-        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en?last_version=1',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn',
+        'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en',
       ],
       gitHub: [],
     });
@@ -80,57 +74,51 @@ describe('useFormattedProtocolUrls', () => {
 
   it('should handle URLs with no http or https prefix', () => {
     const protocolUrls = 'dx.doi.org/10.17504/protocols.io.btnfnmbn/v1';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
 
   it('should handle URLs with no version number', () => {
     const protocolUrls = 'https://dx.doi.org/10.17504/protocols.io.btnfnmbn';
-    const lastVersion = 2;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=2'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
 
   it('should handle empty input', () => {
     const protocolUrls = '';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({ protocols: [], gitHub: [] });
   });
 
   it('should filter out empty strings from trailing commas', () => {
     const protocolUrls = 'https://dx.doi.org/10.17504/protocols.io.btnfnmbn,';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
 
   it('should filter out empty strings from multiple consecutive commas', () => {
     const protocolUrls = 'https://dx.doi.org/10.17504/protocols.io.btnfnmbn,,https://github.com/user/repo';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: ['https://github.com/user/repo'],
     });
   });
 
   it('should filter out empty strings from leading and trailing commas', () => {
     const protocolUrls = ',https://dx.doi.org/10.17504/protocols.io.btnfnmbn,';
-    const lastVersion = 1;
-    const result = getResult(protocolUrls, lastVersion);
+    const result = getResult(protocolUrls);
     expect(result).toEqual({
-      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+      protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
       gitHub: [],
     });
   });
@@ -138,8 +126,7 @@ describe('useFormattedProtocolUrls', () => {
   describe('GitHub link detection', () => {
     it('should detect a GitHub URL', () => {
       const protocolUrls = 'https://github.com/user/repo';
-      const lastVersion = 1;
-      const result = getResult(protocolUrls, lastVersion);
+      const result = getResult(protocolUrls);
       expect(result).toEqual({
         protocols: [],
         gitHub: ['https://github.com/user/repo'],
@@ -148,8 +135,7 @@ describe('useFormattedProtocolUrls', () => {
 
     it('should detect a GitHub URL with case-insensitive matching', () => {
       const protocolUrls = 'https://GitHub.com/user/repo';
-      const lastVersion = 1;
-      const result = getResult(protocolUrls, lastVersion);
+      const result = getResult(protocolUrls);
       expect(result).toEqual({
         protocols: [],
         gitHub: ['https://GitHub.com/user/repo'],
@@ -158,8 +144,7 @@ describe('useFormattedProtocolUrls', () => {
 
     it('should detect a GitHub URL without protocol', () => {
       const protocolUrls = 'github.com/user/repo/blob/main/README.md';
-      const lastVersion = 1;
-      const result = getResult(protocolUrls, lastVersion);
+      const result = getResult(protocolUrls);
       expect(result).toEqual({
         protocols: [],
         gitHub: ['github.com/user/repo/blob/main/README.md'],
@@ -168,8 +153,7 @@ describe('useFormattedProtocolUrls', () => {
 
     it('should detect a GitHub URL with http protocol', () => {
       const protocolUrls = 'http://github.com/hubmapconsortium/portal-ui';
-      const lastVersion = 1;
-      const result = getResult(protocolUrls, lastVersion);
+      const result = getResult(protocolUrls);
       expect(result).toEqual({
         protocols: [],
         gitHub: ['http://github.com/hubmapconsortium/portal-ui'],
@@ -178,8 +162,7 @@ describe('useFormattedProtocolUrls', () => {
 
     it('should handle multiple GitHub URLs separated by commas', () => {
       const protocolUrls = 'https://github.com/user/repo1, https://github.com/user/repo2';
-      const lastVersion = 1;
-      const result = getResult(protocolUrls, lastVersion);
+      const result = getResult(protocolUrls);
       expect(result).toEqual({
         protocols: [],
         gitHub: ['https://github.com/user/repo1', 'https://github.com/user/repo2'],
@@ -188,10 +171,9 @@ describe('useFormattedProtocolUrls', () => {
 
     it('should handle mixed GitHub and protocol URLs', () => {
       const protocolUrls = 'https://dx.doi.org/10.17504/protocols.io.btnfnmbn, https://github.com/user/repo';
-      const lastVersion = 1;
-      const result = getResult(protocolUrls, lastVersion);
+      const result = getResult(protocolUrls);
       expect(result).toEqual({
-        protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1'],
+        protocols: ['https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn'],
         gitHub: ['https://github.com/user/repo'],
       });
     });
@@ -199,12 +181,11 @@ describe('useFormattedProtocolUrls', () => {
     it('should handle GitHub URLs interspersed with protocol URLs', () => {
       const protocolUrls =
         'https://github.com/user/repo1, https://dx.doi.org/10.17504/protocols.io.btnfnmbn, https://github.com/user/repo2, dx.doi.org/10.17504/protocols.io.7d5h6en/v1';
-      const lastVersion = 1;
-      const result = getResult(protocolUrls, lastVersion);
+      const result = getResult(protocolUrls);
       expect(result).toEqual({
         protocols: [
-          'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1',
-          'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en?last_version=1',
+          'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn',
+          'https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.7d5h6en',
         ],
         gitHub: ['https://github.com/user/repo1', 'https://github.com/user/repo2'],
       });

--- a/context/app/static/js/hooks/useProtocolData.ts
+++ b/context/app/static/js/hooks/useProtocolData.ts
@@ -73,9 +73,6 @@ export function useFormattedProtocolUrls(protocolUrls: string): FormattedProtoco
         // Strip `dx.doi.org/` from the beginning of the URL if it exists
         // dx.doi.org/10.17504/protocols.io.btnfnmbn -> 10.17504/protocols.io.btnfnmbn
         processedUrl = processedUrl.replace(/^dx\.doi\.org\//i, '');
-        // Strip version number from end of the URL if it exists
-        // 10.17504/protocols.io.btnfnmbn/v1 -> 10.17504/protocols.io.btnfnmbn
-        processedUrl = processedUrl.replace(/\/v\d+$/, '');
         // Format into the API call URL
         // 10.17504/protocols.io.btnfnmbn -> https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn
         links.protocols.push(`https://www.protocols.io/api/v4/protocols/${processedUrl}`);

--- a/context/app/static/js/hooks/useProtocolData.ts
+++ b/context/app/static/js/hooks/useProtocolData.ts
@@ -41,13 +41,12 @@ export function isGithubUrl(url: string): boolean {
  * Occasionally (e.g. for Object x Analyte datasets), there may be a GitHub link instead of a Protocols.io link.
  *
  * @param protocolUrls the protocol URL(s) string from the entity metadata
- * @param lastVersion the last version number to request from the Protocols.io API
  * @returns {
  *  protocols: string[] - array of formatted protocol URLs for API requests
  *  gitHub: string[] - array of GitHub links found in the input URLs
  * }
  */
-export function useFormattedProtocolUrls(protocolUrls: string, lastVersion: number): FormattedProtocolUrls {
+export function useFormattedProtocolUrls(protocolUrls: string): FormattedProtocolUrls {
   return useMemo(() => {
     const links: FormattedProtocolUrls = { gitHub: [], protocols: [] };
     if (protocolUrls.length === 0) {
@@ -78,13 +77,13 @@ export function useFormattedProtocolUrls(protocolUrls: string, lastVersion: numb
         // 10.17504/protocols.io.btnfnmbn/v1 -> 10.17504/protocols.io.btnfnmbn
         processedUrl = processedUrl.replace(/\/v\d+$/, '');
         // Format into the API call URL
-        // 10.17504/protocols.io.btnfnmbn -> https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn?last_version=1
-        links.protocols.push(`https://www.protocols.io/api/v4/protocols/${processedUrl}?last_version=${lastVersion}`);
+        // 10.17504/protocols.io.btnfnmbn -> https://www.protocols.io/api/v4/protocols/10.17504/protocols.io.btnfnmbn
+        links.protocols.push(`https://www.protocols.io/api/v4/protocols/${processedUrl}`);
       }
     });
 
     return links;
-  }, [protocolUrls, lastVersion]);
+  }, [protocolUrls]);
 }
 
 interface ProtocolData {


### PR DESCRIPTION
## Summary

This PR removes the `last_version=1` parameter from our protocols.io URL requests. This parameter was historically present since before I joined the team, but it was misleading to users since it's more accurate to present the actual protocol a sample/donor was processed with, rather than the latest version of it.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1553

## Testing

Protocol URL formatting specs have been updated to no longer expect `last_version` parameter.

Sample to test with: /browse/sample/3ad9fa2f2b1254116bfe4e2747843a30

## Screenshots/Video

<img width="1342" height="202" alt="image" src="https://github.com/user-attachments/assets/7d8427ab-91df-48e8-b781-3c6e078e9246" />

Leads to https://www.protocols.io/view/631-1-hubmap-lung-tissue-microarray-protocol-seatt-yxmvmmd46v3p/v1

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
