### PR TITLE
NickAkhmetov/CAT-1625 Improve organ display handling for multi-organ datasets

### DIFF
--- a/CHANGELOG-cat-1625.md
+++ b/CHANGELOG-cat-1625.md
@@ -1,0 +1,1 @@
+- Improve display of datasets with many associated organs.

--- a/context/app/static/js/components/detailPage/summary/Summary/Summary.tsx
+++ b/context/app/static/js/components/detailPage/summary/Summary/Summary.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from 'react';
+import Box from '@mui/material/Box';
 import { useFlaskDataContext } from 'js/components/Contexts';
 import DetailPageSection from 'js/components/detailPage/DetailPageSection';
 import SummaryData from 'js/components/detailPage/summary/SummaryData';
@@ -41,7 +42,9 @@ function Summary({
       >
         {children}
       </SummaryData>
-      <SummaryBody />
+      <Box mt={1}>
+        <SummaryBody />
+      </Box>
       {bottomFold}
     </DetailPageSection>
   );

--- a/context/app/static/js/pages/Dataset/DatasetPageSummaryChildren.tsx
+++ b/context/app/static/js/pages/Dataset/DatasetPageSummaryChildren.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 
 import SummaryItem from 'js/components/detailPage/summary/SummaryItem';
 import { useTrackEntityPageEvent } from 'js/components/detailPage/useTrackEntityPageEvent';
@@ -13,10 +16,40 @@ interface SummaryDataChildrenProps {
   origin_samples: Sample[];
 }
 
+// Number of organs shown inline before the rest collapse into a "N more..." chip.
+const MAX_VISIBLE_ORGANS = 2;
+
+function OrganLinkContent({ organ }: { organ: string }) {
+  // SummaryItem wraps its content in a <p>; keep everything inline so the HTML stays valid.
+  return (
+    <Stack
+      component="span"
+      direction="row"
+      spacing={0.5}
+      alignItems="center"
+      display="inline-flex"
+      // A center-aligned inline-flex box synthesizes its baseline at its bottom edge, so it rides
+      // above the adjacent plain-text links; middle-align it against the surrounding text instead.
+      sx={{ verticalAlign: 'middle' }}
+    >
+      <OrganIcon component="span" organName={organ} />
+      <Typography component="span" fontSize="inherit">
+        {organ}
+      </Typography>
+    </Stack>
+  );
+}
+
 export default function SummaryDataChildren({ mapped_data_types, origin_samples }: SummaryDataChildrenProps) {
   const trackEntityPageEvent = useTrackEntityPageEvent();
   const dataTypes = mapped_data_types.join(', ');
-  const mapped_organs = new Set(origin_samples.flatMap((s) => s.mapped_organ));
+  const mapped_organs = [...new Set(origin_samples.flatMap((s) => s.mapped_organ))];
+
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  const visibleOrgans = mapped_organs.slice(0, MAX_VISIBLE_ORGANS);
+  const hiddenOrgans = mapped_organs.slice(MAX_VISIBLE_ORGANS);
+
   return (
     <>
       <SummaryItem>
@@ -30,21 +63,40 @@ export default function SummaryDataChildren({ mapped_data_types, origin_samples 
           {dataTypes}
         </InternalLink>
       </SummaryItem>
-      {[...mapped_organs].map((mapped_organ, idx) => (
-        <SummaryItem showDivider={idx !== mapped_organs.size - 1} key={mapped_organ}>
+      {visibleOrgans.map((mapped_organ, idx) => (
+        <SummaryItem showDivider={hiddenOrgans.length > 0 || idx !== visibleOrgans.length - 1} key={mapped_organ}>
           <InternalLink href={`/organs/${mapped_organ}`} underline="none">
-            {/* SummaryItem wraps its content in a <p>; render both this
-                flex container and the label as inline elements so the
-                resulting HTML stays valid. */}
-            <Stack component="span" direction="row" spacing={0.5} alignItems="center" display="inline-flex">
-              <OrganIcon component="span" organName={mapped_organ} />
-              <Typography component="span" fontSize="inherit">
-                {mapped_organ}
-              </Typography>
-            </Stack>
+            <OrganLinkContent organ={mapped_organ} />
           </InternalLink>
         </SummaryItem>
       ))}
+      {hiddenOrgans.length > 0 && (
+        <SummaryItem showDivider={false}>
+          <Chip
+            clickable
+            variant="outlined"
+            color="primary"
+            size="small"
+            label={`${hiddenOrgans.length} more...`}
+            aria-haspopup="menu"
+            aria-expanded={Boolean(anchorEl)}
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+          />
+          <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+            {hiddenOrgans.map((mapped_organ) => (
+              <MenuItem
+                key={mapped_organ}
+                component={InternalLink}
+                href={`/organs/${mapped_organ}`}
+                underline="none"
+                onClick={() => setAnchorEl(null)}
+              >
+                <OrganLinkContent organ={mapped_organ} />
+              </MenuItem>
+            ))}
+          </Menu>
+        </SummaryItem>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Summary

This PR adjusts the display of multi-organ datasets so that if there are more than two organs, it shows a chip with links to the others. This will allow common cases where the two organs are two lateralities of the same organ (e.g. an integrated map of left and right kidney data, or lc-ms datasets with small and large intestines) to avoid having the chip display, but handles outliers like the 17-organ object by analyte EPIC.

## Design Documentation/Original Tickets
https://hms-dbmi.atlassian.net/browse/CAT-1625

## Testing


## Screenshots/Video


<img width="1242" height="281" alt="image" src="https://github.com/user-attachments/assets/4e634a9a-ec6a-4801-a6dc-0c0aac1e3152" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
