### PR TITLE
NickAkhmetov/CAT-1623 Langfuse session id tracing support

### DIFF
--- a/CHANGELOG-udi-langfuse-session-tracking.md
+++ b/CHANGELOG-udi-langfuse-session-tracking.md
@@ -1,0 +1,1 @@
+- Tag UDI agent langfuse traces with a stable `session_id` so multiple completions from the same conversation are grouped together as one session in langfuse. Same-origin/authenticated callers derive it from the Flask session; cross-origin BYOK callers can supply their own via the new `X-Conversation-Id` request header.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ All designs are in [Figma](https://www.figma.com/files/team/834568130405102661/H
     - Install dependencies with `uv sync --dev` (to include development dependencies) or `uv sync` (production only).
 - `nodejs/npm`: Suggest installing a node version manager and then using it to install the appropriate node version:
   - [`nvm`](https://github.com/nvm-sh/nvm#installing-and-updating)
-    - `` nvm install `cat .nvmrc`  ``
-    - `` nvm use `cat .nvmrc`  ``
+    - ``nvm install `cat .nvmrc` ``
+    - ``nvm use `cat .nvmrc` ``
   - [`n`](https://github.com/tj/n#installation)
     - `` n `cat .nvmrc` ``
 
@@ -284,3 +284,29 @@ Particular to HuBMAP:
 - [`portal-visualization`](https://github.com/hubmapconsortium/portal-visualization): Given HuBMAP Dataset JSON, creates a Vitessce configuration.
 - [`portal-containers`](https://github.com/hubmapconsortium/portal-containers): Docker containers for visualization preprocessing.
 - [`airflow-dev`](https://github.com/hubmapconsortium/airflow-dev): CWL pipelines wrapping those Docker containers.
+
+### Langfuse
+
+Langfuse is used to track user interactions with the Say and See mode. To run it against the shared dev instance locally:
+
+1. Open an SSH tunnel through the PSC login node, forwarding the remote Langfuse to local port `13001`:
+
+```
+ssh -f -N -L 13001:vm001.hive.psc.edu:3001 {your_username_here}@hive.psc.edu
+```
+
+2. Add the Langfuse config to `context/instance/app.conf` (keys are in 1Password):
+
+```
+LANGFUSE_BASE_URL = 'https://langfuse.b2-workspaces-pt.dev.hubmapconsortium.org:13001'
+LANGFUSE_SECRET_KEY = (see 1Password)
+LANGFUSE_PUBLIC_KEY = (see 1Password)
+```
+
+3. Add an `/etc/hosts` entry pointing that hostname at the tunnel:
+
+```
+echo '127.0.0.1 langfuse.b2-workspaces-pt.dev.hubmapconsortium.org' | sudo tee -a /etc/hosts
+```
+
+The tunnel listens on the loopback, but Langfuse's TLS cert isn't valid for `localhost` — so we point a name covered by the cert's wildcard SAN (`*.b2-workspaces-pt.dev.hubmapconsortium.org`) at `127.0.0.1`, which lets cert verification pass without disabling it. Use this exact `BASE_URL`; reverting it to `localhost` reintroduces the SSL error.

--- a/context/app/routes_udi.py
+++ b/context/app/routes_udi.py
@@ -2,6 +2,8 @@ import hashlib
 import json
 import os
 import time
+import uuid
+from contextlib import nullcontext
 
 from flask import current_app, jsonify, make_response, request, session
 
@@ -84,7 +86,7 @@ _UDI_DEV_ALLOWED_ORIGINS = [
     'http://localhost:5173',
     'http://127.0.0.1:5173',
 ]
-_UDI_ALLOWED_HEADERS = 'Content-Type, Authorization, X-OpenAI-Key'
+_UDI_ALLOWED_HEADERS = 'Content-Type, Authorization, X-OpenAI-Key, X-Conversation-Id'
 _UDI_ALLOWED_METHODS = 'GET, POST, OPTIONS'
 
 
@@ -112,6 +114,53 @@ def _udi_cors_after_request(response):
         response.headers['Access-Control-Allow-Headers'] = _UDI_ALLOWED_HEADERS
         response.headers['Vary'] = 'Origin'
     return response
+
+
+# Key under which a stable per-Flask-session identifier is stashed in the
+# signed session cookie. Reused across requests so every UDI completion from
+# the same browser session shares one langfuse `session_id`.
+_LANGFUSE_SESSION_KEY = 'udi_langfuse_session_id'
+
+
+def _langfuse_enabled():
+    """Mirror UDIAgent's opt-in: langfuse is active when any of the three
+    config values is set."""
+    return any(
+        current_app.config.get(key)
+        for key in ('LANGFUSE_PUBLIC_KEY', 'LANGFUSE_SECRET_KEY', 'LANGFUSE_BASE_URL')
+    )
+
+
+def _get_session_id():
+    """Return a stable session id to group a user's conversation turns under
+    one langfuse `session_id`.
+
+    Cross-origin BYOK callers (e.g. the standalone udi-yac frontend) don't get
+    a credentialed CORS response, so the Flask session cookie never persists
+    for them. They supply their own conversation id via `X-Conversation-Id`,
+    which takes precedence when present. Same-origin/authenticated callers
+    fall back to a UUID generated and persisted in the Flask session on first
+    use, reused on subsequent requests carrying the session cookie.
+    """
+    header_id = request.headers.get('X-Conversation-Id')
+    if header_id:
+        return header_id
+    session_id = session.get(_LANGFUSE_SESSION_KEY)
+    if not session_id:
+        session_id = uuid.uuid4().hex
+        session[_LANGFUSE_SESSION_KEY] = session_id
+    return session_id
+
+
+def _langfuse_session_context():
+    """Context manager tagging all langfuse traces emitted within it with the
+    current Flask session's id, so they're grouped as one langfuse session.
+    A no-op when langfuse isn't configured."""
+    if not _langfuse_enabled():
+        return nullcontext()
+    from langfuse import propagate_attributes
+
+    return propagate_attributes(session_id=_get_session_id())
 
 
 def _build_orchestrator(openai_api_key):
@@ -304,12 +353,13 @@ def yac_completions():
         ), 401
 
     try:
-        result = orchestrator.run(
-            messages=messages,
-            data_schema=data_schema,
-            data_domains=data_domains,
-            openai_api_key=openai_api_key,
-        )
+        with _langfuse_session_context():
+            result = orchestrator.run(
+                messages=messages,
+                data_schema=data_schema,
+                data_domains=data_domains,
+                openai_api_key=openai_api_key,
+            )
     except Exception as e:
         current_app.logger.exception('UDIAgent orchestrator failed')
         return _get_api_json_error(500, f'UDIAgent orchestration error: {e}'), 500

--- a/context/app/routes_udi.py
+++ b/context/app/routes_udi.py
@@ -163,6 +163,22 @@ def _langfuse_session_context():
     return propagate_attributes(session_id=_get_session_id())
 
 
+# Maps the portal's deployed hostname to the environment name reported to
+# langfuse. Anything not listed (localhost, 127.0.0.1, branch deploys, etc.)
+# falls back to 'localhost'.
+_LANGFUSE_ENVIRONMENTS = {
+    'portal.hubmapconsortium.org': 'prod',
+    'portal-prod.test.hubmapconsortium.org': 'prod-test',
+    'portal.test.hubmapconsortium.org': 'test',
+    'portal.dev.hubmapconsortium.org': 'dev',
+}
+
+
+def _langfuse_environment():
+    host = request.host.split(':')[0]  # strip any :port
+    return _LANGFUSE_ENVIRONMENTS.get(host, 'localhost')
+
+
 def _build_orchestrator(openai_api_key):
     agent = UDIAgent(
         gpt_model_name=current_app.config.get('UDI_GPT_MODEL_NAME', 'gpt-5.4'),
@@ -170,6 +186,7 @@ def _build_orchestrator(openai_api_key):
         langfuse_public_key=current_app.config.get('LANGFUSE_PUBLIC_KEY'),
         langfuse_secret_key=current_app.config.get('LANGFUSE_SECRET_KEY'),
         langfuse_host=current_app.config.get('LANGFUSE_BASE_URL'),
+        langfuse_environment=_langfuse_environment(),
     )
     return Orchestrator(agent=agent)
 

--- a/context/app/test_routes_udi.py
+++ b/context/app/test_routes_udi.py
@@ -209,7 +209,7 @@ def test_yac_completions_preflight_from_localhost(client):
         headers={
             'Origin': 'http://localhost:5173',
             'Access-Control-Request-Method': 'POST',
-            'Access-Control-Request-Headers': 'authorization,content-type,x-openai-key',
+            'Access-Control-Request-Headers': 'authorization,content-type,x-openai-key,x-conversation-id',
         },
     )
     assert response.status_code in (200, 204)
@@ -218,6 +218,7 @@ def test_yac_completions_preflight_from_localhost(client):
     assert 'authorization' in allowed_headers
     assert 'x-openai-key' in allowed_headers
     assert 'content-type' in allowed_headers
+    assert 'x-conversation-id' in allowed_headers
     assert 'POST' in response.headers.get('Access-Control-Allow-Methods', '')
 
 
@@ -338,6 +339,88 @@ def test_build_orchestrator_forwards_langfuse_config(client, mocker):
     assert captured['langfuse_secret_key'] == 'sk-lf-test'
     assert captured['langfuse_host'] == 'https://langfuse.example.com'
     assert captured['openai_api_key'] == 'sk-server'
+
+
+def test_yac_completions_propagates_flask_session_id_to_langfuse(client, mocker):
+    """When langfuse is configured, the run is wrapped in a context that tags
+    traces with a stable session_id derived from the Flask session, and the
+    same id is reused across requests sharing the session cookie."""
+    client.application.config['LANGFUSE_PUBLIC_KEY'] = 'pk-lf'
+    client.application.config['LANGFUSE_SECRET_KEY'] = 'sk-lf'
+
+    propagate_calls = []
+
+    def _fake_propagate(*, session_id, **_kwargs):
+        propagate_calls.append(session_id)
+        from contextlib import nullcontext
+
+        return nullcontext()
+
+    mocker.patch('langfuse.propagate_attributes', side_effect=_fake_propagate)
+    _capture_run(mocker)
+
+    first = client.post(
+        '/v1/yac/completions',
+        json=_sample_completion_body,
+        headers={'X-OpenAI-Key': 'sk-anon'},
+    )
+    assert first.status == '200 OK'
+    second = client.post(
+        '/v1/yac/completions',
+        json=_sample_completion_body,
+        headers={'X-OpenAI-Key': 'sk-anon'},
+    )
+    assert second.status == '200 OK'
+
+    assert len(propagate_calls) == 2
+    # Stable id reused across requests within the same session.
+    assert propagate_calls[0] == propagate_calls[1]
+    assert propagate_calls[0]
+
+
+def test_yac_completions_skips_langfuse_context_when_unconfigured(client, mocker):
+    """With no langfuse config, propagate_attributes must never be invoked."""
+    client.application.config['LANGFUSE_PUBLIC_KEY'] = None
+    client.application.config['LANGFUSE_SECRET_KEY'] = None
+    client.application.config['LANGFUSE_BASE_URL'] = None
+
+    propagate = mocker.patch('langfuse.propagate_attributes')
+    _capture_run(mocker)
+
+    response = client.post(
+        '/v1/yac/completions',
+        json=_sample_completion_body,
+        headers={'X-OpenAI-Key': 'sk-anon'},
+    )
+    assert response.status == '200 OK'
+    propagate.assert_not_called()
+
+
+def test_yac_completions_conversation_id_header_overrides_session(client, mocker):
+    """A cross-origin BYOK caller (no persisted session cookie) supplies its
+    own conversation id via X-Conversation-Id, which is used verbatim as the
+    langfuse session_id."""
+    client.application.config['LANGFUSE_PUBLIC_KEY'] = 'pk-lf'
+    client.application.config['LANGFUSE_SECRET_KEY'] = 'sk-lf'
+
+    propagate_calls = []
+
+    def _fake_propagate(*, session_id, **_kwargs):
+        propagate_calls.append(session_id)
+        from contextlib import nullcontext
+
+        return nullcontext()
+
+    mocker.patch('langfuse.propagate_attributes', side_effect=_fake_propagate)
+    _capture_run(mocker)
+
+    response = client.post(
+        '/v1/yac/completions',
+        json=_sample_completion_body,
+        headers={'X-OpenAI-Key': 'sk-anon', 'X-Conversation-Id': 'conv-123'},
+    )
+    assert response.status == '200 OK'
+    assert propagate_calls == ['conv-123']
 
 
 def test_yac_completions_non_hubmap_authed_user_needs_header(client):

--- a/context/app/test_routes_udi.py
+++ b/context/app/test_routes_udi.py
@@ -339,6 +339,25 @@ def test_build_orchestrator_forwards_langfuse_config(client, mocker):
     assert captured['langfuse_secret_key'] == 'sk-lf-test'
     assert captured['langfuse_host'] == 'https://langfuse.example.com'
     assert captured['openai_api_key'] == 'sk-server'
+    # test_request_context() serves host 'localhost', which maps to 'localhost'.
+    assert captured['langfuse_environment'] == 'localhost'
+
+
+@pytest.mark.parametrize(
+    'host, expected',
+    [
+        ('portal.hubmapconsortium.org', 'prod'),
+        ('portal-prod.test.hubmapconsortium.org', 'prod-test'),
+        ('portal.test.hubmapconsortium.org', 'test'),
+        ('portal.dev.hubmapconsortium.org', 'dev'),
+        ('localhost:5000', 'localhost'),
+        ('127.0.0.1:5001', 'localhost'),
+        ('some-branch-deploy.hubmapconsortium.org', 'localhost'),
+    ],
+)
+def test_langfuse_environment_maps_host(client, host, expected):
+    with client.application.test_request_context(base_url=f'http://{host}'):
+        assert routes_udi._langfuse_environment() == expected
 
 
 def test_yac_completions_propagates_flask_session_id_to_langfuse(client, mocker):

--- a/context/app/test_routes_udi.py
+++ b/context/app/test_routes_udi.py
@@ -360,6 +360,31 @@ def test_langfuse_environment_maps_host(client, host, expected):
         assert routes_udi._langfuse_environment() == expected
 
 
+def test_real_orchestrator_trace_uses_installed_langfuse_api(client, monkeypatch):
+    """Build the orchestrator with the REAL UDIAgent + langfuse (not mocked)
+    and open a trace span, exercising the actual installed langfuse API.
+
+    This is the guard that would have caught the langfuse v3->v4 break: if
+    UDIAgent and the resolved langfuse version disagree on the span API
+    (start_as_current_span vs start_as_current_observation) or the Langfuse()
+    constructor kwargs, entering trace() raises and this test fails. It costs
+    nothing and needs no live langfuse — no OpenAI request is made, and
+    LANGFUSE_TRACING_ENABLED=false skips span export (the real methods are
+    still dispatched, so a future rename/signature change still fails here).
+    """
+    monkeypatch.setenv('LANGFUSE_TRACING_ENABLED', 'false')
+    client.application.config['LANGFUSE_PUBLIC_KEY'] = 'pk-lf-fake'
+    client.application.config['LANGFUSE_SECRET_KEY'] = 'sk-lf-fake'
+    client.application.config['LANGFUSE_BASE_URL'] = 'http://localhost:1'
+    client.application.config['OPENAI_API_KEY'] = 'sk-fake-not-used'
+
+    with client.application.test_request_context():
+        orchestrator = routes_udi._get_hubmap_orchestrator()
+        # The real failure mode: opening a trace against installed langfuse.
+        with orchestrator.agent.trace(session_id='ci-smoke'):
+            pass
+
+
 def test_yac_completions_propagates_flask_session_id_to_langfuse(client, mocker):
     """When langfuse is configured, the run is wrapped in a context that tags
     traces with a stable session_id derived from the Flask session, and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ dependencies = [
     "hubmap-api-py-client>=0.0.11",
     "hubmap-commons>=2.1.20",
     "portal-visualization[full]>=0.5.5",
-    "udiagent>=0.2.3",
-    "udiagent[langfuse]>=0.2.3",
+    "udiagent>=0.2.6",
+    "udiagent[langfuse]>=0.2.6",
     "gunicorn>=23.0.0",
     "whitenoise[brotli]>=6.9.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -889,8 +889,8 @@ requires-dist = [
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.32.5" },
-    { name = "udiagent", specifier = ">=0.2.3" },
-    { name = "udiagent", extras = ["langfuse"], specifier = ">=0.2.3" },
+    { name = "udiagent", specifier = ">=0.2.6" },
+    { name = "udiagent", extras = ["langfuse"], specifier = ">=0.2.6" },
     { name = "whitenoise", extras = ["brotli"], specifier = ">=6.9.0" },
 ]
 
@@ -1220,7 +1220,7 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "4.5.1"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -1232,9 +1232,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/bd/9b12c9dd3ae1883619b20daa6d60f20a780ce2d25564d9b2168db27cbeb0/langfuse-4.5.1.tar.gz", hash = "sha256:fe8f9219f4101c0921934b0aeb1b45834f8e7d248e5f830b2c89c5b40aea6d83", size = 279735, upload-time = "2026-04-24T15:21:43.976Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/d8/442d3f874c1ae396db42332f09efb331edb5b50c59bf372803ef0aa1ecc1/langfuse-4.10.0.tar.gz", hash = "sha256:5e6c8f2aff218b8c75c2dc97e86b3d452cc1e936ac1533df2b7584c69d49ef58", size = 346374, upload-time = "2026-06-23T10:02:41.593Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2b/63/77bd7220dfd60885a272a851f780b3f83e0f653ee3a852347552c3e24a28/langfuse-4.5.1-py3-none-any.whl", hash = "sha256:5923cafe8289c9e3c53cb6992f4b46ec3132473b9f9eb65eb33ad28e2682db81", size = 479527, upload-time = "2026-04-24T15:21:45.568Z" },
+    { url = "https://files.pythonhosted.org/packages/78/4d/279f93ea5a5fbd9dd4519e5df169237bb8d2f2164fc76d19afae0d5aa95c/langfuse-4.10.0-py3-none-any.whl", hash = "sha256:3bb110df24755245721374ac622e286f2fcfab68f4a9df45d24dde5d6fee1a77", size = 607392, upload-time = "2026-06-23T10:02:40.136Z" },
 ]
 
 [[package]]
@@ -2709,7 +2709,7 @@ wheels = [
 
 [[package]]
 name = "udiagent"
-version = "0.2.3"
+version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jsonschema" },
@@ -2717,9 +2717,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/1e/ffa1452e4e8478da661a5039bb4b1d1238d6d8048df62543d4c16bea908e/udiagent-0.2.3.tar.gz", hash = "sha256:706927eef43528ad970d3b54cab0209633f2b269c71f7016e3a2c043b9c5157d", size = 28250004, upload-time = "2026-04-30T19:04:14.965Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/8c/1a1ecf33626cb3687af13dea1a2c452af5be5c38474029e210f38bfdb78a/udiagent-0.2.6.tar.gz", hash = "sha256:0d868f837db41638f0d7450fe48386d2b7d3aca0fb7ade19930944180dcdb36a", size = 28250812, upload-time = "2026-06-23T17:16:09.966Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/93/e339150f1953e941188cca85b35c3aa0067a9aba9951a33fc572656db5c9/udiagent-0.2.3-py3-none-any.whl", hash = "sha256:2849b0469a5d842c732d7472f9bbafd30064895783df1d0af0720164e8d48674", size = 82368, upload-time = "2026-04-30T19:04:13.276Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/81/ccb7b3d6a23b3ad0fba44d9ec86585647ae9679005015a4c59b061f33a48/udiagent-0.2.6-py3-none-any.whl", hash = "sha256:7ae96428231e7123dcaf94148a0b762eba398c777e20e099b3ab6de1335781b7", size = 83141, upload-time = "2026-06-23T17:16:07.924Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

This PR adjusts the langfuse config to include session ID in trace logs to simplify event tracking upstream.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1623

## Testing


1. create SSH tunnel using PSC login: 

```ssh -f -N -L 13001:vm001.hive.psc.edu:3001 {your_username_here}@hive.psc.edu```

2. Set up environment variables:

```
LANGFUSE_BASE_URL = 'https://langfuse.b2-workspaces-pt.dev.hubmapconsortium.org:13001'
LANGFUSE_SECRET_KEY = (see 1Password)
LANGFUSE_PUBLIC_KEY = (see 1Password)
```

3. Add an /etc/hosts entry for langfuse so it doesn't throw SSL errors:

```
echo '127.0.0.1 langfuse.b2-workspaces-pt.dev.hubmapconsortium.org' | sudo tee -a /etc/hosts
```

## Screenshots/Video

Local traces are recording into Langfuse, now with environment specified:

<img width="897" height="196" alt="image" src="https://github.com/user-attachments/assets/454a1f5d-7e9d-46db-bced-bd66d988ad87" />



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Corresponding revisions to the udi-yac front-end to send the X-Conversation-Id for non-portal users are in progress; support for this header is included in this PR. This will allow us to accurately trace non-portal users' sessions.
