### PR TITLE
NickAkhmetov/CAT-1585 Render workflow descriptions as Markdown to enable links

### DIFF
--- a/CHANGELOG-workflow-descriptions-markdown.md
+++ b/CHANGELOG-workflow-descriptions-markdown.md
@@ -1,0 +1,1 @@
+- Render workflow descriptions as Markdown to enable links.

--- a/context/app/static/js/components/Markdown/MarkdownRenderer.tsx
+++ b/context/app/static/js/components/Markdown/MarkdownRenderer.tsx
@@ -1,7 +1,7 @@
-import React, { AnchorHTMLAttributes } from 'react';
+import React, { AnchorHTMLAttributes, useMemo } from 'react';
 import ReactMarkdown, { Options } from 'react-markdown';
 import rehypeRaw from 'rehype-raw';
-import { InternalLink } from 'js/shared-styles/Links';
+import { InternalLink, OutboundLink } from 'js/shared-styles/Links';
 
 function MarkdownLink({ href, children, ...rest }: AnchorHTMLAttributes<HTMLAnchorElement>) {
   return (
@@ -11,16 +11,42 @@ function MarkdownLink({ href, children, ...rest }: AnchorHTMLAttributes<HTMLAnch
   );
 }
 
-export default function MarkdownRenderer({ children, rehypePlugins = [], components = {}, ...rest }: Options) {
+function OutboundMarkdownLink({ href, children, ...rest }: AnchorHTMLAttributes<HTMLAnchorElement>) {
   return (
-    <ReactMarkdown
-      rehypePlugins={[rehypeRaw as NonNullable<Options['rehypePlugins']>[number], ...(rehypePlugins ?? [])]}
-      components={{
-        a: MarkdownLink,
-        ...components,
-      }}
-      {...rest}
-    >
+    <OutboundLink href={href} {...rest}>
+      {children}
+    </OutboundLink>
+  );
+}
+
+interface MarkdownRendererProps extends Options {
+  externalLinks?: boolean;
+}
+
+export default function MarkdownRenderer({
+  children,
+  rehypePlugins = [],
+  components = {},
+  externalLinks = false,
+  ...rest
+}: MarkdownRendererProps) {
+  const componentsWithLinks = useMemo(() => {
+    const linkComponent = externalLinks ? OutboundMarkdownLink : MarkdownLink;
+    return {
+      a: linkComponent,
+      ...components,
+    };
+  }, [components, externalLinks]);
+
+  const rehypePluginsWithRaw = useMemo(() => {
+    if (rehypePlugins?.some((plugin) => plugin === rehypeRaw)) {
+      return rehypePlugins;
+    }
+    return [rehypeRaw as NonNullable<Options['rehypePlugins']>[number], ...(rehypePlugins ?? [])];
+  }, [rehypePlugins]);
+
+  return (
+    <ReactMarkdown rehypePlugins={rehypePluginsWithRaw} components={componentsWithLinks} {...rest}>
       {children}
     </ReactMarkdown>
   );

--- a/context/app/static/js/components/detailPage/AnalysisDetails/AnalysisDetails.tsx
+++ b/context/app/static/js/components/detailPage/AnalysisDetails/AnalysisDetails.tsx
@@ -291,7 +291,7 @@ function AnalysisDetails({ dagListData, workflow_description, workflow_version }
   return (
     <Stack spacing={1}>
       {workflow_version && <Typography variant="subtitle2">Workflow (v{workflow_version})</Typography>}
-      {workflow_description && <MarkdownRenderer>{workflow_description}</MarkdownRenderer>}
+      {workflow_description && <MarkdownRenderer externalLinks>{workflow_description}</MarkdownRenderer>}
       {hasInputParameters && (
         <Box>
           <Button variant="outlined" onClick={collapseSteps} disabled={Object.keys(expandedRows).length === 0}>

--- a/context/app/static/js/components/detailPage/AnalysisDetails/AnalysisDetails.tsx
+++ b/context/app/static/js/components/detailPage/AnalysisDetails/AnalysisDetails.tsx
@@ -23,6 +23,7 @@ import { OutboundLink } from 'js/shared-styles/Links';
 import { useHandleCopyClick } from 'js/hooks/useCopyText';
 import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import { StyledTableContainer } from 'js/shared-styles/tables';
+import MarkdownRenderer from 'js/components/Markdown/MarkdownRenderer';
 
 interface AnalysisDetailsProps {
   dagListData: DagProvenanceType[];
@@ -290,7 +291,7 @@ function AnalysisDetails({ dagListData, workflow_description, workflow_version }
   return (
     <Stack spacing={1}>
       {workflow_version && <Typography variant="subtitle2">Workflow (v{workflow_version})</Typography>}
-      {workflow_description && <Typography>{workflow_description}</Typography>}
+      {workflow_description && <MarkdownRenderer>{workflow_description}</MarkdownRenderer>}
       {hasInputParameters && (
         <Box>
           <Button variant="outlined" onClick={collapseSteps} disabled={Object.keys(expandedRows).length === 0}>

--- a/context/jest.config.js
+++ b/context/jest.config.js
@@ -30,7 +30,7 @@ const config = {
     '@mui/styled-engine': '@mui/styled-engine-sc',
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(?:\\.pnpm/[^/]+/node_modules/)?(lodash-es|@mui/material|@mui/system|@mui/styled-engine-sc|@babel|pretty-bytes|uuid|chart-js|history|pdfjs-dist|until-async|nuqs|rettime|@open-draft/deferred-promise)/)',
+    'node_modules/(?!(?:\\.pnpm/[^/]+/node_modules/)?(lodash-es|@mui/material|@mui/system|@mui/styled-engine-sc|@babel|pretty-bytes|uuid|chart-js|history|pdfjs-dist|until-async|nuqs|rettime|@open-draft/deferred-promise|react-markdown|rehype-raw|remark-parse|remark-rehype|unified|bail|ccount|character-entities(?:-html4|-legacy)?|character-reference-invalid|comma-separated-tokens|decode-named-character-reference|devlop|escape-string-regexp|estree-util-is-identifier-name|estree-walker|extend|hastscript|hast-util-[^/]+|html-url-attributes|html-void-elements|inline-style-parser|is-plain-obj|longest-streak|mdast-util-[^/]+|micromark|micromark-[^/]+|unist-util-[^/]+|property-information|space-separated-tokens|stringify-entities|style-to-js|style-to-object|trim-lines|trough|vfile|vfile-location|vfile-message|web-namespaces|zwitch)/)',
   ],
   transform: {
     '^.+\\.(t|j)sx?$': [


### PR DESCRIPTION
## Summary

This PR replaces the `Typography` wrapper of workflow descriptions with the `<MarkdownRenderer>` component to enable rendering workflow descriptions with linksg. 

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1585

## Testing

Hard-coded sample markdown description - see screenshot below.

## Screenshots/Video

PLEASE NOTE: I hard-coded the description as a local string for the sake of testing since it wasn't live on production yet.

<img width="1246" height="3829" alt="image" src="https://github.com/user-attachments/assets/55d1c916-1997-4c8d-b665-92411e6dd69d" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

I'm using outbound links without icons - let me know if there is a preferred alternative.
