### PR TITLE
NickAkhmetov/CAT-1595 Gracefully handle gene pages for genes not present in scFind

### DIFF
--- a/CHANGELOG-genes-empty-state.md
+++ b/CHANGELOG-genes-empty-state.md
@@ -1,0 +1,1 @@
+- Show an empty-state message on the biomarker detail page's Cell Types and Datasets sections when no scFind results exist for the gene in either modality.

--- a/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
+++ b/context/app/static/js/components/genes/CellTypes/GeneCellTypes.tsx
@@ -399,30 +399,42 @@ export default function CellTypes() {
     return openTabIndex;
   }, [openTabIndex, rnaCount, atacCount]);
 
+  const hasNoCellTypes = !isLoading && rnaCount === 0 && atacCount === 0;
+
   return (
     <CollapsibleDetailPageSection
       id={cellTypesSection.id}
       title={`Cell Types with ${geneSymbolUpper} as Marker Gene`}
       trackingInfo={trackingInfo}
     >
-      <Description>
-        The table displays cell types expressing this marker gene as identified by the <SCFindLink />. It calculates
-        cell count proportions and statistical metrics based on uniformly processed HuBMAP RNAseq and ATACseq datasets
-        with cell type annotations.
-        <Divider sx={{ opacity: 0, my: 1 }} />
-        The table can be filtered by organs and available for download for further analysis. Filtering by organ will
-        recompute the results and recalculate statistical values accordingly.
-      </Description>
-      <Tabs value={effectiveTabIndex} onChange={handleTabChange}>
-        <Tab label={`RNAseq (${rnaCount} Cell Types)`} index={0} disabled={!isLoading && rnaCount === 0} />
-        <Tab label={`ATACseq (${atacCount} Cell Types)`} index={1} disabled={!isLoading && atacCount === 0} />
-      </Tabs>
-      <TabPanel value={effectiveTabIndex} index={0}>
-        <CellTypesTable modality={undefined} />
-      </TabPanel>
-      <TabPanel value={effectiveTabIndex} index={1}>
-        <CellTypesTable modality="ATAC" />
-      </TabPanel>
+      {hasNoCellTypes ? (
+        <Description>
+          No cell types expressing this marker gene were identified by the <SCFindLink />, which calculates cell count
+          proportions and statistical metrics based on uniformly processed HuBMAP RNAseq or ATACseq datasets with cell
+          type annotations.
+        </Description>
+      ) : (
+        <>
+          <Description>
+            The table displays cell types expressing this marker gene as identified by the <SCFindLink />. It calculates
+            cell count proportions and statistical metrics based on uniformly processed HuBMAP RNAseq and ATACseq
+            datasets with cell type annotations.
+            <Divider sx={{ opacity: 0, my: 1 }} />
+            The table can be filtered by organs and available for download for further analysis. Filtering by organ will
+            recompute the results and recalculate statistical values accordingly.
+          </Description>
+          <Tabs value={effectiveTabIndex} onChange={handleTabChange}>
+            <Tab label={`RNAseq (${rnaCount} Cell Types)`} index={0} disabled={!isLoading && rnaCount === 0} />
+            <Tab label={`ATACseq (${atacCount} Cell Types)`} index={1} disabled={!isLoading && atacCount === 0} />
+          </Tabs>
+          <TabPanel value={effectiveTabIndex} index={0}>
+            <CellTypesTable modality={undefined} />
+          </TabPanel>
+          <TabPanel value={effectiveTabIndex} index={1}>
+            <CellTypesTable modality="ATAC" />
+          </TabPanel>
+        </>
+      )}
     </CollapsibleDetailPageSection>
   );
 }

--- a/context/app/static/js/components/genes/Datasets/GeneDatasetsResults.tsx
+++ b/context/app/static/js/components/genes/Datasets/GeneDatasetsResults.tsx
@@ -13,35 +13,11 @@ import { SCFindGeneQueryDatasetList } from 'js/components/cells/SCFindResults/SC
 import SCFindDatasetTableActions from 'js/components/cells/SCFindResults/SCFindDatasetTableActions';
 import DatasetsOverview from 'js/components/cells/DatasetsOverview';
 import SelectableTableProvider, { useSelectableTableStore } from 'js/shared-styles/tables/SelectableTableProvider';
-import { DatasetsForGenesResponse } from 'js/api/scfind/useFindDatasetForGenes';
 import { useGeneDatasetsData, useGeneSymbol } from '../hooks';
+import { useGeneMatchedDatasets } from './hooks';
 
 const RNA_TAB = 0;
 const ATAC_TAB = 1;
-
-/**
- * Collapse a `findDatasets` aggregate slice into the matched-dataset id list + a hubmap_id -> count
- * map for the table's matching-gene column. The gene-detail aggregate queries a single gene, so we
- * read the one entry regardless of the exact key casing scFind echoes back.
- */
-function useGeneMatchedDatasets(data: DatasetsForGenesResponse | undefined) {
-  return useMemo(() => {
-    const findDatasets = data?.findDatasets ?? {};
-    const allCounts = data?.counts ?? {};
-    const key = Object.keys(findDatasets)[0];
-    const datasets = key ? findDatasets[key] : [];
-    const counts = key ? (allCounts[key] ?? []) : [];
-
-    const countsMap: Record<string, number> = {};
-    datasets.forEach((hubmapId, index) => {
-      if (hubmapId) {
-        countsMap[hubmapId] = counts[index] ?? 0;
-      }
-    });
-    const ids = Object.keys(countsMap);
-    return { ids, countsMap, datasetIds: ids.map((hubmap_id) => ({ hubmap_id })) };
-  }, [data]);
-}
 
 /**
  * A single modality's dataset table. Rendered inside its own SelectableTableProvider (one per tab),

--- a/context/app/static/js/components/genes/Datasets/GenePageDatasets.tsx
+++ b/context/app/static/js/components/genes/Datasets/GenePageDatasets.tsx
@@ -7,22 +7,37 @@ import SCFindLink from 'js/shared-styles/Links/SCFindLink';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import { datasets } from '../constants';
-import { useGeneDetailPageTrackingInfo, useGeneSymbol, useTrackGeneDetailPage } from '../hooks';
+import { useGeneDatasetsData, useGeneDetailPageTrackingInfo, useGeneSymbol, useTrackGeneDetailPage } from '../hooks';
 import GeneDatasetsResults from './GeneDatasetsResults';
+import { useGeneMatchedDatasets } from './hooks';
 
 export default function Datasets() {
   const geneSymbol = useGeneSymbol();
+  const trackingInfo = useGeneDetailPageTrackingInfo();
+
+  const { data: rnaData, isLoading } = useGeneDatasetsData(undefined);
+  const { data: atacData } = useGeneDatasetsData('ATAC');
+  const rna = useGeneMatchedDatasets(rnaData);
+  const atac = useGeneMatchedDatasets(atacData);
+  const hasNoDatasets = !isLoading && rna.ids.length === 0 && atac.ids.length === 0;
 
   const trackExploreWithBiomarkerAndCellTypeSearchTool = useTrackGeneDetailPage({
     action: 'Datasets / Select "Explore with Molecular and Cellular Query" button',
   });
 
+  if (hasNoDatasets) {
+    return (
+      <CollapsibleDetailPageSection id={datasets.id} title={`Datasets with ${geneSymbol}`} trackingInfo={trackingInfo}>
+        <Description>
+          No datasets containing this gene were identified by the <SCFindLink /> within uniformly processed HuBMAP
+          RNAseq or ATACseq datasets.
+        </Description>
+      </CollapsibleDetailPageSection>
+    );
+  }
+
   return (
-    <CollapsibleDetailPageSection
-      id={datasets.id}
-      title={`Datasets with ${geneSymbol}`}
-      trackingInfo={useGeneDetailPageTrackingInfo()}
-    >
+    <CollapsibleDetailPageSection id={datasets.id} title={`Datasets with ${geneSymbol}`} trackingInfo={trackingInfo}>
       <Description
         belowTheFold={
           <Box mt={2}>

--- a/context/app/static/js/components/genes/Datasets/hooks.ts
+++ b/context/app/static/js/components/genes/Datasets/hooks.ts
@@ -1,0 +1,26 @@
+import { DatasetsForGenesResponse } from 'js/api/scfind/useFindDatasetForGenes';
+import { useMemo } from 'react';
+
+/**
+ * Collapse a `findDatasets` aggregate slice into the matched-dataset id list + a hubmap_id -> count
+ * map for the table's matching-gene column. The gene-detail aggregate queries a single gene, so we
+ * read the one entry regardless of the exact key casing scFind echoes back.
+ */
+export function useGeneMatchedDatasets(data: DatasetsForGenesResponse | undefined) {
+  return useMemo(() => {
+    const findDatasets = data?.findDatasets ?? {};
+    const allCounts = data?.counts ?? {};
+    const key = Object.keys(findDatasets)[0];
+    const datasets = key ? findDatasets[key] : [];
+    const counts = key ? (allCounts[key] ?? []) : [];
+
+    const countsMap: Record<string, number> = {};
+    datasets.forEach((hubmapId, index) => {
+      if (hubmapId) {
+        countsMap[hubmapId] = counts[index] ?? 0;
+      }
+    });
+    const ids = Object.keys(countsMap);
+    return { ids, countsMap, datasetIds: ids.map((hubmap_id) => ({ hubmap_id })) };
+  }, [data]);
+}

--- a/context/app/static/js/pages/Genes/Genes.tsx
+++ b/context/app/static/js/pages/Genes/Genes.tsx
@@ -29,8 +29,8 @@ function GeneDetails({ geneSymbol }: Props) {
         <SummaryTitle entityIcon="Gene">Gene</SummaryTitle>
         <GenePageTitle />
         <Summary />
-        {shouldDisplaySection[cellTypes] && <CellTypes />}
-        {shouldDisplaySection[datasets] && <Datasets />}
+        <CellTypes />
+        <Datasets />
       </DetailLayout>
     </GenePageProvider>
   );


### PR DESCRIPTION
## Summary

This PR improves the gene detail page's handling of genes that are present in UBKG and not present in scFind by showing appropriately targeted messages.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1595

## Testing

Manually tested.

## Screenshots/Video

<img width="1620" height="1047" alt="image" src="https://github.com/user-attachments/assets/953fc282-97d8-454f-9faa-ec761cca5657" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Also pulled the helper hook out into a hooks file for organization