### PR TITLE
NickAkhmetov/Completely hide entity header when at top of page

### DIFF
--- a/CHANGELOG-entity-header-hidden-at-top.md
+++ b/CHANGELOG-entity-header-hidden-at-top.md
@@ -1,0 +1,1 @@
+- The entity header bar on detail pages is now hidden while the page is scrolled to the top, instead of showing an empty bar with its action buttons. It fades in once the page title scrolls out of view, and stays visible whenever the header is expanded or a visualization is fullscreen.

--- a/context/app/static/js/components/detailPage/entityHeader/EntityHeader/EntityHeader.tsx
+++ b/context/app/static/js/components/detailPage/entityHeader/EntityHeader/EntityHeader.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { useShallow } from 'zustand/react/shallow';
-import { animated } from '@react-spring/web';
+import { animated, useSpring } from '@react-spring/web';
 import Box from '@mui/material/Box';
 
 import useEntityStore, { SummaryViewsType } from 'js/stores/useEntityStore';
@@ -20,7 +20,14 @@ const visualizationSelector = (state: VisualizationStore) => ({
 });
 
 function Header() {
-  const { springs, view, setView, summaryHeight, setSummaryHeight } = useEntityStore();
+  const {
+    springs,
+    view,
+    setView,
+    summaryHeight,
+    setSummaryHeight,
+    summaryComponentObserver: { summaryInView },
+  } = useEntityStore();
   const startViewChangeSpring = useStartViewChangeSpring();
   const isLargeDesktop = useIsLargeDesktop();
   const { vizIsFullscreen } = useVisualizationStore(useShallow(visualizationSelector));
@@ -72,6 +79,13 @@ function Header() {
     wasLargeDesktop.current = isLargeDesktop;
   }, [isLargeDesktop, handleViewChange, view]);
 
+  // The header keeps its sticky slot at all times so that section offsets and visualization
+  // sizing stay stable, but the container itself should not be visible until the summary
+  // title scrolls out of view. It is also revealed when expanded or when a viz is fullscreen,
+  // since it hosts the controls for both.
+  const isRevealed = !summaryInView || view !== 'narrow' || vizIsFullscreen;
+  const { opacity } = useSpring({ opacity: isRevealed ? 1 : 0 });
+
   const [springValues] = springs;
 
   if (springValues[0] === undefined) {
@@ -79,7 +93,17 @@ function Header() {
   }
 
   return (
-    <AnimatedPaper elevation={4} data-testid="entity-header" sx={{ overflow: 'hidden' }} style={springValues[0]}>
+    <AnimatedPaper
+      elevation={4}
+      data-testid="entity-header"
+      sx={{ overflow: 'hidden' }}
+      style={{
+        ...springValues[0],
+        opacity,
+        // Hidden rather than merely transparent so the collapsed header cannot be clicked or tabbed into.
+        visibility: opacity.to((o) => (o === 0 ? 'hidden' : 'visible')),
+      }}
+    >
       <Box>
         <EntityHeaderContent setView={handleViewChange} view={view} />
         {isLargeDesktop && (


### PR DESCRIPTION
## Summary

This PR adjusts the entity header behavior to be completely invisible while at the top of the page. This behavior was in place so that it can be a container for the actions at the top of the page (download JSON, download Vitessce config, add to workspaces, etc).

## Design Documentation/Original Tickets

https://hms-dbmi.slack.com/archives/GU9AJC1Q8/p1787678872032509

## Testing

Describe how the feature has been tested, including both automated and manual testing strategies.

## Screenshots/Video

Include screenshots or video demonstrating any significant visual or behavioral changes.

## Checklist

- [ ] Code follows the project's coding standards
  - [ ] Lint checks pass locally
  - [ ] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [ ] Unit tests covering the new feature have been added
- [ ] All existing tests pass
- [ ] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [ ] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Pending final confirmation from Nils before opening for review. This changes a long-standing behavior, so it calls for some caution.
