### PR TITLE
NickAkhmetov/CAT-1626 Add placeholder dash for empty search result table cells

### DIFF
--- a/CHANGELOG-cat-1626.md
+++ b/CHANGELOG-cat-1626.md
@@ -1,0 +1,1 @@
+- Show a placeholder dash in search result table cells (e.g. donor age/BMI/sex/race) when no value is available.

--- a/context/app/static/js/components/search/Results/CellContent.tsx
+++ b/context/app/static/js/components/search/Results/CellContent.tsx
@@ -174,7 +174,8 @@ export function CellContent({
   latestRevisionUrl,
 }: CellContentProps) {
   if (!fieldValue) {
-    return null;
+    // Placeholder so columns without a value (e.g. a donor missing age/BMI/sex/race) aren't blank.
+    return <>—</>;
   }
 
   switch (field.split('.').pop() ?? '') {


### PR DESCRIPTION
## Summary

This PR adjusts the cell content on the search page to show a hyphen if there is nothing else to display.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1626

## Testing

Manually confirmed.

## Screenshots/Video

<img width="1600" height="1037" alt="image" src="https://github.com/user-attachments/assets/3129a589-5e2c-4ae5-9958-d72e53b6bffd" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
