### PR TITLE
NickAkhmetov/CAT-1632 Fix color of tutorial button

### DIFF
--- a/CHANGELOG-cat-1632.md
+++ b/CHANGELOG-cat-1632.md
@@ -1,0 +1,1 @@
+- Fix the tutorial card "View Tutorial" button text displaying in the link color instead of white in production builds.

--- a/context/app/static/js/components/Tutorials/TutorialList.tsx
+++ b/context/app/static/js/components/Tutorials/TutorialList.tsx
@@ -13,7 +13,6 @@ import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import SelectableCard from 'js/shared-styles/cards/SelectableCard';
 import Typography from '@mui/material/Typography';
-import { InternalLink } from 'js/shared-styles/Links';
 import Button from '@mui/material/Button';
 import { tutorialIsReady } from './utils';
 
@@ -32,13 +31,7 @@ function TutorialButton({ tutorial }: TutorialDisplayProps) {
     );
   } else {
     return (
-      <Button
-        component={InternalLink}
-        href={`/tutorials/${tutorial.route}`}
-        fullWidth
-        variant="contained"
-        color="primary"
-      >
+      <Button href={`/tutorials/${tutorial.route}`} fullWidth variant="contained" color="primary">
         View Tutorial
       </Button>
     );


### PR DESCRIPTION
## Summary

This PR adjusts the display of the tutorial button so that it uses appropriate button styles. Not sure why it looked correct on local but broken on build, but this should ensure that internal link styles don't leak in.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1632

## Testing

The InternalLink class which was being applied is no longer present locally.

## Screenshots/Video


<img width="746" height="90" alt="image" src="https://github.com/user-attachments/assets/e88bde7a-0eb3-434f-8756-0292c56e4bdd" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes
