### PR TITLE
NickAkhmetov/Restore missing text to homepage datasets section description

### DIFF
--- a/CHANGELOG-text-fix.md
+++ b/CHANGELOG-text-fix.md
@@ -1,0 +1,1 @@
+- Restore missing text to homepage datasets section description.

--- a/context/app/static/js/pages/Home/Home.tsx
+++ b/context/app/static/js/pages/Home/Home.tsx
@@ -81,7 +81,7 @@ function Home() {
               >
                 Filter &amp; Browse Mode
               </InternalLink>{' '}
-              data with natural language with our new{' '}
+              or ask questions about our data with natural language with our new{' '}
               <InternalLink
                 href="/search/datasets?mode=say-see"
                 onClick={() =>


### PR DESCRIPTION
## Summary

This PR fixes the text that was clobbered by the PR which added the link to the filter and browse mode.

## Design Documentation/Original Tickets

https://hms-dbmi.atlassian.net/browse/CAT-1662?atlOrigin=eyJpIjoiOTA3YjkwZDA3M2UxNDRkZmFjMTNjZDdmYjFjZGFhNDEiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## Testing

<img width="1881" height="199" alt="image" src="https://github.com/user-attachments/assets/b52d7dea-6a00-4a56-8548-17559ddd293c" />


## Checklist

- [x] Code follows the project's coding standards
  - [x] Lint checks pass locally
  - [x] New `CHANGELOG-your-feature-name-here.md` is present in the root directory, describing the change(s) in full sentences.
- [x] Unit tests covering the new feature have been added
- [x] All existing tests pass
- [x] Any relevant documentation in JIRA/Confluence has been updated to reflect the new feature
- [x] Any new functionalities have appropriate analytics functionalities added

## Additional Notes

Please specify any additional information or context relevant to this PR.
