### PR TITLE
NickAkhmetov/Improve processed dataset loading

### DIFF
--- a/CHANGELOG-improve-processed-dataset-loading.md
+++ b/CHANGELOG-improve-processed-dataset-loading.md
@@ -1,0 +1,1 @@
+- Stop blocking processed dataset section content (summary, files, protocols, attribution) while the Vitessce visualization configuration is loading; the visualization subsection now shows its own loading skeleton instead.

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDataset.tsx
@@ -160,12 +160,21 @@ function VisualizationAccordion() {
     sectionDataset,
     sectionDataset: { hubmap_id },
     conf,
+    isLoadingConf,
   } = useProcessedDatasetContext();
 
   const hasBeenSeen = useProcessedDataStore((state) => state.hasBeenSeen(hubmap_id));
 
   const segmentationMetadata = dataset.ingest_metadata?.segmentation_metadata;
   const workflowDetailsHref = `#${datasetSectionId(sectionDataset, 'protocols-and-workflow-details')}`;
+
+  if (isLoadingConf) {
+    return (
+      <Subsection title="Visualization" icon={<VisualizationIcon />}>
+        <Skeleton variant="rectangular" height={500} />
+      </Subsection>
+    );
+  }
 
   if (!conf) {
     return null;
@@ -278,9 +287,10 @@ export default function ProcessedDataset({ sectionDataset }: ProcessedDataVisual
   return (
     <ProcessedDatasetContextProvider
       conf={conf}
+      isLoadingConf={loadingVitessceConf}
       dataset={datasetDetails}
       sectionDataset={sectionDataset}
-      isLoading={isLoading || loadingVitessceConf}
+      isLoading={isLoading}
       defaultExpanded={defaultExpanded}
     >
       <ProcessedDatasetAccordion>

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetAccordion.tsx
@@ -28,7 +28,7 @@ function LoadingFallback() {
 }
 
 export function ProcessedDatasetAccordion({ children }: PropsWithChildren) {
-  const { defaultExpanded, dataset, sectionDataset, conf, isLoading } = useProcessedDatasetContext();
+  const { defaultExpanded, dataset, sectionDataset, conf, isLoading, isLoadingConf } = useProcessedDatasetContext();
   const { isRetracted } = useRetractedDatasetContext();
   const visualizationIcon = conf ? <VisualizationIcon /> : null;
   const track = useTrackEntityPageEvent();
@@ -94,7 +94,7 @@ export function ProcessedDatasetAccordion({ children }: PropsWithChildren) {
         slotProps={{ transition: { unmountOnExit: true } }}
       >
         <AccordionSummary expandIcon={<ArrowDropDownRounded />}>
-          {isLoading ? iconPlaceholder : visualizationIcon}
+          {isLoading || isLoadingConf ? iconPlaceholder : visualizationIcon}
           <Typography variant="subtitle1" color="inherit" component="h4">
             {sectionDataset.pipeline ?? sectionDataset.assay_display_name[0]}
           </Typography>

--- a/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetContext.tsx
+++ b/context/app/static/js/components/detailPage/ProcessedData/ProcessedDataset/ProcessedDatasetContext.tsx
@@ -10,6 +10,7 @@ export interface ProcessedDataVisualizationProps {
 
 interface ProcessedDatasetContext extends ProcessedDataVisualizationProps {
   conf?: object;
+  isLoadingConf?: boolean;
   dataset: ProcessedDatasetDetails;
   defaultExpanded: boolean;
 }


### PR DESCRIPTION
## Summary

This PR adjusts the loading logic for the processed dataset section to keep vitessce configs from blocking the loading of the rest of the processed dataset.

## Testing

Loaded http://localhost:5001/browse/dataset/72b0dc83701c045d954b457baed40697?redirected=True&redirectedFromId=HBM928.NHRQ.399&redirectedFromPipeline=DeepCell+%2B+SPRM#section-hbm928.nhrq.399 - processed dataset accordion loaded before the vitessce config did.

## Screenshots/Video

<img width="1392" height="1425" alt="image" src="https://github.com/user-attachments/assets/e87d44b9-312e-43cb-8dcf-330664cce54c" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
