### PR TITLE
NickAkhmetov/CAT-1653 Update tooltip language for "Show Associated Datasets" toggle

### DIFF
--- a/CHANGELOG-cat-1653.md
+++ b/CHANGELOG-cat-1653.md
@@ -1,0 +1,1 @@
+- Update the Integrated Data / publication Data table's "Show Associated" toggle tooltip to name the current page's entity type instead of the generic "entity".

--- a/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.tsx
+++ b/context/app/static/js/components/detailPage/IntegratedData/IntegratedDataTables.tsx
@@ -24,6 +24,7 @@ import { Copy } from 'js/shared-styles/tables/actions';
 import SaveEntitiesButtonFromSearch from 'js/components/savedLists/SaveEntitiesButtonFromSearch';
 import WorkspacesDropdownMenu from 'js/components/workspaces/WorkspacesDropdownMenu';
 import DownloadsDropdownMenu from 'js/components/data-transfer/DownloadsDropdownMenu';
+import { useFlaskDataContext } from 'js/components/Contexts';
 
 const datasetColumns = [
   hubmapID,
@@ -112,6 +113,8 @@ function IntegratedDataTables({
   directDatasetIds,
 }: IntegratedDataTablesProps) {
   const [showAncestorDatasets, setShowAncestorDatasets] = useState(false);
+  // The toggle's tooltip refers to the entity whose page the tables are embedded in ("dataset", "publication").
+  const currentEntityLabel = useFlaskDataContext().entity.entity_type.toLowerCase();
 
   const entitiesTableConfig: EntitiesTabTypes<Entity>[] = useMemo(() => {
     const integratedEntityList = entityList.filter(isIntegratedEntity);
@@ -128,8 +131,8 @@ function IntegratedDataTables({
         enabledLabel="Show All Ancestors"
         ariaLabel="Show ancestor datasets"
         noWrapOptionLabels
-        disabledTooltip="Show only the datasets directly associated with this entity."
-        enabledTooltip="Also show the ancestor datasets these were derived from, such as the raw datasets they were processed from."
+        disabledTooltip={`Show only the datasets directly associated with this ${currentEntityLabel}.`}
+        enabledTooltip="Show directly associated datasets and the ancestor datasets these were derived from, such as the raw datasets they were processed from."
       />
     ) : null;
     // Only surface the retracted-first status column when a retracted dataset is actually visible.
@@ -226,7 +229,7 @@ function IntegratedDataTables({
       },
     ];
     return entities;
-  }, [entityList, tableTooltips, datasetRetractedSortMap, directDatasetIds, showAncestorDatasets]);
+  }, [entityList, tableTooltips, datasetRetractedSortMap, directDatasetIds, showAncestorDatasets, currentEntityLabel]);
 
   const numSelected = useSelectableTableStore((s) => s.selectedRows.size);
 


### PR DESCRIPTION
## Summary

This PR adjusts the verbiage of the "show associated datasets" toggle to explicitly use the appropriate entity type.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1653

## Testing

Manually tested.

## Screenshots/Video


<img width="688" height="172" alt="image" src="https://github.com/user-attachments/assets/5e4bd2e4-8815-4209-9b0b-d7b669785105" />

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
