### PR TITLE
NickAkhmetov/CAT-1565 / CAT-1176 Enable searching for superseded entities in search

### DIFF
--- a/CHANGELOG-find-superseded-by-hubmap-id.md
+++ b/CHANGELOG-find-superseded-by-hubmap-id.md
@@ -1,2 +1,3 @@
 - Search by HuBMAP ID (top search bar or HuBMAP ID column-header popover) now surfaces entities that have been superseded by a newer revision, with a "Superseded" badge on the result so users know what they're clicking. Other search modes continue to hide superseded entities by default.
+- Add an "Include superseded entities" checkbox to the facets sidebar (after the Status section) so users can opt to include superseded entities in any search. When active, an "Including superseded entities" chip appears alongside the other filter chips.
 - Scope the top search bar's query to the `all_text` field; the HuBMAP ID column popover continues to query the `hubmap_id` field directly.

--- a/CHANGELOG-find-superseded-by-hubmap-id.md
+++ b/CHANGELOG-find-superseded-by-hubmap-id.md
@@ -1,0 +1,2 @@
+- Search by HuBMAP ID (top search bar or HuBMAP ID column-header popover) now surfaces entities that have been superseded by a newer revision, with a "Superseded" badge on the result so users know what they're clicking. Other search modes continue to hide superseded entities by default.
+- Scope the top search bar's query to the `all_text` field; the HuBMAP ID column popover continues to query the `hubmap_id` field directly.

--- a/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 
-import Chip from '@mui/material/Chip';
+import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Tile from 'js/shared-styles/tiles/Tile';
 import EntityTileThumbnail from 'js/components/entity-tile/EntityTileThumbnail';
 import { getOriginSamplesOrgan } from 'js/helpers/functions';
 import { EntityWithType, isDataset, isDonor, isSample } from 'js/components/types';
 import DonorAgeTooltip from 'js/shared-styles/tooltips/DonorAgeTooltip';
-import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import {
+  HuBMAPIdLabel,
+  RetractedChip,
+  ViewLatestVersionChip,
+  getHuBMAPIdDisplayInfo,
+} from 'js/components/search/Results/CellContent';
 import { Flex, StyledDiv, BodyWrapper } from './style';
 
 const thumbnailDimension = 80;
@@ -20,17 +25,21 @@ interface EntityTileBodyProps {
 }
 
 function EntityTileBody({ entity_type, id, entityData, invertColors }: EntityTileBodyProps) {
-  const isSuperseded = Boolean(entityData.next_revision_uuid);
+  const { isSuperseded, isRetracted, latestRevisionUrl } = getHuBMAPIdDisplayInfo(entityData);
+  const isStale = isSuperseded || isRetracted;
   return (
     <BodyWrapper $thumbnailDimension={thumbnailDimension}>
       <StyledDiv>
-        <Stack direction="row" gap={0.5} alignItems="center">
-          <Tile.Title>{id}</Tile.Title>
-          {isSuperseded && (
-            <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Use /browse/latest to navigate to it.">
-              <Chip label="Superseded" size="small" color="warning" variant="outlined" data-testid="superseded-chip" />
-            </SecondaryBackgroundTooltip>
+        <Stack direction="column" gap={0.5} alignItems="flex-start">
+          <Tile.Title>
+            <Box component="span" sx={isStale ? { color: 'warning.main' } : undefined}>
+              <HuBMAPIdLabel hubmapId={id} isSuperseded={isSuperseded} isRetracted={isRetracted} />
+            </Box>
+          </Tile.Title>
+          {isSuperseded && latestRevisionUrl && (
+            <ViewLatestVersionChip latestRevisionUrl={latestRevisionUrl} programmaticNavigation />
           )}
+          {isRetracted && !isSuperseded && <RetractedChip />}
         </Stack>
         {'origin_samples_unique_mapped_organs' in entityData && (isSample(entityData) || isDataset(entityData)) && (
           <Tile.Text>{getOriginSamplesOrgan(entityData)}</Tile.Text>

--- a/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
@@ -45,8 +45,8 @@ function EntityTileBody({ entity_type, id, entityData, invertColors }: EntityTil
           <Tile.Text>{getOriginSamplesOrgan(entityData)}</Tile.Text>
         )}
         {'sample_category' in entityData && isSample(entityData) && <Tile.Text>{entityData.sample_category}</Tile.Text>}
-        {'mapped_data_types' in entityData && isDataset(entityData) && (
-          <Tile.Text>{entityData.mapped_data_types.join(', ')}</Tile.Text>
+        {'assay_display_name' in entityData && isDataset(entityData) && (
+          <Tile.Text>{entityData.assay_display_name.join(', ')}</Tile.Text>
         )}
         {entity_type === 'Donor' && 'mapped_metadata' in entityData && isDonor(entityData) && (
           <>

--- a/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
@@ -36,9 +36,7 @@ function EntityTileBody({ entity_type, id, entityData, invertColors }: EntityTil
               <HuBMAPIdLabel hubmapId={id} isSuperseded={isSuperseded} isRetracted={isRetracted} />
             </Box>
           </Tile.Title>
-          {isSuperseded && latestRevisionUrl && (
-            <ViewLatestVersionChip latestRevisionUrl={latestRevisionUrl} programmaticNavigation />
-          )}
+          {isSuperseded && latestRevisionUrl && <ViewLatestVersionChip latestRevisionUrl={latestRevisionUrl} />}
           {isRetracted && !isSuperseded && <RetractedChip />}
         </Stack>
         {'origin_samples_unique_mapped_organs' in entityData && (isSample(entityData) || isDataset(entityData)) && (

--- a/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
+++ b/context/app/static/js/components/entity-tile/EntityTileBody/EntityTileBody.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
 import Tile from 'js/shared-styles/tiles/Tile';
 import EntityTileThumbnail from 'js/components/entity-tile/EntityTileThumbnail';
 import { getOriginSamplesOrgan } from 'js/helpers/functions';
 import { EntityWithType, isDataset, isDonor, isSample } from 'js/components/types';
 import DonorAgeTooltip from 'js/shared-styles/tooltips/DonorAgeTooltip';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { Flex, StyledDiv, BodyWrapper } from './style';
 
 const thumbnailDimension = 80;
@@ -17,10 +20,18 @@ interface EntityTileBodyProps {
 }
 
 function EntityTileBody({ entity_type, id, entityData, invertColors }: EntityTileBodyProps) {
+  const isSuperseded = Boolean(entityData.next_revision_uuid);
   return (
     <BodyWrapper $thumbnailDimension={thumbnailDimension}>
       <StyledDiv>
-        <Tile.Title>{id}</Tile.Title>
+        <Stack direction="row" gap={0.5} alignItems="center">
+          <Tile.Title>{id}</Tile.Title>
+          {isSuperseded && (
+            <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Use /browse/latest to navigate to it.">
+              <Chip label="Superseded" size="small" color="warning" variant="outlined" data-testid="superseded-chip" />
+            </SecondaryBackgroundTooltip>
+          )}
+        </Stack>
         {'origin_samples_unique_mapped_organs' in entityData && (isSample(entityData) || isDataset(entityData)) && (
           <Tile.Text>{getOriginSamplesOrgan(entityData)}</Tile.Text>
         )}

--- a/context/app/static/js/components/search/Facets/Facets.tsx
+++ b/context/app/static/js/components/search/Facets/Facets.tsx
@@ -21,6 +21,7 @@ import DateRangeFacet from './DateRangeFacet';
 import ExistsFacet from './ExistsFacet';
 import BooleanGroupFacet from './BooleanGroupFacet';
 import FacetSearchCombobox from './FacetSearchCombobox';
+import IncludeSupersededFacet from './IncludeSupersededFacet';
 import Divider from '@mui/material/Divider';
 
 export function Facets({ facetGroups }: { facetGroups: FacetGroups }) {
@@ -40,34 +41,31 @@ export function Facets({ facetGroups }: { facetGroups: FacetGroups }) {
           </Box>
           {Object.entries(facetGroups).map(([k, v], i) => (
             <FacetAccordion title={k} position="outer" key={k} isFirst={i === 0}>
-              {v.map((f) => {
+              {v.flatMap((f) => {
                 if ('visible' in f && !f.visible) {
-                  return null;
+                  return [];
                 }
+                const rendered: React.ReactNode[] = [];
                 if (isHierarchicalFacet(f)) {
-                  return <HierarchicalTermFacet {...f} key={f.field} />;
-                }
-                if (isRangeFacet(f)) {
-                  return <RangeFacet {...f} key={f.field} />;
-                }
-
-                if (isDateFacet(f)) {
-                  return <DateRangeFacet {...f} key={f.field} />;
-                }
-
-                if (isTermFacet(f)) {
-                  return <TermFacet {...f} key={f.field} />;
-                }
-
-                if (isExistsFacet(f)) {
-                  return <ExistsFacet {...f} key={f.field} />;
+                  rendered.push(<HierarchicalTermFacet {...f} key={f.field} />);
+                } else if (isRangeFacet(f)) {
+                  rendered.push(<RangeFacet {...f} key={f.field} />);
+                } else if (isDateFacet(f)) {
+                  rendered.push(<DateRangeFacet {...f} key={f.field} />);
+                } else if (isTermFacet(f)) {
+                  rendered.push(<TermFacet {...f} key={f.field} />);
+                } else if (isExistsFacet(f)) {
+                  rendered.push(<ExistsFacet {...f} key={f.field} />);
+                } else if (isBooleanGroupFacet(f)) {
+                  rendered.push(<BooleanGroupFacet {...f} key={f.field} />);
                 }
 
-                if (isBooleanGroupFacet(f)) {
-                  return <BooleanGroupFacet {...f} key={f.field} />;
+                // Inject the "Include superseded" toggle directly after the Status facet
+                if (f.field === 'mapped_status') {
+                  rendered.push(<IncludeSupersededFacet key="include-superseded" />);
                 }
 
-                return null;
+                return rendered;
               })}
             </FacetAccordion>
           ))}

--- a/context/app/static/js/components/search/Facets/FilterChips.tsx
+++ b/context/app/static/js/components/search/Facets/FilterChips.tsx
@@ -519,17 +519,28 @@ function SearchChip() {
   return <FilterChip label={label} onDelete={() => setSearch('')} />;
 }
 
+function IncludeSupersededChip() {
+  const includeSupersededEntities = useSearchStore((state) => state.includeSupersededEntities);
+  const setIncludeSupersededEntities = useSearchStore((state) => state.setIncludeSupersededEntities);
+
+  if (!includeSupersededEntities) return null;
+
+  return <FilterChip label="Including superseded entities" onDelete={() => setIncludeSupersededEntities(false)} />;
+}
+
 function FilterChips() {
   const filters = useSearchStore((state) => state.filters);
   const facets = useSearchStore((state) => state.facets);
   const search = useSearchStore((state) => state.search);
+  const includeSupersededEntities = useSearchStore((state) => state.includeSupersededEntities);
 
   const chipElements = useChipElements(filters, facets);
-  const hasActiveFilters = chipElements.length > 0 || Boolean(search);
+  const hasActiveFilters = chipElements.length > 0 || Boolean(search) || Boolean(includeSupersededEntities);
 
   const { containerRef, isExpanded, setIsExpanded, overflowCount } = useOverflowCount(hasActiveFilters, [
     filters,
     search,
+    includeSupersededEntities,
   ]);
 
   if (!hasActiveFilters) {
@@ -555,6 +566,7 @@ function FilterChips() {
         }}
       >
         <SearchChip />
+        <IncludeSupersededChip />
         {chipElements}
       </Box>
       <Stack direction="row" spacing={1} flexShrink={0} alignItems="flex-start">

--- a/context/app/static/js/components/search/Facets/FilterChips.tsx
+++ b/context/app/static/js/components/search/Facets/FilterChips.tsx
@@ -38,6 +38,7 @@ import {
   filterHasValues,
 } from '../store';
 import { useGetFieldLabel, useGetTransformedFieldValue } from '../fieldConfigurations';
+import { isHbmIdFormat, isUuidFormat } from '../utils';
 
 function FilterChip({ onDelete, label, ...props }: ChipProps & { onDelete: () => void }) {
   const analyticsCategory = useSearchStore((state) => state.analyticsCategory);
@@ -508,13 +509,21 @@ function SearchChip() {
 
   if (!search) return null;
 
-  // Treat as a HuBMAP ID only when it matches the wildcard-ID pattern (e.g. "*676*").
+  // Detect ID-style searches so the chip surfaces what the user is actually looking up.
   const isWildcardId = /^\*.*\*$/.test(search);
+  const isQuotedHbmId = /^"\s*HBM\S+\s*"$/i.test(search);
 
-  // For wildcard-ID queries, strip leading/trailing "*" for display; otherwise use the raw search text.
-  const displayValue = isWildcardId ? search.replace(/^\*|\*$/g, '') : search;
-
-  const label = isWildcardId ? `HuBMAP ID: ${displayValue}` : `Search: ${displayValue}`;
+  let label: string;
+  if (isWildcardId) {
+    // For wildcard-ID queries, strip leading/trailing "*" for display.
+    label = `HuBMAP ID: ${search.replace(/^\*|\*$/g, '')}`;
+  } else if (isHbmIdFormat(search) || isQuotedHbmId) {
+    label = `HuBMAP ID: ${search.replace(/^"|"$/g, '')}`;
+  } else if (isUuidFormat(search)) {
+    label = `UUID: ${search}`;
+  } else {
+    label = `Search: ${search}`;
+  }
 
   return <FilterChip label={label} onDelete={() => setSearch('')} />;
 }

--- a/context/app/static/js/components/search/Facets/IncludeSupersededFacet.tsx
+++ b/context/app/static/js/components/search/Facets/IncludeSupersededFacet.tsx
@@ -1,0 +1,51 @@
+import React, { useCallback } from 'react';
+
+import { trackEvent } from 'js/helpers/trackers';
+import { useSearchStore } from '../store';
+import { useSearch } from '../Search';
+import { StyledCheckBoxBlankIcon, StyledCheckBoxIcon, StyledCheckbox, StyledFormControlLabel } from './style';
+import FacetAccordion from './FacetAccordion';
+
+function IncludeSupersededFacet() {
+  const analyticsCategory = useSearchStore((state) => state.analyticsCategory);
+  const includeSupersededEntities = useSearchStore((state) => state.includeSupersededEntities);
+  const setIncludeSupersededEntities = useSearchStore((state) => state.setIncludeSupersededEntities);
+  const { isLoading } = useSearch();
+
+  const handleClick = useCallback(() => {
+    const next = !includeSupersededEntities;
+    setIncludeSupersededEntities(next);
+    trackEvent({
+      category: analyticsCategory,
+      action: `${next ? 'Select' : 'Unselect'} Facet`,
+      label: 'Include Superseded Entities',
+    });
+  }, [analyticsCategory, includeSupersededEntities, setIncludeSupersededEntities]);
+
+  // Hide until other facets have loaded their aggregations, for visual consistency
+  // with the rest of the sidebar.
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <FacetAccordion title="Superseded" position="inner">
+      <StyledFormControlLabel
+        control={
+          <StyledCheckbox
+            checked={includeSupersededEntities}
+            name="include-superseded-checkbox"
+            color="primary"
+            icon={<StyledCheckBoxBlankIcon />}
+            checkedIcon={<StyledCheckBoxIcon />}
+            onChange={handleClick}
+            data-testid="include-superseded-checkbox"
+          />
+        }
+        label="Include superseded entities"
+      />
+    </FacetAccordion>
+  );
+}
+
+export default IncludeSupersededFacet;

--- a/context/app/static/js/components/search/Results/CellContent.tsx
+++ b/context/app/static/js/components/search/Results/CellContent.tsx
@@ -62,15 +62,9 @@ export function HuBMAPIdLabel({
 
 interface ViewLatestChipProps {
   latestRevisionUrl: string;
-  /**
-   * Navigate via onClick (with stopPropagation) instead of an `<a>` element.
-   * Required inside ancestors that are already `<a>` tags (e.g. tiles), since
-   * nested anchors are invalid HTML.
-   */
-  programmaticNavigation?: boolean;
 }
 
-export function ViewLatestVersionChip({ latestRevisionUrl, programmaticNavigation }: ViewLatestChipProps) {
+export function ViewLatestVersionChip({ latestRevisionUrl }: ViewLatestChipProps) {
   return (
     <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Click to navigate to it.">
       <Chip
@@ -82,15 +76,8 @@ export function ViewLatestVersionChip({ latestRevisionUrl, programmaticNavigatio
         icon={<ArrowRight />}
         clickable
         sx={{ flexDirection: 'row-reverse', pr: 1, '.MuiChip-label': { paddingRight: 0 } }}
-        {...(programmaticNavigation
-          ? {
-              onClick: (e: React.MouseEvent) => {
-                e.preventDefault();
-                e.stopPropagation();
-                window.location.href = latestRevisionUrl;
-              },
-            }
-          : { component: 'a' as const, href: latestRevisionUrl })}
+        href={latestRevisionUrl}
+        component="a"
       />
     </SecondaryBackgroundTooltip>
   );

--- a/context/app/static/js/components/search/Results/CellContent.tsx
+++ b/context/app/static/js/components/search/Results/CellContent.tsx
@@ -142,6 +142,9 @@ export function CellContent({
   isRetracted,
   latestRevisionUrl,
 }: CellContentProps) {
+  if (!fieldValue) {
+    return null;
+  }
   switch (field.split('.').pop()) {
     case 'hubmap_id':
       return (
@@ -156,10 +159,6 @@ export function CellContent({
     case 'last_modified_timestamp':
     case 'published_timestamp':
     case 'created_timestamp':
-      // Handle datasets without published timestamps.
-      if (!fieldValue) {
-        return null;
-      }
       return <>{format(fieldValue, 'yyyy-MM-dd')}</>;
     case 'age':
       return <DonorAgeTooltip donorAge={fieldValue}>{fieldValue}</DonorAgeTooltip>;

--- a/context/app/static/js/components/search/Results/CellContent.tsx
+++ b/context/app/static/js/components/search/Results/CellContent.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
+import WarningRounded from '@mui/icons-material/WarningRounded';
+import ArrowRight from '@mui/icons-material/ChevronRightRounded';
+import { format } from 'date-fns/format';
+
+import { InternalLink } from 'js/shared-styles/Links';
+import { VitessceIcon } from 'js/shared-styles/icons';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import DonorAgeTooltip from 'js/shared-styles/tooltips/DonorAgeTooltip';
+import { Entity } from 'js/components/types';
+
+export interface HuBMAPIdDisplayInfo {
+  hasVisualization?: boolean;
+  isSuperseded?: boolean;
+  isRetracted?: boolean;
+  latestRevisionUrl?: string;
+}
+
+/**
+ * Derives display-time flags from an entity source. Centralized so result tables
+ * and tiles render identical state for the same entity.
+ */
+export function getHuBMAPIdDisplayInfo(source: Partial<Entity>): HuBMAPIdDisplayInfo {
+  const nextRevisionUuid = typeof source.next_revision_uuid === 'string' ? source.next_revision_uuid : undefined;
+  const isSuperseded = Boolean(nextRevisionUuid);
+  const isRetracted = Boolean(source.sub_status);
+  const hasVisualization = Boolean(source.visualization);
+  const latestRevisionUrl =
+    nextRevisionUuid && source.entity_type
+      ? `/browse/${source.entity_type.toLowerCase()}/${nextRevisionUuid}`
+      : undefined;
+  return { isSuperseded, isRetracted, hasVisualization, latestRevisionUrl };
+}
+
+/**
+ * Renders the HuBMAP ID text, prefixing a warning icon and tooltip when the
+ * entity is superseded or retracted. Stays presentation-only so callers can
+ * wrap it in whatever link/title element fits their context.
+ */
+export function HuBMAPIdLabel({
+  hubmapId,
+  isSuperseded,
+  isRetracted,
+}: { hubmapId: string } & Pick<HuBMAPIdDisplayInfo, 'isSuperseded' | 'isRetracted'>) {
+  const isStale = isSuperseded || isRetracted;
+  if (!isStale) {
+    return <>{hubmapId}</>;
+  }
+  return (
+    <SecondaryBackgroundTooltip
+      title={isSuperseded ? 'A newer revision of this entity exists.' : 'This entity has been retracted.'}
+    >
+      <Stack direction="row" gap={0.5} alignItems="center" component="span">
+        <WarningRounded fontSize="small" />
+        {hubmapId}
+      </Stack>
+    </SecondaryBackgroundTooltip>
+  );
+}
+
+interface ViewLatestChipProps {
+  latestRevisionUrl: string;
+  /**
+   * Navigate via onClick (with stopPropagation) instead of an `<a>` element.
+   * Required inside ancestors that are already `<a>` tags (e.g. tiles), since
+   * nested anchors are invalid HTML.
+   */
+  programmaticNavigation?: boolean;
+}
+
+export function ViewLatestVersionChip({ latestRevisionUrl, programmaticNavigation }: ViewLatestChipProps) {
+  return (
+    <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Click to navigate to it.">
+      <Chip
+        label="View Latest Version"
+        size="small"
+        color="success"
+        variant="outlined"
+        data-testid="superseded-chip"
+        icon={<ArrowRight />}
+        clickable
+        sx={{ flexDirection: 'row-reverse', pr: 1, '.MuiChip-label': { paddingRight: 0 } }}
+        {...(programmaticNavigation
+          ? {
+              onClick: (e: React.MouseEvent) => {
+                e.preventDefault();
+                e.stopPropagation();
+                window.location.href = latestRevisionUrl;
+              },
+            }
+          : { component: 'a' as const, href: latestRevisionUrl })}
+      />
+    </SecondaryBackgroundTooltip>
+  );
+}
+
+export function RetractedChip() {
+  return (
+    <SecondaryBackgroundTooltip title="This entity has been retracted.">
+      <Chip label="Retracted" size="small" color="warning" variant="outlined" data-testid="retracted-chip" />
+    </SecondaryBackgroundTooltip>
+  );
+}
+
+interface HuBMAPIDCellContentProps extends HuBMAPIdDisplayInfo {
+  hubmapId: string;
+}
+
+/**
+ * Full HuBMAP ID rendering for the search results table cell: a link to the
+ * entity detail page, an optional Vitessce icon, and superseded/retracted chips.
+ */
+export function HuBMAPIDCellContent({
+  hubmapId,
+  hasVisualization,
+  isSuperseded,
+  isRetracted,
+  latestRevisionUrl,
+}: HuBMAPIDCellContentProps) {
+  const isStale = isSuperseded || isRetracted;
+  return (
+    <Stack direction="column" gap={0.5} alignItems="flex-start">
+      <Stack direction="row" gap={0.5} alignItems="center">
+        <InternalLink
+          href={`/browse/${hubmapId}`}
+          data-testid="hubmap-id-link"
+          sx={isStale ? { color: 'warning.main' } : undefined}
+        >
+          <HuBMAPIdLabel hubmapId={hubmapId} isSuperseded={isSuperseded} isRetracted={isRetracted} />
+        </InternalLink>
+        {hasVisualization && (
+          <SecondaryBackgroundTooltip title="This dataset has a Vitessce visualization available.">
+            <VitessceIcon display="inline-block" color="primary" />
+          </SecondaryBackgroundTooltip>
+        )}
+      </Stack>
+      {isSuperseded && latestRevisionUrl && <ViewLatestVersionChip latestRevisionUrl={latestRevisionUrl} />}
+      {isRetracted && !isSuperseded && <RetractedChip />}
+    </Stack>
+  );
+}
+
+interface CellContentProps extends HuBMAPIdDisplayInfo {
+  field: string;
+  fieldValue: string;
+}
+
+export function CellContent({
+  field,
+  fieldValue,
+  hasVisualization,
+  isSuperseded,
+  isRetracted,
+  latestRevisionUrl,
+}: CellContentProps) {
+  switch (field.split('.').pop()) {
+    case 'hubmap_id':
+      return (
+        <HuBMAPIDCellContent
+          hubmapId={fieldValue}
+          hasVisualization={hasVisualization}
+          isSuperseded={isSuperseded}
+          isRetracted={isRetracted}
+          latestRevisionUrl={latestRevisionUrl}
+        />
+      );
+    case 'last_modified_timestamp':
+    case 'published_timestamp':
+    case 'created_timestamp':
+      // Handle datasets without published timestamps.
+      if (!fieldValue) {
+        return null;
+      }
+      return <>{format(fieldValue, 'yyyy-MM-dd')}</>;
+    case 'age':
+      return <DonorAgeTooltip donorAge={fieldValue}>{fieldValue}</DonorAgeTooltip>;
+    default:
+      return <>{fieldValue}</>;
+  }
+}

--- a/context/app/static/js/components/search/Results/ResultsTable.tsx
+++ b/context/app/static/js/components/search/Results/ResultsTable.tsx
@@ -5,17 +5,13 @@ import TableRow from '@mui/material/TableRow';
 import TableHead from '@mui/material/TableHead';
 import Skeleton from '@mui/material/Skeleton';
 import Box from '@mui/material/Box';
-import Chip from '@mui/material/Chip';
+import Stack from '@mui/material/Stack';
 import DOMPurify from 'isomorphic-dompurify';
 import parse from 'html-react-parser';
-import { format } from 'date-fns/format';
 
-import { InternalLink } from 'js/shared-styles/Links';
 import { Entity } from 'js/components/types';
 import SelectableHeaderCell from 'js/shared-styles/tables/SelectableHeaderCell';
 import SelectableRowCell from 'js/shared-styles/tables/SelectableRowCell';
-import DonorAgeTooltip from 'js/shared-styles/tooltips/DonorAgeTooltip';
-import { VitessceIcon } from 'js/shared-styles/icons';
 import { useSelectableTableStore } from 'js/shared-styles/tables/SelectableTableProvider';
 import NumSelectedHeader from 'js/shared-styles/tables/NumSelectedHeader';
 import { useAllSearchIDs } from 'js/hooks/useSearchData';
@@ -25,122 +21,13 @@ import { useSearch } from '../Search';
 import { useSearchStore } from '../store';
 import { useGetFieldLabel } from '../fieldConfigurations';
 import ViewMoreResults from './ViewMoreResults';
-import Stack from '@mui/material/Stack';
 import { buildQuery, isDevSearch } from '../utils';
 import useESmapping from '../useEsMapping';
 import SearchTableHeaderCell from './SearchTableHeaderCell';
 import TableHeaderActions from './TableHeaderActions';
 import FilterChips from '../Facets/FilterChips';
 import TopSearchBar from '../TopSearchBar';
-import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
-import ArrowRight from '@mui/icons-material/ChevronRightRounded';
-import WarningRounded from '@mui/icons-material/WarningRounded';
-
-interface CellContentProps {
-  field: string;
-  fieldValue: string;
-  hasVisualization?: boolean;
-  isSuperseded?: boolean;
-  isRetracted?: boolean;
-  latestRevisionUrl?: string;
-}
-
-function HuBMAPIDCellContent({
-  fieldValue,
-  hasVisualization,
-  isSuperseded,
-  isRetracted,
-  latestRevisionUrl,
-}: Omit<CellContentProps, 'field'>) {
-  const isStale = isSuperseded || isRetracted;
-  return (
-    <Stack direction="column" gap={0.5} alignItems="flex-start">
-      <Stack direction="row" gap={0.5} alignItems="center">
-        <InternalLink
-          href={`/browse/${fieldValue}`}
-          data-testid="hubmap-id-link"
-          sx={isStale ? { color: 'warning.main' } : undefined}
-        >
-          <Stack direction="row" gap={0.5} alignItems="center">
-            {isStale ? (
-              <SecondaryBackgroundTooltip
-                title={isSuperseded ? 'A newer revision of this entity exists.' : 'This entity has been retracted.'}
-              >
-                <Stack direction="row" gap={0.5} alignItems="center">
-                  <WarningRounded fontSize="small" />
-                  {fieldValue}
-                </Stack>
-              </SecondaryBackgroundTooltip>
-            ) : (
-              fieldValue
-            )}
-          </Stack>
-        </InternalLink>
-        {hasVisualization && (
-          <SecondaryBackgroundTooltip title="This dataset has a Vitessce visualization available.">
-            <VitessceIcon display="inline-block" color="primary" />
-          </SecondaryBackgroundTooltip>
-        )}
-      </Stack>
-      {isSuperseded && latestRevisionUrl && (
-        <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Click to navigate to it.">
-          <Chip
-            label="View Latest Version"
-            size="small"
-            color="success"
-            variant="outlined"
-            component="a"
-            href={latestRevisionUrl}
-            clickable
-            data-testid="superseded-chip"
-            icon={<ArrowRight />}
-            sx={{ flexDirection: 'row-reverse', pr: 1, '.MuiChip-label': { paddingRight: 0 } }}
-          />
-        </SecondaryBackgroundTooltip>
-      )}
-      {isRetracted && !isSuperseded && (
-        <SecondaryBackgroundTooltip title="This entity has been retracted.">
-          <Chip label="Retracted" size="small" color="warning" variant="outlined" data-testid="retracted-chip" />
-        </SecondaryBackgroundTooltip>
-      )}
-    </Stack>
-  );
-}
-
-function CellContent({
-  field,
-  fieldValue,
-  hasVisualization,
-  isSuperseded,
-  isRetracted,
-  latestRevisionUrl,
-}: CellContentProps) {
-  switch (field.split('.').pop()) {
-    case 'hubmap_id': {
-      return (
-        <HuBMAPIDCellContent
-          fieldValue={fieldValue}
-          hasVisualization={hasVisualization}
-          isSuperseded={isSuperseded}
-          isRetracted={isRetracted}
-          latestRevisionUrl={latestRevisionUrl}
-        />
-      );
-    }
-    case 'last_modified_timestamp':
-    case 'published_timestamp':
-    case 'created_timestamp':
-      // Handle datasets without published timestamps.
-      if (!fieldValue) {
-        return null;
-      }
-      return format(fieldValue, 'yyyy-MM-dd');
-    case 'age':
-      return <DonorAgeTooltip donorAge={fieldValue}>{fieldValue}</DonorAgeTooltip>;
-    default:
-      return fieldValue;
-  }
-}
+import { CellContent, getHuBMAPIdDisplayInfo } from './CellContent';
 
 function ResultCell({ hit, field }: { field: string; hit: SearchHit<Partial<Entity>> }) {
   const source = hit?._source;
@@ -151,24 +38,11 @@ function ResultCell({ hit, field }: { field: string; hit: SearchHit<Partial<Enti
 
   const fieldValue = getByPath(source, field);
   const isHubmapIdField = field.split('.').pop() === 'hubmap_id';
-  const hasVisualization = isHubmapIdField ? Boolean(source.visualization) : undefined;
-  const isSuperseded = isHubmapIdField ? Boolean(source.next_revision_uuid) : undefined;
-  const isRetracted = isHubmapIdField ? Boolean(source.sub_status) : undefined;
-  const latestRevisionUrl =
-    isHubmapIdField && isSuperseded && source.entity_type && source.uuid
-      ? `/browse/${source.entity_type.toLowerCase()}/${source.uuid}`
-      : undefined;
+  const displayInfo = isHubmapIdField ? getHuBMAPIdDisplayInfo(source) : {};
 
   return (
     <StyledTableCell key={field}>
-      <CellContent
-        field={field}
-        fieldValue={fieldValue}
-        hasVisualization={hasVisualization}
-        isSuperseded={isSuperseded}
-        isRetracted={isRetracted}
-        latestRevisionUrl={latestRevisionUrl}
-      />
+      <CellContent field={field} fieldValue={fieldValue} {...displayInfo} />
     </StyledTableCell>
   );
 }

--- a/context/app/static/js/components/search/Results/ResultsTable.tsx
+++ b/context/app/static/js/components/search/Results/ResultsTable.tsx
@@ -62,14 +62,18 @@ function HuBMAPIDCellContent({
           sx={isStale ? { color: 'warning.main' } : undefined}
         >
           <Stack direction="row" gap={0.5} alignItems="center">
-            {isStale && (
+            {isStale ? (
               <SecondaryBackgroundTooltip
                 title={isSuperseded ? 'A newer revision of this entity exists.' : 'This entity has been retracted.'}
               >
-                <WarningRounded fontSize="small" />
+                <Stack direction="row" gap={0.5} alignItems="center">
+                  <WarningRounded fontSize="small" />
+                  {fieldValue}
+                </Stack>
               </SecondaryBackgroundTooltip>
+            ) : (
+              fieldValue
             )}
-            {fieldValue}
           </Stack>
         </InternalLink>
         {hasVisualization && (

--- a/context/app/static/js/components/search/Results/ResultsTable.tsx
+++ b/context/app/static/js/components/search/Results/ResultsTable.tsx
@@ -5,6 +5,7 @@ import TableRow from '@mui/material/TableRow';
 import TableHead from '@mui/material/TableHead';
 import Skeleton from '@mui/material/Skeleton';
 import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 import DOMPurify from 'isomorphic-dompurify';
 import parse from 'html-react-parser';
 import { format } from 'date-fns/format';
@@ -37,10 +38,12 @@ function CellContent({
   field,
   fieldValue,
   hasVisualization,
+  isSuperseded,
 }: {
   field: string;
   fieldValue: string;
   hasVisualization?: boolean;
+  isSuperseded?: boolean;
 }) {
   switch (field.split('.').pop()) {
     case 'hubmap_id':
@@ -52,6 +55,11 @@ function CellContent({
           {hasVisualization && (
             <SecondaryBackgroundTooltip title="This dataset has a Vitessce visualization available.">
               <VitessceIcon display="inline-block" color="primary" />
+            </SecondaryBackgroundTooltip>
+          )}
+          {isSuperseded && (
+            <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Use /browse/latest to navigate to it.">
+              <Chip label="Superseded" size="small" color="warning" variant="outlined" data-testid="superseded-chip" />
             </SecondaryBackgroundTooltip>
           )}
         </Stack>
@@ -79,11 +87,18 @@ function ResultCell({ hit, field }: { field: string; hit: SearchHit<Partial<Enti
   }
 
   const fieldValue = getByPath(source, field);
-  const hasVisualization = field.split('.').pop() === 'hubmap_id' ? Boolean(source.visualization) : undefined;
+  const isHubmapIdField = field.split('.').pop() === 'hubmap_id';
+  const hasVisualization = isHubmapIdField ? Boolean(source.visualization) : undefined;
+  const isSuperseded = isHubmapIdField ? Boolean(source.next_revision_uuid) : undefined;
 
   return (
     <StyledTableCell key={field}>
-      <CellContent field={field} fieldValue={fieldValue} hasVisualization={hasVisualization} />
+      <CellContent
+        field={field}
+        fieldValue={fieldValue}
+        hasVisualization={hasVisualization}
+        isSuperseded={isSuperseded}
+      />
     </StyledTableCell>
   );
 }

--- a/context/app/static/js/components/search/Results/ResultsTable.tsx
+++ b/context/app/static/js/components/search/Results/ResultsTable.tsx
@@ -33,37 +33,96 @@ import TableHeaderActions from './TableHeaderActions';
 import FilterChips from '../Facets/FilterChips';
 import TopSearchBar from '../TopSearchBar';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
+import ArrowRight from '@mui/icons-material/ChevronRightRounded';
+import WarningRounded from '@mui/icons-material/WarningRounded';
+
+interface CellContentProps {
+  field: string;
+  fieldValue: string;
+  hasVisualization?: boolean;
+  isSuperseded?: boolean;
+  isRetracted?: boolean;
+  latestRevisionUrl?: string;
+}
+
+function HuBMAPIDCellContent({
+  fieldValue,
+  hasVisualization,
+  isSuperseded,
+  isRetracted,
+  latestRevisionUrl,
+}: Omit<CellContentProps, 'field'>) {
+  const isStale = isSuperseded || isRetracted;
+  return (
+    <Stack direction="column" gap={0.5} alignItems="flex-start">
+      <Stack direction="row" gap={0.5} alignItems="center">
+        <InternalLink
+          href={`/browse/${fieldValue}`}
+          data-testid="hubmap-id-link"
+          sx={isStale ? { color: 'warning.main' } : undefined}
+        >
+          <Stack direction="row" gap={0.5} alignItems="center">
+            {isStale && (
+              <SecondaryBackgroundTooltip
+                title={isSuperseded ? 'A newer revision of this entity exists.' : 'This entity has been retracted.'}
+              >
+                <WarningRounded fontSize="small" />
+              </SecondaryBackgroundTooltip>
+            )}
+            {fieldValue}
+          </Stack>
+        </InternalLink>
+        {hasVisualization && (
+          <SecondaryBackgroundTooltip title="This dataset has a Vitessce visualization available.">
+            <VitessceIcon display="inline-block" color="primary" />
+          </SecondaryBackgroundTooltip>
+        )}
+      </Stack>
+      {isSuperseded && latestRevisionUrl && (
+        <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Click to navigate to it.">
+          <Chip
+            label="View Latest Version"
+            size="small"
+            color="success"
+            variant="outlined"
+            component="a"
+            href={latestRevisionUrl}
+            clickable
+            data-testid="superseded-chip"
+            icon={<ArrowRight />}
+            sx={{ flexDirection: 'row-reverse', pr: 1, '.MuiChip-label': { paddingRight: 0 } }}
+          />
+        </SecondaryBackgroundTooltip>
+      )}
+      {isRetracted && !isSuperseded && (
+        <SecondaryBackgroundTooltip title="This entity has been retracted.">
+          <Chip label="Retracted" size="small" color="warning" variant="outlined" data-testid="retracted-chip" />
+        </SecondaryBackgroundTooltip>
+      )}
+    </Stack>
+  );
+}
 
 function CellContent({
   field,
   fieldValue,
   hasVisualization,
   isSuperseded,
-}: {
-  field: string;
-  fieldValue: string;
-  hasVisualization?: boolean;
-  isSuperseded?: boolean;
-}) {
+  isRetracted,
+  latestRevisionUrl,
+}: CellContentProps) {
   switch (field.split('.').pop()) {
-    case 'hubmap_id':
+    case 'hubmap_id': {
       return (
-        <Stack direction="row" gap={0.5} alignItems="center">
-          <InternalLink href={`/browse/${fieldValue}`} data-testid="hubmap-id-link">
-            {fieldValue}
-          </InternalLink>
-          {hasVisualization && (
-            <SecondaryBackgroundTooltip title="This dataset has a Vitessce visualization available.">
-              <VitessceIcon display="inline-block" color="primary" />
-            </SecondaryBackgroundTooltip>
-          )}
-          {isSuperseded && (
-            <SecondaryBackgroundTooltip title="A newer revision of this entity exists. Use /browse/latest to navigate to it.">
-              <Chip label="Superseded" size="small" color="warning" variant="outlined" data-testid="superseded-chip" />
-            </SecondaryBackgroundTooltip>
-          )}
-        </Stack>
+        <HuBMAPIDCellContent
+          fieldValue={fieldValue}
+          hasVisualization={hasVisualization}
+          isSuperseded={isSuperseded}
+          isRetracted={isRetracted}
+          latestRevisionUrl={latestRevisionUrl}
+        />
       );
+    }
     case 'last_modified_timestamp':
     case 'published_timestamp':
     case 'created_timestamp':
@@ -90,6 +149,11 @@ function ResultCell({ hit, field }: { field: string; hit: SearchHit<Partial<Enti
   const isHubmapIdField = field.split('.').pop() === 'hubmap_id';
   const hasVisualization = isHubmapIdField ? Boolean(source.visualization) : undefined;
   const isSuperseded = isHubmapIdField ? Boolean(source.next_revision_uuid) : undefined;
+  const isRetracted = isHubmapIdField ? Boolean(source.sub_status) : undefined;
+  const latestRevisionUrl =
+    isHubmapIdField && isSuperseded && source.entity_type && source.uuid
+      ? `/browse/${source.entity_type.toLowerCase()}/${source.uuid}`
+      : undefined;
 
   return (
     <StyledTableCell key={field}>
@@ -98,6 +162,8 @@ function ResultCell({ hit, field }: { field: string; hit: SearchHit<Partial<Enti
         fieldValue={fieldValue}
         hasVisualization={hasVisualization}
         isSuperseded={isSuperseded}
+        isRetracted={isRetracted}
+        latestRevisionUrl={latestRevisionUrl}
       />
     </StyledTableCell>
   );

--- a/context/app/static/js/components/search/SaySeePanel/SaySeePanel.tsx
+++ b/context/app/static/js/components/search/SaySeePanel/SaySeePanel.tsx
@@ -34,6 +34,17 @@ const API_BASE_URL = document.location.origin;
 const FETCH_OPTIONS: RequestInit = { credentials: 'include' };
 const NON_EXPANDED_HEIGHT = 700;
 
+const STYLES = {
+  height: '100%',
+  width: '100%',
+};
+
+const ENTITY_ICONS = {
+  datasets: DatasetIcon,
+  samples: SampleIcon,
+  donors: DonorIcon,
+};
+
 function visualizationSelector(store: VisualizationStore) {
   return {
     fullscreenVizId: store.fullscreenVizId,
@@ -48,7 +59,7 @@ function ChatFallback() {
 }
 
 function SaySeePanel() {
-  const { isAuthenticated, isHubmapUser, isWorkspacesUser } = useAppContext();
+  const { isHubmapUser, isWorkspacesUser } = useAppContext();
   const { fullscreenVizId, theme, expandViz, collapseViz } = useVisualizationStore(visualizationSelector);
   const isFullscreen = fullscreenVizId === SAY_SEE_VIZ_ID;
   const { savedPreferences: rawPrefs, isLoading: prefsLoading } = useSavedPreferences();
@@ -98,13 +109,9 @@ function SaySeePanel() {
                 apiBaseUrl={API_BASE_URL}
                 dataPackagePath={dataPackagePath}
                 fetchOptions={FETCH_OPTIONS}
-                requireApiKey={!isAuthenticated}
-                style={{ height: '100%', width: '100%' }}
-                entityIcons={{
-                  datasets: DatasetIcon,
-                  samples: SampleIcon,
-                  donors: DonorIcon,
-                }}
+                requireApiKey={!isHubmapUser}
+                style={STYLES}
+                entityIcons={ENTITY_ICONS}
                 mascot={<HuBMAPPerson style={{ width: 300, height: 'auto' }} />}
                 onEvent={onEvent}
                 downloadActions={downloadActions}

--- a/context/app/static/js/components/search/Search.tsx
+++ b/context/app/static/js/components/search/Search.tsx
@@ -82,6 +82,7 @@ export function useSearch() {
     sourceFields,
     sortField,
     defaultQuery,
+    latestRevisionFilter,
   }: SearchStoreState = useSearchStore();
 
   return useScrollSearchHits<Partial<Entity>, Aggregations>({
@@ -95,6 +96,7 @@ export function useSearch() {
     sourceFields,
     sortField,
     defaultQuery,
+    latestRevisionFilter,
   });
 }
 
@@ -148,6 +150,7 @@ type SearchConfig = Pick<
   | 'size'
   | 'type'
   | 'defaultQuery'
+  | 'latestRevisionFilter'
   | 'analyticsCategory'
 > & {
   facets: FacetGroups;

--- a/context/app/static/js/components/search/Search.tsx
+++ b/context/app/static/js/components/search/Search.tsx
@@ -465,7 +465,7 @@ function SearchWrapper({ config }: { config: Omit<SearchConfig, 'endpoint' | 'an
   const { elasticsearchEndpoint } = useAppContext();
   const { type, facets } = config;
 
-  const { search, sortField, filters, ...rest } = buildInitialSearchState({
+  const { search, sortField, filters, includeSupersededEntities, ...rest } = buildInitialSearchState({
     ...config,
     endpoint: elasticsearchEndpoint,
     analyticsCategory: `${type}s Search Page Interactions`,
@@ -478,7 +478,7 @@ function SearchWrapper({ config }: { config: Omit<SearchConfig, 'endpoint' | 'an
   }
 
   const initialState = {
-    ...merge({ search, sortField, filters }, initialUrlState, options),
+    ...merge({ search, sortField, filters, includeSupersededEntities }, initialUrlState, options),
     ...rest,
     initialFilters: filters,
   };

--- a/context/app/static/js/components/search/Search.tsx
+++ b/context/app/static/js/components/search/Search.tsx
@@ -83,6 +83,7 @@ export function useSearch() {
     sortField,
     defaultQuery,
     latestRevisionFilter,
+    includeSupersededEntities,
   }: SearchStoreState = useSearchStore();
 
   return useScrollSearchHits<Partial<Entity>, Aggregations>({
@@ -97,6 +98,7 @@ export function useSearch() {
     sortField,
     defaultQuery,
     latestRevisionFilter,
+    includeSupersededEntities,
   });
 }
 
@@ -159,6 +161,7 @@ type SearchConfig = Pick<
 function buildInitialSearchState({ facets, sourceFields, swrConfig = {}, ...rest }: SearchConfig) {
   return {
     search: '',
+    includeSupersededEntities: false,
     ...buildFacets({ facetGroups: facets }),
     swrConfig,
     sourceFields,

--- a/context/app/static/js/components/search/SearchBar.tsx
+++ b/context/app/static/js/components/search/SearchBar.tsx
@@ -21,16 +21,19 @@ function SearchBar({ type }: SearchTypeProps) {
     (e: React.FormEvent<HTMLFormElement>) => {
       e.preventDefault();
 
-      setSearch(/^\s*HBM\S+\s*$/i.exec(input) ? `"${input}"` : input);
+      // Trim incidental whitespace so HuBMAP-ID and UUID format detection in buildQuery
+      // can match the canonical formats exactly.
+      const trimmed = input.trim();
+      setSearch(trimmed);
 
       const action = 'Free Text Search';
 
-      if (input) {
-        trackSiteSearch(input, action);
+      if (trimmed) {
+        trackSiteSearch(trimmed, action);
         trackEvent({
           category: analyticsCategory,
           action,
-          label: input,
+          label: trimmed,
         });
       }
     },

--- a/context/app/static/js/components/search/store.ts
+++ b/context/app/static/js/components/search/store.ts
@@ -134,6 +134,7 @@ export interface SearchState<V> {
   initialFilters: FiltersType<V>;
   facets: FacetsType;
   defaultQuery?: esb.Query;
+  latestRevisionFilter?: esb.Query;
   search: string;
   searchFields: string[];
   sortField: SortField;

--- a/context/app/static/js/components/search/store.ts
+++ b/context/app/static/js/components/search/store.ts
@@ -209,6 +209,7 @@ const searchURLStateSchema = z
     search: z.string(),
     sortField: sortFieldSchema,
     filters: filtersSchema,
+    includeSupersededEntities: z.boolean(),
     scFindParams: z
       .object({
         genes: z.array(z.string()).optional(),
@@ -404,7 +405,7 @@ export function createDatasetSearchLink(values: Record<string, string[]>) {
 }
 
 function replaceURLSearchParams(state: SearchStoreState) {
-  const { search, sortField, filters } = state;
+  const { search, sortField, filters, includeSupersededEntities } = state;
 
   const readableParamValues: Record<string, string[]> = {};
   const remainingFilters: FiltersType = {};
@@ -423,11 +424,12 @@ function replaceURLSearchParams(state: SearchStoreState) {
     }
   }
 
-  const hasRemaining = search || Object.keys(remainingFilters).length > 0;
+  const hasRemaining = search || Object.keys(remainingFilters).length > 0 || includeSupersededEntities;
   const qValue = hasRemaining
     ? LZString.compressToEncodedURIComponent(
-        JSON.stringify({ search, sortField, filters: remainingFilters }, (_key, value: unknown) =>
-          value instanceof Set ? [...value] : value,
+        JSON.stringify(
+          { search, sortField, filters: remainingFilters, includeSupersededEntities },
+          (_key, value: unknown) => (value instanceof Set ? [...value] : value),
         ),
       )
     : null;
@@ -606,6 +608,7 @@ export const createStore = ({ initialState }: { initialState: SearchStoreState }
     setIncludeSupersededEntities: (value) => {
       set((state) => {
         state.includeSupersededEntities = value;
+        replaceURLSearchParams(state);
       });
     },
   }));

--- a/context/app/static/js/components/search/store.ts
+++ b/context/app/static/js/components/search/store.ts
@@ -135,6 +135,7 @@ export interface SearchState<V> {
   facets: FacetsType;
   defaultQuery?: esb.Query;
   latestRevisionFilter?: esb.Query;
+  includeSupersededEntities?: boolean;
   search: string;
   searchFields: string[];
   sortField: SortField;
@@ -259,6 +260,7 @@ export interface SearchStoreActions {
   filterDate: ({ field, min, max }: { field: string; min?: number; max?: number }) => void;
   filterExists: ({ field }: { field: string }) => void;
   filterBooleanGroupItem: ({ field, itemKey }: { field: string; itemKey: string }) => void;
+  setIncludeSupersededEntities: (value: boolean) => void;
 }
 
 export interface SearchStore extends SearchStoreState, SearchStoreActions {}
@@ -446,6 +448,7 @@ export const createStore = ({ initialState }: { initialState: SearchStoreState }
     ...initialState,
     resetFilters: () => {
       set((state) => {
+        state.includeSupersededEntities = false;
         state.filters = state.initialFilters;
         replaceURLSearchParams(state);
       });
@@ -598,6 +601,11 @@ export const createStore = ({ initialState }: { initialState: SearchStoreState }
           filter.values.add(itemKey);
         }
         replaceURLSearchParams(state);
+      });
+    },
+    setIncludeSupersededEntities: (value) => {
+      set((state) => {
+        state.includeSupersededEntities = value;
       });
     },
   }));

--- a/context/app/static/js/components/search/utils.spec.ts
+++ b/context/app/static/js/components/search/utils.spec.ts
@@ -1,0 +1,76 @@
+import esb from 'elastic-builder';
+import { buildQuery } from './utils';
+import { Mappings } from './useEsMapping';
+
+const mappings: Mappings = {
+  mappings: {
+    properties: {
+      uuid: { fields: { keyword: { type: 'keyword' } } },
+      hubmap_id: { fields: { keyword: { type: 'keyword' } } },
+      entity_type: { fields: { keyword: { type: 'keyword' } } },
+      all_text: { type: 'text' },
+      last_modified_timestamp: { type: 'date' },
+    },
+  },
+};
+
+const defaultQuery = esb.boolQuery().must([esb.termsQuery('entity_type.keyword', ['Dataset'])]);
+const latestRevisionFilter = esb
+  .boolQuery()
+  .mustNot([esb.existsQuery('next_revision_uuid'), esb.existsQuery('sub_status')]);
+
+function run(search: string) {
+  return buildQuery({
+    filters: {},
+    facets: {},
+    search,
+    size: 18,
+    searchFields: ['all_text'],
+    sourceFields: { table: ['hubmap_id'] },
+    sortField: { field: 'last_modified_timestamp', direction: 'desc' },
+    defaultQuery,
+    latestRevisionFilter,
+    mappings,
+    buildAggregations: false,
+  }) as { query: { bool: { must: unknown[] } } } | null;
+}
+
+function mustOf(result: ReturnType<typeof run>): string {
+  if (!result) throw new Error('buildQuery returned null');
+  return JSON.stringify(result.query.bool.must);
+}
+
+describe('buildQuery HuBMAP-ID lookup handling', () => {
+  test('free-text search keeps the latestRevisionFilter and targets all_text', () => {
+    const serialized = mustOf(run('kidney atlas'));
+
+    expect(serialized).toContain('next_revision_uuid');
+    expect(serialized).toContain('simple_query_string');
+    expect(serialized).toContain('all_text');
+    expect(serialized).toContain('kidney atlas');
+  });
+
+  test('wildcard HuBMAP-ID search drops the latestRevisionFilter and targets hubmap_id', () => {
+    const serialized = mustOf(run('*676*'));
+
+    expect(serialized).not.toContain('next_revision_uuid');
+    expect(serialized).toContain('wildcard');
+    expect(serialized).toContain('hubmap_id');
+    expect(serialized).toContain('*676*');
+  });
+
+  test('quoted HBM-ID search drops the latestRevisionFilter', () => {
+    const serialized = mustOf(run('"HBM123.ABCD.456"'));
+
+    expect(serialized).not.toContain('next_revision_uuid');
+    expect(serialized).toContain('simple_query_string');
+    expect(serialized).toContain('all_text');
+    expect(serialized).toContain('HBM123.ABCD.456');
+  });
+
+  test('empty search keeps the latestRevisionFilter', () => {
+    const serialized = mustOf(run(''));
+
+    expect(serialized).toContain('next_revision_uuid');
+  });
+});

--- a/context/app/static/js/components/search/utils.spec.ts
+++ b/context/app/static/js/components/search/utils.spec.ts
@@ -19,7 +19,7 @@ const latestRevisionFilter = esb
   .boolQuery()
   .mustNot([esb.existsQuery('next_revision_uuid'), esb.existsQuery('sub_status')]);
 
-function run(search: string) {
+function run(search: string, opts: { includeSupersededEntities?: boolean } = {}) {
   return buildQuery({
     filters: {},
     facets: {},
@@ -30,6 +30,7 @@ function run(search: string) {
     sortField: { field: 'last_modified_timestamp', direction: 'desc' },
     defaultQuery,
     latestRevisionFilter,
+    includeSupersededEntities: opts.includeSupersededEntities ?? false,
     mappings,
     buildAggregations: false,
   }) as { query: { bool: { must: unknown[] } } } | null;
@@ -72,5 +73,13 @@ describe('buildQuery HuBMAP-ID lookup handling', () => {
     const serialized = mustOf(run(''));
 
     expect(serialized).toContain('next_revision_uuid');
+  });
+
+  test('includeSupersededEntities=true drops the latestRevisionFilter for free-text search', () => {
+    const serialized = mustOf(run('kidney atlas', { includeSupersededEntities: true }));
+
+    expect(serialized).not.toContain('next_revision_uuid');
+    expect(serialized).toContain('simple_query_string');
+    expect(serialized).toContain('kidney atlas');
   });
 });

--- a/context/app/static/js/components/search/utils.spec.ts
+++ b/context/app/static/js/components/search/utils.spec.ts
@@ -82,4 +82,53 @@ describe('buildQuery HuBMAP-ID lookup handling', () => {
     expect(serialized).toContain('simple_query_string');
     expect(serialized).toContain('kidney atlas');
   });
+
+  test('HuBMAP-ID format search drops the latestRevisionFilter and uses term match on hubmap_id', () => {
+    const serialized = mustOf(run('HBM123.ABCD.456'));
+
+    expect(serialized).not.toContain('next_revision_uuid');
+    expect(serialized).not.toContain('simple_query_string');
+    expect(serialized).toContain('"term"');
+    expect(serialized).toContain('hubmap_id');
+    expect(serialized).toContain('HBM123.ABCD.456');
+  });
+
+  test('UUID format search drops the latestRevisionFilter and uses term match on uuid', () => {
+    const uuid = 'a'.repeat(32);
+    const serialized = mustOf(run(uuid));
+
+    expect(serialized).not.toContain('next_revision_uuid');
+    expect(serialized).not.toContain('simple_query_string');
+    expect(serialized).toContain('"term"');
+    expect(serialized).toContain('uuid');
+    expect(serialized).toContain(uuid);
+  });
+
+  test('non-canonical HBM-prefixed text remains a free-text search', () => {
+    const serialized = mustOf(run('HBM kidney datasets'));
+
+    expect(serialized).toContain('next_revision_uuid');
+    expect(serialized).toContain('simple_query_string');
+  });
+
+  test('lowercase HuBMAP-ID input is treated as an ID lookup and normalized to uppercase', () => {
+    const serialized = mustOf(run('hbm123.abcd.456'));
+
+    expect(serialized).not.toContain('next_revision_uuid');
+    expect(serialized).toContain('"term"');
+    expect(serialized).toContain('hubmap_id');
+    expect(serialized).toContain('HBM123.ABCD.456');
+    expect(serialized).not.toContain('hbm123.abcd.456');
+  });
+
+  test('uppercase UUID input is treated as an ID lookup and normalized to lowercase', () => {
+    const upper = 'A'.repeat(32);
+    const lower = 'a'.repeat(32);
+    const serialized = mustOf(run(upper));
+
+    expect(serialized).not.toContain('next_revision_uuid');
+    expect(serialized).toContain('"term"');
+    expect(serialized).toContain(lower);
+    expect(serialized).not.toContain(upper);
+  });
 });

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -72,11 +72,20 @@ export function buildQuery({
   sourceFields,
   sortField,
   defaultQuery,
+  latestRevisionFilter,
   mappings,
   buildAggregations = true,
 }: { buildAggregations?: boolean; mappings: UseESMappingType } & Pick<
   SearchStoreState,
-  'filters' | 'facets' | 'search' | 'size' | 'searchFields' | 'sourceFields' | 'sortField' | 'defaultQuery'
+  | 'filters'
+  | 'facets'
+  | 'search'
+  | 'size'
+  | 'searchFields'
+  | 'sourceFields'
+  | 'sortField'
+  | 'defaultQuery'
+  | 'latestRevisionFilter'
 >) {
   if (!isESMapping(mappings)) {
     return null;
@@ -89,16 +98,23 @@ export function buildQuery({
 
   const hasTextQuery = search.length > 0;
 
-  // Detect wildcard HuBMAP ID searches (e.g. "*676*") and use a wildcard query on hubmap_id
+  // Column-header HuBMAP ID popover wraps input as *...* (SearchTableHeaderCell.tsx);
+  // top search bar quotes exact HBM IDs (SearchBar.tsx). Either form is treated as an
+  // entity-id lookup: it bypasses the "latest revision only" filter so superseded
+  // entities can still be found by their HuBMAP ID.
   const isWildcardIdSearch = hasTextQuery && /^\*.*\*$/.test(search);
+  const isQuotedHbmIdSearch = hasTextQuery && /^"\s*HBM\S+\s*"$/i.test(search);
+  const isIdLookupSearch = isWildcardIdSearch || isQuotedHbmIdSearch;
+
   const freeTextQueries = hasTextQuery
     ? isWildcardIdSearch
       ? [esb.wildcardQuery(getESField({ field: 'hubmap_id', mappings }), search)]
       : [esb.simpleQueryStringQuery(search).fields(searchFields)]
     : [];
   const defaultQueries = defaultQuery ? [defaultQuery] : [];
+  const revisionFilterQueries = latestRevisionFilter && !isIdLookupSearch ? [latestRevisionFilter] : [];
 
-  query.query(esb.boolQuery().must([...defaultQueries, ...freeTextQueries]));
+  query.query(esb.boolQuery().must([...defaultQueries, ...revisionFilterQueries, ...freeTextQueries]));
 
   if (hasTextQuery && !isWildcardIdSearch) {
     query.highlight(esb.highlight(searchFields));

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -25,6 +25,21 @@ const maxAggSize = 10000;
 
 type FilterClauses = Record<string, esb.Query>;
 
+// Canonical HuBMAP ID format, e.g. "HBM123.ABCD.456" — three dot-separated parts,
+// with exactly 3 digits in each numeric segment.
+const HBM_ID_FORMAT_REGEX = /^HBM\d{3}\.[A-Z0-9]+\.\d{3}$/i;
+
+// HuBMAP UUIDs are exactly 32 hex characters with no dashes.
+const UUID_FORMAT_REGEX = /^[a-f0-9]{32}$/i;
+
+export function isHbmIdFormat(value: string): boolean {
+  return HBM_ID_FORMAT_REGEX.test(value);
+}
+
+export function isUuidFormat(value: string): boolean {
+  return UUID_FORMAT_REGEX.test(value);
+}
+
 function buildFilterAggregation({
   field,
   portalFields,
@@ -100,18 +115,28 @@ export function buildQuery({
 
   const hasTextQuery = search.length > 0;
 
-  // Column-header HuBMAP ID popover wraps input as *...* (SearchTableHeaderCell.tsx);
-  // top search bar quotes exact HBM IDs (SearchBar.tsx). Either form is treated as an
-  // entity-id lookup: it bypasses the "latest revision only" filter so superseded
-  // entities can still be found by their HuBMAP ID.
+  // Entity-id lookups bypass the "latest revision only" filter so superseded entities
+  // can still be found by ID. Detection covers:
+  //   - wildcard form `*...*` (column-header HuBMAP ID popover)
+  //   - canonical HuBMAP ID format `HBM###.XXXX.###`
+  //   - 32-hex-char UUIDs
+  //   - legacy quoted-HBM form `"HBM..."` (preserved for backward compat with old URLs)
   const isWildcardIdSearch = hasTextQuery && /^\*.*\*$/.test(search);
+  const isHbmIdFormatSearch = hasTextQuery && isHbmIdFormat(search);
+  const isUuidFormatSearch = hasTextQuery && isUuidFormat(search);
   const isQuotedHbmIdSearch = hasTextQuery && /^"\s*HBM\S+\s*"$/i.test(search);
-  const isIdLookupSearch = isWildcardIdSearch || isQuotedHbmIdSearch;
+  const isIdLookupSearch = isWildcardIdSearch || isHbmIdFormatSearch || isUuidFormatSearch || isQuotedHbmIdSearch;
 
+  // ES keyword fields are case-sensitive; HuBMAP IDs are stored uppercase and UUIDs
+  // lowercase, so normalize the search term to the canonical case before exact match.
   const freeTextQueries = hasTextQuery
     ? isWildcardIdSearch
       ? [esb.wildcardQuery(getESField({ field: 'hubmap_id', mappings }), search)]
-      : [esb.simpleQueryStringQuery(search).fields(searchFields)]
+      : isHbmIdFormatSearch
+        ? [esb.termQuery(getESField({ field: 'hubmap_id', mappings }), search.toUpperCase())]
+        : isUuidFormatSearch
+          ? [esb.termQuery(getESField({ field: 'uuid', mappings }), search.toLowerCase())]
+          : [esb.simpleQueryStringQuery(search).fields(searchFields)]
     : [];
   const defaultQueries = defaultQuery ? [defaultQuery] : [];
   const revisionFilterQueries =
@@ -119,7 +144,8 @@ export function buildQuery({
 
   query.query(esb.boolQuery().must([...defaultQueries, ...revisionFilterQueries, ...freeTextQueries]));
 
-  if (hasTextQuery && !isWildcardIdSearch) {
+  // Highlight only for free-text queries; exact-match ID lookups don't need highlighting.
+  if (hasTextQuery && !isWildcardIdSearch && !isHbmIdFormatSearch && !isUuidFormatSearch) {
     query.highlight(esb.highlight(searchFields));
   }
 

--- a/context/app/static/js/components/search/utils.ts
+++ b/context/app/static/js/components/search/utils.ts
@@ -73,6 +73,7 @@ export function buildQuery({
   sortField,
   defaultQuery,
   latestRevisionFilter,
+  includeSupersededEntities,
   mappings,
   buildAggregations = true,
 }: { buildAggregations?: boolean; mappings: UseESMappingType } & Pick<
@@ -86,6 +87,7 @@ export function buildQuery({
   | 'sortField'
   | 'defaultQuery'
   | 'latestRevisionFilter'
+  | 'includeSupersededEntities'
 >) {
   if (!isESMapping(mappings)) {
     return null;
@@ -112,7 +114,8 @@ export function buildQuery({
       : [esb.simpleQueryStringQuery(search).fields(searchFields)]
     : [];
   const defaultQueries = defaultQuery ? [defaultQuery] : [];
-  const revisionFilterQueries = latestRevisionFilter && !isIdLookupSearch ? [latestRevisionFilter] : [];
+  const revisionFilterQueries =
+    latestRevisionFilter && !isIdLookupSearch && !includeSupersededEntities ? [latestRevisionFilter] : [];
 
   query.query(esb.boolQuery().must([...defaultQueries, ...revisionFilterQueries, ...freeTextQueries]));
 

--- a/context/app/static/js/pages/search/S.tsx
+++ b/context/app/static/js/pages/search/S.tsx
@@ -21,6 +21,7 @@ const sharedTileFields = [
   'entity_type',
   'descendant_counts.entity_type',
   'next_revision_uuid',
+  'sub_status',
 ];
 
 const sharedAffiliationFilters = [

--- a/context/app/static/js/pages/search/S.tsx
+++ b/context/app/static/js/pages/search/S.tsx
@@ -7,7 +7,7 @@ import { EntityWithType, isDonor } from 'js/components/types';
 import { useAppContext } from 'js/components/Contexts';
 
 const sharedConfig = {
-  searchFields: ['all_text', 'description'],
+  searchFields: ['all_text'],
   // TODO: figure out how to make assertion unnecessary.
   size: 18,
 };
@@ -20,6 +20,7 @@ const sharedTileFields = [
   'published_timestamp',
   'entity_type',
   'descendant_counts.entity_type',
+  'next_revision_uuid',
 ];
 
 const sharedAffiliationFilters = [
@@ -41,12 +42,10 @@ function makeDonorMetadataFilters(e: EntityWithType) {
 
 function buildDefaultQuery(type: 'Dataset' | 'Donor' | 'Sample') {
   return {
-    defaultQuery: esb
+    defaultQuery: esb.boolQuery().must([esb.termsQuery('entity_type.keyword', [type])]),
+    latestRevisionFilter: esb
       .boolQuery()
-      .must([
-        esb.termsQuery('entity_type.keyword', [type]),
-        esb.boolQuery().mustNot([esb.existsQuery('next_revision_uuid'), esb.existsQuery('sub_status')]),
-      ]),
+      .mustNot([esb.existsQuery('next_revision_uuid'), esb.existsQuery('sub_status')]),
   };
 }
 


### PR DESCRIPTION
## Summary

This PR:
* Adjusts HuBMAP ID search behavior to surface datasets with new versions when users explicitly specify its HuBMAP ID (CAT-1565)
  * Free text searches for HuBMAP ID's/UUIDs are automatically detected as such.
* Adds an "include superseded entities" facet (CAT-1176) to enable viewing superseded entities in general.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1565
https://hms-dbmi.atlassian.net/browse/CAT-1176

## Testing

* Added unit tests for search query forming
* Dataset for testing: HBM937.RTLZ.357 / bf76c484f7b2489aacd64f3e983879c0

## Screenshots/Video

Search by HuBMAP ID:
<img width="979" height="357" alt="image" src="https://github.com/user-attachments/assets/5088fa7d-f4e3-49cb-ab96-bb240c52a3db" />

Search by partial HuBMAP ID (no results):
<img width="1253" height="621" alt="image" src="https://github.com/user-attachments/assets/75b6c48c-9ef4-445d-94aa-30ff8c19b0ca" />

Search by partial HuBMAP ID with superseded datasets facet enabled:
<img width="1230" height="1169" alt="image" src="https://github.com/user-attachments/assets/667e54b5-9898-4f9d-802a-2aea7aece0bf" />

Search by UUID:
<img width="955" height="322" alt="image" src="https://github.com/user-attachments/assets/6624134c-1dbc-480f-a488-5fd35674eb24" />

Tile view (directs to current version only, due to nested links):
<img width="339" height="154" alt="image" src="https://github.com/user-attachments/assets/203a58be-a9d5-44ad-a4ba-5a43e3a7e0a1" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
