### PR TITLE
NickAkhmetov/CAT-1649, CAT-1650 Fix spacing between top-of-page alerts and top of page, adjust proportion fo text to video on parallax slides

### DIFF
--- a/CHANGELOG-alert-margins-and-slide-proportions.md
+++ b/CHANGELOG-alert-margins-and-slide-proportions.md
@@ -1,0 +1,2 @@
+- Widen the parallax slides' video relative to their text (1/3 text, 2/3 video) to match the visualizations slide.
+- Add a consistent top margin above top-of-page alerts (Say & See, workspace relaunch, and workspace launching), matching the global alert banner.

--- a/context/app/static/js/components/home/AnalysisAndVisualizations/ParallaxSlide/styles.ts
+++ b/context/app/static/js/components/home/AnalysisAndVisualizations/ParallaxSlide/styles.ts
@@ -93,7 +93,7 @@ export const SlideGrid = styled(Box)<SlideGridProps>(({ theme, $layout }) => ({
 
   [theme.breakpoints.up('md')]: {
     display: 'grid',
-    gridTemplateColumns: $layout === 'text-left' ? '5fr 4fr' : '4fr 5fr',
+    gridTemplateColumns: $layout === 'text-left' ? '1fr 2fr' : '2fr 1fr',
     gap: theme.spacing(6),
     alignItems: 'start',
   },

--- a/context/app/static/js/components/search/SaySeeAlert/SaySeeAlert.tsx
+++ b/context/app/static/js/components/search/SaySeeAlert/SaySeeAlert.tsx
@@ -33,7 +33,9 @@ function SaySeeAlert() {
   return (
     <Alert
       severity="info"
-      $marginTop={24}
+      // `&&` doubles specificity to beat the parent Stack's `& > * { margin: 0 }` reset. Matches
+      // the global alert banner's 24px top margin (see components/style.ts).
+      sx={{ '&&': { mt: 3 } }}
       action={
         <Stack direction="row" spacing={1} alignItems="center">
           <Button color="primary" size="small" onClick={exploreAndDismiss}>

--- a/context/app/static/js/components/search/SaySeeAlert/SaySeeAlert.tsx
+++ b/context/app/static/js/components/search/SaySeeAlert/SaySeeAlert.tsx
@@ -33,6 +33,7 @@ function SaySeeAlert() {
   return (
     <Alert
       severity="info"
+      $marginTop={24}
       action={
         <Stack direction="row" spacing={1} alignItems="center">
           <Button color="primary" size="small" onClick={exploreAndDismiss}>

--- a/context/app/static/js/components/workspaces/WorkspaceRelaunchAlert.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceRelaunchAlert.tsx
@@ -38,6 +38,7 @@ function WorkspaceRelaunchAlert({ workspaceId }: { workspaceId: number }) {
   return (
     <Alert
       severity="error"
+      $marginTop={24}
       action={
         <Stack direction="row" spacing={1} justifyContent="center">
           <Button onClick={openLaunch}>Relaunch</Button>

--- a/context/app/static/js/components/workspaces/WorkspaceRelaunchAlert.tsx
+++ b/context/app/static/js/components/workspaces/WorkspaceRelaunchAlert.tsx
@@ -38,7 +38,9 @@ function WorkspaceRelaunchAlert({ workspaceId }: { workspaceId: number }) {
   return (
     <Alert
       severity="error"
-      $marginTop={24}
+      // `&&` doubles specificity to beat the parent Stack's `& > * { margin: 0 }` reset. Matches
+      // the global alert banner's 24px top margin (see components/style.ts).
+      sx={{ '&&': { mt: 3 } }}
       action={
         <Stack direction="row" spacing={1} justifyContent="center">
           <Button onClick={openLaunch}>Relaunch</Button>

--- a/context/app/static/js/pages/WorkspacePleaseWait/style.ts
+++ b/context/app/static/js/pages/WorkspacePleaseWait/style.ts
@@ -2,6 +2,7 @@ import { styled } from '@mui/material/styles';
 import { Alert } from 'js/shared-styles/alerts';
 
 const StyledAlert = styled(Alert)(({ theme }) => ({
+  marginTop: theme.spacing(3),
   marginBottom: theme.spacing(3),
 }));
 


### PR DESCRIPTION
## Summary

This PR:
* Adds margin to the top of the workspaces and say & see alerts that appear at the top of the page
* Adjusts the proportion of the text/video sections of the first parallax slides to match the proportion of the hubmap tools slide

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1649
https://hms-dbmi.atlassian.net/browse/CAT-1650

## Testing

Checked homepage, search page, and workspace loading screen.

## Screenshots/Video

<img width="1816" height="1878" alt="image" src="https://github.com/user-attachments/assets/1a79c838-d570-42dc-95ef-3b93b20e8350" />

<img width="1816" height="211" alt="image" src="https://github.com/user-attachments/assets/de2dd8ad-4d70-4064-b134-17ab1bd69d79" />

<img width="1834" height="256" alt="image" src="https://github.com/user-attachments/assets/e6b1450b-5f4e-486f-a2b5-36f6f7110f2e" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
