### PR TITLE
NickAkhmetov/Improve integrated datasets table loading logic

### DIFF
--- a/CHANGELOG-improve-publication-load.md
+++ b/CHANGELOG-improve-publication-load.md
@@ -1,0 +1,4 @@
+- Lazy-load iframes embedded in publication vignette descriptions so they no longer grab focus and scroll the page on load.
+- Reserve the Integrated Data / publication Data table's height while it loads so content below it (such as publication vignettes) no longer shifts up into view.
+- Speed up the Integrated Data / publication Data section by requesting only the fields needed up front and loading each tab's rows lazily.
+- Default the Integrated Data / publication Data table to the directly associated datasets, with a "Show All Ancestors" toggle to also include the ancestor datasets they were derived from.

--- a/CHANGELOG-improve-publication-load.md
+++ b/CHANGELOG-improve-publication-load.md
@@ -1,4 +1,3 @@
-- Lazy-load iframes embedded in publication vignette descriptions so they no longer grab focus and scroll the page on load.
 - Reserve the Integrated Data / publication Data table's height while it loads so content below it (such as publication vignettes) no longer shifts up into view.
 - Speed up the Integrated Data / publication Data section by requesting only the fields needed up front and loading each tab's rows lazily.
 - Default the Integrated Data / publication Data table to the directly associated datasets, with a "Show All Ancestors" toggle to also include the ancestor datasets they were derived from.

--- a/context/app/static/js/components/detailPage/IntegratedData/IntegratedData.tsx
+++ b/context/app/static/js/components/detailPage/IntegratedData/IntegratedData.tsx
@@ -16,9 +16,11 @@ import Description from 'js/shared-styles/sections/Description';
 interface IntegratedDataSectionProps {
   entities: (Donor | Dataset | Sample)[];
   includeCurrentEntity?: boolean;
+  /** Datasets shown by default; others are hidden behind the ancestor-datasets toggle. */
+  directDatasetIds?: Set<string>;
 }
 
-function IntegratedDataSection({ entities, includeCurrentEntity }: IntegratedDataSectionProps) {
+function IntegratedDataSection({ entities, includeCurrentEntity, directDatasetIds }: IntegratedDataSectionProps) {
   const { entity } = useFlaskDataContext();
 
   const trackEntityPageEvent = useTrackEntityPageEvent();
@@ -67,6 +69,7 @@ function IntegratedDataSection({ entities, includeCurrentEntity }: IntegratedDat
       </Description>
       <IntegratedDataTables
         entities={fullEntities}
+        directDatasetIds={directDatasetIds}
         tableTooltips={{
           Dataset: 'Dataset count includes current dataset.',
         }}

--- a/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.spec.tsx
+++ b/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.spec.tsx
@@ -1,4 +1,5 @@
 import { Dataset, Donor, Sample, Entity } from 'js/components/types';
+import { getDisplayedDatasetIds } from './IntegratedDataTables';
 
 // Helper function to create mock entities
 function createMockDataset(uuid: string, partial?: Partial<Dataset>): Dataset {
@@ -254,6 +255,30 @@ describe('IntegratedDataTables utility functions', () => {
 
       expect(uuids).toEqual(['uuid-1', 'uuid-1', 'uuid-2']);
       expect(uuids.length).toBe(3);
+    });
+  });
+
+  describe('getDisplayedDatasetIds (direct vs. ancestor datasets)', () => {
+    const allDatasetIds = ['direct-1', 'direct-2', 'ancestor-1', 'ancestor-2'];
+    const directDatasetIds = new Set(['direct-1', 'direct-2']);
+
+    it('shows only direct datasets by default', () => {
+      expect(getDisplayedDatasetIds(allDatasetIds, directDatasetIds, false)).toEqual(['direct-1', 'direct-2']);
+    });
+
+    it('shows all datasets when the ancestor-datasets toggle is on', () => {
+      expect(getDisplayedDatasetIds(allDatasetIds, directDatasetIds, true)).toEqual(allDatasetIds);
+    });
+
+    it('shows all datasets when no direct set is provided (backward compatible)', () => {
+      expect(getDisplayedDatasetIds(allDatasetIds, undefined, false)).toEqual(allDatasetIds);
+    });
+
+    it('preserves original order of the direct datasets', () => {
+      expect(getDisplayedDatasetIds(['ancestor-1', 'direct-2', 'direct-1'], directDatasetIds, false)).toEqual([
+        'direct-2',
+        'direct-1',
+      ]);
     });
   });
 });

--- a/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.tsx
+++ b/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.tsx
@@ -1,5 +1,6 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
+import LabeledPrimarySwitch from 'js/shared-styles/switches/LabeledPrimarySwitch';
 import { Dataset, Donor, Entity, Sample } from 'js/components/types';
 import EntitiesTables from 'js/shared-styles/tables/EntitiesTable/EntitiesTables';
 import { EntitiesTabTypes } from 'js/shared-styles/tables/EntitiesTable/types';
@@ -46,9 +47,29 @@ const isIntegratedEntity = (e: Entity): e is IntegratedEntity => {
   return ['Donor', 'Sample', 'Dataset'].includes(e.entity_type);
 };
 
-function getHeaderActions(entityType: IntegratedEntityTypes, entityIdsByType: Record<IntegratedEntityTypes, string[]>) {
+/**
+ * Datasets to show in the Dataset tab: all of them when no direct set is provided or the
+ * ancestor-datasets toggle is enabled, otherwise only the directly-integrated datasets.
+ */
+export function getDisplayedDatasetIds(
+  allDatasetIds: string[],
+  directDatasetIds: Set<string> | undefined,
+  showAncestorDatasets: boolean,
+): string[] {
+  if (!directDatasetIds || showAncestorDatasets) {
+    return allDatasetIds;
+  }
+  return allDatasetIds.filter((id) => directDatasetIds.has(id));
+}
+
+function getHeaderActions(
+  entityType: IntegratedEntityTypes,
+  entityIdsByType: Record<IntegratedEntityTypes, string[]>,
+  extraActions?: React.ReactNode,
+) {
   return (
     <>
+      {extraActions}
       <SaveEntitiesButtonFromSearch entity_type={entityType} />
       <Copy />
       <WorkspacesDropdownMenu type={entityType} />
@@ -74,6 +95,12 @@ interface IntegratedDataTablesProps {
    * retracted datasets to the top by default (overridable by clicking another column header).
    */
   datasetRetractedSortMap?: Record<string, number>;
+  /**
+   * UUIDs of the datasets directly integrated into the entity being viewed. These are always shown
+   * in the Dataset tab; any other datasets in `entities` are treated as ancestor datasets and are
+   * hidden behind a "Show ancestor datasets" toggle. When omitted, every dataset is shown.
+   */
+  directDatasetIds?: Set<string>;
 }
 
 function IntegratedDataTables({
@@ -82,13 +109,32 @@ function IntegratedDataTables({
   isLoading,
   useDefaultQuery = true,
   datasetRetractedSortMap,
+  directDatasetIds,
 }: IntegratedDataTablesProps) {
+  const [showAncestorDatasets, setShowAncestorDatasets] = useState(false);
+
   const entitiesTableConfig: EntitiesTabTypes<Entity>[] = useMemo(() => {
     const integratedEntityList = entityList.filter(isIntegratedEntity);
-    // When the publication contains retracted datasets, surface a status column whose client-side
-    // custom sort values place retracted datasets first by default.
+    const allDatasetIds = integratedEntityList.filter((e) => e.entity_type === 'Dataset').map((e) => e.uuid);
+    const ancestorDatasetsPresent = Boolean(directDatasetIds) && allDatasetIds.some((id) => !directDatasetIds!.has(id));
+    const displayedDatasetIds = getDisplayedDatasetIds(allDatasetIds, directDatasetIds, showAncestorDatasets);
+    // Toggle (rendered in the Dataset tab's header actions) to reveal the ancestor datasets of the
+    // directly-integrated datasets. Only shown when there are ancestor datasets to reveal.
+    const ancestorDatasetsToggle = ancestorDatasetsPresent ? (
+      <LabeledPrimarySwitch
+        checked={showAncestorDatasets}
+        onChange={(_, checked) => setShowAncestorDatasets(checked)}
+        disabledLabel="Show Associated"
+        enabledLabel="Show All Ancestors"
+        ariaLabel="Show ancestor datasets"
+        noWrapOptionLabels
+        disabledTooltip="Show only the datasets directly associated with this entity."
+        enabledTooltip="Also show the ancestor datasets these were derived from, such as the raw datasets they were processed from."
+      />
+    ) : null;
+    // Only surface the retracted-first status column when a retracted dataset is actually visible.
     const hasRetracted = Boolean(
-      datasetRetractedSortMap && Object.values(datasetRetractedSortMap).some((v) => v === 0),
+      datasetRetractedSortMap && displayedDatasetIds.some((id) => datasetRetractedSortMap[id] === 0),
     );
     const datasetTabColumns = hasRetracted
       ? [
@@ -117,6 +163,9 @@ function IntegratedDataTables({
         Dataset: [],
       },
     );
+    // Restrict the Dataset tab (query, counts, and download/save defaults) to the datasets currently
+    // displayed. Sample/Donor tabs already only contain sample/donor ancestors.
+    entityIdsByType.Dataset = displayedDatasetIds;
     const entities: EntitiesTabTypes<Entity>[] = [
       {
         entityType: 'Dataset',
@@ -135,7 +184,7 @@ function IntegratedDataTables({
           ...(hasRetracted && { size: 10000 }),
         },
         columns: datasetTabColumns,
-        headerActions: getHeaderActions('Dataset', entityIdsByType),
+        headerActions: getHeaderActions('Dataset', entityIdsByType, ancestorDatasetsToggle),
         initialSortState: datasetInitialSortState,
         tabTooltipText: tableTooltips?.Dataset,
       },
@@ -177,7 +226,7 @@ function IntegratedDataTables({
       },
     ];
     return entities;
-  }, [entityList, tableTooltips, datasetRetractedSortMap]);
+  }, [entityList, tableTooltips, datasetRetractedSortMap, directDatasetIds, showAncestorDatasets]);
 
   const numSelected = useSelectableTableStore((s) => s.selectedRows.size);
 

--- a/context/app/static/js/components/publications/PublicationsDataSection/PublicationsDataSection.tsx
+++ b/context/app/static/js/components/publications/PublicationsDataSection/PublicationsDataSection.tsx
@@ -100,11 +100,22 @@ function PublicationsDataSection({ ancestorIds, associatedCollectionUUID }: Publ
     isLoadingEffectiveDatasetUUIDs || effectiveDatasetUUIDs.length === 0,
   );
 
-  // Fetch ancestor entities (samples and donors)
-  const [allEntities, isLoadingEntities] = useEntitiesData(allAncestorIds, undefined, {
-    shouldFetch: !isLoadingAncestorIds,
-    useDefaultQuery: false,
-  });
+  // Fetch ancestor entities (datasets, samples, donors). Only the fields needed to build the
+  // per-type table queries, retracted-sort map, and download defaults are requested -- the tables
+  // themselves lazily fetch full display data for the open tab, so full `_source` here would be a
+  // redundant, expensive up-front load of every tab's entities.
+  const [allEntities, isLoadingEntities] = useEntitiesData(
+    allAncestorIds,
+    ['uuid', 'entity_type', 'mapped_status', 'status'],
+    {
+      shouldFetch: !isLoadingAncestorIds,
+      useDefaultQuery: false,
+    },
+  );
+
+  // The datasets the publication directly references are always shown; their ancestor datasets are
+  // hidden behind a toggle in IntegratedDataTables.
+  const directDatasetIds = useMemo(() => new Set(effectiveDatasetUUIDs.filter(Boolean)), [effectiveDatasetUUIDs]);
 
   const loadingTableEntities = isLoadingEntities || allEntities.length === 0;
 
@@ -139,6 +150,7 @@ function PublicationsDataSection({ ancestorIds, associatedCollectionUUID }: Publ
         isLoading={loadingTableEntities}
         useDefaultQuery={false}
         datasetRetractedSortMap={datasetRetractedSortMap}
+        directDatasetIds={directDatasetIds}
       />
       {associatedCollectionUUID && <PublicationCollections collectionsData={collections} isCollectionPublication />}
     </CollapsibleDetailPageSection>

--- a/context/app/static/js/pages/Dataset/IntegratedDataset.tsx
+++ b/context/app/static/js/pages/Dataset/IntegratedDataset.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Skeleton from '@mui/material/Skeleton';
 
 import ProvSection from 'js/components/detailPage/provenance/ProvSection';
@@ -77,11 +77,34 @@ function IntegratedDatasetPage({ assayMetadata }: EntityDetailProps<Dataset>) {
 
   const protocolUrl = useProtocolURL(assayMetadata, isExternal);
 
-  const [entities, loadingEntities] = useEntitiesData<Dataset | Donor | Sample>([uuid, ...ancestor_ids]);
+  // Only the fields needed to build the per-type table queries, retracted-sort map, and download
+  // defaults are requested. The tables lazily fetch full display data for the open tab, so full
+  // `_source` here would be a redundant up-front load of every tab's entities.
+  const [entities, loadingEntities] = useEntitiesData<Dataset | Donor | Sample>(
+    [uuid, ...ancestor_ids],
+    ['uuid', 'entity_type', 'mapped_status', 'status'],
+  );
 
-  // Is this filtering necessary? I'm not sure if there will ever be datasets that are not immediate ancestors.
-  const entitiesForImmediateAncestors = entities.filter(
-    (entity) => entity.entity_type !== 'Dataset' || immediate_ancestor_ids.includes(entity.uuid),
+  // Ancestors of the current dataset (the section re-adds the current dataset via includeCurrentEntity).
+  // The full ancestor set is passed so ancestor datasets can be revealed via the section's toggle.
+  const ancestorEntities = useMemo(() => entities.filter((entity) => entity.uuid !== uuid), [entities, uuid]);
+
+  // Datasets shown by default: the current dataset plus its immediate ancestor (component) datasets.
+  const directDatasetIds = useMemo(
+    () =>
+      new Set<string>([
+        uuid,
+        ...entities
+          .filter((entity) => entity.entity_type === 'Dataset' && immediate_ancestor_ids.includes(entity.uuid))
+          .map((entity) => entity.uuid),
+      ]),
+    [entities, uuid, immediate_ancestor_ids],
+  );
+
+  // Non-dataset ancestors plus immediate ancestor datasets -- what the table shows before the toggle.
+  const defaultVisibleAncestors = useMemo(
+    () => ancestorEntities.filter((entity) => entity.entity_type !== 'Dataset' || directDatasetIds.has(entity.uuid)),
+    [ancestorEntities, directDatasetIds],
   );
 
   const { contributors, contacts } = useContributorsAndContacts(assayMetadata);
@@ -103,7 +126,7 @@ function IntegratedDatasetPage({ assayMetadata }: EntityDetailProps<Dataset>) {
     visualization: Boolean(visualization || vitessceConfig.data || vitessceConfig.isLoading),
     files: Boolean(files),
     'bulk-data-transfer': true,
-    'integrated-data': Boolean(entitiesForImmediateAncestors.length),
+    'integrated-data': Boolean(defaultVisibleAncestors.length),
     provenance: true,
     // External datasets have protocol URLs, internal datasets should have workflow details
     'protocols-and-workflow-details': Boolean(protocolUrl || (!isExternal && dag_provenance_list)),
@@ -112,10 +135,8 @@ function IntegratedDatasetPage({ assayMetadata }: EntityDetailProps<Dataset>) {
     attribution: true,
   };
 
-  const uuidsForBulkDataTransfer = new Set<string>([
-    ...entitiesForImmediateAncestors.filter((e) => e.entity_type === 'Dataset').map((ds) => ds.uuid),
-    uuid,
-  ]);
+  // The current dataset plus its immediate ancestor datasets == directDatasetIds.
+  const uuidsForBulkDataTransfer = directDatasetIds;
 
   const trackFilesSectionEvents = useEventCallback((info: { action: string; label: string }) => {
     trackEvent({
@@ -156,7 +177,8 @@ function IntegratedDatasetPage({ assayMetadata }: EntityDetailProps<Dataset>) {
             customUUIDs={uuidsForBulkDataTransfer}
           />
           <IntegratedDataSection
-            entities={entitiesForImmediateAncestors}
+            entities={ancestorEntities}
+            directDatasetIds={directDatasetIds}
             shouldDisplay={shouldDisplaySection['integrated-data']}
             includeCurrentEntity
           />

--- a/context/app/static/js/shared-styles/switches/LabeledPrimarySwitch.tsx
+++ b/context/app/static/js/shared-styles/switches/LabeledPrimarySwitch.tsx
@@ -3,6 +3,7 @@ import Typography, { TypographyProps } from '@mui/material/Typography';
 import Stack from '@mui/material/Stack';
 import PrimarySwitch from 'js/shared-styles/switches/PrimarySwitch';
 import { SwitchProps } from '@mui/material/Switch';
+import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import InfoTextTooltip from '../tooltips/InfoTextTooltip';
 
 interface LabeledPrimarySwitchProps extends Omit<SwitchProps, 'label'> {
@@ -14,6 +15,11 @@ interface LabeledPrimarySwitchProps extends Omit<SwitchProps, 'label'> {
   enabledLabel?: string;
   tooltip?: string;
   labelVariant?: TypographyProps['variant'];
+  /** Optional hover tooltips explaining each side of the toggle. */
+  disabledTooltip?: string;
+  enabledTooltip?: string;
+  /** Prevent the on/off option labels from wrapping onto multiple lines. */
+  noWrapOptionLabels?: boolean;
 }
 export default function LabeledPrimarySwitch({
   label,
@@ -22,6 +28,10 @@ export default function LabeledPrimarySwitch({
   ariaLabel,
   disabledLabel = 'Disabled',
   enabledLabel = 'Enabled',
+  tooltip,
+  disabledTooltip,
+  enabledTooltip,
+  noWrapOptionLabels = false,
   sx,
   labelVariant = 'subtitle2',
   ...rest
@@ -31,17 +41,25 @@ export default function LabeledPrimarySwitch({
       {label}
     </Typography>
   ) : null;
-  const tooltipNode = rest.tooltip ? (
-    <InfoTextTooltip tooltipTitle={rest.tooltip} infoIconSize="medium">
-      {labelNode}
-    </InfoTextTooltip>
-  ) : null;
+  const tooltipNode =
+    tooltip && labelNode ? (
+      <InfoTextTooltip tooltipTitle={tooltip} infoIconSize="medium">
+        {labelNode}
+      </InfoTextTooltip>
+    ) : null;
   const actualLabel = tooltipNode ?? labelNode;
+
+  const optionLabelSx = noWrapOptionLabels ? { whiteSpace: 'nowrap' as const } : undefined;
+  const renderOptionLabel = (text: React.ReactNode, optionTooltip?: string) => {
+    const node = <Typography sx={optionLabelSx}>{text}</Typography>;
+    return optionTooltip ? <SecondaryBackgroundTooltip title={optionTooltip}>{node}</SecondaryBackgroundTooltip> : node;
+  };
+
   return (
     <Stack useFlexGap alignItems="start" sx={sx}>
       {actualLabel}
       <Stack direction="row" component="label" alignItems="center" mt={0}>
-        <Typography>{disabledLabel}</Typography>
+        {renderOptionLabel(disabledLabel, disabledTooltip)}
         <PrimarySwitch
           checked={checked}
           onChange={onChange}
@@ -50,7 +68,7 @@ export default function LabeledPrimarySwitch({
           }}
           {...rest}
         />
-        <Typography>{enabledLabel}</Typography>
+        {renderOptionLabel(enabledLabel, enabledTooltip)}
       </Stack>
     </Stack>
   );

--- a/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
+++ b/context/app/static/js/shared-styles/tables/EntitiesTable/EntitiesTables.tsx
@@ -16,6 +16,13 @@ import { SecondaryBackgroundTooltip } from 'js/shared-styles/tooltips';
 import Skeleton from '@mui/material/Skeleton';
 import Box from '@mui/material/Box';
 
+// Approximate table dimensions used to reserve loading-placeholder height so the panel doesn't
+// collapse while its data loads (which would pull content below the table up into view).
+const ESTIMATED_ROW_HEIGHT = 48;
+const ESTIMATED_HEADER_HEIGHT = 108; // action row (~48) + sticky column header (~60)
+const FALLBACK_MAX_HEIGHT = 600;
+const MAX_SKELETON_ROWS = 12;
+
 interface EntitiesTablesProps<Doc extends Entity> {
   isSelectable?: boolean;
   numSelected?: number;
@@ -162,6 +169,7 @@ function EntitiesTablesBodies<Doc extends Entity>({
   isLoading,
   totalHitsCounts,
   useDefaultQuery,
+  maxHeight,
   ...restSharedProps
 }: EntitiesTablesBodiesProps<Doc>) {
   return (
@@ -170,15 +178,22 @@ function EntitiesTablesBodies<Doc extends Entity>({
         const queryItems = totalHitsCounts?.[i] ?? 0;
 
         if (isLoading) {
-          const minRows = 3;
-          const maxRows = 6;
-          const rows = Math.min(Math.max(queryItems, minRows), maxRows);
+          const cap = maxHeight ?? FALLBACK_MAX_HEIGHT;
+          // Reserve the height the loaded table will occupy. When the row count is known (e.g. the
+          // count query has resolved), size to it; otherwise hold the full height so slower parent
+          // fetches don't leave the panel collapsed and pull content below into the viewport.
+          const reservedHeight =
+            queryItems > 0 ? Math.min(ESTIMATED_HEADER_HEIGHT + queryItems * ESTIMATED_ROW_HEIGHT, cap) : cap;
+          const skeletonRows = Math.min(
+            Math.max(Math.round(reservedHeight / ESTIMATED_ROW_HEIGHT), 3),
+            MAX_SKELETON_ROWS,
+          );
 
           return (
             <TabPanel key={entityType} value={openTabIndex} index={i}>
-              <Stack width="100%">
-                {Array.from({ length: rows }).map((_, idx) => (
-                  <Skeleton height={30} key={idx} width="100%" />
+              <Stack width="100%" minHeight={reservedHeight} spacing={0.5}>
+                {Array.from({ length: skeletonRows }).map((_, idx) => (
+                  <Skeleton height={ESTIMATED_ROW_HEIGHT} key={idx} width="100%" />
                 ))}
               </Stack>
             </TabPanel>
@@ -197,7 +212,13 @@ function EntitiesTablesBodies<Doc extends Entity>({
 
         return (
           <TabPanel key={entityType} value={openTabIndex} index={i}>
-            <EntityTable query={query} useDefaultQuery={useDefaultQuery} {...entityTableProps} {...restSharedProps} />
+            <EntityTable
+              query={query}
+              useDefaultQuery={useDefaultQuery}
+              maxHeight={maxHeight}
+              {...entityTableProps}
+              {...restSharedProps}
+            />
           </TabPanel>
         );
       })}


### PR DESCRIPTION
## Summary
This PR improves the loading behavior of the integrated datasets table by showing a placeholder while data loads. It also adds a toggle to display either only the datasets directly associated with the integrated entity or to display all ancestors of the entity.

## Design Documentation/Original Tickets

Original motivation was to help resolve https://hms-dbmi.atlassian.net/browse/CAT-1630, but this is now an unrelated enhancement.

## Testing

Unit tests added for direct vs. ancestor logic.

## Screenshots/Video

Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes
