### PR TITLE
NickAkhmetov/Add vanity slug for data portal publication

### DIFF
--- a/CHANGELOG-hubmap-data-portal-publication-redirect.md
+++ b/CHANGELOG-hubmap-data-portal-publication-redirect.md
@@ -1,0 +1,1 @@
+- Add a permanent redirect from `/publications/hubmap-data-portal` to the HuBMAP Data Portal publication page.

--- a/context/app/routes_main.py
+++ b/context/app/routes_main.py
@@ -115,6 +115,19 @@ def publications():
     )
 
 
+@blueprint.route('/publications/hubmap-data-portal')
+def hubmap_data_portal_publication():
+    # Vanity URL for the HuBMAP Data Portal paper, cited in print and elsewhere.
+    return redirect(
+        url_for(
+            'routes_browse.details',
+            type='publication',
+            uuid='6c9a473b6c49b85d58f1cdfd159a934b',
+        ),
+        code=301,
+    )
+
+
 @blueprint.route('/integrated-maps')
 def integrated_maps():
     organs = get_organs()

--- a/context/app/test_routes_main.py
+++ b/context/app/test_routes_main.py
@@ -120,6 +120,12 @@ def test_302_redirect(client, path, mocker):
     assert response.status == '302 FOUND'
 
 
+def test_301_hubmap_data_portal_publication(client):
+    response = client.get('/publications/hubmap-data-portal')
+    assert response.status == '301 MOVED PERMANENTLY'
+    assert response.location == '/browse/publication/6c9a473b6c49b85d58f1cdfd159a934b'
+
+
 @pytest.mark.parametrize('path', ['/browse/sample/fake-uuid', '/browse/dataset/fake-uuid'])
 def test_301_entity_type_normalization(client, path, mocker):
     # The mocked entity is a Donor, so these URLs normalize to /browse/donor/fake-uuid.


### PR DESCRIPTION
## Summary

This PR adds a vanity slug for the data portal paper to make it easier for paper readers to access.

## Design Documentation/Original Tickets

https://hms-dbmi.slack.com/archives/C083DDM8ABS/p1787168425636589

## Testing

Added unit test.

## Screenshots/Video

N/A

## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
