### PR TITLE
NickAkhmetov/CAT-1640 Add CC BY 4.0 licensing information

### DIFF
--- a/CHANGELOG-cc-licensing.md
+++ b/CHANGELOG-cc-licensing.md
@@ -1,0 +1,1 @@
+- Add CC BY 4.0 licensing information to the data use agreement dialog and the bulk data transfer section on dataset pages.

--- a/CHANGELOG-cc-licensing.md
+++ b/CHANGELOG-cc-licensing.md
@@ -1,1 +1,1 @@
-- Add CC BY 4.0 licensing information to the data use agreement dialog and the bulk data transfer section on dataset pages.
+- Add CC BY 4.0 licensing information to the data use agreement dialog, the bulk data transfer section, and the schema.org metadata on dataset pages.

--- a/context/app/routes_browse.py
+++ b/context/app/routes_browse.py
@@ -200,6 +200,7 @@ def sitemap_txt():
                 f'{url_base}/tutorials',
                 f'{url_base}/templates',
                 f'{url_base}/organs',
+                f'{url_base}/integrated-maps',
                 # Detail pages
                 *[f'{url_base}/templates/{key}' for key in template_keys],
                 *[f'{url_base}/organs/{key}' for key in organ_keys],

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/BulkDataTransferSection.tsx
@@ -5,16 +5,19 @@ import { useEventCallback } from '@mui/material/utils';
 
 import { CollapsibleDetailPageSection } from 'js/components/detailPage/DetailPageSection';
 import { FilesContextProvider } from 'js/components/detailPage/files/FilesContext';
+import HubmapDataFooter from 'js/components/detailPage/files/HubmapDataFooter';
 import { Tabs, Tab, TabPanel } from 'js/shared-styles/tables/TableTabs';
 import { DetailSectionPaper } from 'js/shared-styles/surfaces';
 import { OutboundLink } from 'js/shared-styles/Links';
 import withShouldDisplay from 'js/helpers/withShouldDisplay';
 import { sectionIconMap } from 'js/shared-styles/icons/sectionIconMap';
 import { SectionDescription } from 'js/shared-styles/sections/SectionDescription';
+import LabelledSectionText from 'js/shared-styles/sections/LabelledSectionText';
 import BulkDownloadTextButton from 'js/components/bulkDownload/buttons/BulkDownloadTextButton';
 import { LINKS } from 'js/components/bulkDownload/constants';
 import BulkDownloadSuccessAlert from 'js/components/bulkDownload/BulkDownloadSuccessAlert';
 import BulkDataTransferPanels from './BulkDataTransferPanels';
+import LicensingText from './LicensingText';
 import { useProcessedDatasetTabs } from '../ProcessedData/ProcessedDataset/hooks';
 import SnareSeq2Alert from '../multi-assay/SnareSeq2Alert';
 import { useDetailContext } from '../DetailContext';
@@ -51,6 +54,9 @@ function BulkDataTransferDescription({
     <SectionDescription>
       <Stack spacing={1}>
         {isIntegratedEntity ? integratedEntityDescription : description}
+        <LabelledSectionText label="Licensing">
+          <LicensingText />
+        </LabelledSectionText>
         <BulkDownloadTextButton uuids={uuids} />
       </Stack>
     </SectionDescription>
@@ -136,6 +142,7 @@ function BulkDataTransfer({ integratedEntityUUID, customUUIDs }: BulkDataTransfe
         ) : (
           <RegularBulkDataTransfer />
         )}
+        <HubmapDataFooter />
       </FilesContextProvider>
     </CollapsibleDetailPageSection>
   );

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/FileBrowserDUA.tsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/FileBrowserDUA.tsx
@@ -10,6 +10,7 @@ import Typography from '@mui/material/Typography';
 import OptDisabledButton from 'js/shared-styles/buttons/OptDisabledButton';
 import OutboundLink from 'js/shared-styles/Links/OutboundLink';
 import { getDUAText } from './utils';
+import LicensingText from './LicensingText';
 import { ObliqueSpan, StyledHeader, StyledDiv } from './style';
 
 interface FileBrowserDUAProps {
@@ -61,6 +62,11 @@ function FileBrowserDUA({ isOpen, handleAgree, handleClose, mapped_data_access_l
               https://hubmapconsortium.org/policies/
             </OutboundLink>
             .
+          </Typography>
+
+          <StyledHeader variant="h4">Licensing</StyledHeader>
+          <Typography variant="body1">
+            <LicensingText />
           </Typography>
         </StyledDiv>
         <FormControlLabel

--- a/context/app/static/js/components/detailPage/BulkDataTransfer/LicensingText.tsx
+++ b/context/app/static/js/components/detailPage/BulkDataTransfer/LicensingText.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import OutboundIconLink from 'js/shared-styles/Links/iconLinks/OutboundIconLink';
+
+function LicensingText() {
+  return (
+    <>
+      HuBMAP data is licensed under{' '}
+      <OutboundIconLink href="https://creativecommons.org/licenses/by/4.0/">
+        Creative Commons Attribution 4.0
+      </OutboundIconLink>
+      .
+    </>
+  );
+}
+
+export default LicensingText;

--- a/context/app/static/js/schema.org.spec.ts
+++ b/context/app/static/js/schema.org.spec.ts
@@ -24,6 +24,7 @@ test('full', () => {
   expect(getDatasetLD(entity)).toEqual({
     '@context': 'https://schema.org/',
     '@type': 'Dataset',
+    license: 'https://creativecommons.org/licenses/by/4.0/',
     creator: [
       {
         '@type': 'Person',
@@ -54,6 +55,7 @@ test('minimal, with donor', () => {
   expect(getDatasetLD(entity)).toEqual({
     '@context': 'https://schema.org/',
     '@type': 'Dataset',
+    license: 'https://creativecommons.org/licenses/by/4.0/',
     creator: [
       {
         '@type': 'Person',
@@ -81,6 +83,7 @@ test('no donor', () => {
   expect(getDatasetLD(entity)).toEqual({
     '@context': 'https://schema.org/',
     '@type': 'Dataset',
+    license: 'https://creativecommons.org/licenses/by/4.0/',
     creator: [
       {
         '@type': 'Person',
@@ -107,6 +110,7 @@ test('multiple organs', () => {
   expect(getDatasetLD(entity)).toEqual({
     '@context': 'https://schema.org/',
     '@type': 'Dataset',
+    license: 'https://creativecommons.org/licenses/by/4.0/',
     creator: [
       {
         '@type': 'Person',

--- a/context/app/static/js/schema.org.ts
+++ b/context/app/static/js/schema.org.ts
@@ -46,6 +46,7 @@ function getDatasetLD(entity: DatasetForLD) {
       entity.description && entity.description.length >= 50
         ? entity.description
         : `${fallbackDescription}. ${entity.description}`,
+    license: 'https://creativecommons.org/licenses/by/4.0/' as const,
     creator: [
       {
         '@type': 'Person' as const,


### PR DESCRIPTION
## Summary

This PR adds CC 4.0 licensing information to the DUA popups and the bulk data transfer section.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1640

## Testing

Viewed affected sections.

## Screenshots/Video

Normal Dataset:

<img width="1813" height="1128" alt="image" src="https://github.com/user-attachments/assets/319235ec-6681-4870-8cea-6d468c525149" />

Integrated Dataset:

<img width="1785" height="796" alt="image" src="https://github.com/user-attachments/assets/0d085959-6090-419b-b1c9-7c10c00bf0c2" />

DUA Dialog:

<img width="985" height="1213" alt="image" src="https://github.com/user-attachments/assets/a38a2db9-e340-4cc3-bc9b-8649d55bde9a" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
