### PR TITLE
NickAkhmetov/SCFind ATACseq QA Fixes

### DIFF
--- a/CHANGELOG-scfind-atac-bugfixes.md
+++ b/CHANGELOG-scfind-atac-bugfixes.md
@@ -1,0 +1,16 @@
+- Fix Gene detail pages for genes indexed only in ATACseq: the page now uses the ATACseq modality for its lookups instead of erroring against the RNAseq index.
+- Fix 500 errors on Cell Type detail pages for cell types whose names contain commas (e.g. "CD4-positive, alpha-beta T cell").
+- Speed up Cell Type detail page loading by running its scFind queries in parallel and rendering the cell type name immediately from server data.
+- Precache ATACseq cell counts at server start so switching the cell type distribution chart to ATACseq is instant on first use.
+- Fix charts (Datasets Overview, Cell Type Distribution, and others) overflowing their container and getting cut off on smaller screens.
+- Fix alignment of the column headers with their content on the Cell Types and Biomarkers landing pages.
+- Add missing spacing between section descriptions and their content on the Cell Type and Gene detail pages.
+- Open scFind Method links in a new tab.
+- Update the scFind Method page button text to "Biomarker and Cell Type Search".
+- Remove the info tooltip from the "Datasets with 'gene'" section header on the Gene detail page.
+- Clarify the description text for the "Datasets with 'gene'" section.
+- Remove the "View Indexed Datasets" button from the datasets overview.
+- Add a period after the Datasets Overview tooltip text and rename "query" to "results" for clarity.
+- Add "Cell Types" / "Biomarkers" after the count in the result tabs for clarity.
+- Update the "Datasets containing 'cell type'" section description and make the section collapsible.
+- Move the outbound link icon inside the trailing period in the metadata description section.

--- a/context/app/routes_cell_types.py
+++ b/context/app/routes_cell_types.py
@@ -46,7 +46,11 @@ def cell_types_detail_view(cl_id):
     return render_template(
         'base-pages/react-content.html',
         title='Cell Type Details',
-        flask_data={**get_default_flask_data(), 'cell_type': cl_id, 'cell_type_name': cell_type_name},
+        flask_data={
+            **get_default_flask_data(),
+            'cell_type': cl_id,
+            'cell_type_name': cell_type_name,
+        },
     )
 
 

--- a/context/app/routes_cell_types.py
+++ b/context/app/routes_cell_types.py
@@ -3,6 +3,7 @@ from asyncio import gather, to_thread
 
 from .routes_file_based import _get_organ_list
 from .routes_cells import _get_client
+from .routes_scfind import peek_cell_type_name
 
 from .utils import make_blueprint, get_client, get_default_flask_data
 
@@ -34,10 +35,18 @@ def cell_types_view():
 
 @blueprint.route('/cell-types/<cl_id>')
 def cell_types_detail_view(cl_id):
+    # Seed the cell type name from the warmed CLID->label map so the page title renders immediately,
+    # rather than waiting on the page's async scfind aggregate fetch. Best-effort: a cache miss (or
+    # any error) yields no name and the page falls back to the aggregate; it never blocks rendering.
+    try:
+        cell_type_name = peek_cell_type_name(cl_id)
+    except Exception as e:
+        current_app.logger.warning(f'Failed to resolve cell type name for {cl_id}: {e}')
+        cell_type_name = ''
     return render_template(
         'base-pages/react-content.html',
         title='Cell Type Details',
-        flask_data={**get_default_flask_data(), 'cell_type': cl_id},
+        flask_data={**get_default_flask_data(), 'cell_type': cl_id, 'cell_type_name': cell_type_name},
     )
 
 

--- a/context/app/routes_scfind.py
+++ b/context/app/routes_scfind.py
@@ -664,8 +664,8 @@ def _gather(tasks):
                 return label, default
 
     results = {}
-    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
-        futures = [
+    max_workers = min(current_app.config.get('SCFIND_MAX_WORKERS', 20), len(tasks))
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
             executor.submit(run, label, fn, default) for label, (fn, default) in tasks.items()
         ]
         for future in as_completed(futures):

--- a/context/app/routes_scfind.py
+++ b/context/app/routes_scfind.py
@@ -665,7 +665,9 @@ def _gather(tasks):
 
     results = {}
     with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
-        futures = [executor.submit(run, label, fn, default) for label, (fn, default) in tasks.items()]
+        futures = [
+            executor.submit(run, label, fn, default) for label, (fn, default) in tasks.items()
+        ]
         for future in as_completed(futures):
             label, result = future.result()
             results[label] = result
@@ -919,9 +921,14 @@ def _build_cell_type_detail(clid):
     # (e.g. a high-cardinality cell type scfind rejects) no longer 500s the whole page.
     results = _gather(
         {
-            'markers': (lambda: _cell_type_markers_for(cell_types).get('findGeneSignatures', []), []),
+            'markers': (
+                lambda: _cell_type_markers_for(cell_types).get('findGeneSignatures', []),
+                [],
+            ),
             'markers_atac': (
-                lambda: _cell_type_markers_for(cell_types, modality='ATAC').get('findGeneSignatures', []),
+                lambda: _cell_type_markers_for(cell_types, modality='ATAC').get(
+                    'findGeneSignatures', []
+                ),
                 [],
             ),
             'datasets_for_cell_types': (lambda: _build_datasets_for_cell_types(cell_types), {}),

--- a/context/app/routes_scfind.py
+++ b/context/app/routes_scfind.py
@@ -136,6 +136,33 @@ def _get_or_build_map(name, builder):
     return data
 
 
+def _load_cached_map(name):
+    """
+    Return an already-built aggregate map from the in-process memo or the shared disk cache, WITHOUT
+    building it — returns ``None`` if it hasn't been built yet.
+
+    For latency-sensitive paths (e.g. server-rendering a page) that want the warmed data when it's
+    available but must never trigger the expensive build (which ``_get_or_build_map`` would do).
+    """
+    with _memory_lock:
+        if name in _memory_cache:
+            return _memory_cache[name]
+    path = _scfind_cache_path(name)
+    ttl = current_app.config.get('SCFIND_CACHE_TTL')
+    if not os.path.exists(path):
+        return None
+    if ttl and (time.time() - os.path.getmtime(path)) > ttl:
+        return None
+    try:
+        with open(path) as data_file:
+            data = json.load(data_file)
+    except (OSError, ValueError):
+        return None
+    with _memory_lock:
+        _memory_cache[name] = data
+    return data
+
+
 def warm_scfind_caches(app):
     """
     Pre-build the cell type mappings in a background thread at app startup.
@@ -356,7 +383,14 @@ def _get_label_to_clid_mapping(cell_type):
     Returns:
         List of CLIDs for the given cell type
     """
-    response = _make_scfind_request('CellType2CLID', {'cell_type': cell_type})
+    # A comma in a cell type name (e.g. "CD4-positive, alpha-beta T cell") is parsed as a multi-value
+    # list when sent as a GET query param, yielding the wrong/no CLID — which leaves that cell type
+    # (and its CLID) out of the label<->CLID maps, breaking its detail page. POST the body instead
+    # (the same workaround the front-end uses for comma-containing cell type names).
+    if ',' in cell_type:
+        response = _make_scfind_post_request('CellType2CLID', {'cell_type': cell_type})
+    else:
+        response = _make_scfind_request('CellType2CLID', {'cell_type': cell_type})
     return response.get('CLIDs', [])
 
 
@@ -562,6 +596,22 @@ def _extract_cell_types_info(cell_types):
     return {'name': name, 'organs': organs, 'variants': variants}
 
 
+def peek_cell_type_name(clid):
+    """
+    Best-effort cell type name for a CLID from the already-built CLID->label map, without triggering
+    a build (returns '' if the map isn't cached yet).
+
+    Lets the Cell Type detail page server-render the name from the warmed map (a fast cache hit)
+    instead of waiting on the page's async aggregate fetch, so the title appears immediately. When
+    the map isn't warmed yet it returns '' and the page falls back to the aggregate as before — it
+    never blocks the HTML render on the expensive build.
+    """
+    clid_to_label_map = _load_cached_map('clid_to_label')
+    if not clid_to_label_map:
+        return ''
+    return _extract_cell_types_info(clid_to_label_map.get(clid, []))['name']
+
+
 def _fan_out(items, fetch_one, label):
     """
     Run ``fetch_one(item)`` for each item across a bounded thread pool, returning ``{item: result}``.
@@ -589,6 +639,36 @@ def _fan_out(items, fetch_one, label):
             item, result = future.result()
             if result is not None:
                 results[item] = result
+    return results
+
+
+def _gather(tasks):
+    """
+    Run independent ``{label: (callable, default)}`` tasks concurrently, returning ``{label: result}``.
+
+    Like ``_fan_out`` but for a fixed set of heterogeneous operations (rather than one function over
+    many items): each task runs in its own thread, re-entering the captured app context (worker
+    threads don't inherit it). A task that raises degrades to its ``default`` (logged) instead of
+    failing the whole aggregate, so e.g. one modality's scfind error doesn't 500 the page.
+    """
+    if not tasks:
+        return {}
+    app = current_app._get_current_object()
+
+    def run(label, fn, default):
+        with app.app_context():
+            try:
+                return label, fn()
+            except Exception as e:
+                current_app.logger.warning(f'{label} failed (treating as empty): {e}')
+                return label, default
+
+    results = {}
+    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+        futures = [executor.submit(run, label, fn, default) for label, (fn, default) in tasks.items()]
+        for future in as_completed(futures):
+            label, result = future.result()
+            results[label] = result
     return results
 
 
@@ -833,6 +913,24 @@ def _build_cell_type_detail(clid):
     clid_to_label_map = _build_clid_to_label_map()
     cell_types = clid_to_label_map.get(clid, [])
     info = _extract_cell_types_info(cell_types)
+    # The RNA + ATAC markers and datasets are independent, so fetch them concurrently rather than one
+    # after another (the four sequential scfind ops were the bulk of the first-load latency). Each op
+    # degrades to empty on a scfind error so a single failing modality's `cellTypeMarkers` request
+    # (e.g. a high-cardinality cell type scfind rejects) no longer 500s the whole page.
+    results = _gather(
+        {
+            'markers': (lambda: _cell_type_markers_for(cell_types).get('findGeneSignatures', []), []),
+            'markers_atac': (
+                lambda: _cell_type_markers_for(cell_types, modality='ATAC').get('findGeneSignatures', []),
+                [],
+            ),
+            'datasets_for_cell_types': (lambda: _build_datasets_for_cell_types(cell_types), {}),
+            'datasets_for_cell_types_atac': (
+                lambda: _build_datasets_for_cell_types(cell_types, modality='ATAC'),
+                {},
+            ),
+        }
+    )
     return {
         'cell_types': cell_types,
         'name': info['name'],
@@ -840,14 +938,7 @@ def _build_cell_type_detail(clid):
         'variants': info['variants'],
         # RNA + ATAC markers and datasets so the page's biomarker and dataset modality tabs (with
         # counts) come from this single aggregate fetch.
-        'markers': _cell_type_markers_for(cell_types).get('findGeneSignatures', []),
-        'markers_atac': _cell_type_markers_for(cell_types, modality='ATAC').get(
-            'findGeneSignatures', []
-        ),
-        'datasets_for_cell_types': _build_datasets_for_cell_types(cell_types),
-        'datasets_for_cell_types_atac': _build_datasets_for_cell_types(
-            cell_types, modality='ATAC'
-        ),
+        **results,
     }
 
 

--- a/context/app/routes_scfind.py
+++ b/context/app/routes_scfind.py
@@ -177,8 +177,11 @@ def warm_scfind_caches(app):
                 _get_all_cell_type_names('ATAC')
                 landing = _build_cell_types_landing()
                 # Warm the per-organ cell-type counts the distribution chart fetches one-per-organ;
-                # they share `_cached_scfind_get`, so the chart's requests are then served warm.
+                # they share `_cached_scfind_get`, so the chart's requests are then served warm. Warm
+                # both modalities so toggling the chart's RNAseq/ATACseq "Data Type" switch (which the
+                # client also prefetches) is served from cache rather than fetched cold on first use.
                 _build_cell_counts_for_tissues(landing['organs'])
+                _build_cell_counts_for_tissues(landing['organs'], modality='ATAC')
                 current_app.logger.info('Finished warming scfind cell type mapping caches.')
             except Exception as e:
                 current_app.logger.warning(f'Failed to warm scfind caches at startup: {e}')

--- a/context/app/routes_scfind.py
+++ b/context/app/routes_scfind.py
@@ -666,6 +666,7 @@ def _gather(tasks):
     results = {}
     max_workers = min(current_app.config.get('SCFIND_MAX_WORKERS', 20), len(tasks))
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
             executor.submit(run, label, fn, default) for label, (fn, default) in tasks.items()
         ]
         for future in as_completed(futures):

--- a/context/app/routes_scfind.py
+++ b/context/app/routes_scfind.py
@@ -268,6 +268,26 @@ def _cached_scfind_get(endpoint, params_items):
     return _make_scfind_request(endpoint, params or None)
 
 
+def _safe_scfind_get(endpoint, params_items, default):
+    """Like ``_cached_scfind_get`` but returns ``default`` instead of raising on a scfind error.
+
+    A gene (or cell type) present in only one modality's index makes the OTHER modality's query
+    fail — scfind errors on an entity it doesn't know. When assembling a per-page aggregate that
+    queries both modalities, treat such a failure as "no data for this modality" so a
+    single-modality entity still yields a usable payload instead of failing the whole page.
+    """
+    try:
+        return _cached_scfind_get(endpoint, params_items)
+    except requests.RequestException as e:
+        current_app.logger.info(
+            'scfind %s returned no data for params %s (treating as empty): %s',
+            endpoint,
+            dict(params_items),
+            e,
+        )
+        return default
+
+
 def _proxy_scfind_get(endpoint, allowed):
     """Forward an allowlisted GET to scfind, served from the shared cache when possible."""
     params = _collect_args(allowed)
@@ -753,16 +773,23 @@ def _build_gene_detail(gene_symbol):
     RNA and ATAC counterparts are both bundled so the page's cell-types and datasets modality tabs
     (with counts) are served from this single aggregate fetch.
     """
-    hyper_query = _cached_scfind_get(
-        'hyperQueryCellTypes', (('gene_list', gene_symbol), ('include_prefix', 'true'))
+    # A gene may be indexed in only one modality; querying the other modality errors at scfind.
+    # Fetch each modality independently and degrade a failure to "no data" so an ATAC-only (or
+    # RNA-only) gene still returns a usable aggregate instead of 500ing the whole page.
+    empty_find_datasets = {'counts': {}, 'findDatasets': {}}
+    hyper_query = _safe_scfind_get(
+        'hyperQueryCellTypes', (('gene_list', gene_symbol), ('include_prefix', 'true')), {}
     ).get('findGeneSignatures', [])
-    hyper_query_atac = _cached_scfind_get(
+    hyper_query_atac = _safe_scfind_get(
         'hyperQueryCellTypes',
         (('gene_list', gene_symbol), ('include_prefix', 'true'), ('modality', 'ATAC')),
+        {},
     ).get('findGeneSignatures', [])
-    find_datasets = _cached_scfind_get('findDatasets', (('gene_list', gene_symbol),))
-    find_datasets_atac = _cached_scfind_get(
-        'findDatasets', (('gene_list', gene_symbol), ('modality', 'ATAC'))
+    find_datasets = _safe_scfind_get(
+        'findDatasets', (('gene_list', gene_symbol),), empty_find_datasets
+    )
+    find_datasets_atac = _safe_scfind_get(
+        'findDatasets', (('gene_list', gene_symbol), ('modality', 'ATAC')), empty_find_datasets
     )
 
     def cell_types_of(signatures):

--- a/context/app/static/js/components/Contexts.tsx
+++ b/context/app/static/js/components/Contexts.tsx
@@ -14,6 +14,7 @@ export interface FlaskDataContextType {
   redirectedFromPipeline?: string | null;
   siblingIds?: string[];
   integrated?: boolean; // true if the entity is an integrated dataset
+  cell_type_name?: string; // cell type name seeded server-side for the detail page title
 }
 
 export const FlaskDataContext = createContext<FlaskDataContextType>('FlaskDataContext');

--- a/context/app/static/js/components/biomarkers/BiomarkersPanelItem.tsx
+++ b/context/app/static/js/components/biomarkers/BiomarkersPanelItem.tsx
@@ -41,8 +41,10 @@ function BiomarkerHeaderPanel() {
   if (isMobile) {
     return null;
   }
+  // Match the body rows' default StackTemplate spacing (4) so the header labels line up with the
+  // left edge of each column's content.
   return (
-    <StackTemplate spacing={1}>
+    <StackTemplate spacing={4}>
       <HeaderCell {...desktopConfig.name}>Name</HeaderCell>
       <HeaderCell {...desktopConfig.description}>Description</HeaderCell>
       <HeaderCell {...desktopConfig.dataType}>

--- a/context/app/static/js/components/cell-types/CellTypesBiomarkersTable.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesBiomarkersTable.tsx
@@ -198,8 +198,8 @@ function CellTypesBiomarkersTableSection() {
         annotations. The table can be downloaded in TSV format for further analysis.
       </Description>
       <Tabs value={openTabIndex} onChange={handleTabChange}>
-        <Tab label={`RNAseq (${rnaCount})`} index={0} disabled={rnaCount === 0} />
-        <Tab label={`ATACseq (${atacCount})`} index={1} disabled={atacCount === 0} />
+        <Tab label={`RNAseq (${rnaCount} Biomarkers)`} index={0} disabled={rnaCount === 0} />
+        <Tab label={`ATACseq (${atacCount} Biomarkers)`} index={1} disabled={atacCount === 0} />
       </Tabs>
       <TabPanel value={openTabIndex} index={0}>
         <BiomarkersTable modality={undefined} />

--- a/context/app/static/js/components/cell-types/CellTypesBiomarkersTable.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesBiomarkersTable.tsx
@@ -192,7 +192,7 @@ function CellTypesBiomarkersTableSection() {
 
   return (
     <CollapsibleDetailPageSection id="biomarkers" title="Biomarkers" trackingInfo={trackingInfo}>
-      <Description>
+      <Description sx={{ mb: 1 }}>
         Explore marker genes associated with the cell type and its statistical metrics as computed by the scFind method.
         It calculates statistical metrics based on uniformly processed HuBMAP RNAseq and ATACseq datasets with cell type
         annotations. The table can be downloaded in TSV format for further analysis.

--- a/context/app/static/js/components/cell-types/CellTypesDatasetsResults.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDatasetsResults.tsx
@@ -91,7 +91,6 @@ export default function CellTypesDatasetsResults() {
 
   const overviewEffective = showModalitySelection ? overviewModality : pinnedModality;
   const overviewActive = overviewEffective === 'ATAC' ? atac : rna;
-  const overviewModalityLabel = overviewEffective === 'ATAC' ? 'ATACseq' : 'RNAseq';
 
   const resultsEffective = showModalitySelection ? resultsModality : pinnedModality;
   const resultsActive = resultsEffective === 'ATAC' ? atac : rna;
@@ -108,9 +107,10 @@ export default function CellTypesDatasetsResults() {
           dataType={overviewEffective}
           onDataTypeChange={showModalitySelection ? setOverviewModality : undefined}
         >
-          These results are derived from {overviewModalityLabel} datasets that were indexed by the <SCFindLink />. Not
-          all HuBMAP datasets are currently compatible with this method due to data modalities or the availability of
-          cell annotations.
+          These are datasets that contain this cell type as identified by Azimuth and indexed by the <SCFindLink /> with
+          uniformly processed HuBMAP RNAseq or ATACseq datasets that contain cell type annotations. The datasets
+          overview plot displays an overview of the datasets metadata compared to either the indexed datasets or all the
+          HuBMAP datasets available. The table is available for download in TSV format for further analysis.
         </DatasetsOverview>
       </SCFindModalityProvider>
       {showModalitySelection ? (

--- a/context/app/static/js/components/cell-types/CellTypesDatasetsResults.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDatasetsResults.tsx
@@ -11,6 +11,8 @@ import DatasetsOverview from 'js/components/cells/DatasetsOverview';
 import { DatasetsForCellType } from 'js/api/scfind/useCellTypeDetailData';
 import SCFindDatasetTableActions from 'js/components/cells/SCFindResults/SCFindDatasetTableActions';
 import { useCellTypeDatasetsData, useCellTypesDetailPageContext } from './CellTypesDetailPageContext';
+import DetailsAccordion from 'js/shared-styles/accordions/DetailsAccordion';
+import Typography from '@mui/material/Typography';
 
 const RNA_TAB = 0;
 const ATAC_TAB = 1;
@@ -107,41 +109,47 @@ export default function CellTypesDatasetsResults() {
           dataType={overviewEffective}
           onDataTypeChange={showModalitySelection ? setOverviewModality : undefined}
         >
-          These are datasets that contain this cell type as identified by Azimuth and indexed by the <SCFindLink /> with
-          uniformly processed HuBMAP RNAseq or ATACseq datasets that contain cell type annotations. The datasets
-          overview plot displays an overview of the datasets metadata compared to either the indexed datasets or all the
-          HuBMAP datasets available. The table is available for download in TSV format for further analysis.
+          These results are derived from RNAseq or ATACseq datasets that were indexed by the <SCFindLink />. Not all
+          HuBMAP datasets are currently compatible with this method due to data modalities or the availability of cell
+          annotations.
         </DatasetsOverview>
       </SCFindModalityProvider>
-      {showModalitySelection ? (
-        <div>
-          <Tabs
-            value={resultsTabValue}
-            onChange={(_event, value: number) => setResultsModality(value === ATAC_TAB ? 'ATAC' : undefined)}
-          >
-            <Tab label={`RNAseq (${rna.ids.length})`} index={RNA_TAB} />
-            <Tab label={`ATACseq (${atac.ids.length})`} index={ATAC_TAB} />
-          </Tabs>
-          <TabPanel value={resultsTabValue} index={RNA_TAB} sx={{ mt: 0 }}>
-            <SelectableTableProvider tableLabel={`${tableLabel} - RNAseq`}>
-              <CellTypeDatasetsTable modality={undefined} datasetIds={rna.datasetIds} countsMap={rna.countsMap} />
-            </SelectableTableProvider>
-          </TabPanel>
-          <TabPanel value={resultsTabValue} index={ATAC_TAB} sx={{ mt: 0 }}>
-            <SelectableTableProvider tableLabel={`${tableLabel} - ATACseq`}>
-              <CellTypeDatasetsTable modality="ATAC" datasetIds={atac.datasetIds} countsMap={atac.countsMap} />
-            </SelectableTableProvider>
-          </TabPanel>
-        </div>
-      ) : (
-        <SelectableTableProvider tableLabel={tableLabel}>
-          <CellTypeDatasetsTable
-            modality={pinnedModality}
-            datasetIds={resultsActive.datasetIds}
-            countsMap={resultsActive.countsMap}
-          />
-        </SelectableTableProvider>
-      )}
+
+      <DetailsAccordion
+        summary={<Typography variant="subtitle1">Datasets with {name}</Typography>}
+        defaultExpanded
+        summaryProps={{ sx: { '.MuiAccordionSummary-content': { mr: 'auto' } } }}
+      >
+        {showModalitySelection ? (
+          <div>
+            <Tabs
+              value={resultsTabValue}
+              onChange={(_event, value: number) => setResultsModality(value === ATAC_TAB ? 'ATAC' : undefined)}
+            >
+              <Tab label={`RNAseq (${rna.ids.length})`} index={RNA_TAB} />
+              <Tab label={`ATACseq (${atac.ids.length})`} index={ATAC_TAB} />
+            </Tabs>
+            <TabPanel value={resultsTabValue} index={RNA_TAB} sx={{ mt: 0 }}>
+              <SelectableTableProvider tableLabel={`${tableLabel} - RNAseq`}>
+                <CellTypeDatasetsTable modality={undefined} datasetIds={rna.datasetIds} countsMap={rna.countsMap} />
+              </SelectableTableProvider>
+            </TabPanel>
+            <TabPanel value={resultsTabValue} index={ATAC_TAB} sx={{ mt: 0 }}>
+              <SelectableTableProvider tableLabel={`${tableLabel} - ATACseq`}>
+                <CellTypeDatasetsTable modality="ATAC" datasetIds={atac.datasetIds} countsMap={atac.countsMap} />
+              </SelectableTableProvider>
+            </TabPanel>
+          </div>
+        ) : (
+          <SelectableTableProvider tableLabel={tableLabel}>
+            <CellTypeDatasetsTable
+              modality={pinnedModality}
+              datasetIds={resultsActive.datasetIds}
+              countsMap={resultsActive.countsMap}
+            />
+          </SelectableTableProvider>
+        )}
+      </DetailsAccordion>
     </Stack>
   );
 }

--- a/context/app/static/js/components/cell-types/CellTypesDetailPageContext.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDetailPageContext.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren, useMemo, useContext as useOptionalContext } f
 import { createContext, useContext } from 'js/helpers/context';
 import useCellTypeDetailData, { CellTypeMarker, DatasetsForCellType } from 'js/api/scfind/useCellTypeDetailData';
 import { extractCellTypesInfo } from 'js/api/scfind/utils';
+import { useFlaskDataContext } from 'js/components/Contexts';
 import { SCFindModality } from 'js/components/cells/MolecularDataQueryForm/types';
 
 interface CellTypesContextProps {
@@ -35,7 +36,11 @@ export default function CellTypesProvider({ children, cellId }: PropsWithChildre
   // while `isLoading`.
   const { data, isLoading, error } = useCellTypeDetailData(cellId);
   const cellTypes = useMemo(() => data?.cell_types ?? [], [data]);
-  const { name, organs, variants } = extractCellTypesInfo(cellTypes);
+  const { name: extractedName, organs, variants } = extractCellTypesInfo(cellTypes);
+  // The name is server-rendered into Flask data (from the warmed CLID->label map), so the title can
+  // show immediately; fall back to it until the aggregate resolves (both derive the same name).
+  const { cell_type_name: flaskCellTypeName } = useFlaskDataContext();
+  const name = extractedName || flaskCellTypeName || '';
   const value = useMemo(
     () => ({
       cellId,

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
@@ -13,6 +13,7 @@ import Skeleton from '@mui/material/Skeleton';
 import { unselectedCellColors } from 'js/components/cells/CellTypeDistributionChart/utils';
 import { trackEvent } from 'js/helpers/trackers';
 import { useLabelToCLIDMap } from 'js/api/scfind/useLabelToCLID';
+import { useCellTypeCountForTissues } from 'js/api/scfind/useCellTypeCountForTissue';
 import { useEventCallback } from '@mui/material/utils';
 import { BarGroupBar, SeriesPoint } from '@visx/shape/lib/types';
 import { SCFindModality } from 'js/components/cells/MolecularDataQueryForm/types';
@@ -208,6 +209,12 @@ function MultiOrganCellTypeDistributionChart({
   const { showOtherCellTypes, showPercentages } = useCellTypesDistributionChartContext();
 
   const atacAvailable = useHasAtacData(cellTypes, organs);
+
+  // Prefetch the ATAC per-organ counts in the background (warms the SWR cache, which the server also
+  // warms at startup) so flipping the "Data Type" switch to ATACseq is instant instead of showing a
+  // loading skeleton on first toggle. RNAseq is the default and already loaded, so only ATAC needs
+  // prefetching; no-op (empty key) when there's no ATAC data for these cell types.
+  useCellTypeCountForTissues(atacAvailable ? organs : [], 'ATAC');
 
   const chartPalette = useChartPalette();
   const chartPaletteSubset = chartPalette.slice(0, targetCellTypeKeys.length);

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/MultiOrganCellTypesDistributionChart.tsx
@@ -53,7 +53,7 @@ function ChartControls({ atacAvailable }: { atacAvailable: boolean }) {
   const trackingInfo = cellTypeContext?.trackingInfo;
 
   return (
-    <Stack direction="row" spacing={2} alignItems="center">
+    <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
       {atacAvailable && (
         <LabeledPrimarySwitch
           label={

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/index.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/index.tsx
@@ -75,7 +75,7 @@ function CellTypesDistribution() {
       id="cell-type-distribution"
       trackingInfo={trackingInfo}
     >
-      <Description>
+      <Description sx={{ mb: 1 }}>
         This visualization displays the distribution of the cell type across the available organs, as identified by
         Azimuth and indexed by the <SCFindLink />. Only organs that contain at least one indexable dataset containing
         this cell type are included.

--- a/context/app/static/js/components/cell-types/CellTypesDistribution/index.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesDistribution/index.tsx
@@ -5,6 +5,7 @@ import Description from 'js/shared-styles/sections/Description';
 import Paper from '@mui/material/Paper';
 import Stack from '@mui/material/Stack';
 import Box from '@mui/material/Box';
+import Skeleton from '@mui/material/Skeleton';
 import { capitalize } from '@mui/material/utils';
 import { Tab, TabPanel, Tabs, useTabs } from 'js/shared-styles/tabs';
 import OrganIcon from 'js/shared-styles/icons/OrganIcon';
@@ -16,11 +17,17 @@ import CellTypeDistributionChart from '../../cells/CellTypeDistributionChart';
 import MultiOrganCellTypeDistributionChart from './MultiOrganCellTypesDistributionChart';
 
 function Chart() {
-  const { organs, cellTypes } = useCellTypesDetailPageContext();
+  const { organs, cellTypes, isLoading } = useCellTypesDetailPageContext();
   const { openTabIndex, handleTabChange } = useTabs();
   // RNA/ATAC selection is shared across all tabs: the multi-organ chart's toggle drives it, and the
   // per-organ single charts read it via SCFindModalityProvider.
   const [dataType, setDataType] = useState<SCFindModality>(undefined);
+
+  // Show a skeleton until the aggregate provides the organs/cell types. Rendering the chart with an
+  // empty organs list paints a blank plot first, which flashes before the real chart appears.
+  if (isLoading) {
+    return <Skeleton variant="rectangular" width="100%" height={500} />;
+  }
 
   // Tab 0 is the multi-organ chart (default); tabs 1..N are individual organs' fraction charts.
   return (

--- a/context/app/static/js/components/cell-types/CellTypesEntitiesTables.tsx
+++ b/context/app/static/js/components/cell-types/CellTypesEntitiesTables.tsx
@@ -45,9 +45,9 @@ function CellTypesEntitiesTables() {
         }
       >
         These are datasets that contain this cell type as identified by Azimuth and indexed by the <SCFindLink /> with
-        uniformly processed HuBMAP RNAseq datasets that contain cell type annotations. The datasets overview plot
-        displays an overview of the datasets metadata compared to either the indexed datasets or all the HuBMAP datasets
-        available. The table is available for download in TSV format for further analysis.
+        uniformly processed HuBMAP RNAseq or ATACseq datasets that contain cell type annotations. The datasets overview
+        plot displays an overview of the datasets metadata compared to either the indexed datasets or all the HuBMAP
+        datasets available. The table is available for download in TSV format for further analysis.
       </Description>
       <Box py={1} />
       <MolecularDataQueryFormTrackingProvider category="Cell Type Detail Page">

--- a/context/app/static/js/components/cells/CellTypeDistributionChart/FractionGraphLegend.tsx
+++ b/context/app/static/js/components/cells/CellTypeDistributionChart/FractionGraphLegend.tsx
@@ -20,8 +20,16 @@ export default function FractionGraphLegend({
   totalCellCount,
 }: FractionGraphLegendProps) {
   return (
-    <Stack direction="row" justifyContent="space-between" alignItems="flex-start" mt={1}>
-      <Stack>
+    <Stack
+      direction="row"
+      justifyContent="space-between"
+      alignItems="flex-start"
+      flexWrap="wrap"
+      gap={2}
+      useFlexGap
+      mt={1}
+    >
+      <Stack sx={{ minWidth: 0 }}>
         <Typography variant="body2" color="textSecondary" my={1}>
           Targeted Cell Types
         </Typography>
@@ -46,7 +54,7 @@ export default function FractionGraphLegend({
           )}
         </LegendOrdinal>
       </Stack>
-      <Stack>
+      <Stack sx={{ minWidth: 0 }}>
         <Typography variant="body2" color="textSecondary" my={1}>
           Other Cell Types
         </Typography>

--- a/context/app/static/js/components/cells/DatasetsOverview/DatasetsOverviewChart.tsx
+++ b/context/app/static/js/components/cells/DatasetsOverview/DatasetsOverviewChart.tsx
@@ -362,7 +362,7 @@ export default function DatasetsOverviewChart({
           </>
         }
         additionalControls={
-          <Stack direction="row" spacing={2} px={1} pt={1} alignItems="center" useFlexGap>
+          <Stack direction="row" spacing={2} px={1} pt={1} alignItems="center" flexWrap="wrap" useFlexGap>
             {onDataTypeChange && (
               <LabeledPrimarySwitch
                 label="Data Type"
@@ -387,7 +387,7 @@ export default function DatasetsOverviewChart({
             <SecondaryBackgroundTooltip
               title={showComparison ? undefined : 'Set "Plot Type" to "With Comparison" to toggle these options'}
             >
-              <Stack direction="row" spacing={2} alignItems="center" useFlexGap>
+              <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap" useFlexGap>
                 <LabeledPrimarySwitch
                   label="Comparison Group"
                   checked={compareToAll}

--- a/context/app/static/js/components/cells/DatasetsOverview/DownloadDatasetsOverview.tsx
+++ b/context/app/static/js/components/cells/DatasetsOverview/DownloadDatasetsOverview.tsx
@@ -22,5 +22,5 @@ export default function DownloadDatasetsOverview({ rows }: DownloadDatasetsOverv
     ],
     rows: useDownloadableRows(rows),
   });
-  return <DownloadButton tooltip="Download dataset overview statistics for current query" onClick={downloadTable} />;
+  return <DownloadButton tooltip="Download dataset overview statistics for current results." onClick={downloadTable} />;
 }

--- a/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
+++ b/context/app/static/js/components/cells/SCFindResults/SCFindGeneQueryResults.tsx
@@ -14,7 +14,6 @@ import EntityTable from 'js/shared-styles/tables/EntitiesTable/EntityTable';
 import Description from 'js/shared-styles/sections/Description';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
-import ViewIndexedDatasetsButton from 'js/components/organ/OrganCellTypes/ViewIndexedDatasetsButton';
 import useSCFindIDAdapter from 'js/api/scfind/useSCFindIDAdapter';
 import DatasetsOverview from '../DatasetsOverview';
 
@@ -251,18 +250,7 @@ function SCFindGeneQueryResultsLoader({ trackingInfo }: SCFindGeneQueryResultsLo
   return (
     <GeneCountsContextProvider value={geneCountsContextValue}>
       {!noResults && (
-        <DatasetsOverview
-          datasets={deduplicatedResults}
-          belowTheFold={
-            <ViewIndexedDatasetsButton
-              scFindParams={{
-                scFindOnly: true,
-              }}
-              isLoading={false}
-            />
-          }
-          trackingInfo={trackingInfo}
-        >
+        <DatasetsOverview datasets={deduplicatedResults} trackingInfo={trackingInfo}>
           This overview provides a summary of the matched datasets and their proportions relative to both indexed
           datasets and the total HuBMAP datasets. The summary is available in two formats: a visualization view and a
           tabular view. Both views can be downloaded, with the visualization available as a PNG and the table as a TSV

--- a/context/app/static/js/components/detailPage/MetadataSection/MetadataSection.tsx
+++ b/context/app/static/js/components/detailPage/MetadataSection/MetadataSection.tsx
@@ -33,7 +33,7 @@ function DatasetDescriptionNote() {
       &nbsp;Metadata from the donor or sample of this dataset may also be included in this list.
       <br />
       Additional information about the metadata available for each type of dataset can be found in the&nbsp;
-      <OutboundIconLink href="https://docs.hubmapconsortium.org/metadata">HuBMAP documentation.</OutboundIconLink>
+      <OutboundIconLink href="https://docs.hubmapconsortium.org/metadata">HuBMAP documentation</OutboundIconLink>.
     </>
   );
 }

--- a/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
@@ -414,8 +414,8 @@ export default function CellTypes() {
         recompute the results and recalculate statistical values accordingly.
       </Description>
       <Tabs value={effectiveTabIndex} onChange={handleTabChange}>
-        <Tab label={`RNAseq (${rnaCount})`} index={0} disabled={!isLoading && rnaCount === 0} />
-        <Tab label={`ATACseq (${atacCount})`} index={1} disabled={!isLoading && atacCount === 0} />
+        <Tab label={`RNAseq (${rnaCount} Cell Types)`} index={0} disabled={!isLoading && rnaCount === 0} />
+        <Tab label={`ATACseq (${atacCount} Cell Types)`} index={1} disabled={!isLoading && atacCount === 0} />
       </Tabs>
       <TabPanel value={effectiveTabIndex} index={0}>
         <CellTypesTable modality={undefined} />

--- a/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
@@ -390,6 +390,15 @@ export default function CellTypes() {
     [atacCellTypes],
   );
 
+  // Focus the modality that actually has cell types: an ATAC-only gene (no RNAseq cell types) opens
+  // on the ATACseq tab so its organ-scoped queries hit the ATAC index, instead of an empty RNAseq
+  // tab. When both modalities have data, the user's tab selection is respected.
+  const effectiveTabIndex = useMemo(() => {
+    if (rnaCount === 0 && atacCount > 0) return 1;
+    if (atacCount === 0 && rnaCount > 0) return 0;
+    return openTabIndex;
+  }, [openTabIndex, rnaCount, atacCount]);
+
   return (
     <CollapsibleDetailPageSection
       id={cellTypesSection.id}
@@ -404,14 +413,14 @@ export default function CellTypes() {
         The table can be filtered by organs and available for download for further analysis. Filtering by organ will
         recompute the results and recalculate statistical values accordingly.
       </Description>
-      <Tabs value={openTabIndex} onChange={handleTabChange}>
-        <Tab label={`RNAseq (${rnaCount})`} index={0} />
+      <Tabs value={effectiveTabIndex} onChange={handleTabChange}>
+        <Tab label={`RNAseq (${rnaCount})`} index={0} disabled={!isLoading && rnaCount === 0} />
         <Tab label={`ATACseq (${atacCount})`} index={1} disabled={!isLoading && atacCount === 0} />
       </Tabs>
-      <TabPanel value={openTabIndex} index={0}>
+      <TabPanel value={effectiveTabIndex} index={0}>
         <CellTypesTable modality={undefined} />
       </TabPanel>
-      <TabPanel value={openTabIndex} index={1}>
+      <TabPanel value={effectiveTabIndex} index={1}>
         <CellTypesTable modality="ATAC" />
       </TabPanel>
     </CollapsibleDetailPageSection>

--- a/context/app/static/js/components/genes/Datasets/GeneDatasetsResults.tsx
+++ b/context/app/static/js/components/genes/Datasets/GeneDatasetsResults.tsx
@@ -8,6 +8,7 @@ import { Tab, TabPanel, Tabs } from 'js/shared-styles/tabs';
 import { SCFindModality } from 'js/components/cells/MolecularDataQueryForm/types';
 import { SCFindModalityProvider } from 'js/components/cells/SCFindResults/SCFindModalityContext';
 import { CurrentGeneContextProvider } from 'js/components/cells/SCFindResults/CurrentGeneContext';
+import { GeneCountsContextProvider } from 'js/components/cells/SCFindResults/GeneCountsContext';
 import { SCFindGeneQueryDatasetList } from 'js/components/cells/SCFindResults/SCFindGeneQueryResults';
 import SCFindDatasetTableActions from 'js/components/cells/SCFindResults/SCFindDatasetTableActions';
 import DatasetsOverview from 'js/components/cells/DatasetsOverview';
@@ -60,15 +61,22 @@ function GeneDatasetsTable({
   countsMap: Record<string, number>;
 }) {
   const numSelected = useSelectableTableStore((state) => state.selectedRows.size);
+  // The matching-gene % column reads the gene's per-dataset cell counts from GeneCountsContext
+  // (keyed by gene -> hubmap_id). Provide it from the aggregate's counts for this modality so the
+  // percentage isn't always 0 (the shared SCFindGeneQueryResultsLoader supplies this on the Cells
+  // query page, but this detail-page table renders the list directly).
+  const geneCounts = useMemo(() => ({ [geneSymbol]: countsMap }), [geneSymbol, countsMap]);
   return (
     <SCFindModalityProvider value={modality}>
       <CurrentGeneContextProvider value={geneSymbol}>
-        <SCFindGeneQueryDatasetList
-          datasetIds={datasetIds}
-          countsMap={countsMap}
-          numSelected={numSelected}
-          headerActions={<SCFindDatasetTableActions />}
-        />
+        <GeneCountsContextProvider value={geneCounts}>
+          <SCFindGeneQueryDatasetList
+            datasetIds={datasetIds}
+            countsMap={countsMap}
+            numSelected={numSelected}
+            headerActions={<SCFindDatasetTableActions />}
+          />
+        </GeneCountsContextProvider>
       </CurrentGeneContextProvider>
     </SCFindModalityProvider>
   );

--- a/context/app/static/js/components/genes/Datasets/GeneDatasetsResults.tsx
+++ b/context/app/static/js/components/genes/Datasets/GeneDatasetsResults.tsx
@@ -12,7 +12,6 @@ import { GeneCountsContextProvider } from 'js/components/cells/SCFindResults/Gen
 import { SCFindGeneQueryDatasetList } from 'js/components/cells/SCFindResults/SCFindGeneQueryResults';
 import SCFindDatasetTableActions from 'js/components/cells/SCFindResults/SCFindDatasetTableActions';
 import DatasetsOverview from 'js/components/cells/DatasetsOverview';
-import ViewIndexedDatasetsButton from 'js/components/organ/OrganCellTypes/ViewIndexedDatasetsButton';
 import SelectableTableProvider, { useSelectableTableStore } from 'js/shared-styles/tables/SelectableTableProvider';
 import { DatasetsForGenesResponse } from 'js/api/scfind/useFindDatasetForGenes';
 import { useGeneDatasetsData, useGeneSymbol } from '../hooks';
@@ -130,7 +129,6 @@ export default function GeneDatasetsResults() {
           datasets={overviewActive.ids}
           dataType={overviewEffective}
           onDataTypeChange={showModalitySelection ? setOverviewModality : undefined}
-          belowTheFold={<ViewIndexedDatasetsButton scFindParams={{ scFindOnly: true }} isLoading={false} />}
         >
           This overview summarizes the matched {overviewModalityLabel} datasets and their proportions relative to both
           the scFind-indexed datasets and all HuBMAP datasets, as identified by the <SCFindLink />. The summary is

--- a/context/app/static/js/components/genes/Datasets/GenePageDatasets.tsx
+++ b/context/app/static/js/components/genes/Datasets/GenePageDatasets.tsx
@@ -21,7 +21,6 @@ export default function Datasets() {
     <CollapsibleDetailPageSection
       id={datasets.id}
       title={`Datasets with ${geneSymbol}`}
-      iconTooltipText={datasets.tooltip}
       trackingInfo={useGeneDetailPageTrackingInfo()}
     >
       <Description

--- a/context/app/static/js/components/genes/Datasets/GenePageDatasets.tsx
+++ b/context/app/static/js/components/genes/Datasets/GenePageDatasets.tsx
@@ -38,9 +38,9 @@ export default function Datasets() {
         }
       >
         These are datasets that contain this gene as identified by the <SCFindLink /> with uniformly processed HuBMAP
-        RNAseq datasets. Not all HuBMAP datasets are currently compatible with this method due to data modalities or the
-        availability of cell annotations. To find datasets with additional parameters such as finding datasets with
-        multiple genes, use the Biomarker and Cell Type Search tool.
+        RNAseq or ATACseq datasets. Not all HuBMAP datasets are currently compatible with this method due to data
+        modalities or the availability of cell annotations. To find datasets with additional parameters such as finding
+        datasets with multiple genes, use the biomarker and cell type search tool.
       </Description>
       <Box py={1} />
       <MolecularDataQueryFormTrackingProvider category="Gene Detail Page">

--- a/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
@@ -7,7 +7,6 @@ import { trackEvent } from 'js/helpers/trackers';
 import { useEventCallback } from '@mui/material/utils';
 import Skeleton from '@mui/material/Skeleton';
 import { StyledDetailsAccordion } from './styles';
-import ViewIndexedDatasetsButton from './ViewIndexedDatasetsButton';
 import { SCFindParams } from '../utils';
 
 interface IndexedDatasetsSummaryProps {
@@ -33,7 +32,6 @@ function IndexedDatasetsSummary({
   children,
   trackingInfo,
   context = 'Cell Types',
-  scFindParams = {},
 }: PropsWithChildren<IndexedDatasetsSummaryProps>) {
   const trackExpandChange = useEventCallback((_, expanded: boolean) => {
     if (trackingInfo) {
@@ -117,13 +115,6 @@ function IndexedDatasetsSummary({
               ))}
         </Stack>
       </StyledDetailsAccordion>
-      <ViewIndexedDatasetsButton
-        context={context}
-        isLoading={isLoadingDatasets}
-        trackingInfo={trackingInfo}
-        scFindParams={scFindParams}
-        sx={{ mt: 2 }}
-      />
     </StyledDetailsAccordion>
   );
 }

--- a/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
+++ b/context/app/static/js/components/organ/OrganCellTypes/IndexedDatasetsSummary.tsx
@@ -7,10 +7,8 @@ import { trackEvent } from 'js/helpers/trackers';
 import { useEventCallback } from '@mui/material/utils';
 import Skeleton from '@mui/material/Skeleton';
 import { StyledDetailsAccordion } from './styles';
-import { SCFindParams } from '../utils';
 
 interface IndexedDatasetsSummaryProps {
-  scFindParams: SCFindParams;
   datasetTypes: { key: string; doc_count: number }[];
   organs?: { key: string; doc_count: number }[];
   isLoadingDatasets?: boolean;

--- a/context/app/static/js/pages/ScFindAbout/ScFindAbout.tsx
+++ b/context/app/static/js/pages/ScFindAbout/ScFindAbout.tsx
@@ -14,7 +14,7 @@ import useIndexedDatasets from 'js/api/scfind/useIndexedDatasets';
 import ScFindDatasetsSection from './ScFindDatasetsSection';
 
 const relevantPages = [
-  { link: '/search/biomarkers-cell-types', children: 'Molecular & Cellular Query' },
+  { link: '/search/biomarkers-cell-types', children: 'Biomarker and Cell Type Search' },
   { link: '/cell-types', children: 'Cell Types' },
   { link: '/biomarkers', children: 'Biomarkers' },
 ];

--- a/context/app/static/js/shared-styles/Links/SCFindLink.tsx
+++ b/context/app/static/js/shared-styles/Links/SCFindLink.tsx
@@ -6,5 +6,9 @@ import InternalLink from './InternalLink';
  * original scFind publication; everywhere else points here so users land on the portal's overview.
  */
 export default function SCFindLink({ children = 'scFind method' }: PropsWithChildren) {
-  return <InternalLink href="/scfind/about">{children}</InternalLink>;
+  return (
+    <InternalLink href="/scfind/about" target="_blank">
+      {children}
+    </InternalLink>
+  );
 }

--- a/context/app/static/js/shared-styles/Links/SCFindLink.tsx
+++ b/context/app/static/js/shared-styles/Links/SCFindLink.tsx
@@ -7,7 +7,7 @@ import InternalLink from './InternalLink';
  */
 export default function SCFindLink({ children = 'scFind method' }: PropsWithChildren) {
   return (
-    <InternalLink href="/scfind/about" target="_blank">
+    <InternalLink href="/scfind/about" target="_blank" rel="noopener noreferrer">
       {children}
     </InternalLink>
   );

--- a/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
+++ b/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
@@ -100,12 +100,9 @@ function ChartWrapper(
           )}
         </Box>
       )}
-      <Stack
-        direction="row"
-        gap={1}
-        flexWrap="wrap"
-        sx={{ gridArea: 'axis-controls', p: hasAxisDropdown ? 1 : 0, minWidth: 0 }}
-      >
+      {/* Keep the X/Y axis selects on a single row; minWidth:0 lets the fullWidth selects shrink to
+          fit on narrow screens rather than wrapping onto separate rows. */}
+      <Stack direction="row" gap={1} sx={{ gridArea: 'axis-controls', p: hasAxisDropdown ? 1 : 0, minWidth: 0 }}>
         {xAxisDropdown}
         {yAxisDropdown}
       </Stack>

--- a/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
+++ b/context/app/static/js/shared-styles/charts/ChartWrapper/ChartWrapper.tsx
@@ -77,8 +77,14 @@ function ChartWrapper(
       sx={{
         display: 'grid',
         gridTemplateAreas: fullWidthGraph ? fullWidthGraphTemplateAreas : defaultGridTemplateAreas,
-        overflow: 'none',
-        gridTemplateColumns: 'auto auto auto minmax(175px, auto)',
+        overflow: 'hidden',
+        // Fit the container and let the chart-area columns shrink below their (SVG-driven) content
+        // width, so the chart fills the available space instead of pushing the layout wider than the
+        // viewport on smaller screens.
+        width: '100%',
+        maxWidth: '100%',
+        minWidth: 0,
+        gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(175px, auto)',
         gridTemplateRows: `auto auto minmax(0, auto) ${chartHeight}px minmax(0, auto)`,
         ...sx,
       }}
@@ -94,11 +100,16 @@ function ChartWrapper(
           )}
         </Box>
       )}
-      <Stack direction="row" gap={1} sx={{ gridArea: 'axis-controls', p: hasAxisDropdown ? 1 : 0 }}>
+      <Stack
+        direction="row"
+        gap={1}
+        flexWrap="wrap"
+        sx={{ gridArea: 'axis-controls', p: hasAxisDropdown ? 1 : 0, minWidth: 0 }}
+      >
         {xAxisDropdown}
         {yAxisDropdown}
       </Stack>
-      <Box sx={{ gridArea: 'chart' }}>{children}</Box>
+      <Box sx={{ gridArea: 'chart', minWidth: 0 }}>{children}</Box>
       <Box sx={{ gridArea: 'legend', display: fullWidthGraph ? 'none' : 'grid' }}>
         <Stack direction="column" px={1}>
           {dropdown && <Box sx={{ marginY: 1, width: '100%', minWidth: 'fit-content' }}>{dropdown}</Box>}
@@ -182,7 +193,7 @@ function ChartWrapper(
           </Box>
         </Stack>
       </Box>
-      <Box sx={{ gridArea: 'top-controls' }}>{additionalControls}</Box>
+      <Box sx={{ gridArea: 'top-controls', minWidth: 0 }}>{additionalControls}</Box>
       <Box sx={{ gridArea: 'caption', p: 1 }}>
         <Typography variant="caption" color="textSecondary">
           {caption}

--- a/context/app/static/js/shared-styles/panels/PanelList/PanelList.tsx
+++ b/context/app/static/js/shared-styles/panels/PanelList/PanelList.tsx
@@ -3,7 +3,7 @@ import Stack from '@mui/material/Stack';
 import Paper from '@mui/material/Paper';
 
 import Panel, { PanelProps } from 'js/shared-styles/panels/Panel';
-import { PanelScrollBox } from './style';
+import { PanelScrollBox, PanelHeaderBox } from './style';
 
 interface PanelListProps {
   panelsProps: PanelProps[];
@@ -22,7 +22,11 @@ function PanelList({ panelsProps }: PanelListProps) {
         minHeight: 0,
       }}
     >
-      {headerProps && <Panel {...headerProps} />}
+      {headerProps && (
+        <PanelHeaderBox>
+          <Panel {...headerProps} />
+        </PanelHeaderBox>
+      )}
       <PanelScrollBox>
         {itemProps.map((props) => (
           // React's reserved `key` must be passed directly, not via spread.

--- a/context/app/static/js/shared-styles/panels/PanelList/style.ts
+++ b/context/app/static/js/shared-styles/panels/PanelList/style.ts
@@ -12,4 +12,16 @@ const PanelScrollBox = styled(Paper)(({ theme }) => {
   };
 });
 
-export { PanelScrollBox };
+// Wraps the (non-scrolling) header row. The item list above reserves space for its scrollbar on md+
+// (PanelScrollBox is `overflow-y: scroll`), making the rows narrower than the full-width header;
+// flex-grow then shifts the header's later column labels right of the row content. Reserving the
+// same scrollbar gutter here gives the header and rows identical column geometry so the labels line
+// up. (`overflow: hidden` only clips the row's horizontal margin overflow; the header never scrolls.)
+const PanelHeaderBox = styled('div')(({ theme }) => ({
+  [`@media (min-width: ${theme.breakpoints.values.md}px)`]: {
+    overflow: 'hidden',
+    scrollbarGutter: 'stable',
+  },
+}));
+
+export { PanelScrollBox, PanelHeaderBox };

--- a/context/app/static/js/typings/global.d.ts
+++ b/context/app/static/js/typings/global.d.ts
@@ -27,6 +27,9 @@ interface FlaskData {
   vignette_json?: Record<string, unknown>;
   geneSymbol?: string;
   cell_type?: string;
+  // Cell type name resolved server-side from the warmed CLID->label map, so the detail page title
+  // can render before the async aggregate fetch resolves.
+  cell_type_name?: string;
   redirected_from?: string;
   redirected?: boolean;
   type?: string;

--- a/context/app/test_routes_scfind.py
+++ b/context/app/test_routes_scfind.py
@@ -1021,6 +1021,57 @@ class TestPerPageAggregates:
         assert 'markers_atac' in data
         assert 'datasets_for_cell_types_atac' in data
 
+    def test_cell_type_detail_marker_failure(self, client, mocker):
+        """An scFind error on one modality's markers degrades to empty instead of 500ing the page."""
+
+        def fail_atac_markers_get(url, **kwargs):
+            params = kwargs.get('params', {}) or {}
+            if 'cellTypeMarkers' in url and params.get('modality') == 'ATAC':
+                raise requests.exceptions.HTTPError('cellTypeMarkers failed for ATAC')
+            return mock_scfind_get(url, **kwargs)
+
+        def fail_atac_markers_post(url, **kwargs):
+            body = kwargs.get('json', {}) or {}
+            if 'cellTypeMarkers' in url and body.get('modality') == 'ATAC':
+                raise requests.exceptions.HTTPError('cellTypeMarkers failed for ATAC')
+            return mock_scfind_post(url, **kwargs)
+
+        mocker.patch('requests.get', side_effect=fail_atac_markers_get)
+        mocker.patch('requests.post', side_effect=fail_atac_markers_post)
+        response = client.get('/scfind/cell-type-detail/CL:0000066.json')
+        assert response.status_code == 200
+        data = response.get_json()
+        # The failing ATAC markers op degrades to empty rather than failing the whole aggregate...
+        assert data['markers_atac'] == []
+        # ...while the RNA markers and both datasets slices stay populated.
+        assert data['markers'] == mock_cell_type_markers['findGeneSignatures']
+        assert 'datasets_for_cell_types' in data
+        assert 'datasets_for_cell_types_atac' in data
+
+    def test_label_to_clid_posts_comma_cell_types(self, client, mocker):
+        """A comma in a cell type name (e.g. "CD4-positive, alpha-beta T cell") must be POSTed, not
+        sent as a GET query param scFind would split into multiple cell types — otherwise the cell
+        type's CLID is lost from the label<->CLID maps and its detail page can't resolve."""
+        get_mock = mocker.patch('requests.get', side_effect=mock_scfind_get)
+        post_mock = mocker.patch('requests.post', side_effect=mock_scfind_post)
+        with client.application.app_context():
+            clids = routes_scfind._get_label_to_clid_mapping('blood.CD4-positive, alpha-beta T cell')
+        assert clids == mock_label_to_clid['CLIDs']
+        # The comma-containing lookup went out as a POST, not a GET.
+        assert any('CellType2CLID' in call.args[0] for call in post_mock.call_args_list)
+        assert not any('CellType2CLID' in call.args[0] for call in get_mock.call_args_list)
+
+    def test_peek_cell_type_name(self, client, mocker):
+        """The detail-page name resolves from the warmed CLID->label map without triggering a build."""
+        mocker.patch('requests.get', side_effect=mock_scfind_get)
+        mocker.patch('requests.post', side_effect=mock_scfind_post)
+        with client.application.app_context():
+            # Map not built/cached yet -> empty name, and no build is triggered.
+            assert routes_scfind.peek_cell_type_name('CL:0000066') == ''
+            # Once the map is built/cached, the name resolves synchronously from cache.
+            routes_scfind._build_clid_to_label_map()
+            assert routes_scfind.peek_cell_type_name('CL:0000066') == 'epithelial cell'
+
     @pytest.mark.parametrize('clid', ['cl:0000236', 'CL:abc', 'CL%3A', '0000236'])
     def test_cell_type_detail_invalid_clid(self, client, mocker, clid):
         mock_get = mocker.patch('requests.get', side_effect=mock_scfind_get)

--- a/context/app/test_routes_scfind.py
+++ b/context/app/test_routes_scfind.py
@@ -1055,7 +1055,9 @@ class TestPerPageAggregates:
         get_mock = mocker.patch('requests.get', side_effect=mock_scfind_get)
         post_mock = mocker.patch('requests.post', side_effect=mock_scfind_post)
         with client.application.app_context():
-            clids = routes_scfind._get_label_to_clid_mapping('blood.CD4-positive, alpha-beta T cell')
+            clids = routes_scfind._get_label_to_clid_mapping(
+                'blood.CD4-positive, alpha-beta T cell'
+            )
         assert clids == mock_label_to_clid['CLIDs']
         # The comma-containing lookup went out as a POST, not a GET.
         assert any('CellType2CLID' in call.args[0] for call in post_mock.call_args_list)

--- a/context/app/test_routes_scfind.py
+++ b/context/app/test_routes_scfind.py
@@ -971,6 +971,32 @@ class TestPerPageAggregates:
         assert 'find_datasets_atac' in data
         assert 'organs_atac' in data
 
+    def test_gene_detail_atac_only_gene(self, client, mocker):
+        """A gene indexed only in ATAC must not 500: the failing RNA queries degrade to empty."""
+
+        def atac_only_get(url, **kwargs):
+            params = kwargs.get('params', {}) or {}
+            is_atac = params.get('modality') == 'ATAC'
+            # The gene is absent from the RNA index, so its non-modality gene queries error; ATAC
+            # queries and the label->CLID mapping calls succeed via the normal mock.
+            if not is_atac and ('hyperQueryCellTypes' in url or 'findDatasets' in url):
+                raise requests.exceptions.HTTPError('gene not in RNA index')
+            return mock_scfind_get(url, **kwargs)
+
+        mocker.patch('requests.get', side_effect=atac_only_get)
+        mocker.patch('requests.post', side_effect=mock_scfind_post)
+        response = client.get('/scfind/gene-detail/ATAConlyGene.json')
+        assert response.status_code == 200
+        data = response.get_json()
+        # RNA queries degraded to empty rather than failing the page...
+        assert data['hyper_query'] == []
+        assert data['find_datasets'] == {'counts': {}, 'findDatasets': {}}
+        assert data['organs'] == []
+        # ...while the ATAC data is populated so the page can focus on the ATAC modality.
+        assert data['hyper_query_atac'] == mock_hyper_query['findGeneSignatures']
+        assert data['find_datasets_atac'] == mock_find_datasets
+        assert data['organs_atac'] == ['kidney']
+
     @pytest.mark.parametrize('gene_symbol', ['a%20b', '.hidden', 'a%3Bb'])
     def test_gene_detail_invalid_symbol(self, client, mocker, gene_symbol):
         mock_get = mocker.patch('requests.get', side_effect=mock_scfind_get)

--- a/context/package.json
+++ b/context/package.json
@@ -141,6 +141,10 @@
   "lint-staged": {
     "app/static/js/**/*.{js,jsx,ts,tsx}": [
       "eslint --cache --cache-location node_modules/.cache/eslint/"
+    ],
+    "**/*.py": [
+      "uv run ruff check --fix",
+      "uv run ruff format"
     ]
   },
   "msw": {


### PR DESCRIPTION
## Summary

This PR covers fixes for the issues filed for release v1.46.5.

For ease of review, I'm going to break down the tickets/related changes one by one, include links to the relevant commits, and a screenshot of the fix.

## [CAT-1596 - Move outbound icon within period in metadata description section](https://hms-dbmi.atlassian.net/browse/CAT-1596)

* Trivial fix implemented as described
* https://github.com/hubmapconsortium/portal-ui/commit/d6bdf651ccab30b53a9c6fd75dad140ffeba0eb9

<img width="1629" height="198" alt="image" src="https://github.com/user-attachments/assets/921f6c93-2edc-453e-8994-56806facf154" />

## [CAT-1597 / CAT-1608 - Improve alignment of panel list headings and content](https://hms-dbmi.atlassian.net/browse/CAT-1597)

* Alignment for panel lists was being thrown off by scrollbars affecting the available space for panel list items while headers were excluded. Spacing between heading items was also adjusted specifically for biomarkers case.
* https://github.com/hubmapconsortium/portal-ui/commit/2c3d6286eabebeff1c71bc8630a7e0dc9b2f516e

<img width="1614" height="210" alt="image" src="https://github.com/user-attachments/assets/28c52a87-687d-418f-832a-16262a4c4aab" />

## [CAT-1598 - Fix crashes for ATAC-only gene pages ](https://hms-dbmi.atlassian.net/browse/CAT-1598)

* ATAC-only gene pages were not properly setting the modality for their lookups and were making lookups against the RNA index. This has been resolved to properly set the modality page-wide when no RNAseq index entries are available but ATAC entries are available.
* https://github.com/hubmapconsortium/portal-ui/commit/70ca17b3362e4ec71f4b07a8d04945d81c69114b

## [CAT-1600 - Remove tooltip for `datasets with <gene>` section](https://hms-dbmi.atlassian.net/browse/CAT-1600)

* Trivial fix implemented as described
* https://github.com/hubmapconsortium/portal-ui/commit/de8eef5463c38dfa59228959ea7d9d9c9240b2cf

<img width="606" height="123" alt="image" src="https://github.com/user-attachments/assets/fe15ed38-39c2-4629-9459-e31b1d2805a4" />


## [CAT-1601 - Update main description section for "Datasets with `<gene>`"](https://hms-dbmi.atlassian.net/browse/CAT-1601)

* Trivial fix, implemented as described. Previous behavior toggled between RNA/ATAC depending on which was selected, this is clearer.
* https://github.com/hubmapconsortium/portal-ui/commit/33abab2ad7cb626d0793614a9b2ccc0b2fd157a0

<img width="1586" height="276" alt="image" src="https://github.com/user-attachments/assets/82210b8b-ca8f-42a8-8735-8a8236000461" />


## [CAT-1602 - Remove "View Indexed Datasets" button](https://hms-dbmi.atlassian.net/browse/CAT-1602)

* Trivial fix, implemented as described.
* https://github.com/hubmapconsortium/portal-ui/commit/e4419bcc3d16d831a104d6bafaa19b0647b8d38a

<img width="1636" height="455" alt="image" src="https://github.com/user-attachments/assets/54bd7241-8ed0-4a5d-b49b-a64f9e274a76" />


## [CAT-1603 - Add period after tooltip in Data Overview and change `query` to `results` to be more user-friendly](https://hms-dbmi.atlassian.net/browse/CAT-1603)

* Trivial fix, implemented as described.
* https://github.com/hubmapconsortium/portal-ui/commit/a1e071ac330a20cb8cffcc3bb4c636bc0c0b776e

<img width="412" height="419" alt="image" src="https://github.com/user-attachments/assets/9e220393-a5e4-416d-a21c-64854441307f" />


## [CAT-1604 - Add "Cell Types" after cell type count in tabs for clarity](https://hms-dbmi.atlassian.net/browse/CAT-1604)

* Trivial fix, implemented as described
* https://github.com/hubmapconsortium/portal-ui/commit/a89e8a311098f20158155cfdfaa6a250088b9472
 
<img width="1629" height="420" alt="image" src="https://github.com/user-attachments/assets/14970c8d-2323-4c5d-8372-a7e3ce1b5d8d" />


## [CAT-1605 / CAT-1611 - Fix graph overflows](https://hms-dbmi.atlassian.net/browse/CAT-1605)

* Same issue applied to all visx charts throughout site - chart wrapper now constrains its own grid to prevent this overflow from occurring.
* https://github.com/hubmapconsortium/portal-ui/commit/b97beec191d29f7e24efb1ec3970f7ee3f96095e


https://github.com/user-attachments/assets/c391d3fe-4bf5-4f35-8efa-751ac5edcb45



## [CAT-1606 - Adjust scFind method links to open in new tab](https://hms-dbmi.atlassian.net/browse/CAT-1606)

* Trivial fix, just needed to add the target prop to the shared component.
* https://github.com/hubmapconsortium/portal-ui/commit/ccf91748fc9f009aa4cb20c09bf94bcea00c9de1

https://github.com/user-attachments/assets/8cc835ad-49b7-4c9b-88a2-01d040e54c26

## [CAT-1607 - Improve first time load for ATACseq cell type distribution chart](https://hms-dbmi.atlassian.net/browse/CAT-1607)

* Added ATACseq cell counts to the caching that occurs on initial server start, allowing those values to be toggled instantly by users.
* https://github.com/hubmapconsortium/portal-ui/commit/de7fb483c20562b64bea508b322bdc6062e1dcdb


https://github.com/user-attachments/assets/c2a63762-b0ef-47e2-8c3a-dd940f3ca475


## [CAT-1609 - Improve cell type detail page loading behavior/speed](https://hms-dbmi.atlassian.net/browse/CAT-1609)

* Parallelized the loading behavior for the cell type data so that the queries don't execute one after another
* Provided cell type name in initial payload from flask since it's precomputed in the mapping
* Also fixed issues with cell types containing commas failing to load
* https://github.com/hubmapconsortium/portal-ui/commit/4e14294a023e3bafa7822eaa36df82e97f083e6a

## [CAT-1610 - Add missing spacing between descriptions and section content](https://hms-dbmi.atlassian.net/browse/CAT-1610)

* Trivial fix, implemented as described
* https://github.com/hubmapconsortium/portal-ui/commit/b8eabba461bc665284f08c052c2e107487c5e9bf

<img width="1631" height="280" alt="image" src="https://github.com/user-attachments/assets/cca26f71-c955-4eb2-b2d8-77ef5708c095" />
<img width="1652" height="367" alt="image" src="https://github.com/user-attachments/assets/21cebdac-59e7-447a-82f5-3c2faa6ab7c1" />


## [CAT-1612 - Update button text to be "Biomarker and Cell Type Search" on scFind Method page](https://hms-dbmi.atlassian.net/browse/CAT-1612)

* Trivial fix, implemented as described
* https://github.com/hubmapconsortium/portal-ui/commit/8e0afe33062cf9a66418e6b01da0be6c973c9e2b

<img width="1582" height="229" alt="image" src="https://github.com/user-attachments/assets/f7defd61-6710-483a-8503-88a68865933c" />


## [CAT-1613 - Certain cell types pages throw 500 errors](https://hms-dbmi.atlassian.net/browse/CAT-1613)

Fixed in same commit as CAT-1609 - issue was caused by server-side queries needing to handle cell type names with commas in them by sending POST requests for those queries instead.

## [CAT-1614 - Add biomarkers to tab label after count on cell type detail page](https://hms-dbmi.atlassian.net/browse/CAT-1614)

* Trivial fix, implemented as described
* https://github.com/hubmapconsortium/portal-ui/commit/77f929aa691f6bee4a3b1ac69d52281c58ca43c7

<img width="1635" height="341" alt="image" src="https://github.com/user-attachments/assets/8545f58e-0508-4d17-a668-f19603afc586" />


## [CAT-1615 - Update description for "Datasets containing <cell type>"](https://hms-dbmi.atlassian.net/browse/CAT-1615)

* Originally applied the fix to the wrong description - fixed the error and also added the missing "datasets with <cell type>" collapsible indicated in the designs
* https://github.com/hubmapconsortium/portal-ui/commit/aa5b057686afd0bfc4b8b7ed2e3f276fefd2c8c6
* https://github.com/hubmapconsortium/portal-ui/commit/1708cd558df0eb16280e962fb8f6dc4e09f7aee8

<img width="1665" height="543" alt="image" src="https://github.com/user-attachments/assets/7b93cb2d-e9db-4ab0-abb0-960dcf660950" />
<img width="1634" height="209" alt="image" src="https://github.com/user-attachments/assets/09febede-1ae9-4f8b-ac08-7b04903a7e55" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
