### PR TITLE
NickAkhmetov/CAT-1573 Display provenance for publications with associated collections

### DIFF
--- a/CHANGELOG-cat-1573.md
+++ b/CHANGELOG-cat-1573.md
@@ -1,0 +1,1 @@
+- Display provenance tree for all publications.

--- a/context/app/static/js/pages/Publication/Publication.tsx
+++ b/context/app/static/js/pages/Publication/Publication.tsx
@@ -34,10 +34,6 @@ function Publication({ publication, vignette_json }: PublicationProps) {
 
   useTrackID({ entity_type, hubmap_id });
 
-  const associatedCollectionUUID = associated_collection?.uuid;
-
-  const shouldDisplayProvenance = !associatedCollectionUUID;
-
   const shouldDisplaySection = {
     summary: true,
     data: true,
@@ -45,14 +41,14 @@ function Publication({ publication, vignette_json }: PublicationProps) {
     files: Boolean(files?.length),
     'bulk-data-transfer': true,
     authors: true,
-    provenance: shouldDisplayProvenance,
+    provenance: true,
   };
 
   return (
     <DetailContextProvider uuid={uuid} hubmap_id={hubmap_id} mapped_data_access_level="Public" entityType="Publication">
       <DetailLayout sections={shouldDisplaySection}>
         <PublicationSummary />
-        <PublicationsDataSection ancestorIds={ancestor_ids} associatedCollectionUUID={associatedCollectionUUID} />
+        <PublicationsDataSection ancestorIds={ancestor_ids} associatedCollectionUUID={associated_collection?.uuid} />
         {shouldDisplaySection.visualizations && (
           <PublicationsVisualizationSection vignette_json={vignette_json} uuid={uuid} />
         )}
@@ -61,7 +57,7 @@ function Publication({ publication, vignette_json }: PublicationProps) {
           <BulkDataTransfer customUUIDs={new Set(ancestor_ids)} integratedEntityUUID={uuid} />
         )}
         <ContributorsTable contributors={contributors} contacts={contacts} title="Authors" />
-        {shouldDisplaySection.provenance && <ProvSection />}
+        <ProvSection />
       </DetailLayout>
     </DetailContextProvider>
   );


### PR DESCRIPTION
## Summary

This PR enables display of the provenance section for all publications.

We historically hid those due to them missing provenance info when the dataset ancestors were not present, since they were associated with the collection instead; those connections are now present.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1573

## Testing

Viewed publication f53d60b5994333777a446dd7ad3b0304 on production and locally.

## Screenshots/Video


<img width="1868" height="3820" alt="image" src="https://github.com/user-attachments/assets/be442154-d321-4e88-8f30-42f4be288e10" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added
