### PR TITLE
NickAkhmetov/CAT-1636 Grey out icons for entities in metadata tables with no available metadata

### DIFF
--- a/CHANGELOG-cat-1636.md
+++ b/CHANGELOG-cat-1636.md
@@ -1,0 +1,1 @@
+- Grey out icons for entities in metadata tables with no available metadata.

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
@@ -106,7 +106,7 @@ function MetadataTabs({ entities }: { entities: MultiAssayEntityWithTableRows[] 
 
   return (
     <Box sx={{ width: '100%' }}>
-      <Tabs value={openTabIndex} onChange={handleTabChange} variant={entities.length > 5 ? 'scrollable' : 'fullWidth'}>
+      <Tabs value={openTabIndex} onChange={handleTabChange} variant={entities.length > 6 ? 'scrollable' : 'fullWidth'}>
         {disambiguatedEntities.map(({ label, uuid, icon, hasMetadata }, index) => (
           <MetadataTab label={label} uuid={uuid} index={index} key={uuid} icon={icon} disabled={!hasMetadata} />
         ))}

--- a/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
+++ b/context/app/static/js/components/detailPage/multi-assay/MultiAssayMetadataTabs/MultiAssayMetadataTabs.tsx
@@ -33,7 +33,7 @@ interface MultiAssayEntityTabProps {
 function MetadataTab({ label, uuid, index, icon: Icon, disabled, ...props }: MultiAssayEntityTabProps) {
   const tab = (
     <Tab
-      icon={<Icon fontSize="1.5rem" color="primary" />}
+      icon={<Icon fontSize="1.5rem" color={disabled ? 'inherit' : 'primary'} />}
       label={label}
       index={index}
       iconPosition="start"


### PR DESCRIPTION
## Summary

This PR sets the tab icons to inherit the color styling for the tab when there is no available metadata, which sets their color to the same shade as the disabled label. They are otherwise set to "primary" to indicate they have metadata available.

I also bumped up the number of entities it takes for the tabs to become scrollable to account for the maximum number of entities in provenance before disambiguation with HuBMAP IDs kicks in.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1636

## Testing

Manually tested.

## Screenshots/Video

<img width="1558" height="438" alt="image" src="https://github.com/user-attachments/assets/e2b10e9a-8aa8-41c5-9743-4e8ec996ae37" />

First tab is selected entity with available metadata.
Second tab is unselected entity with available metadata.
Third tab onwards are unselected entities without available metadata.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
