### PR TITLE
NickAkhmetov/CAT-1621 Enhance metadata display for datasets and samples

### DIFF
--- a/CHANGELOG-metadata-improvements.md
+++ b/CHANGELOG-metadata-improvements.md
@@ -1,0 +1,2 @@
+- On dataset pages, surface every ancestor in the metadata section: ancestors without their own metadata now appear as disabled tabs with a tooltip explaining that metadata is not available for that entity, instead of being omitted.
+- On sample pages, the metadata section now shows the sample and its donor (and any intermediate ancestor samples) as separate tabs rather than collapsing to a single donor-only table, with disabled tabs for entities that lack metadata.

--- a/context/app/static/js/components/detailPage/MetadataSection/utils.spec.ts
+++ b/context/app/static/js/components/detailPage/MetadataSection/utils.spec.ts
@@ -1,5 +1,6 @@
 import { DonorIcon } from 'js/shared-styles/icons';
-import { buildTableData, sortEntities, TableEntity } from './utils';
+import { Dataset, Donor, Sample } from 'js/components/types';
+import { buildTableData, getTableEntities, sortEntities, TableEntity } from './utils';
 
 /**
  * =============================================================================
@@ -66,6 +67,7 @@ test('should remove keys that are not metadata', () => {
 const baseEntity = {
   icon: DonorIcon,
   tableRows: [],
+  hasMetadata: false,
 };
 
 const current: TableEntity = {
@@ -142,4 +144,50 @@ test('should return only the current entity if no other entities are present', (
       uuid: 'current',
     }),
   ).toEqual([current]);
+});
+
+/**
+ * =============================================================================
+ *                                getTableEntities
+ * =============================================================================
+ */
+
+test('should retain entities without metadata and flag them via hasMetadata', () => {
+  const datasetEntity = {
+    entity_type: 'Dataset',
+    uuid: 'dataset',
+    hubmap_id: 'HBM.dataset',
+    assay_display_name: ['Histology'],
+    metadata: { assay_type: 'Histology' },
+  } as unknown as Dataset;
+
+  // Organs carry no sample-level metadata of their own.
+  const organEntity = {
+    entity_type: 'Sample',
+    uuid: 'organ',
+    hubmap_id: 'HBM.organ',
+    sample_category: 'organ',
+  } as unknown as Sample;
+
+  const donorEntity = {
+    entity_type: 'Donor',
+    uuid: 'donor',
+    hubmap_id: 'HBM.donor',
+    mapped_metadata: { sex: 'Female' },
+  } as unknown as Donor;
+
+  const result = getTableEntities({
+    entities: [datasetEntity, organEntity, donorEntity],
+    uuid: 'dataset',
+    fieldDescriptions: {},
+  });
+
+  // No entity is dropped, even when it lacks metadata.
+  expect(result.map((e) => e.uuid).sort()).toEqual(['dataset', 'donor', 'organ']);
+
+  const byUuid = Object.fromEntries(result.map((e) => [e.uuid, e]));
+  expect(byUuid.dataset.hasMetadata).toBe(true);
+  expect(byUuid.donor.hasMetadata).toBe(true);
+  expect(byUuid.organ.hasMetadata).toBe(false);
+  expect(byUuid.organ.tableRows).toEqual([]);
 });

--- a/context/app/static/js/components/detailPage/MetadataSection/utils.ts
+++ b/context/app/static/js/components/detailPage/MetadataSection/utils.ts
@@ -34,6 +34,9 @@ export interface TableEntity {
   tableRows: TableRows;
   entity_type: ESEntityType;
   hubmap_id: string;
+  // Whether the entity has any displayable metadata. Entities without metadata
+  // are still surfaced (as disabled tabs) so the lineage is visible.
+  hasMetadata: boolean;
 }
 
 interface sortEntitiesProps {
@@ -98,20 +101,22 @@ function getTableEntities({ entities, uuid, fieldDescriptions }: getTableEntitie
   const tableEntities = entities.map((entity) => {
     // Generate a label with the HuBMAP ID if there are multiple samples with the same category
     const label = getEntityLabel({ entity, sampleCategoryCounts });
+    const tableRows = buildTableData(
+      getMetadata({
+        targetEntityType: entity.entity_type,
+        currentEntity: entity,
+      }),
+      fieldDescriptions,
+      { hubmap_id: entity.hubmap_id, label },
+    );
     return {
       uuid: entity.uuid,
       label: label ?? '',
       icon: getEntityIcon(entity),
-      tableRows: buildTableData(
-        getMetadata({
-          targetEntityType: entity.entity_type,
-          currentEntity: entity,
-        }),
-        fieldDescriptions,
-        { hubmap_id: entity.hubmap_id, label },
-      ),
+      tableRows,
       entity_type: entity.entity_type,
       hubmap_id: entity.hubmap_id,
+      hasMetadata: tableRows.length > 0,
     };
   });
 

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
@@ -106,7 +106,7 @@ function MetadataTabs({ entities }: { entities: MultiAssayEntityWithTableRows[] 
 
   return (
     <Box sx={{ width: '100%' }}>
-      <Tabs value={openTabIndex} onChange={handleTabChange} variant={entities.length > 4 ? 'scrollable' : 'fullWidth'}>
+      <Tabs value={openTabIndex} onChange={handleTabChange} variant={entities.length > 5 ? 'scrollable' : 'fullWidth'}>
         {disambiguatedEntities.map(({ label, uuid, icon, hasMetadata }, index) => (
           <MetadataTab label={label} uuid={uuid} index={index} key={uuid} icon={icon} disabled={!hasMetadata} />
         ))}

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
@@ -1,30 +1,57 @@
 import React, { useMemo } from 'react';
 import Box from '@mui/material/Box';
+import { styled } from '@mui/material/styles';
 
 import { Tabs, Tab, TabPanel } from 'js/shared-styles/tables/TableTabs';
 import { useTabs } from 'js/shared-styles/tabs';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import MetadataTable from 'js/components/detailPage/MetadataTable';
 import { MultiAssayEntity } from '../useRelatedMultiAssayDatasets';
 import { TableRows } from '../../MetadataSection/MetadataSection';
 import Stack from '@mui/material/Stack';
+
+const noMetadataTooltip = 'Metadata is not available for this entity.';
+
+// Disabled tabs suppress pointer events, so the tooltip wraps the tab in a span
+// that can still receive hover/focus events. Match the tab's flex sizing when the
+// surrounding Tabs use the `fullWidth` variant so disabled tabs stay evenly sized.
+const DisabledTabWrapper = styled('span', { shouldForwardProp: (prop) => prop !== '$fullWidth' })<{
+  $fullWidth?: boolean;
+}>(({ $fullWidth }) => ({
+  display: 'flex',
+  ...($fullWidth && { flex: 1 }),
+}));
 
 interface MultiAssayEntityTabProps {
   label: React.ReactNode;
   uuid: string;
   index: number;
   icon: React.ElementType;
+  disabled?: boolean;
 }
 
-function MetadataTab({ label, uuid, index, icon: Icon, ...props }: MultiAssayEntityTabProps) {
-  return (
+function MetadataTab({ label, uuid, index, icon: Icon, disabled, ...props }: MultiAssayEntityTabProps) {
+  const tab = (
     <Tab
       icon={<Icon fontSize="1.5rem" color="primary" />}
       label={label}
-      key={uuid}
       index={index}
       iconPosition="start"
+      disabled={disabled}
       {...props}
     />
+  );
+
+  if (!disabled) {
+    return tab;
+  }
+
+  // `fullWidth` is injected by the parent Tabs based on its variant.
+  const { fullWidth } = props as { fullWidth?: boolean };
+  return (
+    <SecondaryBackgroundTooltip title={noMetadataTooltip}>
+      <DisabledTabWrapper $fullWidth={fullWidth}>{tab}</DisabledTabWrapper>
+    </SecondaryBackgroundTooltip>
   );
 }
 
@@ -32,10 +59,17 @@ type MultiAssayEntityWithTableRows = Pick<MultiAssayEntity, 'uuid' | 'hubmap_id'
   tableRows: TableRows;
   label: string;
   icon: React.ElementType;
+  hasMetadata: boolean;
 };
 
 function MetadataTabs({ entities }: { entities: MultiAssayEntityWithTableRows[] }) {
-  const { openTabIndex, handleTabChange } = useTabs();
+  // Open the first tab that actually has metadata, since leading tabs (e.g. the
+  // current entity) may be disabled when they lack metadata of their own.
+  const initialTabIndex = Math.max(
+    0,
+    entities.findIndex(({ hasMetadata }) => hasMetadata),
+  );
+  const { openTabIndex, handleTabChange } = useTabs(initialTabIndex);
 
   // If multiple entities share the same label, append the entity's HuBMAP ID.
   // e.g. if there are multiple "SNARE-seq" entities, the tabs will be labeled
@@ -73,15 +107,17 @@ function MetadataTabs({ entities }: { entities: MultiAssayEntityWithTableRows[] 
   return (
     <Box sx={{ width: '100%' }}>
       <Tabs value={openTabIndex} onChange={handleTabChange} variant={entities.length > 4 ? 'scrollable' : 'fullWidth'}>
-        {disambiguatedEntities.map(({ label, uuid, icon }, index) => (
-          <MetadataTab label={label} uuid={uuid} index={index} key={uuid} icon={icon} />
+        {disambiguatedEntities.map(({ label, uuid, icon, hasMetadata }, index) => (
+          <MetadataTab label={label} uuid={uuid} index={index} key={uuid} icon={icon} disabled={!hasMetadata} />
         ))}
       </Tabs>
-      {disambiguatedEntities.map(({ uuid, tableRows }, index) => (
-        <TabPanel value={openTabIndex} index={index} key={uuid}>
-          <MetadataTable tableRows={tableRows} />
-        </TabPanel>
-      ))}
+      {disambiguatedEntities.map(({ uuid, tableRows, hasMetadata }, index) =>
+        hasMetadata ? (
+          <TabPanel value={openTabIndex} index={index} key={uuid}>
+            <MetadataTable tableRows={tableRows} />
+          </TabPanel>
+        ) : null,
+      )}
     </Box>
   );
 }

--- a/context/app/static/js/pages/Dataset/Dataset.tsx
+++ b/context/app/static/js/pages/Dataset/Dataset.tsx
@@ -25,7 +25,6 @@ import { useDatasetRelationships } from 'js/components/detailPage/DatasetRelatio
 import { useDatasetsCollections } from 'js/hooks/useDatasetsCollections';
 import useTrackID from 'js/hooks/useTrackID';
 import { useEntitiesData } from 'js/hooks/useEntityData';
-import { hasMetadata } from 'js/helpers/metadata';
 import SnareSeq2Alert from 'js/components/detailPage/multi-assay/SnareSeq2Alert';
 import MultiAssayRelationship from 'js/components/detailPage/multi-assay/MultiAssayRelationship';
 import PublicationsSection from 'js/components/detailPage/PublicationsSection';
@@ -72,9 +71,6 @@ function DatasetDetail({ assayMetadata }: EntityDetailProps<Dataset>) {
   } = assayMetadata;
 
   const [entities, loadingEntities] = useEntitiesData<Dataset | Donor | Sample>([uuid, ...ancestor_ids]);
-  const entitiesWithMetadata = entities.filter((e) =>
-    hasMetadata({ targetEntityType: e.entity_type, currentEntity: e }),
-  );
 
   useRedirectAlert();
 
@@ -152,7 +148,7 @@ function DatasetDetail({ assayMetadata }: EntityDetailProps<Dataset>) {
             >
               <SummaryDataChildren mapped_data_types={mapped_data_types} origin_samples={origin_samples} />
             </Summary>
-            <MetadataSection entities={entitiesWithMetadata} shouldDisplay={shouldDisplaySection.metadata} />
+            <MetadataSection entities={entities} shouldDisplay={shouldDisplaySection.metadata} />
             <ProcessedData shouldDisplay={Boolean(shouldDisplaySection['processed-data'])} />
             <BulkDataTransfer shouldDisplay={Boolean(shouldDisplaySection['bulk-data-transfer'])} />
             <ProvSection shouldDisplay={shouldDisplaySection.provenance} additionalUuids={processedDatasetUuids} />

--- a/context/app/static/js/pages/Sample/Sample.tsx
+++ b/context/app/static/js/pages/Sample/Sample.tsx
@@ -87,7 +87,7 @@ function SampleDetail() {
         <SampleTissue />
         <ProvSection />
         {shouldDisplaySection.protocols && <Protocol protocol_url={protocol_url} showHeader />}
-        <MetadataSection entities={entitiesWithMetadata} shouldDisplay={shouldDisplaySection.metadata} />
+        <MetadataSection entities={entities} shouldDisplay={shouldDisplaySection.metadata} />
         <Attribution />
       </DetailLayout>
     </DetailContextProvider>


### PR DESCRIPTION
## Summary

This PR adjusts the handling for metadata tables on dataset and sample pages: All ancestors are now surfaced and display a disabled tab if they have no metadata. 

I also bumped the limit at which the tabs become scrollable from 5 to 6, since datasets' metadata tabs will too commonly be set to the scrollable option by default (primary dataset + organ / block / section + donor = 5 tabs, and only took up half of the available width in the tab view)

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1621

## Testing

Extended metadata section unit tests.

## Screenshots/Video

HBM795.JBKS.528 (block and organ don't have metadata)

<img width="1644" height="753" alt="image" src="https://github.com/user-attachments/assets/3f361a90-d347-4b12-9e7b-d1761a3f39c1" /> 


HBM346.XNKF.372 (same as above)

<img width="1599" height="805" alt="image" src="https://github.com/user-attachments/assets/974a9f0c-face-427a-9077-6b3d20263a46" /> 



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
