### PR TITLE
NickAkhmetov/CAT-1641 Final fix for view visualizations link, improve search url parameter handling

### DIFF
--- a/CHANGELOG-dataset-features-readable-params.md
+++ b/CHANGELOG-dataset-features-readable-params.md
@@ -1,0 +1,3 @@
+- Fix the "View Visualizations" homepage link dropping its filter, and share each Dataset Features filter as a readable URL parameter (e.g. `/search/datasets?visualization=true`) instead of inside the compressed `q` blob.
+- Preserve unrelated search URL parameters, such as `mode=say-see`, when a filter changes.
+- Restore the `mapped_status` tiebreaker on the dataset search's published-timestamp sort.

--- a/context/app/static/js/components/home/AnalysisAndVisualizations/config.spec.ts
+++ b/context/app/static/js/components/home/AnalysisAndVisualizations/config.spec.ts
@@ -1,0 +1,17 @@
+import { VISUALIZE_DATA_SLIDE } from './config';
+import { DATASET_FEATURES_FIELD, parseReadableParams } from 'js/components/search/searchParams';
+
+describe('VISUALIZE_DATA_SLIDE', () => {
+  // Regression: this href used to be a hand-authored compressed `q` blob whose filter values were
+  // a `Set("…")` string rather than an array. That failed zod validation, so parseURLState threw and
+  // silently discarded the whole URL state, landing the CTA on an unfiltered dataset search page.
+  test('the View Visualizations CTA links to datasets filtered to visualization available', () => {
+    const { href } = VISUALIZE_DATA_SLIDE.views[0].ctaButton;
+
+    expect(href).toBe('/search/datasets?visualization=true');
+    expect(parseReadableParams(href.slice(href.indexOf('?'))).filters?.[DATASET_FEATURES_FIELD]).toEqual({
+      type: 'BOOLEAN_GROUP',
+      values: ['visualization::true'],
+    });
+  });
+});

--- a/context/app/static/js/components/home/AnalysisAndVisualizations/config.ts
+++ b/context/app/static/js/components/home/AnalysisAndVisualizations/config.ts
@@ -4,6 +4,8 @@ import DescriptionRounded from '@mui/icons-material/DescriptionRounded';
 import { SlideConfig, MultiViewSlideConfig } from './types';
 import { DatasetIcon, GeneIcon, WorkspacesIcon, FileIcon } from 'js/shared-styles/icons';
 import { cdnUrl } from 'js/helpers/cdn';
+import { buildSearchLink } from 'js/components/search/store';
+import { DATASET_FEATURES_FIELD } from 'js/components/search/searchParams';
 
 export const DATASETS_SEARCH_SLIDE: SlideConfig = {
   id: 'datasets-search',
@@ -134,7 +136,10 @@ export const VISUALIZE_DATA_SLIDE: MultiViewSlideConfig = {
       description: 'Visualize single-cell and spatial data with Vitessce',
       ctaButton: {
         label: 'View Visualizations',
-        href: '/search/datasets?q=N4IgzgpghgTgxgCxALhCANOA9jALgMQEsIAbAExVADNjyUQAHAVwCMTCwEIyB9XQgLYQwuKAIYYQZQjAhx%2BWAHb0ywuJMhwlZWAE8ipCsmq0jIAVAYNuPEVFxMwk6bPmElKtSAC%2B3zDRJcCBgnYxAeHVFIXB4qaAdZUNAANygSJmF6AGUIXAAKAB0QZI4mNMIAL3t3RWRkXBgMooBKSVxda3oAIQB5HoAZAFEAQQA5HgBxACUegFUABR8-EEJFOHTVLKZrEO5uQcV%2BfkzkKjTIbyA',
+        href: buildSearchLink({
+          entity_type: 'Dataset',
+          filters: { [DATASET_FEATURES_FIELD]: { type: 'BOOLEAN_GROUP', values: ['visualization::true'] } },
+        }),
         variant: 'contained',
         trackingLabel: 'View Visualizations Button',
       },

--- a/context/app/static/js/components/search/searchParams.spec.ts
+++ b/context/app/static/js/components/search/searchParams.spec.ts
@@ -4,6 +4,8 @@ import {
   decodeHierarchical,
   isLegacyCompressedURL,
   parseReadableParams,
+  preserveUnownedParams,
+  DATASET_FEATURE_PARAMS,
   READABLE_PARAM_FIELDS,
 } from './searchParams';
 import { parseURLState } from './store';
@@ -189,6 +191,78 @@ describe('parseReadableParams', () => {
   test('readable scFind params take precedence over a legacy q blob', () => {
     const q = LZString.compressToEncodedURIComponent(JSON.stringify({ scFindParams: { genes: ['LEGACY'] } }));
     expect(parseReadableParams(`?genes=CD4&q=${q}`).scFindParams).toEqual({ genes: ['CD4'] });
+  });
+});
+
+describe('parseReadableParams dataset features', () => {
+  test('parses the visualization feature into a BOOLEAN_GROUP filter', () => {
+    expect(parseReadableParams('?visualization=true').filters?.['_dataset_features']).toEqual({
+      type: 'BOOLEAN_GROUP',
+      values: ['visualization::true'],
+    });
+  });
+
+  test('parses multiple features together', () => {
+    const filter = parseReadableParams('?visualization=true&spatial=true&publications=true').filters?.[
+      '_dataset_features'
+    ];
+    expect(filter?.type).toBe('BOOLEAN_GROUP');
+    expect(filter?.values).toEqual(
+      expect.arrayContaining(['visualization::true', 'spatial', 'descendant_counts.entity_type.Publication']),
+    );
+  });
+
+  test('combines dataset features with other readable params', () => {
+    const result = parseReadableParams('?visualization=true&organ=Kidney');
+    expect(result.filters?.['_dataset_features']).toEqual({
+      type: 'BOOLEAN_GROUP',
+      values: ['visualization::true'],
+    });
+    expect(result.filters?.['origin_samples_unique_mapped_organs']).toEqual({ type: 'TERM', values: ['Kidney'] });
+  });
+
+  test('ignores a feature param that is not set to true', () => {
+    expect(parseReadableParams('?visualization=false').filters?.['_dataset_features']).toBeUndefined();
+  });
+
+  test('still reads dataset features from an existing q blob for backward compatibility', () => {
+    const q = LZString.compressToEncodedURIComponent(
+      JSON.stringify({ filters: { _dataset_features: { type: 'BOOLEAN_GROUP', values: ['visualization::true'] } } }),
+    );
+    expect(parseReadableParams(`?q=${q}`).filters?.['_dataset_features']).toEqual({
+      type: 'BOOLEAN_GROUP',
+      values: ['visualization::true'],
+    });
+  });
+
+  test('unions readable features with item keys carried in q rather than replacing them', () => {
+    // Item keys with no readable param stay in `q`; both halves must survive the round-trip.
+    const q = LZString.compressToEncodedURIComponent(
+      JSON.stringify({ filters: { _dataset_features: { type: 'BOOLEAN_GROUP', values: ['some_future_item'] } } }),
+    );
+    const values = parseReadableParams(`?visualization=true&q=${q}`).filters?.['_dataset_features']?.values;
+    expect(values).toEqual(expect.arrayContaining(['some_future_item', 'visualization::true']));
+    expect(values).toHaveLength(2);
+  });
+
+  test('preserveUnownedParams keeps params the search state does not own', () => {
+    const preserved = preserveUnownedParams('?mode=say-see&organ=Kidney&visualization=true&q=abc&genes=CD4');
+    expect(preserved.get('mode')).toBe('say-see');
+    expect([...preserved.keys()]).toEqual(['mode']);
+  });
+
+  test('preserveUnownedParams returns an empty set when only search params are present', () => {
+    expect([...preserveUnownedParams('?organ=Kidney&status=Published.Public&data_product=dp-1').keys()]).toEqual([]);
+  });
+
+  test('DATASET_FEATURE_PARAMS maps each Dataset Features checkbox to a readable param', () => {
+    // Keys must match getBooleanGroupItemKey output for the _dataset_features items in S.tsx.
+    expect(DATASET_FEATURE_PARAMS).toEqual({
+      visualization: 'visualization::true',
+      publications: 'descendant_counts.entity_type.Publication',
+      cell_annotations: 'calculated_metadata.object_types::CL:0000000',
+      spatial: 'spatial',
+    });
   });
 });
 

--- a/context/app/static/js/components/search/searchParams.ts
+++ b/context/app/static/js/components/search/searchParams.ts
@@ -1,7 +1,7 @@
 import LZString from 'lz-string';
 import { createSerializer, parseAsArrayOf, parseAsString } from 'nuqs';
 import type { SCFindParams } from '../organ/utils';
-import { parseURLState } from './store';
+import { isBooleanGroupFilter, parseURLState } from './store';
 import type { SearchURLState } from './store';
 
 /**
@@ -66,11 +66,13 @@ const DATA_PRODUCT_PARAM = 'data_product';
 export function buildScFindAndDataProductParams({
   scFindParams,
   dataProductID,
+  params = new URLSearchParams(),
 }: {
   scFindParams?: SCFindParams;
   dataProductID?: string;
+  /** Existing params to append into. Defaults to a fresh set. */
+  params?: URLSearchParams;
 }): URLSearchParams {
-  const params = new URLSearchParams();
   if (scFindParams?.scFindOnly) {
     params.set(SCFIND_ONLY_PARAM, 'true');
   }
@@ -114,6 +116,79 @@ export function parseScFindAndDataProductParams(params: URLSearchParams): {
     ...(Object.keys(scFindParams).length > 0 && { scFindParams }),
     ...(dataProduct && { dataProductID: dataProduct }),
   };
+}
+
+/** ES field name of the synthetic "Dataset Features" boolean-group facet. */
+export const DATASET_FEATURES_FIELD = '_dataset_features';
+
+/**
+ * Mapping from URL param name to `_dataset_features` boolean-group item key, so each Dataset
+ * Features checkbox shares as a readable `?visualization=true` param instead of being buried in the
+ * opaque compressed `q` blob.
+ *
+ * Item keys must match `getBooleanGroupItemKey` output for the `_dataset_features` facet items in
+ * js/pages/search/S.tsx: `exists` items key on `field`, `term` items on `field::value`. Add an entry
+ * here when adding an item there; unmapped keys still round-trip, but only via `q`.
+ */
+export const DATASET_FEATURE_PARAMS = {
+  visualization: 'visualization::true',
+  publications: 'descendant_counts.entity_type.Publication',
+  cell_annotations: 'calculated_metadata.object_types::CL:0000000',
+  spatial: 'spatial',
+} as const;
+
+/** Reverse mapping: boolean-group item key → URL param name */
+const ITEM_KEY_TO_FEATURE_PARAM: Record<string, string> = Object.fromEntries(
+  Object.entries(DATASET_FEATURE_PARAMS).map(([param, itemKey]) => [itemKey, param]),
+);
+
+/**
+ * Sets a `<feature>=true` param for each mapped boolean-group item key, and returns the keys with no
+ * param mapping so callers can keep those in the `q` blob rather than dropping them from the URL.
+ */
+export function appendDatasetFeatureParams(params: URLSearchParams, itemKeys: Iterable<string>): string[] {
+  const unmapped: string[] = [];
+  for (const itemKey of itemKeys) {
+    const param = ITEM_KEY_TO_FEATURE_PARAM[itemKey];
+    if (param) {
+      params.set(param, 'true');
+    } else {
+      unmapped.push(itemKey);
+    }
+  }
+  return unmapped;
+}
+
+/** Reads the params produced by {@link appendDatasetFeatureParams} back into boolean-group item keys. */
+export function parseDatasetFeatureParams(params: URLSearchParams): string[] {
+  return Object.entries(DATASET_FEATURE_PARAMS)
+    .filter(([param]) => params.get(param) === 'true')
+    .map(([, itemKey]) => itemKey);
+}
+
+/** Every URL param the search state owns and rewrites whenever the query changes. */
+const SEARCH_OWNED_PARAMS: string[] = [
+  ...Object.values(READABLE_PARAM_FIELDS),
+  'q',
+  SCFIND_ONLY_PARAM,
+  GENES_PARAM,
+  CELL_TYPES_PARAM,
+  MODALITY_PARAM,
+  ALL_MODALITIES_PARAM,
+  DATA_PRODUCT_PARAM,
+  ...Object.keys(DATASET_FEATURE_PARAMS),
+];
+
+/**
+ * Returns the params on the current URL that the search state does *not* own, to serialize the fresh
+ * search params into. The search state rewrites the whole query string whenever a filter changes, so
+ * without this any unrelated param — such as `mode=say-see` from useSearchMode — would be dropped on
+ * the first facet interaction.
+ */
+export function preserveUnownedParams(search: string): URLSearchParams {
+  const params = new URLSearchParams(search.startsWith('?') ? search.slice(1) : search);
+  SEARCH_OWNED_PARAMS.forEach((param) => params.delete(param));
+  return params;
 }
 
 /**
@@ -207,6 +282,18 @@ export function parseReadableParams(search: string): Partial<SearchURLState> {
     ...(remainingState.filters ?? {}),
     ...filters,
   };
+
+  // Dataset-feature params union with any `_dataset_features` values already decoded from `q`,
+  // rather than replacing them, so item keys without a readable param survive alongside.
+  const featureItemKeys = parseDatasetFeatureParams(params);
+  if (featureItemKeys.length > 0) {
+    const fromQ = mergedFilters[DATASET_FEATURES_FIELD];
+    const qValues = fromQ && isBooleanGroupFilter<string[]>(fromQ) ? fromQ.values : [];
+    mergedFilters[DATASET_FEATURES_FIELD] = {
+      type: 'BOOLEAN_GROUP',
+      values: [...new Set([...qValues, ...featureItemKeys])],
+    };
+  }
 
   // scFind / data product readable params take precedence over any legacy values from the `q` blob.
   const { scFindParams, dataProductID } = parseScFindAndDataProductParams(params);

--- a/context/app/static/js/components/search/store.spec.ts
+++ b/context/app/static/js/components/search/store.spec.ts
@@ -1,5 +1,7 @@
-import { buildSearchLink } from './store';
-import { parseReadableParams } from './searchParams';
+import history from 'history/browser';
+import { buildSearchLink, createStore } from './store';
+import type { SearchStoreState } from './store';
+import { DATASET_FEATURES_FIELD, parseReadableParams } from './searchParams';
 import { getSearchURL } from '../organ/utils';
 
 describe('buildSearchLink dataProductID', () => {
@@ -66,6 +68,109 @@ describe('buildSearchLink scFindParams', () => {
     const parsed = parseReadableParams(link.slice(link.indexOf('?')));
     expect(parsed.scFindParams).toEqual({ genes: ['CD4'] });
     expect(parsed.filters?.['origin_samples_unique_mapped_organs']).toEqual({ type: 'TERM', values: ['Kidney'] });
+  });
+});
+
+describe('buildSearchLink dataset features', () => {
+  const visualizationFeature = { type: 'BOOLEAN_GROUP' as const, values: ['visualization::true'] };
+  const visualizationFilter = { [DATASET_FEATURES_FIELD]: visualizationFeature };
+
+  test('encodes the visualization feature as a readable param (not the opaque q blob)', () => {
+    // Regression: the home page "View Visualizations" CTA previously hardcoded a hand-authored q
+    // blob whose `values` was a `Set("…")` string, which failed zod validation and silently
+    // discarded the entire URL state, landing on an unfiltered search page.
+    const link = buildSearchLink({ entity_type: 'Dataset', filters: visualizationFilter });
+    expect(link).toBe('/search/datasets?visualization=true');
+  });
+
+  test('round-trips the visualization feature through build → parse', () => {
+    const link = buildSearchLink({ entity_type: 'Dataset', filters: visualizationFilter });
+    expect(parseReadableParams(link.slice(link.indexOf('?'))).filters?.[DATASET_FEATURES_FIELD]).toEqual(
+      visualizationFeature,
+    );
+  });
+
+  test('round-trips multiple features alongside a readable organ filter', () => {
+    const filters = {
+      [DATASET_FEATURES_FIELD]: { type: 'BOOLEAN_GROUP' as const, values: ['visualization::true', 'spatial'] },
+      origin_samples_unique_mapped_organs: { type: 'TERM' as const, values: ['Kidney'] },
+    };
+    const link = buildSearchLink({ entity_type: 'Dataset', filters });
+    expect(link).not.toContain('q=');
+    const parsed = parseReadableParams(link.slice(link.indexOf('?')));
+    expect(parsed.filters?.['_dataset_features']?.values).toEqual(
+      expect.arrayContaining(['visualization::true', 'spatial']),
+    );
+    expect(parsed.filters?.['origin_samples_unique_mapped_organs']).toEqual({ type: 'TERM', values: ['Kidney'] });
+  });
+
+  test('falls back to the q blob for an item key with no readable param', () => {
+    const link = buildSearchLink({
+      entity_type: 'Dataset',
+      filters: {
+        [DATASET_FEATURES_FIELD]: { type: 'BOOLEAN_GROUP', values: ['visualization::true', 'some_future_item'] },
+      },
+    });
+    expect(link).toContain('visualization=true');
+    expect(link).toContain('q=');
+    expect(parseReadableParams(link.slice(link.indexOf('?'))).filters?.['_dataset_features']?.values).toEqual(
+      expect.arrayContaining(['visualization::true', 'some_future_item']),
+    );
+  });
+});
+
+describe('replaceURLSearchParams', () => {
+  const initialState: SearchStoreState = {
+    search: '',
+    filters: {
+      [DATASET_FEATURES_FIELD]: { type: 'BOOLEAN_GROUP', values: new Set<string>() },
+      origin_samples_unique_mapped_organs: { type: 'TERM', values: new Set<string>() },
+    },
+    initialFilters: {},
+    facets: {},
+    searchFields: ['all_text'],
+    sortField: { field: 'last_modified_timestamp', direction: 'desc' },
+    sourceFields: { table: ['hubmap_id'] },
+    view: 'table',
+    size: 18,
+    endpoint: 'http://example.com/search',
+    type: 'Dataset',
+    analyticsCategory: 'Datasets Search Page Interactions',
+    includeSupersededEntities: false,
+  };
+
+  function toggleVisualization() {
+    const store = createStore({ initialState });
+    store.getState().filterBooleanGroupItem({ field: DATASET_FEATURES_FIELD, itemKey: 'visualization::true' });
+    return store;
+  }
+
+  test('writes a checked dataset feature as a readable param, with no q blob', () => {
+    history.replace('/search/datasets');
+    toggleVisualization();
+
+    const params = new URLSearchParams(history.location.search);
+    expect(params.get('visualization')).toBe('true');
+    expect(params.get('q')).toBeNull();
+  });
+
+  test('preserves params the search state does not own', () => {
+    // Regression: the query string is rebuilt from scratch on every filter change, which used to
+    // destroy unrelated params — `mode=say-see` vanished on the first facet interaction.
+    history.replace('/search/datasets?mode=say-see');
+    toggleVisualization();
+
+    expect(new URLSearchParams(history.location.search).get('mode')).toBe('say-see');
+  });
+
+  test('clears its own params when a filter is unchecked, without touching unowned params', () => {
+    history.replace('/search/datasets?mode=say-see');
+    const store = toggleVisualization();
+    store.getState().filterBooleanGroupItem({ field: DATASET_FEATURES_FIELD, itemKey: 'visualization::true' });
+
+    const params = new URLSearchParams(history.location.search);
+    expect(params.get('visualization')).toBeNull();
+    expect(params.get('mode')).toBe('say-see');
   });
 });
 

--- a/context/app/static/js/components/search/store.ts
+++ b/context/app/static/js/components/search/store.ts
@@ -7,8 +7,11 @@ import { z } from 'zod';
 import { SCFindParams } from '../organ/utils';
 import { SearchTypeProps } from './utils';
 import {
+  DATASET_FEATURES_FIELD,
   READABLE_PARAM_FIELDS,
+  appendDatasetFeatureParams,
   encodeHierarchical,
+  preserveUnownedParams,
   serializeReadableParams,
   buildScFindAndDataProductParams,
 } from './searchParams';
@@ -371,11 +374,19 @@ export function buildSearchLink({
     return `/search/${entity_type.toLowerCase()}s`;
   }
 
+  const urlSearchParams = buildScFindAndDataProductParams({ scFindParams, dataProductID });
   const readableParamValues: Record<string, string[]> = {};
   const remainingFilters: FiltersType<string[]> = {};
 
   if (filters) {
     for (const [field, filter] of Object.entries(filters)) {
+      if (field === DATASET_FEATURES_FIELD && isBooleanGroupFilter<string[]>(filter)) {
+        const unmapped = appendDatasetFeatureParams(urlSearchParams, filter.values);
+        if (unmapped.length > 0) {
+          remainingFilters[field] = { ...filter, values: unmapped };
+        }
+        continue;
+      }
       const paramName = READABLE_PARAM_FIELDS[field as keyof typeof READABLE_PARAM_FIELDS];
       if (paramName) {
         if (filter.type === 'TERM') {
@@ -399,7 +410,7 @@ export function buildSearchLink({
       ? LZString.compressToEncodedURIComponent(JSON.stringify({ filters: remainingFilters }))
       : null;
 
-  const urlParams = serializeReadableParams(buildScFindAndDataProductParams({ scFindParams, dataProductID }), {
+  const urlParams = serializeReadableParams(urlSearchParams, {
     organ: readableParamValues['organ'] ?? [],
     analyte: readableParamValues['analyte'] ?? [],
     dataset_type: readableParamValues['dataset_type'] ?? [],
@@ -429,12 +440,24 @@ function replaceURLSearchParams(state: SearchStoreState) {
   // params as the source of truth (re-resolved on load) rather than serializing every UUID into `q`.
   const uuidIsDerived = Boolean(scFindParams && Object.keys(scFindParams).length > 0) || Boolean(dataProductID);
 
+  const urlSearchParams = buildScFindAndDataProductParams({
+    scFindParams,
+    dataProductID,
+    params: preserveUnownedParams(history.location.search),
+  });
   const readableParamValues: Record<string, string[]> = {};
   const remainingFilters: FiltersType = {};
 
   for (const [field, filter] of Object.entries(filters)) {
     if (!filterHasValues({ filter })) continue;
     if (uuidIsDerived && field === 'uuid') continue;
+    if (field === DATASET_FEATURES_FIELD && isBooleanGroupFilter(filter)) {
+      const unmapped = appendDatasetFeatureParams(urlSearchParams, filter.values);
+      if (unmapped.length > 0) {
+        remainingFilters[field] = { ...filter, values: new Set(unmapped) };
+      }
+      continue;
+    }
     const paramName = READABLE_PARAM_FIELDS[field as keyof typeof READABLE_PARAM_FIELDS];
     if (paramName) {
       if (isTermFilter(filter)) {
@@ -457,7 +480,7 @@ function replaceURLSearchParams(state: SearchStoreState) {
       )
     : null;
 
-  const urlParams = serializeReadableParams(buildScFindAndDataProductParams({ scFindParams, dataProductID }), {
+  const urlParams = serializeReadableParams(urlSearchParams, {
     organ: readableParamValues['organ'] ?? [],
     analyte: readableParamValues['analyte'] ?? [],
     dataset_type: readableParamValues['dataset_type'] ?? [],

--- a/context/app/static/js/components/search/utils.spec.ts
+++ b/context/app/static/js/components/search/utils.spec.ts
@@ -1,6 +1,7 @@
 import esb from 'elastic-builder';
 import { buildQuery } from './utils';
 import { Mappings } from './useEsMapping';
+import type { SortField } from './store';
 
 const mappings: Mappings = {
   mappings: {
@@ -9,6 +10,7 @@ const mappings: Mappings = {
       hubmap_id: { fields: { keyword: { type: 'keyword' } } },
       entity_type: { fields: { keyword: { type: 'keyword' } } },
       all_text: { type: 'text' },
+      mapped_status: { fields: { keyword: { type: 'keyword' } } },
       last_modified_timestamp: { type: 'date' },
     },
   },
@@ -217,5 +219,45 @@ describe('buildQuery range filter overlap', () => {
     expect(serialized).toContain('"donor_demographics.age_value":{"lte":60}');
     // ...not a single combined range, which would require one element inside [20, 60].
     expect(serialized).not.toContain('"gte":20,"lte":60');
+  });
+});
+
+describe('buildQuery sorting', () => {
+  function sortOf(sortField: SortField) {
+    const result = buildQuery({
+      filters: {},
+      facets: {},
+      search: '',
+      size: 18,
+      searchFields: ['all_text'],
+      sourceFields: { table: ['hubmap_id'] },
+      sortField,
+      defaultQuery,
+      latestRevisionFilter,
+      includeSupersededEntities: false,
+      mappings,
+      buildAggregations: false,
+    }) as { sort: unknown[] } | null;
+    if (!result) throw new Error('buildQuery returned null');
+    return result.sort;
+  }
+
+  test('emits the secondarySort tiebreaker between the primary sort and the unique sort', () => {
+    // Regression: the dataset search config spelled this key `secondaryField`, which buildSortField
+    // never reads, so anonymous users' published-timestamp sort silently lost its tiebreaker.
+    expect(
+      sortOf({
+        field: 'last_modified_timestamp',
+        direction: 'desc',
+        secondarySort: { field: 'mapped_status', direction: 'desc' },
+      }),
+    ).toEqual([{ last_modified_timestamp: 'desc' }, { 'mapped_status.keyword': 'desc' }, { 'uuid.keyword': 'desc' }]);
+  });
+
+  test('omits the tiebreaker when no secondarySort is configured', () => {
+    expect(sortOf({ field: 'last_modified_timestamp', direction: 'desc' })).toEqual([
+      { last_modified_timestamp: 'desc' },
+      { 'uuid.keyword': 'desc' },
+    ]);
   });
 });

--- a/context/app/static/js/pages/search/S.tsx
+++ b/context/app/static/js/pages/search/S.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import esb from 'elastic-builder';
 
 import Search from 'js/components/search';
-import { FACETS } from 'js/components/search/store';
+import { FACETS, type SortField } from 'js/components/search/store';
 import { EntityWithType, isDonor } from 'js/components/types';
 import { useAppContext } from 'js/components/Contexts';
 
@@ -234,13 +234,15 @@ function buildDatasetConfig(isHubmapUser: boolean) {
       _extra: ['visualization'],
       tile: [...sharedTileFields, 'thumbnail_file.file_uuid', 'origin_samples_unique_mapped_organs'],
     },
+    // `satisfies` rather than a bare literal: `secondarySort` is optional on SortField, so a
+    // misspelled key would otherwise be silently accepted and the tiebreaker quietly dropped.
     sortField: isHubmapUser
-      ? { field: 'last_modified_timestamp', direction: 'desc' as const }
-      : {
+      ? ({ field: 'last_modified_timestamp', direction: 'desc' } satisfies SortField)
+      : ({
           field: 'published_timestamp',
-          direction: 'desc' as const,
-          secondaryField: { field: 'mapped_status', direction: 'desc' as const },
-        },
+          direction: 'desc',
+          secondarySort: { field: 'mapped_status', direction: 'desc' },
+        } satisfies SortField),
     facets: buildDatasetFacetGroups(isHubmapUser),
     ...buildDefaultQuery('Dataset'),
     // TODO: figure out how to make assertion unnecessary.

--- a/context/test-utils/setupTests.ts
+++ b/context/test-utils/setupTests.ts
@@ -1,5 +1,9 @@
 import '@testing-library/jest-dom/vitest';
 import 'intersection-observer'; // polyfill intersection observer (jsdom doesn't ship one)
+import { enableMapSet } from 'immer';
+
+// App.tsx enables this at startup; stores holding Set values (e.g. search filters) need it in tests too.
+enableMapSet();
 
 // Polyfill TextEncoder and TextDecoder, which are no longer provided by jsdom
 import { TextEncoder, TextDecoder } from 'node:util';


### PR DESCRIPTION
## Summary

Fixes the "Visualization Available" dataset search filter not surviving a shared link, and makes the Dataset Features filters human-readable in the URL.

The reported symptom traced to the homepage "View Visualizations" CTA, whose `href` was a compressed `q` blob. Its filter values were serialized as the string `Set("visualization::true")` rather than an array, so `booleanGroupFilterSchema` rejected it, `parseURLState` threw, and the entire URL state — filter, search, and sort — was silently discarded, landing on an unfiltered search page. That link is now generated by `buildSearchLink` instead of pasted, so the encoding can't drift again.

Each Dataset Features checkbox now serializes as its own readable param (`/search/datasets?visualization=true&spatial=true`) rather than being buried in the opaque `q` blob. `_dataset_features` can't use `READABLE_PARAM_FIELDS` (one field maps to N item keys), so it rides the `URLSearchParams` base like the existing `scfind` / `data_product` params. Item keys with no param mapping still fall back to `q`, so adding a fifth checkbox can't silently drop it from shared links, and existing `q`-encoded links keep working.

Two adjacent bugs found while tracing, fixed here:

- The dataset search sort config spelled its tiebreaker `secondaryField`, but `buildSortField` reads `secondarySort` — anonymous users' published-timestamp sort had no `mapped_status` tiebreaker. Structural typing hid the typo, so the literal now uses `satisfies SortField` to make any future misspelling of that optional key a compile error.
- `replaceURLSearchParams` rebuilt the query string from scratch, destroying unrelated params (`mode=say-see` vanished on the first facet click). It now seeds from the current URL minus the params the search state owns, so params added later are preserved without touching this code.

Implications: the search URL format is additive — old `q`-encoded links, legacy single-blob links in the figure assets, and the pre-existing `visualization` TERM encoding all still resolve. `enableMapSet()` was added to the shared Vitest setup (it lives in `App.tsx`, which specs don't load) so any spec exercising a Set-holding store works.

## Design Documentation/Original Tickets

Follow-up to CAT-1641 / #4051. https://hms-dbmi.atlassian.net/browse/CAT-1641

## Testing

16 new unit tests; full suite green at 914 passed / 7 skipped, with `pnpm lint` and `pnpm tsc` clean. Ran the whole suite rather than the search subset because the shared test setup changed.

- `store.spec.ts` — drives the real store through `filterBooleanGroupItem` and asserts against actual `history.location`, covering the wiring rather than just the helpers: features write as readable params with no `q`, `mode` survives a facet change, and owned params are cleared on uncheck while `mode` persists. This is `replaceURLSearchParams`' first test coverage.
- `config.spec.ts` — regression test that the homepage CTA's href is `/search/datasets?visualization=true` and parses back to the filter. Also confirms the `store.ts` ↔ `searchParams.ts` import cycle doesn't break the module-scope `buildSearchLink` call.
- `searchParams.spec.ts` — feature params parse singly and together, combine with other readable params, union with (rather than replace) item keys carried in `q`, and ignore `=false`; plus `preserveUnownedParams` coverage.
- `utils.spec.ts` — `secondarySort` emits the tiebreaker between the primary and unique sort, and is omitted when unset.
- The `satisfies SortField` guard was verified by reintroducing the `secondaryField` typo and confirming `tsc` fails, then reverting.

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-dataset-features-readable-params.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added — no new tracked interactions; the CTA keeps its existing `trackingLabel` and facet tracking is unchanged.

## Additional Notes

`DATASET_FEATURE_PARAMS` in `searchParams.ts` duplicates the four item keys from the facet config in `S.tsx`, because `searchParams.ts` can't import the page config (`parseReadableParams` runs before any store exists, and the import would be circular). A drift-guard test pins the map, and the facet config carries a pointer comment. Unmapped keys degrade to `q` rather than breaking.
