### PR TITLE
NickAkhmetov/CAT-1568 CAT-1569 Display segmentation channel/quality score info

### DIFF
--- a/CHANGELOG-segmentation-channels-quality.md
+++ b/CHANGELOG-segmentation-channels-quality.md
@@ -1,0 +1,1 @@
+- Display segmentation channels and quality scores (Quality Score, Mean SNZ, ACVF) below the visualization for datasets with `ingest_metadata.segmentation_metadata`.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -68,8 +68,7 @@ def details(type, uuid):
     if should_redirect_entity(entity):
         raw_dataset = find_raw_dataset_ancestor(client, entity.get('ancestor_ids'))
 
-        pipeline_anchor = entity.get('pipeline', entity.get('hubmap_id')).replace(' ', '')
-        anchor = quote(f'section-{pipeline_anchor}-{entity.get("status")}').lower()
+        anchor = quote(f'section-{entity.get("hubmap_id")}').lower()
 
         if raw_dataset is None or len(raw_dataset) == 0:
             abort(404)

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -19,7 +19,9 @@ import ContactUsLink from 'js/shared-styles/Links/ContactUsLink';
 import ContributorsTable from 'js/components/detailPage/ContributorsTable';
 import { DatasetAttributionDescription } from 'js/components/detailPage/Attribution/Attribution';
 import VisualizationWrapper from 'js/components/detailPage/visualization/VisualizationWrapper';
+import SegmentationChannelsAndQuality from 'js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality';
 import AnalysisDetails from 'js/components/detailPage/AnalysisDetails';
+import { datasetSectionId } from 'js/pages/Dataset/utils';
 // import Protocol from 'js/components/detailPage/Protocol';
 import { useSelectedVersionStore } from 'js/components/detailPage/VersionSelect/SelectedVersionStore';
 import { useVersions } from 'js/components/detailPage/VersionSelect/hooks';
@@ -152,12 +154,17 @@ function FilesAccordion() {
 
 function VisualizationAccordion() {
   const {
+    dataset,
     dataset: { uuid },
+    sectionDataset,
     sectionDataset: { hubmap_id },
     conf,
   } = useProcessedDatasetContext();
 
   const hasBeenSeen = useProcessedDataStore((state) => state.hasBeenSeen(hubmap_id));
+
+  const segmentationMetadata = dataset.ingest_metadata?.segmentation_metadata;
+  const workflowDetailsHref = `#${datasetSectionId(sectionDataset, 'protocols-and-workflow-details')}`;
 
   if (!conf) {
     return null;
@@ -177,6 +184,13 @@ function VisualizationAccordion() {
         shouldDisplayHeader={false}
         hasBeenMounted={hasBeenSeen}
         hasNotebook
+        renderBelowFooter={({ activeConfigName }) => (
+          <SegmentationChannelsAndQuality
+            segmentationMetadata={segmentationMetadata}
+            activeConfigName={activeConfigName}
+            workflowDetailsHref={workflowDetailsHref}
+          />
+        )}
       />
     </Subsection>
   );

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/hooks.ts
@@ -53,6 +53,7 @@ export function useProcessedDatasetDetails(uuid: string) {
       'ingest_metadata.dag_provenance_list',
       'ingest_metadata.workflow_description',
       'ingest_metadata.workflow_version',
+      'ingest_metadata.segmentation_metadata',
       'metadata',
       'protocol_url',
       'dataset_type',

--- a/context/app/static/js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality.tsx
+++ b/context/app/static/js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality.tsx
@@ -1,0 +1,102 @@
+import React, { useMemo } from 'react';
+import Box from '@mui/material/Box';
+import Link from '@mui/material/Link';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+
+import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
+import SectionPaper from 'js/shared-styles/sections/SectionPaper';
+import { SegmentationMetadataEntry } from 'js/components/types';
+
+const TOOLTIPS = {
+  QualityScore:
+    'Overall quality score of image and segmentation results, computed from all available metrics weighted by a PCA model.',
+  Mean_SNZ: 'Signal to noise ratio of expression image, averaged across all channels.',
+  ACVF: 'Coefficient of variation in foreground pixels outside cells, averaged across all expression image channels.',
+};
+
+function formatChannels(channels: string[] | undefined): string {
+  if (!channels || channels.length === 0) {
+    return 'Unknown';
+  }
+  if (channels.length === 1 && channels[0].toLowerCase() === 'none') {
+    return 'Unknown';
+  }
+  return channels.join(', ');
+}
+
+function pickEntry(
+  segmentationMetadata: SegmentationMetadataEntry[] | undefined,
+  activeConfigName: string | undefined,
+): SegmentationMetadataEntry | undefined {
+  if (!segmentationMetadata || segmentationMetadata.length === 0) {
+    return undefined;
+  }
+  if (segmentationMetadata.length === 1) {
+    return segmentationMetadata[0];
+  }
+  return segmentationMetadata.find((entry) => entry.Image === `${activeConfigName}.ome.tiff`);
+}
+
+interface SegmentationChannelsAndQualityProps {
+  segmentationMetadata?: SegmentationMetadataEntry[];
+  activeConfigName?: string;
+  workflowDetailsHref?: string;
+}
+
+function SegmentationChannelsAndQuality({
+  segmentationMetadata,
+  activeConfigName,
+  workflowDetailsHref = '#protocols-and-workflow-details',
+}: SegmentationChannelsAndQualityProps) {
+  const entry = useMemo(
+    () => pickEntry(segmentationMetadata, activeConfigName),
+    [segmentationMetadata, activeConfigName],
+  );
+
+  if (!entry) {
+    return null;
+  }
+
+  return (
+    <Box mt={2}>
+      <Typography variant="subtitle1" component="h3" gutterBottom>
+        Segmentation Channels & Quality
+      </Typography>
+      <Typography variant="body1" gutterBottom>
+        These channels were used for segmentation, which are visible in the visualization. Segmentation outputs and
+        quality control scores are available for each image, with additional segmentation information described in the
+        workflow description in the <Link href={workflowDetailsHref}>Protocols & Workflow Details</Link> section.
+      </Typography>
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} mt={2}>
+        <SectionPaper sx={{ flex: 1 }}>
+          <Typography variant="subtitle1" component="h4" gutterBottom>
+            Segmentation Channels
+          </Typography>
+          <LabelledSectionText label="Nucleus Segmentation Channels" bottomSpacing={2}>
+            {formatChannels(entry.NucleusSegmentationChannels)}
+          </LabelledSectionText>
+          <LabelledSectionText label="Cell Segmentation Channels">
+            {formatChannels(entry.CellSegmentationChannels)}
+          </LabelledSectionText>
+        </SectionPaper>
+        <SectionPaper sx={{ flex: 1 }}>
+          <Typography variant="subtitle1" component="h4" gutterBottom>
+            Segmentation Quality
+          </Typography>
+          <LabelledSectionText label="Quality Score" iconTooltipText={TOOLTIPS.QualityScore} bottomSpacing={2}>
+            {entry.QualityScore.toFixed(3)}
+          </LabelledSectionText>
+          <LabelledSectionText label="Mean SNZ" iconTooltipText={TOOLTIPS.Mean_SNZ} bottomSpacing={2}>
+            {entry.Mean_SNZ.toFixed(3)}
+          </LabelledSectionText>
+          <LabelledSectionText label="ACVF" iconTooltipText={TOOLTIPS.ACVF}>
+            {entry.ACVF.toFixed(3)}
+          </LabelledSectionText>
+        </SectionPaper>
+      </Stack>
+    </Box>
+  );
+}
+
+export default SegmentationChannelsAndQuality;

--- a/context/app/static/js/components/detailPage/visualization/IntegratedDatasetVisualizationSection/IntegratedDatasetVisualizationSection.tsx
+++ b/context/app/static/js/components/detailPage/visualization/IntegratedDatasetVisualizationSection/IntegratedDatasetVisualizationSection.tsx
@@ -5,10 +5,13 @@ import Description from 'js/shared-styles/sections/Description';
 import { Box } from '@mui/system';
 import { VisualizationIcon } from 'js/shared-styles/icons';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
+import SegmentationChannelsAndQuality from 'js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality';
+import { SegmentationMetadataEntry } from 'js/components/types';
 
 interface IntegratedDatasetVisualizationProps {
   uuid: string;
   vitessceConfig?: object;
+  segmentationMetadata?: SegmentationMetadataEntry[];
 }
 
 const trackingInfo = {
@@ -16,7 +19,11 @@ const trackingInfo = {
   category: 'Integrated Dataset',
 };
 
-function IntegratedDatasetVisualizationSection({ uuid, vitessceConfig }: IntegratedDatasetVisualizationProps) {
+function IntegratedDatasetVisualizationSection({
+  uuid,
+  vitessceConfig,
+  segmentationMetadata,
+}: IntegratedDatasetVisualizationProps) {
   return (
     <CollapsibleDetailPageSection title="Visualization" icon={VisualizationIcon}>
       <Description
@@ -28,6 +35,12 @@ function IntegratedDatasetVisualizationSection({ uuid, vitessceConfig }: Integra
               trackingInfo={trackingInfo}
               shouldDisplayHeader={false}
               hasNotebook
+              renderBelowFooter={({ activeConfigName }) => (
+                <SegmentationChannelsAndQuality
+                  segmentationMetadata={segmentationMetadata}
+                  activeConfigName={activeConfigName}
+                />
+              )}
             />
           </Box>
         }

--- a/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
+++ b/context/app/static/js/components/detailPage/visualization/Visualization/Visualization.tsx
@@ -49,6 +49,7 @@ interface VisualizationProps {
   hideTheme?: boolean;
   hideShare?: boolean;
   title?: React.ReactNode;
+  renderBelowFooter?: (args: { activeConfigName?: string }) => React.ReactNode;
 }
 
 function Visualization({
@@ -63,6 +64,7 @@ function Visualization({
   hideTheme = false,
   hideShare = false,
   title = 'Visualization',
+  renderBelowFooter,
 }: VisualizationProps) {
   const { fullscreenVizId, expandViz, vizTheme, setVitessceState, setVizNotebookId, setVizHubmapId } =
     useVisualizationStore(visualizationStoreSelector);
@@ -212,6 +214,7 @@ function Visualization({
           </ExpandableDiv>
         </Paper>
         <VisualizationFooter />
+        {renderBelowFooter?.({ activeConfigName: (currentConfig as { name?: string } | undefined)?.name })}
         <BodyExpandedCSS id={id} />
       </StyledDetailPageSection>
     )

--- a/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.tsx
+++ b/context/app/static/js/components/detailPage/visualization/VisualizationWrapper/VisualizationWrapper.tsx
@@ -20,6 +20,7 @@ interface VisualizationWrapperProps {
   hideTheme?: boolean;
   hideShare?: boolean;
   title?: React.ReactNode;
+  renderBelowFooter?: (args: { activeConfigName?: string }) => React.ReactNode;
 }
 
 function VisualizationWrapper({
@@ -35,6 +36,7 @@ function VisualizationWrapper({
   hideTheme = false,
   hideShare = false,
   title,
+  renderBelowFooter,
 }: VisualizationWrapperProps) {
   const containerStyles = useMemo(
     () => ({
@@ -61,6 +63,7 @@ function VisualizationWrapper({
             hideTheme={hideTheme}
             hideShare={hideShare}
             title={title}
+            renderBelowFooter={renderBelowFooter}
           />
         </Suspense>
       </VisualizationErrorBoundary>

--- a/context/app/static/js/components/types.ts
+++ b/context/app/static/js/components/types.ts
@@ -47,6 +47,15 @@ export interface IngestPipelineLink {
 
 export type DagProvenanceType = CWLPipelineLink | IngestPipelineLink;
 
+export interface SegmentationMetadataEntry {
+  ACVF: number;
+  Mean_SNZ: number;
+  Image?: string;
+  CellSegmentationChannels: string[];
+  NucleusSegmentationChannels: string[];
+  QualityScore: number;
+}
+
 export interface Entity {
   entity_type: ESEntityType;
   description: string;
@@ -160,6 +169,12 @@ export interface Dataset extends Entity {
   calculated_metadata?: {
     annotation_tools?: string[];
     object_types?: string[];
+  };
+  ingest_metadata: {
+    dag_provenance_list: DagProvenanceType[];
+    workflow_description?: string;
+    workflow_version?: string;
+    segmentation_metadata?: SegmentationMetadataEntry[];
   };
 }
 

--- a/context/app/static/js/pages/Dataset/IntegratedDataset.tsx
+++ b/context/app/static/js/pages/Dataset/IntegratedDataset.tsx
@@ -145,6 +145,7 @@ function IntegratedDatasetPage({ assayMetadata }: EntityDetailProps<Dataset>) {
           <IntegratedDatasetVisualizationSection
             uuid={uuid}
             vitessceConfig={vitessceConfig.data}
+            segmentationMetadata={ingest_metadata?.segmentation_metadata}
             shouldDisplay={shouldDisplaySection.visualization}
           />
           <MetadataSection entities={[assayMetadata]} shouldDisplay={shouldDisplaySection.metadata} />


### PR DESCRIPTION
## Summary
This PR implements the Segmentation Quality/Channel display in the visualization section for datasets and integrated datasets.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1568
https://hms-dbmi.atlassian.net/browse/CAT-1569

## Testing/Screenshots

Tested with the following datasets:
* HBM274.ZSQX.333
	* Multiple images
	* <img width="1266" height="1235" alt="image" src="https://github.com/user-attachments/assets/587a97a9-fa71-4d0f-af75-52177f4d4d34" />
* HBM829.QVHB.362
    * One image
    * <img width="1210" height="1198" alt="image" src="https://github.com/user-attachments/assets/f636e41e-5619-4cb3-8a17-18fd32fd2e23" />
* 9fec34311ea03c4a5c221e65b1d881ba
    * "None" in cell segmentation channels
    * <img width="1215" height="1206" alt="image" src="https://github.com/user-attachments/assets/397cdd5f-e376-47f3-b8a2-78fe6900e703" />
* 70637954487c4f20828b30841b68f1e5
    * Multiple CellSegmentationChannels
    * <img width="1210" height="1106" alt="image" src="https://github.com/user-attachments/assets/06e28c74-304c-45b9-b6d8-0cf849997a9e" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

I also observed and fixed a regression with processed dataset redirects not sending users down to the appropriate section of the detail page.