### PR TITLE
NickAkhmetov/CAT-1567 Fix Say & See panel continuous reload

### DIFF
--- a/CHANGELOG-fix-saysee-endless-reload.md
+++ b/CHANGELOG-fix-saysee-endless-reload.md
@@ -1,0 +1,1 @@
+- Fix the Say & See panel reloading continuously for HuBMAP users who had not yet saved any preferences or lists. The underlying `/user/keys` 404 is now treated as an empty UKV response instead of a retryable error, and the panel keeps the chat mounted once it has resolved at least once.

--- a/context/app/static/js/components/savedLists/api.spec.tsx
+++ b/context/app/static/js/components/savedLists/api.spec.tsx
@@ -1,0 +1,110 @@
+import React, { PropsWithChildren } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { SWRConfig } from 'swr';
+
+import Providers from 'js/components/Providers';
+import { useFetchSavedListsAndEntities } from './api';
+
+jest.mock('@grafana/faro-web-sdk', () => ({
+  faro: {
+    api: {
+      pushError: jest.fn(),
+    },
+  },
+}));
+
+const ukvEndpoint = 'http://fakeUkvEndpoint';
+
+const endpoints = {
+  elasticsearchEndpoint: 'fakeElasticsearchEndpoint',
+  entityEndpoint: 'fakeEntityEndpoint',
+  assetsEndpoint: 'fakeAssetsEndpoint',
+  softAssayEndpoint: 'fakeSoftAssayEndpoint',
+  ukvEndpoint,
+};
+
+let requestCount = 0;
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+afterEach(() => {
+  server.resetHandlers();
+  requestCount = 0;
+});
+afterAll(() => {
+  server.close();
+});
+
+function Wrapper({ children }: PropsWithChildren) {
+  return (
+    <SWRConfig value={{ dedupingInterval: 0, provider: () => new Map() }}>
+      <Providers
+        endpoints={endpoints}
+        groupsToken="fakeGroupsToken"
+        isWorkspacesUser={false}
+        isHubmapUser
+        isAuthenticated
+        flaskData={{ entity: { hubmap_id: 'HBM123', entity_type: 'Entity' } }}
+        userEmail="test@example.com"
+        workspacesToken={undefined}
+        userFirstName={undefined}
+        userLastName={undefined}
+        userGlobusId={undefined}
+        userGlobusAffiliation={undefined}
+      >
+        {children}
+      </Providers>
+    </SWRConfig>
+  );
+}
+
+describe('useFetchSavedListsAndEntities', () => {
+  test('resolves to an empty array on 404 (user has no UKV entries yet) without retrying', async () => {
+    server.use(
+      http.get(`${ukvEndpoint}/user/keys`, () => {
+        requestCount += 1;
+        return new HttpResponse('Not found', { status: 404 });
+      }),
+    );
+
+    const { result } = renderHook(() => useFetchSavedListsAndEntities(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.savedListsAndEntities).toEqual([]);
+    expect(result.current.error).toBeUndefined();
+
+    // Give SWR a chance to attempt a retry (it shouldn't, because we handle 404
+    // as a valid empty response and set shouldRetryOnError: false).
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(requestCount).toBe(1);
+  });
+
+  test('still surfaces a 404 as an error when fetching a specific list UUID', async () => {
+    const listUUID = 'missing-list-uuid';
+    server.use(
+      http.get(`${ukvEndpoint}/user/keys/${listUUID}`, () => {
+        requestCount += 1;
+        return new HttpResponse('Not found', { status: 404 });
+      }),
+    );
+
+    const { result } = renderHook(() => useFetchSavedListsAndEntities(listUUID), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+
+    expect(result.current.savedListsAndEntities).toEqual([]);
+    // shouldRetryOnError: false — exactly one request even for the error case.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 50);
+    });
+    expect(requestCount).toBe(1);
+  });
+});

--- a/context/app/static/js/components/savedLists/api.ts
+++ b/context/app/static/js/components/savedLists/api.ts
@@ -3,6 +3,7 @@ import useSWRMutation from 'swr/mutation';
 import useSWR from 'swr';
 
 import { fetcher } from 'js/helpers/swr/fetchers';
+import { SWRError } from 'js/helpers/swr/errors';
 import { useAppContext } from 'js/components/Contexts';
 import { SavedEntitiesList, SavedPreferences } from 'js/components/savedLists/types';
 import { SAVED_PREFERENCES_KEY } from 'js/components/savedLists/constants';
@@ -75,15 +76,28 @@ function useFetchSavedListsAndEntities(listUUID?: string) {
 
   const { data, isLoading, ...rest } = useSWR(
     buildKey({ url: listsURL }),
-    ([url, head]) =>
-      fetcher<{ key: string; value: SavedEntitiesList }[]>({
-        url,
-        requestInit: { headers: head },
-        errorMessages: {
-          404: listUUID ? `No list with UUID ${listUUID} found.` : 'No lists for the current user were found.',
-        },
-      }),
-    { revalidateOnFocus: hasAccess },
+    async ([url, head]) => {
+      try {
+        return await fetcher<{ key: string; value: SavedEntitiesList }[]>({
+          url,
+          requestInit: { headers: head },
+          errorMessages: {
+            404: listUUID ? `No list with UUID ${listUUID} found.` : 'No lists for the current user were found.',
+          },
+        });
+      } catch (err) {
+        // A user with no UKV entries gets a 404 from `/user/keys` — that's a valid
+        // "no entries yet" state, not an error. Without this, SWR retries forever
+        // with exponential backoff, causing isLoading to flicker and consumers
+        // (e.g. SaySeePanel) to unmount/remount their children on every retry.
+        // The listUUID-scoped variant still treats 404 as a real error.
+        if (!listUUID && err instanceof SWRError && err.status === 404) {
+          return [];
+        }
+        throw err;
+      }
+    },
+    { revalidateOnFocus: hasAccess, shouldRetryOnError: false },
   );
   const savedListsAndEntities = data ?? [];
   return { savedListsAndEntities, isLoading, ...rest };

--- a/context/app/static/js/components/search/SaySeePanel/SaySeePanel.spec.tsx
+++ b/context/app/static/js/components/search/SaySeePanel/SaySeePanel.spec.tsx
@@ -106,6 +106,19 @@ describe('SaySeePanel', () => {
     expect(screen.queryByTestId('udi-chat')).not.toBeInTheDocument();
   });
 
+  it('keeps UDIChat mounted if isLoading flips back to true after a successful resolve', async () => {
+    setup({ isAuthenticated: true, isHubmapUser: true });
+    const { rerender } = render(<SaySeePanel />, { wrapper: Wrapper });
+    const initialChat = await screen.findByTestId('udi-chat');
+
+    // Simulate a background SWR revalidation that lost its cache: isLoading
+    // flips back to true. UDIChat must not unmount.
+    setup({ isAuthenticated: true, isHubmapUser: true }, { isLoading: true });
+    rerender(<SaySeePanel />);
+
+    expect(screen.getByTestId('udi-chat')).toBe(initialChat);
+  });
+
   it('hides OpenInWorkspacesFromYAC for non-Workspaces users', async () => {
     setup({ isAuthenticated: true, isHubmapUser: true, isWorkspacesUser: false });
     render(<SaySeePanel />, { wrapper: Wrapper });

--- a/context/app/static/js/components/search/SaySeePanel/SaySeePanel.tsx
+++ b/context/app/static/js/components/search/SaySeePanel/SaySeePanel.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useRef } from 'react';
 import Paper from '@mui/material/Paper';
 import Skeleton from '@mui/material/Skeleton';
 import Stack from '@mui/material/Stack';
@@ -55,6 +55,12 @@ function SaySeePanel() {
   const savedPreferences = rawPrefs as SavedPreferences;
   const useAuthScope = isHubmapUser && savedPreferences?.saySeeDataScope === 'authenticated';
   const dataPackagePath = useAuthScope ? CONSORTIUM_DATA_PACKAGE_PATH : PUBLIC_DATA_PACKAGE_PATH;
+
+  // Latch on first resolve so a later isLoading=true (e.g. an SWR
+  // revalidation that lost cache) can't unmount the heavy UDIChat tree.
+  const hasResolvedRef = useRef(false);
+  if (!prefsLoading) hasResolvedRef.current = true;
+  const showFallback = !hasResolvedRef.current;
   const downloadActions = useSaySeeDownloadActions();
 
   const toggleFullscreen = useEventCallback(() => {
@@ -90,7 +96,7 @@ function SaySeePanel() {
       <Paper>
         <ExpandableDiv $isExpanded={isFullscreen} $theme={theme} $nonExpandedHeight={NON_EXPANDED_HEIGHT}>
           <Suspense fallback={<ChatFallback />}>
-            {prefsLoading ? (
+            {showFallback ? (
               <ChatFallback />
             ) : (
               <UDIChat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "python-frontmatter>=1.1.0",
     "hubmap-api-py-client>=0.0.11",
     "hubmap-commons>=2.1.20",
-    "portal-visualization[full]>=0.5.3",
+    "portal-visualization[full]>=0.5.4",
     "udiagent>=0.2.3",
     "udiagent[langfuse]>=0.2.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ requires-dist = [
     { name = "globus-sdk", specifier = ">=3.59.0" },
     { name = "hubmap-api-py-client", specifier = ">=0.0.11" },
     { name = "hubmap-commons", specifier = ">=2.1.20" },
-    { name = "portal-visualization", extras = ["full"], specifier = ">=0.5.3" },
+    { name = "portal-visualization", extras = ["full"], specifier = ">=0.5.4" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.5" },
@@ -2076,11 +2076,11 @@ wheels = [
 
 [[package]]
 name = "portal-visualization"
-version = "0.5.3"
+version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/77/06964e7469baa21270bdf1e7c8b78fe427af82ae4d39b9cc5c2215f57cab/portal_visualization-0.5.3.tar.gz", hash = "sha256:3fb7bbda020b066558de10be32167e1151377c24f3fcd50a8fb2b503f51038ae", size = 66017, upload-time = "2026-04-21T19:56:33.137Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/84/e9096c46d2b8059e92c3b827dc3fed925140f3028746295c9b274ec10c7b/portal_visualization-0.5.4.tar.gz", hash = "sha256:6c5b60d4cddaaed07694f6480fe6c14f8592ceb72b8f1c98b5969694e52c082f", size = 66145, upload-time = "2026-05-13T19:45:00.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/2a/a8f5f7b18d57fd31663cbc1870be42a8125202a96c45726081f9216c82d1/portal_visualization-0.5.3-py3-none-any.whl", hash = "sha256:39637216db836dd05c59ab6bc04451127ed3bee8c0be5116ca12fdf4ccd39845", size = 69143, upload-time = "2026-04-21T19:56:32.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/53/d65080a14985ce5920030c322fd7fe9b90e160a65dce54eb4efe61e6da9a/portal_visualization-0.5.4-py3-none-any.whl", hash = "sha256:e4f5fc2aae2eb02b091e4f8402209af0aacf496a1de4aea280a3159070d5dd3a", size = 69285, upload-time = "2026-05-13T19:44:58.979Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

When HuBMAP users did not yet have entries in the UKV preferences store, the front-end continuously queried for them. This led to the `isLoading` flag repeatedly toggling, which resulted in the UDIChat component remounting.

This fix solves the issue on two fronts:
* The saved lists API no longer continuously refetches on error
* The UDI chat no longer unmounts on load (the instance still properly resets when users toggle to use authenticated data.)

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1567

## Testing

Added unit tests.

## Screenshots/Video

N/A

## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

The authenticated data 500 errors will be fixed by merging/releasing https://github.com/x-atlas-consortia/portal-visualization/pull/144 and updating it (likely also in this PR for convenience).