### PR TITLE
NickAkhmetov/CAT-1582 - fix saved entities crashing detail pages

### DIFF
--- a/CHANGELOG-saved-entities-error.md
+++ b/CHANGELOG-saved-entities-error.md
@@ -1,0 +1,1 @@
+- Fix crash when visiting a saved entity page caused by the Edit Saved Status dialog iterating over the `savedPreferences` UKV entry as if it were a list; the dialog now uses the filtered `savedLists` record that excludes reserved keys.

--- a/context/app/static/js/components/savedLists/EditSavedStatusDialog/EditSavedStatusDialog.spec.tsx
+++ b/context/app/static/js/components/savedLists/EditSavedStatusDialog/EditSavedStatusDialog.spec.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { render, screen } from 'test-utils/functions';
+
+import useSavedLists from 'js/components/savedLists/hooks';
+import { SavedEntitiesList } from 'js/components/savedLists/types';
+import { SAVED_ENTITIES_KEY, SAVED_PREFERENCES_KEY } from 'js/components/savedLists/constants';
+import EditSavedStatusDialog, { getSavedListsWhichContainEntity } from './EditSavedStatusDialog';
+
+jest.mock('js/components/savedLists/hooks', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedUseSavedLists = useSavedLists as jest.MockedFunction<(...args: any[]) => any>;
+
+function makeList(overrides: Partial<SavedEntitiesList> = {}): SavedEntitiesList {
+  return {
+    title: 'List',
+    description: '',
+    dateSaved: 0,
+    dateLastModified: 0,
+    savedEntities: {},
+    ...overrides,
+  };
+}
+
+describe('getSavedListsWhichContainEntity', () => {
+  test('returns an empty array when there are no lists', () => {
+    expect(getSavedListsWhichContainEntity({}, 'entity-1')).toEqual([]);
+  });
+
+  test('returns an empty array when no list contains the entity', () => {
+    const lists = {
+      'list-a': makeList({ savedEntities: { other: {} } }),
+      'list-b': makeList({ savedEntities: {} }),
+    };
+    expect(getSavedListsWhichContainEntity(lists, 'entity-1')).toEqual([]);
+  });
+
+  test('returns the IDs of lists that contain the entity', () => {
+    const lists = {
+      'list-a': makeList({ savedEntities: { 'entity-1': {} } }),
+      'list-b': makeList({ savedEntities: { other: {} } }),
+      'list-c': makeList({ savedEntities: { 'entity-1': {}, other: {} } }),
+    };
+    expect(getSavedListsWhichContainEntity(lists, 'entity-1').sort()).toEqual(['list-a', 'list-c']);
+  });
+});
+
+describe('EditSavedStatusDialog', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  /**
+   * Regression: passing `savedListsAndEntities` (which includes the reserved
+   * `savedPreferences` entry without a `savedEntities` field) to
+   * `getSavedListsWhichContainEntity` crashes the page with
+   * "right-hand side of 'in' should be an object, got undefined".
+   * The dialog should be insulated against that by using the filtered
+   * `savedLists` record exposed by `useSavedLists`.
+   */
+  test('renders without crashing when reserved keys exist alongside lists', () => {
+    const realList = makeList({ title: 'My Real List', savedEntities: { 'entity-1': {} } });
+
+    mockedUseSavedLists.mockReturnValue({
+      savedLists: { 'real-list-uuid': realList },
+      // Intentionally include reserved keys here so this test would still pass
+      // a regression that re-introduces reading from `savedListsAndEntities`
+      // only if those reserved entries are *also* shaped like lists. They
+      // aren't in practice — `savedPreferences` has no `savedEntities`
+      // property — so the dialog must not read from this field directly.
+      savedListsAndEntities: {
+        'real-list-uuid': realList,
+        [SAVED_ENTITIES_KEY]: makeList({ title: 'My Saved Items' }),
+        [SAVED_PREFERENCES_KEY]: { enableOpenKeyNav: true },
+      },
+      handleAddEntitiesToList: jest.fn().mockResolvedValue(undefined),
+      handleRemoveEntitiesFromList: jest.fn().mockResolvedValue(undefined),
+    });
+
+    render(<EditSavedStatusDialog dialogIsOpen setDialogIsOpen={jest.fn()} uuid="entity-1" />);
+
+    expect(screen.getByText('My Real List')).toBeInTheDocument();
+  });
+
+  test('does not render reserved-key entries as selectable list rows', () => {
+    mockedUseSavedLists.mockReturnValue({
+      savedLists: { 'real-list-uuid': makeList({ title: 'My Real List' }) },
+      savedListsAndEntities: {
+        'real-list-uuid': makeList({ title: 'My Real List' }),
+        [SAVED_ENTITIES_KEY]: makeList({ title: 'My Saved Items' }),
+        [SAVED_PREFERENCES_KEY]: { enableOpenKeyNav: true },
+      },
+      handleAddEntitiesToList: jest.fn().mockResolvedValue(undefined),
+      handleRemoveEntitiesFromList: jest.fn().mockResolvedValue(undefined),
+    });
+
+    render(<EditSavedStatusDialog dialogIsOpen setDialogIsOpen={jest.fn()} uuid="entity-1" />);
+
+    expect(screen.getByText('My Real List')).toBeInTheDocument();
+    expect(screen.queryByText('My Saved Items')).not.toBeInTheDocument();
+  });
+
+  test('pre-selects the lists that already contain the entity', () => {
+    mockedUseSavedLists.mockReturnValue({
+      savedLists: {
+        'list-with-entity': makeList({ title: 'Contains Entity', savedEntities: { 'entity-1': {} } }),
+        'list-without-entity': makeList({ title: 'Empty' }),
+      },
+      savedListsAndEntities: {},
+      handleAddEntitiesToList: jest.fn().mockResolvedValue(undefined),
+      handleRemoveEntitiesFromList: jest.fn().mockResolvedValue(undefined),
+    });
+
+    render(<EditSavedStatusDialog dialogIsOpen setDialogIsOpen={jest.fn()} uuid="entity-1" />);
+
+    const containingRow = screen.getByText('Contains Entity').closest('li')!;
+    const emptyRow = screen.getByText('Empty').closest('li')!;
+
+    expect(containingRow.querySelector('input[type="checkbox"]')).toBeChecked();
+    expect(emptyRow.querySelector('input[type="checkbox"]')).not.toBeChecked();
+  });
+});

--- a/context/app/static/js/components/savedLists/EditSavedStatusDialog/EditSavedStatusDialog.tsx
+++ b/context/app/static/js/components/savedLists/EditSavedStatusDialog/EditSavedStatusDialog.tsx
@@ -7,7 +7,10 @@ import useSavedLists from 'js/components/savedLists/hooks';
 import { SavedEntitiesList } from 'js/components/savedLists/types';
 import DialogModal from 'js/shared-styles/dialogs/DialogModal';
 
-function getSavedListsWhichContainEntity(savedLists: Record<string, SavedEntitiesList>, entityUUID: string): string[] {
+export function getSavedListsWhichContainEntity(
+  savedLists: Record<string, SavedEntitiesList>,
+  entityUUID: string,
+): string[] {
   return Object.entries(savedLists).reduce<string[]>((acc, [id, obj]) => {
     return entityUUID in obj.savedEntities ? [...acc, id] : acc;
   }, []);
@@ -19,9 +22,9 @@ interface EditSavedStatusDialogProps {
   uuid: string;
 }
 function EditSavedStatusDialog({ dialogIsOpen, setDialogIsOpen, uuid }: EditSavedStatusDialogProps) {
-  const { savedListsAndEntities, handleAddEntitiesToList, handleRemoveEntitiesFromList } = useSavedLists();
+  const { savedLists, handleAddEntitiesToList, handleRemoveEntitiesFromList } = useSavedLists();
   const [selectedLists, addToSelectedLists, removeFromSelectedLists, setSelectedLists] = useStateSet(
-    getSavedListsWhichContainEntity(savedListsAndEntities, uuid),
+    getSavedListsWhichContainEntity(savedLists, uuid),
   );
 
   function updateLists() {
@@ -33,7 +36,7 @@ function EditSavedStatusDialog({ dialogIsOpen, setDialogIsOpen, uuid }: EditSave
     });
 
     // Remove entities from lists that are no longer selected
-    const unselectedLists = Object.keys(savedListsAndEntities).filter((listUUID) => !selectedLists.has(listUUID));
+    const unselectedLists = Object.keys(savedLists).filter((listUUID) => !selectedLists.has(listUUID));
     unselectedLists.forEach((listUUID) => {
       handleRemoveEntitiesFromList({ listUUID, entityUUIDs: new Set([uuid]) }).catch((error) => {
         console.error(error);
@@ -47,14 +50,14 @@ function EditSavedStatusDialog({ dialogIsOpen, setDialogIsOpen, uuid }: EditSave
   }
 
   function handleClose() {
-    setSelectedLists(new Set(getSavedListsWhichContainEntity(savedListsAndEntities, uuid)));
+    setSelectedLists(new Set(getSavedListsWhichContainEntity(savedLists, uuid)));
     setDialogIsOpen(false);
   }
 
   const dialogContent = (
     <AddToList
       selectedLists={selectedLists}
-      allLists={savedListsAndEntities}
+      allLists={savedLists}
       addToSelectedLists={addToSelectedLists}
       removeFromSelectedLists={removeFromSelectedLists}
     />


### PR DESCRIPTION
## Summary

This PR fixes the issue Tiffany discovered where saved entities were being iterated over incorrectly.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1582

## Testing

Added component tests and unit tests.

## Screenshots/Video

HBM938.GZXZ.633 on prod-test: <img width="1080" height="619" alt="image" src="https://github.com/user-attachments/assets/fff97336-aebc-435a-88b0-413fce308f57" />

HBM938.GZXZ.633 on localhost: 
<img width="1676" height="325" alt="image" src="https://github.com/user-attachments/assets/c5bd7182-6c0e-43dc-928a-1470775c8fc9" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
