### PR TITLE
NickAkhmetov/CAT-1592 Update assay links at the top of dataset detail pages

### DIFF
--- a/CHANGELOG-cat-1592.md
+++ b/CHANGELOG-cat-1592.md
@@ -1,0 +1,1 @@
+- Update assay links at the top of dataset detail pages to point to updated documentation with metadata schemas.

--- a/context/app/static/js/pages/Dataset/DatasetPageSummaryChildren.tsx
+++ b/context/app/static/js/pages/Dataset/DatasetPageSummaryChildren.tsx
@@ -21,7 +21,7 @@ export default function SummaryDataChildren({ mapped_data_types, origin_samples 
     <>
       <SummaryItem>
         <InternalLink
-          href="https://docs.hubmapconsortium.org/assays"
+          href="https://docs.hubmapconsortium.org/assays/metadata"
           underline="none"
           onClick={() => {
             trackEntityPageEvent({ action: 'Assay Documentation Navigation', label: dataTypes });


### PR DESCRIPTION
## Summary

This PR updates the link at the top of dataset detail pages to point to https://docs.hubmapconsortium.org/assays/metadata, as this page is more maintained/up to date and contains more in-depth descriptions of the assays.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1592

## Testing

Visited dataset detail page, clicked link.

## Screenshots/Video


https://github.com/user-attachments/assets/00152e3b-391f-4f23-acac-2e386bed77ce



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
