### PR TITLE
NickAkhmetov/CAT-1630 Fix autoscroll from iframe

### DIFF
--- a/CHANGELOG-cat-1630.md
+++ b/CHANGELOG-cat-1630.md
@@ -1,0 +1,1 @@
+- Fix auto-scrolling from iframe focus trap for most clients.

--- a/context/app/static/js/components/Markdown/MarkdownRenderer.tsx
+++ b/context/app/static/js/components/Markdown/MarkdownRenderer.tsx
@@ -83,6 +83,12 @@ const baseComponents: NonNullable<Options['components']> = {
     </Box>
   ),
   img: ({ src, alt }) => <Box component="img" src={src} alt={alt} sx={{ maxWidth: '100%' }} />,
+  // Defer off-screen iframes so a focus-trapping embed can't scroll the page
+  // to itself on load (e.g. publication vignette embeds). Author-set `loading`
+  // wins. ponytail: loading="lazy" handles the below-the-fold case; add a
+  // scroll-restore wrapper only if an above-the-fold embed still jumps.
+  // eslint-disable-next-line jsx-a11y/iframe-has-title
+  iframe: (props) => <iframe loading="lazy" {...props} />,
   table: ({ children }) => (
     <Box
       component="table"


### PR DESCRIPTION
## Summary

This PR fixes the autoscrolling caused by the HRA components for most clients by lazy loading them; the scrolling issue persists for tall viewports (2160px) but would require either upstream fixes or a heavy scroll restoration functionality to resolve which does not provide enough benefit.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1630

## Testing

Loaded http://localhost:5001/browse/publication/f53d60b5994333777a446dd7ad3b0304 with a standard 1080p window.

## Screenshots/Video



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
