### PR TITLE
NickAkhmetov/CAT-1624 Enhance login functionality to restore hash/URL parameters

### DIFF
--- a/CHANGELOG-cat-1624.md
+++ b/CHANGELOG-cat-1624.md
@@ -1,0 +1,1 @@
+- Improve login to restore hash/URL parameters after navigating back to portal.

--- a/context/app/static/js/components/Routes/useSetUrlBeforeLogin.spec.ts
+++ b/context/app/static/js/components/Routes/useSetUrlBeforeLogin.spec.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react';
+import Cookies from 'universal-cookie';
+
+import useSetUrlBeforeLogin from './useSetUrlBeforeLogin';
+
+const readCookie = () => new Cookies().get('urlBeforeLogin') as string | undefined;
+
+describe('useSetUrlBeforeLogin', () => {
+  it('saves the current URL on mount and on programmatic pushState/replaceState (e.g. nuqs)', () => {
+    window.history.replaceState(null, '', '/search/datasets');
+    renderHook(() => useSetUrlBeforeLogin());
+    expect(readCookie()).toBe('/search/datasets');
+
+    // nuqs updates query params via replaceState — no native event fires.
+    window.history.replaceState(null, '', '/search/datasets?mode=say-see');
+    expect(readCookie()).toBe('/search/datasets?mode=say-see');
+
+    // filters push a new entry.
+    window.history.pushState(null, '', '/search/datasets?mode=say-see&q=abc');
+    expect(readCookie()).toBe('/search/datasets?mode=say-see&q=abc');
+  });
+
+  it('stops saving after unmount', () => {
+    window.history.replaceState(null, '', '/before-unmount');
+    const { unmount } = renderHook(() => useSetUrlBeforeLogin());
+    unmount();
+    window.history.replaceState(null, '', '/after-unmount');
+    expect(readCookie()).toBe('/before-unmount');
+  });
+});

--- a/context/app/static/js/components/Routes/useSetUrlBeforeLogin.ts
+++ b/context/app/static/js/components/Routes/useSetUrlBeforeLogin.ts
@@ -1,6 +1,5 @@
 import { useEffect } from 'react';
 import Cookies from 'universal-cookie';
-import history from 'history/browser';
 
 function useSetUrlBeforeLogin() {
   useEffect(() => {
@@ -10,11 +9,29 @@ function useSetUrlBeforeLogin() {
       cookies.set('urlBeforeLogin', url, { path: '/', sameSite: 'lax' });
     };
     saveUrl();
-    // history.listen covers push/replace (query params) and popstate; hashchange covers direct hash updates.
-    const unlisten = history.listen(saveUrl);
+
+    // Programmatic URL changes (the search store's history lib, nuqs query params like ?mode=)
+    // go through history.pushState/replaceState, which fire no native event. Patch them to emit one.
+    const emit = () => window.dispatchEvent(new Event('urlchange'));
+    const pushState = window.history.pushState.bind(window.history);
+    const replaceState = window.history.replaceState.bind(window.history);
+    window.history.pushState = (...args: Parameters<History['pushState']>) => {
+      pushState(...args);
+      emit();
+    };
+    window.history.replaceState = (...args: Parameters<History['replaceState']>) => {
+      replaceState(...args);
+      emit();
+    };
+
+    window.addEventListener('urlchange', saveUrl);
+    window.addEventListener('popstate', saveUrl);
     window.addEventListener('hashchange', saveUrl);
     return () => {
-      unlisten();
+      window.history.pushState = pushState;
+      window.history.replaceState = replaceState;
+      window.removeEventListener('urlchange', saveUrl);
+      window.removeEventListener('popstate', saveUrl);
       window.removeEventListener('hashchange', saveUrl);
     };
   }, []);

--- a/context/app/static/js/components/Routes/useSetUrlBeforeLogin.ts
+++ b/context/app/static/js/components/Routes/useSetUrlBeforeLogin.ts
@@ -1,11 +1,22 @@
 import { useEffect } from 'react';
 import Cookies from 'universal-cookie';
+import history from 'history/browser';
 
 function useSetUrlBeforeLogin() {
   useEffect(() => {
     const cookies = new Cookies();
-    const url = window.location.pathname + window.location.search + window.location.hash;
-    cookies.set('urlBeforeLogin', url, { path: '/', sameSite: 'lax' });
+    const saveUrl = () => {
+      const url = window.location.pathname + window.location.search + window.location.hash;
+      cookies.set('urlBeforeLogin', url, { path: '/', sameSite: 'lax' });
+    };
+    saveUrl();
+    // history.listen covers push/replace (query params) and popstate; hashchange covers direct hash updates.
+    const unlisten = history.listen(saveUrl);
+    window.addEventListener('hashchange', saveUrl);
+    return () => {
+      unlisten();
+      window.removeEventListener('hashchange', saveUrl);
+    };
   }, []);
 }
 


### PR DESCRIPTION
## Summary

Navigating to e.g. the search page, then going to the say and see view, then logging in, sends you back to the faceted search view because the cookie was only saved on initial route load.

The cookie now saves on mount and on every subsequent query-param or hash change, so any filters/queries/etc that were saved to URL state persist after login.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1624

## Testing

Added unit test, tested login manually as well

## Screenshots/Video



## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
