### PR TITLE
NickAkhmetov/CAT-1622 Fix search "select all" to include retracted/superseded datasets and  add tests for dataset display logic

### DIFF
--- a/CHANGELOG-superseded-select-all.md
+++ b/CHANGELOG-superseded-select-all.md
@@ -1,0 +1,1 @@
+- Fixed search "select all" excluding retracted/superseded datasets that have a `next_revision_uuid` or `sub_status`, even when "Include superseded entities" was enabled. The select-all query now mirrors the displayed table results.

--- a/context/app/static/js/components/search/Results/CellContent.spec.tsx
+++ b/context/app/static/js/components/search/Results/CellContent.spec.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { getHuBMAPIdDisplayInfo } from './CellContent';
+
+describe('getHuBMAPIdDisplayInfo', () => {
+  it('flags a retracted dataset with a next_revision_uuid as superseded and builds the replacement url', () => {
+    const info = getHuBMAPIdDisplayInfo({
+      next_revision_uuid: 'abc123',
+      mapped_status: 'Retracted',
+      entity_type: 'Dataset',
+    } as never);
+
+    expect(info.isSuperseded).toBe(true);
+    expect(info.isRetracted).toBe(true);
+    expect(info.latestRevisionUrl).toBe('/browse/dataset/abc123');
+  });
+});

--- a/context/app/static/js/components/search/Results/ResultsTable.tsx
+++ b/context/app/static/js/components/search/Results/ResultsTable.tsx
@@ -131,6 +131,8 @@ function SelectableHeaderCells() {
   const sortField = useSearchStore((state) => state.sortField);
   const defaultQuery = useSearchStore((state) => state.defaultQuery);
   const defaultQueryWithAncestorFilter = useSearchStore((state) => state.defaultQueryWithAncestorFilter);
+  const latestRevisionFilter = useSearchStore((state) => state.latestRevisionFilter);
+  const includeSupersededEntities = useSearchStore((state) => state.includeSupersededEntities);
   const type = useSearchStore((state) => state.type);
 
   const mappings = useESmapping();
@@ -145,11 +147,16 @@ function SelectableHeaderCells() {
     sortField,
     defaultQuery,
     defaultQueryWithAncestorFilter,
+    latestRevisionFilter,
+    includeSupersededEntities,
     mappings,
     buildAggregations: false,
   });
 
-  const { allSearchIDs, isLoading } = useAllSearchIDs(query);
+  // buildQuery already encodes the latest-revision/superseded logic (matching the table),
+  // so skip addRestrictionsToQuery, which would re-exclude next_revision_uuid/sub_status docs
+  // even when "Include superseded entities" is on.
+  const { allSearchIDs, isLoading } = useAllSearchIDs(query, { useDefaultQuery: false });
 
   const devSearch = isDevSearch(type);
 


### PR DESCRIPTION
## Summary

This PR fixes the "select all" logic to respect the inclusion of retracted datasets/datasets with available revisions. I also added a test to confirm that the next revision UUID link is present for any datasets with one available.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1622

## Testing

* Added unit test
* Confirmed that all 296 retracted datasets are now selected with select all, and "view replacement" link is present.

## Screenshots/Video

<img width="1567" height="981" alt="image" src="https://github.com/user-attachments/assets/077725ef-f89c-4758-ba0e-48bd320eb8b9" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added