### PR TITLE
NickAkhmetov/CAT-1577 Support "Approval" status

### DIFF
--- a/CHANGELOG-approval-status.md
+++ b/CHANGELOG-approval-status.md
@@ -1,0 +1,1 @@
+- Add support for new dataset workflow status "Approval"; treated equivalently to "QA" for status icons, provenance queries, and image pyramid visualization lifting.

--- a/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.spec.tsx
+++ b/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.spec.tsx
@@ -10,6 +10,7 @@ const green = '#6C8938';
 test.each([
   ['Reopened', blue],
   ['QA', blue],
+  ['Approval', blue],
   ['Locked', blue],
   ['Processing', blue],
   ['Hold', blue],

--- a/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.tsx
+++ b/context/app/static/js/components/detailPage/StatusIcon/StatusIcon.tsx
@@ -5,7 +5,7 @@ import Box from '@mui/material/Box';
 import ColoredStatusIcon from './ColoredStatusIcon';
 
 function getColor(status: string) {
-  if (['NEW', 'REOPENED', 'QA', 'LOCKED', 'PROCESSING', 'HOLD', 'SUBMITTED'].includes(status)) {
+  if (['NEW', 'REOPENED', 'QA', 'APPROVAL', 'LOCKED', 'PROCESSING', 'HOLD', 'SUBMITTED'].includes(status)) {
     return 'info';
   }
 

--- a/context/app/static/js/components/detailPage/provenance/queries.ts
+++ b/context/app/static/js/components/detailPage/provenance/queries.ts
@@ -18,7 +18,7 @@ export const getAncestorsQuery = (uuid: string) => ({
         },
         {
           terms: {
-            'mapped_status.keyword': ['QA', 'Published'],
+            'mapped_status.keyword': ['QA', 'Approval', 'Published'],
           },
         },
         {
@@ -62,7 +62,7 @@ export const getDescendantsQuery = (uuid: string | string[]): SearchRequest => (
         },
         {
           terms: {
-            'mapped_status.keyword': ['QA', 'Published'],
+            'mapped_status.keyword': ['QA', 'Approval', 'Published'],
           },
         },
       ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "python-frontmatter>=1.1.0",
     "hubmap-api-py-client>=0.0.11",
     "hubmap-commons>=2.1.20",
-    "portal-visualization[full]>=0.5.4",
+    "portal-visualization[full]>=0.5.5",
     "udiagent>=0.2.3",
     "udiagent[langfuse]>=0.2.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -937,7 +937,7 @@ requires-dist = [
     { name = "globus-sdk", specifier = ">=3.59.0" },
     { name = "hubmap-api-py-client", specifier = ">=0.0.11" },
     { name = "hubmap-commons", specifier = ">=2.1.20" },
-    { name = "portal-visualization", extras = ["full"], specifier = ">=0.5.4" },
+    { name = "portal-visualization", extras = ["full"], specifier = ">=0.5.5" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.5" },
@@ -2076,11 +2076,11 @@ wheels = [
 
 [[package]]
 name = "portal-visualization"
-version = "0.5.4"
+version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/84/e9096c46d2b8059e92c3b827dc3fed925140f3028746295c9b274ec10c7b/portal_visualization-0.5.4.tar.gz", hash = "sha256:6c5b60d4cddaaed07694f6480fe6c14f8592ceb72b8f1c98b5969694e52c082f", size = 66145, upload-time = "2026-05-13T19:45:00.441Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/ca/9142e09228eaca91f20150f762179bb45405de06f859bb6bfb0a272a81ac/portal_visualization-0.5.5.tar.gz", hash = "sha256:3706131468daf1f7d077ddb431184d33a2fe87d35965f70ae2af2cc9de72ac74", size = 66172, upload-time = "2026-05-19T19:47:31.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/53/d65080a14985ce5920030c322fd7fe9b90e160a65dce54eb4efe61e6da9a/portal_visualization-0.5.4-py3-none-any.whl", hash = "sha256:e4f5fc2aae2eb02b091e4f8402209af0aacf496a1de4aea280a3159070d5dd3a", size = 69285, upload-time = "2026-05-13T19:44:58.979Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/35/ed0a3fc123b2fa3bfe7c3b2c22885ae24cb444fd9cbf3f6ddbde3e268975/portal_visualization-0.5.5-py3-none-any.whl", hash = "sha256:3b19140899d56dcfeb09fc240a33cbe10976a4558dd4227b5589579f744ca718", size = 69304, upload-time = "2026-05-19T19:47:29.969Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

This PR adds support for the new "Approval" status which is currently out on test. It is treated identically to the "QA" status for the sake of all relevant logic.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1577

## Testing

Added unit tests.

## Screenshots/Video

N/A

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

This PR will also need to include https://github.com/x-atlas-consortia/portal-visualization/pull/145