### PR TITLE
NickAkhmetov/CAT-1641 Update "View Visualizations" link to direct to dataset search page with visualization filter preselected

### DIFF
--- a/CHANGELOG-cat-1641.md
+++ b/CHANGELOG-cat-1641.md
@@ -1,0 +1,1 @@
+- Adjust "View Visualizations" homepage link to go to dataset search page with visualization filter enabled.

--- a/context/app/static/js/components/home/AnalysisAndVisualizations/config.ts
+++ b/context/app/static/js/components/home/AnalysisAndVisualizations/config.ts
@@ -123,7 +123,7 @@ export const VISUALIZE_DATA_SLIDE: MultiViewSlideConfig = {
       description: 'Visualize single-cell and spatial data with Vitessce',
       ctaButton: {
         label: 'View Visualizations',
-        href: '/search?mapped_data_types[0]=scRNA-seq%20%5BSalmon%5D&entity_type[0]=Dataset',
+        href: '/search/datasets?q=N4IgzgpghgTgxgCxALhCANOA9jALgMQEsIAbAExVADNjyUQAHAVwCMTCwEIyB9XQgLYQwuKAIYYQZQjAhx%2BWAHb0ywuJMhwlZWAE8ipCsmq0jIAVAYNuPEVFxMwk6bPmElKtSAC%2B3zDRJcCBgnYxAeHVFIXB4qaAdZUNAANygSJmF6AGUIXAAKAB0QZI4mNMIAL3t3RWRkXBgMooBKSVxda3oAIQB5HoAZAFEAQQA5HgBxACUegFUABR8-EEJFOHTVLKZrEO5uQcV%2BfkzkKjTIbyA',
         variant: 'contained',
         trackingLabel: 'Visualize / View Visualizations',
       },


### PR DESCRIPTION
## Summary

The "view visualizations" link in the parallax slide is not scoped to only target datasets with available visualizations; this PR fixes 

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1641

## Testing

Clicked the link from the homepage, went to search page with visualizations preselected.

## Screenshots/Video

N/A

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

May be a good idea to extend the `getSearchURL` util to work with all search parameters in the future.