### PR TITLE
NickAkhmetov/CAT-1627 Fix padding in protocols section and update Paper component styling

### DIFF
--- a/CHANGELOG-cat-1627.md
+++ b/CHANGELOG-cat-1627.md
@@ -1,0 +1,1 @@
+- Fix protocols section on integrated datasets page to have 16-px padding.

--- a/context/app/static/js/components/detailPage/AnalysisDetails/AnalysisDetailsSection.tsx
+++ b/context/app/static/js/components/detailPage/AnalysisDetails/AnalysisDetailsSection.tsx
@@ -45,7 +45,7 @@ function AnalysisDetailsSection({ isExternal, protocolUrl, dataset }: AnalysisDe
       title="Protocols & Workflow Details"
       icon={sectionIconMap['protocols-and-workflow-details']}
     >
-      <Paper sx={{ px: 2, py: 1 }}>
+      <Paper sx={{ p: 2 }}>
         {protocolUrl && <Protocol protocol_url={protocolUrl} />}
         <AnalysisDetailsWrapper isExternal={isExternal} dataset={dataset} />
       </Paper>


### PR DESCRIPTION
## Summary

This PR adjusts the y-padding of the protocols and details section of the integrated datasets page to be 16px instead of 8px.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1627
 

## Screenshots/Video

<img width="1610" height="220" alt="image" src="https://github.com/user-attachments/assets/b468cf62-9c1f-4f44-9219-b156cecf4de9" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
