### PR TITLE
NickAkhmetov/CAT-1618 Display em dashes for empty fields in integrated maps tables

### DIFF
--- a/CHANGELOG-empty-data-products.md
+++ b/CHANGELOG-empty-data-products.md
@@ -1,0 +1,1 @@
+- Display em dashes for empty Raw Download, Processed Download, and Shiny App entries in the Integrated Maps table.

--- a/context/app/static/js/components/organ/DataProducts/DataProducts.spec.tsx
+++ b/context/app/static/js/components/organ/DataProducts/DataProducts.spec.tsx
@@ -128,6 +128,12 @@ describe('DataProductsTable', () => {
     expect(screen.getByText('2025-12-16')).toBeInTheDocument();
   });
 
+  test('renders em dashes for empty entries', () => {
+    // Neither product has a Shiny App; Heart has no processed download → 3 empty cells.
+    render(<DataProductsTable dataProducts={products} />);
+    expect(screen.getAllByText('—')).toHaveLength(3);
+  });
+
   describe('standalone mode', () => {
     const organs: Record<string, OrganFile> = {
       kidney: {

--- a/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
+++ b/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
@@ -176,57 +176,57 @@ export function DataProductsTable({
           </TableCell>
           <TableCell>{assayName}</TableCell>
           <TableCell>
-            <Stack spacing={0.5}>
-              <InternalLink
-                href={download_raw}
-                onClick={() => {
-                  onTrack?.({ action: 'Download Raw', assayName, fileName: rawFileName, tissueType });
-                }}
-                variant="body2"
-              >
-                {rawFileName}
-              </InternalLink>
-              {rawFileName && rawFileName !== 'none' && (
-                <>
-                  <Typography variant="caption" color="text.secondary">
-                    {raw_file_size_bytes > 0 ? prettyBytes(raw_file_size_bytes) : '—'}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {totalRawCells > 0
-                      ? `${totalRawCells.toLocaleString()} cells, ${rawCellTypes.toLocaleString()} cell types`
-                      : ''}
-                  </Typography>
-                </>
-              )}
-            </Stack>
+            {rawFileName ? (
+              <Stack spacing={0.5}>
+                <InternalLink
+                  href={download_raw}
+                  onClick={() => {
+                    onTrack?.({ action: 'Download Raw', assayName, fileName: rawFileName, tissueType });
+                  }}
+                  variant="body2"
+                >
+                  {rawFileName}
+                </InternalLink>
+                <Typography variant="caption" color="text.secondary">
+                  {raw_file_size_bytes > 0 ? prettyBytes(raw_file_size_bytes) : '—'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {totalRawCells > 0
+                    ? `${totalRawCells.toLocaleString()} cells, ${rawCellTypes.toLocaleString()} cell types`
+                    : ''}
+                </Typography>
+              </Stack>
+            ) : (
+              '—'
+            )}
           </TableCell>
           <TableCell>
-            <Stack spacing={0.5}>
-              <InternalLink
-                href={download}
-                onClick={() => {
-                  onTrack?.({ action: 'Download Processed', assayName, fileName: processedFileName, tissueType });
-                }}
-                variant="body2"
-              >
-                {processedFileName}
-              </InternalLink>
-              {processedFileName && processedFileName !== 'none' && (
-                <>
-                  <Typography variant="caption" color="text.secondary">
-                    {processed_file_sizes_bytes > 0 ? prettyBytes(processed_file_sizes_bytes) : '—'}
-                  </Typography>
-                  <Typography variant="caption" color="text.secondary">
-                    {totalProcessedCells > 0
-                      ? `${totalProcessedCells.toLocaleString()} cells, ${processedCellTypes.toLocaleString()} cell types`
-                      : ''}
-                  </Typography>
-                </>
-              )}
-            </Stack>
+            {processedFileName ? (
+              <Stack spacing={0.5}>
+                <InternalLink
+                  href={download}
+                  onClick={() => {
+                    onTrack?.({ action: 'Download Processed', assayName, fileName: processedFileName, tissueType });
+                  }}
+                  variant="body2"
+                >
+                  {processedFileName}
+                </InternalLink>
+                <Typography variant="caption" color="text.secondary">
+                  {processed_file_sizes_bytes > 0 ? prettyBytes(processed_file_sizes_bytes) : '—'}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  {totalProcessedCells > 0
+                    ? `${totalProcessedCells.toLocaleString()} cells, ${processedCellTypes.toLocaleString()} cell types`
+                    : ''}
+                </Typography>
+              </Stack>
+            ) : (
+              '—'
+            )}
           </TableCell>
           <TableCell>
-            {shiny_app && (
+            {shiny_app ? (
               <OutboundIconLink
                 href={shiny_app}
                 onClick={() => {
@@ -236,6 +236,8 @@ export function DataProductsTable({
               >
                 View
               </OutboundIconLink>
+            ) : (
+              '—'
             )}
           </TableCell>
           <TableCell>{format(new Date(creation_time), 'yyyy-MM-dd')}</TableCell>

--- a/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
+++ b/context/app/static/js/components/organ/DataProducts/DataProducts.tsx
@@ -69,6 +69,52 @@ export function sumCellCounts(counts: Record<string, number> | undefined): numbe
 
 type TrackHandler = (args: { action: string; assayName: string; tissueType: string; fileName?: string }) => void;
 
+function DownloadCell({
+  href,
+  action,
+  fileSizeBytes,
+  cellTypeCounts,
+  assayName,
+  tissueType,
+  onTrack,
+}: {
+  href: string;
+  action: string;
+  fileSizeBytes: number;
+  cellTypeCounts?: Record<string, number>;
+  assayName: string;
+  tissueType: string;
+  onTrack?: TrackHandler;
+}) {
+  const fileName = getFileName(href, 'none');
+  if (!fileName) {
+    return <TableCell>—</TableCell>;
+  }
+  const totalCells = sumCellCounts(cellTypeCounts);
+  const cellTypes = Object.keys(cellTypeCounts ?? {}).length;
+  return (
+    <TableCell>
+      <Stack spacing={0.5}>
+        <InternalLink
+          href={href}
+          onClick={() => {
+            onTrack?.({ action, assayName, fileName, tissueType });
+          }}
+          variant="body2"
+        >
+          {fileName}
+        </InternalLink>
+        <Typography variant="caption" color="text.secondary">
+          {fileSizeBytes > 0 ? prettyBytes(fileSizeBytes) : '—'}
+        </Typography>
+        <Typography variant="caption" color="text.secondary">
+          {totalCells > 0 ? `${totalCells.toLocaleString()} cells, ${cellTypes.toLocaleString()} cell types` : ''}
+        </Typography>
+      </Stack>
+    </TableCell>
+  );
+}
+
 export function DataProductsTable({
   dataProducts,
   onTrack,
@@ -143,14 +189,8 @@ export function DataProductsTable({
       raw_file_size_bytes,
       processed_file_sizes_bytes,
     }) => {
-      const rawFileName = getFileName(download_raw, 'none');
-      const processedFileName = getFileName(download, 'none');
       const { assayName } = assay;
       const { tissuetype: tissueType } = tissue;
-      const totalRawCells = sumCellCounts(raw_cell_type_counts);
-      const rawCellTypes = Object.keys(raw_cell_type_counts ?? {}).length;
-      const totalProcessedCells = sumCellCounts(processed_cell_type_counts);
-      const processedCellTypes = Object.keys(processed_cell_type_counts ?? {}).length;
 
       const normalizedName = tissueType
         .replace(/\s*\((left|right)\)\s*/i, '')
@@ -175,56 +215,24 @@ export function DataProductsTable({
             )}
           </TableCell>
           <TableCell>{assayName}</TableCell>
-          <TableCell>
-            {rawFileName ? (
-              <Stack spacing={0.5}>
-                <InternalLink
-                  href={download_raw}
-                  onClick={() => {
-                    onTrack?.({ action: 'Download Raw', assayName, fileName: rawFileName, tissueType });
-                  }}
-                  variant="body2"
-                >
-                  {rawFileName}
-                </InternalLink>
-                <Typography variant="caption" color="text.secondary">
-                  {raw_file_size_bytes > 0 ? prettyBytes(raw_file_size_bytes) : '—'}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {totalRawCells > 0
-                    ? `${totalRawCells.toLocaleString()} cells, ${rawCellTypes.toLocaleString()} cell types`
-                    : ''}
-                </Typography>
-              </Stack>
-            ) : (
-              '—'
-            )}
-          </TableCell>
-          <TableCell>
-            {processedFileName ? (
-              <Stack spacing={0.5}>
-                <InternalLink
-                  href={download}
-                  onClick={() => {
-                    onTrack?.({ action: 'Download Processed', assayName, fileName: processedFileName, tissueType });
-                  }}
-                  variant="body2"
-                >
-                  {processedFileName}
-                </InternalLink>
-                <Typography variant="caption" color="text.secondary">
-                  {processed_file_sizes_bytes > 0 ? prettyBytes(processed_file_sizes_bytes) : '—'}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {totalProcessedCells > 0
-                    ? `${totalProcessedCells.toLocaleString()} cells, ${processedCellTypes.toLocaleString()} cell types`
-                    : ''}
-                </Typography>
-              </Stack>
-            ) : (
-              '—'
-            )}
-          </TableCell>
+          <DownloadCell
+            href={download_raw}
+            action="Download Raw"
+            fileSizeBytes={raw_file_size_bytes}
+            cellTypeCounts={raw_cell_type_counts}
+            assayName={assayName}
+            tissueType={tissueType}
+            onTrack={onTrack}
+          />
+          <DownloadCell
+            href={download}
+            action="Download Processed"
+            fileSizeBytes={processed_file_sizes_bytes}
+            cellTypeCounts={processed_cell_type_counts}
+            assayName={assayName}
+            tissueType={tissueType}
+            onTrack={onTrack}
+          />
           <TableCell>
             {shiny_app ? (
               <OutboundIconLink


### PR DESCRIPTION
## Summary

This PR adjusts the display for integrated maps tables to show an em dash for fields with nothing in them.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1618

## Testing

Added unit tests

## Screenshots/Video

<img width="1552" height="1552" alt="image" src="https://github.com/user-attachments/assets/55e5f2f6-cf4e-49ee-8bc2-bc7b36d786f5" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
