### PR TITLE
NickAkhmetov/CAT-1581 Fix color of Protocols & Workflow link in segmentation metadata section

### DIFF
--- a/CHANGELOG-cat-1581.md
+++ b/CHANGELOG-cat-1581.md
@@ -1,0 +1,1 @@
+- Fix color of Protocols & Workflow link in segmentation metadata section.

--- a/context/app/static/js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality.tsx
+++ b/context/app/static/js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality.tsx
@@ -66,7 +66,11 @@ function SegmentationChannelsAndQuality({
       <Typography variant="body1" gutterBottom>
         These channels were used for segmentation, which are visible in the visualization. Segmentation outputs and
         quality control scores are available for each image, with additional segmentation information described in the
-        workflow description in the <Link href={workflowDetailsHref}>Protocols & Workflow Details</Link> section.
+        workflow description in the{' '}
+        <Link color="info" href={workflowDetailsHref}>
+          Protocols & Workflow Details
+        </Link>{' '}
+        section.
       </Typography>
       <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} mt={2}>
         <SectionPaper sx={{ flex: 1 }}>

--- a/context/app/static/js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality.tsx
+++ b/context/app/static/js/components/detailPage/SegmentationChannelsAndQuality/SegmentationChannelsAndQuality.tsx
@@ -1,12 +1,12 @@
 import React, { useMemo } from 'react';
 import Box from '@mui/material/Box';
-import Link from '@mui/material/Link';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 
 import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
 import SectionPaper from 'js/shared-styles/sections/SectionPaper';
 import { SegmentationMetadataEntry } from 'js/components/types';
+import { InternalLink } from 'js/shared-styles/Links';
 
 const TOOLTIPS = {
   QualityScore:
@@ -66,10 +66,7 @@ function SegmentationChannelsAndQuality({
       <Typography variant="body1" gutterBottom>
         These channels were used for segmentation, which are visible in the visualization. Segmentation outputs and
         quality control scores are available for each image, with additional segmentation information described in the
-        workflow description in the{' '}
-        <Link color="info" href={workflowDetailsHref}>
-          Protocols & Workflow Details
-        </Link>{' '}
+        workflow description in the <InternalLink href={workflowDetailsHref}>Protocols & Workflow Details</InternalLink>{' '}
         section.
       </Typography>
       <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} mt={2}>


### PR DESCRIPTION
## Summary

This PR adjusts the color of the protocols and workflow details link in the new segmentation metadata section. The original implementation was not using our `InternalLink` component, so the proper default color was not applied.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1581?atlOrigin=eyJpIjoiMzU5YTgxNmY1ZDU1NDhkNTg2ODRhMDRjYjZhNDMxYjgiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## Testing/Screenshots

<img width="1255" height="401" alt="image" src="https://github.com/user-attachments/assets/9c017d41-ca25-45f4-b128-cef9e16d2b31" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
