### PR TITLE
NickAkhmetov/Add filter & browse mode link to the homepage's datasets section

### DIFF
--- a/CHANGELOG-filter-and-browse-mode.md
+++ b/CHANGELOG-filter-and-browse-mode.md
@@ -1,0 +1,1 @@
+- Add filter & browse mode link to the homepage's datasets section.

--- a/context/app/static/js/pages/Home/Home.tsx
+++ b/context/app/static/js/pages/Home/Home.tsx
@@ -72,8 +72,16 @@ function Home() {
             }
           >
             <Typography variant="body1" color="text.secondary" mb={2}>
-              Explore HuBMAP datasets through the Filter &amp; Browse Mode or ask questions about our data with natural
-              language with our new{' '}
+              Explore HuBMAP datasets through the{' '}
+              <InternalLink
+                href="/search/datasets"
+                onClick={() =>
+                  trackEvent({ category: 'Homepage', action: 'HuBMAP Datasets', label: 'Filter & Browse Mode Link' })
+                }
+              >
+                Filter &amp; Browse Mode
+              </InternalLink>{' '}
+              data with natural language with our new{' '}
               <InternalLink
                 href="/search/datasets?mode=say-see"
                 onClick={() =>


### PR DESCRIPTION
## Summary

This PR adds a link to the homepage's datasets section which takes users directly to the main dataset search view (filter and browse)

## Design Documentation/Original Tickets

https://hubmapconsortium.slack.com/archives/C011RF3NQ23/p1787237292514699

## Testing

See screenshot

## Screenshots/Video

<img width="920" height="124" alt="image" src="https://github.com/user-attachments/assets/8952b8da-05d0-4d3c-a018-3e90a680d324" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
