### PR TITLE
NickAkhmetov/CAT-1620 Fix `entity_type` handling in TSV export and tests to ensure correct sourcing from Elasticsearch

### DIFF
--- a/CHANGELOG-fix-metadata-tsv-entity-type.md
+++ b/CHANGELOG-fix-metadata-tsv-entity-type.md
@@ -1,0 +1,1 @@
+- Fix the metadata TSV export reporting `entity_type` as `N/A` for entities whose legacy `metadata` lacked the field, by requesting the always-present top-level `entity_type` from Elasticsearch.

--- a/context/app/static/js/pages/LineUpPage/hooks.test.ts
+++ b/context/app/static/js/pages/LineUpPage/hooks.test.ts
@@ -65,6 +65,7 @@ const createMockEntity = (sourceOverrides = {}) =>
 const sourceFields = [
   'uuid',
   'hubmap_id',
+  'entity_type',
   'published_timestamp',
   'last_modified_timestamp',
   'created_timestamp',
@@ -242,6 +243,27 @@ describe('useLineupEntities', () => {
       // Should not contain nested field names
       expect(result.current.allKeys).not.toContain('metadata');
       expect(result.current.allKeys).not.toContain('organ_donor_data');
+    });
+
+    it('should source entity_type from the top-level field, not nested metadata', () => {
+      // metadata here intentionally omits entity_type, reproducing real entities
+      // whose legacy metadata lacked the field. The top-level value must still win.
+      const mockEntities = [createMockEntity({ metadata: { assay_type: 'scRNA-seq' } })];
+
+      mockUseSearchHits.mockReturnValue({
+        searchHits: mockEntities,
+        isLoading: false,
+        totalHitsCount: 1,
+      });
+
+      const { result } = renderHook(() =>
+        useLineupEntities({
+          entityType: 'Dataset',
+        }),
+      );
+
+      expect(result.current.allKeys).toContain('entity_type');
+      expect(result.current.entities[0].entity_type).toBe('dataset');
     });
 
     it('should filter entities based on selectedKeys', () => {

--- a/context/app/static/js/pages/LineUpPage/hooks.ts
+++ b/context/app/static/js/pages/LineUpPage/hooks.ts
@@ -66,6 +66,10 @@ const nestedFields = [
 const _source = [
   'uuid',
   'hubmap_id',
+  // Top-level entity_type is always present; request it explicitly so the column
+  // isn't sourced from the legacy `metadata.entity_type` field (absent in many
+  // submissions), which left it reading 'N/A' for those entities.
+  'entity_type',
   'published_timestamp',
   'last_modified_timestamp',
   'created_timestamp',


### PR DESCRIPTION
## Summary

### Root cause
The metadata TSV export pipeline fetches entities from Elasticsearch using an explicit _source field projection. That projection list in hooks.ts did not include entity_type.

entity_type is a top-level field on every entity, but since it wasn't requested, ES never returned it. The column only got populated incidentally from the nested metadata.entity_type field — a value present in some legacy metadata submissions but missing in many (e.g. organ entities, newer CODEX sections). When flattenEntity's getValueFromObjects found it in neither source nor metadata, entitiesToTableData filled it with 'N/A' — producing the inconsistent output in the TSV (Sample for some rows, N/A for others).

### The fix
Added 'entity_type' to the _source array in hooks.ts. Because getValueFromObjects checks the top-level source before the nested metadata, the canonical always-present value now takes precedence, and getAllKeys picks the column up for every entity.

### Why the existing tests missed it
The test mock in hooks.test.ts spread a full _source object that already contained entity_type, so it never exercised the production _source projection that omits it.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1620

## Testing


* Added 'entity_type' to the test's sourceFields assertion so the projection is now enforced.
* Added a regression test that builds an entity whose metadata omits entity_type and asserts the flattened value still resolves to the top-level 'dataset'.


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

